### PR TITLE
feat: add mock websocket server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Build stage: Install yarn dependencies
 # ===
-FROM node:14 AS yarn-dependencies
+FROM node:18 AS yarn-dependencies
 WORKDIR /srv
 COPY . .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn CYPRESS_INSTALL_BINARY=0 yarn install

--- a/mock-server/fetchMockData.js
+++ b/mock-server/fetchMockData.js
@@ -1,0 +1,26 @@
+import https from "https";
+
+const fetchMockData = (jsonUrl) =>
+  new Promise((resolve, reject) => {
+    https
+      .get(jsonUrl, (res) => {
+        let body = "";
+
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+
+        res.on("end", async () => {
+          try {
+            await resolve(body);
+          } catch (error) {
+            reject(error.message);
+          }
+        });
+      })
+      .on("error", (error) => {
+        reject(error.message);
+      });
+  });
+
+export default fetchMockData;

--- a/mock-server/handleLogin.js
+++ b/mock-server/handleLogin.js
@@ -1,0 +1,64 @@
+const csrftoken = "mock-token";
+
+const handleLogin = (request, response) => {
+  if (
+    request.headers["content-type"]?.includes(
+      "application/x-www-form-urlencoded"
+    )
+  ) {
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+    request.on("end", () => {
+      const params = new URLSearchParams(body);
+      const username = params.get("username");
+      const password = params.get("password");
+      if (username === "admin" && password === "test1") {
+        response.setHeader(
+          "Set-Cookie",
+          `csrftoken=${csrftoken}; expires=Fri, 23 Jun 2023 12:22:38 GM; Max-Age=31449600;SameSite=Lax; Path=/`
+        );
+        response.writeHead(204);
+        response.end();
+      } else {
+        response.setHeader("Content-Type", "application/json");
+        response.writeHead(400);
+        response.end(
+          JSON.stringify({
+            __all__: [
+              "Please enter a correct username and password. Note that both fields may be case-sensitive.",
+            ],
+          })
+        );
+      }
+    });
+  } else if (request.headers.cookie.includes(`csrftoken=${csrftoken}`)) {
+    console.log(request.headers);
+    response.setHeader("Content-Type", "application/json");
+    response.end(
+      JSON.stringify({
+        authenticated: true,
+        external_auth_url: null,
+        no_users: false,
+      })
+    );
+  } else {
+    response.setHeader("Content-Type", "application/json");
+    response.end(
+      JSON.stringify({
+        authenticated: false,
+        external_auth_url: null,
+        no_users: false,
+      })
+    );
+  }
+};
+
+const handleLogout = (request, response) => {
+  response.clearCookie("csrftoken");
+  response.writeHead(204);
+  response.end();
+};
+
+export { handleLogin, handleLogout };

--- a/mock-server/httpServer.js
+++ b/mock-server/httpServer.js
@@ -1,0 +1,58 @@
+import express from "express";
+import { handleLogin, handleLogout } from "./handleLogin.js";
+
+function main(setMockFromUrl, getEnabledMock) {
+  const httpServer = express();
+
+  httpServer.get("/MAAS/accounts/login", function (request, response) {
+    handleLogin(request, response);
+  });
+
+  httpServer.post("/MAAS/accounts/login", function (request, response) {
+    handleLogin(request, response);
+  });
+
+  httpServer.post("/MAAS/accounts/logout", function (request, response) {
+    handleLogout(request, response);
+  });
+
+  httpServer.post(
+    "/MAAS/accounts/devtools/scenario",
+    function (request, response) {
+      let body = "";
+      request.on("data", (chunk) => {
+        body += chunk.toString();
+      });
+      request.on("end", async () => {
+        const params = new URLSearchParams(body);
+        const url = params.get("url");
+        try {
+          await setMockFromUrl(url);
+          response.writeHead(204);
+        } catch (error) {
+          response.writeHead(404);
+        }
+        response.end();
+      });
+    }
+  );
+  httpServer.get(
+    "/MAAS/accounts/devtools/scenario",
+    function (_request, response) {
+      response.setHeader("Content-Type", "application/json");
+      response.writeHead(200);
+      response.end(JSON.stringify({ url: getEnabledMock() }));
+    }
+  );
+
+  httpServer.get("/MAAS/accounts/", function (request, response) {
+    response.writeHead(404);
+    response.end();
+  });
+
+  return httpServer.listen(8080, function () {
+    console.log(new Date() + " Server is listening on port 8080");
+  });
+}
+
+export default main;

--- a/mock-server/httpServer.js
+++ b/mock-server/httpServer.js
@@ -17,7 +17,7 @@ function main(setMockFromUrl, getEnabledMock) {
   });
 
   httpServer.post(
-    "/MAAS/accounts/devtools/scenario",
+    "/mock-server-devtools/options",
     function (request, response) {
       let body = "";
       request.on("data", (chunk) => {
@@ -37,7 +37,7 @@ function main(setMockFromUrl, getEnabledMock) {
     }
   );
   httpServer.get(
-    "/MAAS/accounts/devtools/scenario",
+    "/mock-server-devtools/options",
     function (_request, response) {
       response.setHeader("Content-Type", "application/json");
       response.writeHead(200);

--- a/mock-server/index.js
+++ b/mock-server/index.js
@@ -1,0 +1,40 @@
+import { parse } from "url";
+import httpServer from "./httpServer.js";
+import webSocketServer from "./webSocketServer.js";
+import fetchMockData from "./fetchMockData.js";
+
+async function main() {
+  const defaultPath = "https://assets.ubuntu.com/v1/cfc9affb-responses.json";
+  let enabledMock = defaultPath;
+  let mocks = {
+    [defaultPath]: await fetchMockData(defaultPath),
+  };
+
+  const setMockFromUrl = async (url) => {
+    const data = await fetchMockData(url);
+    mocks = { ...mocks, [url]: data };
+    enabledMock = url;
+    await data;
+  };
+  const getMockData = async (url = enabledMock) => {
+    if (url in mocks) {
+      return JSON.parse(mocks[url]);
+    } else {
+      await JSON.parse(setMockFromUrl(url));
+    }
+  };
+  const getEnabledMock = () => enabledMock;
+
+  const wss = await webSocketServer(getMockData);
+  const server = httpServer(setMockFromUrl, getEnabledMock);
+
+  server.on("upgrade", function upgrade(request, socket, head) {
+    const { pathname } = parse(request.url);
+    console.log("upgrade", pathname);
+    wss.handleUpgrade(request, socket, head, function done(ws) {
+      wss.emit("connection", ws, request);
+    });
+  });
+}
+
+main();

--- a/mock-server/package.json
+++ b/mock-server/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "module"
+}

--- a/mock-server/webSocketServer.js
+++ b/mock-server/webSocketServer.js
@@ -1,0 +1,78 @@
+import WebSocket, { WebSocketServer } from "ws";
+
+const getHandlers = (mockFile) => {
+  const wsHandler = (method, func) => ({ [method]: func(method) });
+
+  const listGetter = () => (method) => (request, response) =>
+    response({
+      result: mockFile[request.method] || [],
+    });
+  const byIdGetter =
+    (path, id = "system_id") =>
+    (defaultPath) =>
+    (request, response) => {
+      response({
+        result: request.params
+          ? mockFile[path || defaultPath].find?.(
+              (node) => node[id] === request.params[id]
+            )
+          : null,
+      });
+    };
+
+  return [
+    wsHandler("*", listGetter()),
+    wsHandler("machine.get", byIdGetter()),
+    wsHandler("controller.check_images", byIdGetter()),
+    wsHandler("device.get", byIdGetter()),
+    wsHandler("controller.set_active", byIdGetter()),
+    wsHandler("controller.get", byIdGetter("controller.set_active")),
+  ];
+};
+
+async function main(getMockData) {
+  const webSocketServer = new WebSocketServer({ noServer: true });
+  console.log("WebSocket Server is running on port 8080");
+
+  const LOG_LEVEL = process.env.LOG_LEVEL || "normal";
+  const isLogLevelVerbose = LOG_LEVEL === "verbose";
+
+  webSocketServer.on("connection", async function connection(ws) {
+    console.log("WS connection established");
+
+    ws.on("message", async function message(data) {
+      const dataString = data.toString();
+
+      isLogLevelVerbose && console.log("received: %s", dataString);
+      const { method, request_id, params } = JSON.parse(dataString);
+
+      const mockData = await getMockData();
+      const handlersObj = getHandlers(mockData).reduce(
+        (acc, curr) => ({ ...acc, ...curr }),
+        {}
+      );
+
+      const handlerFunc = handlersObj[method] || handlersObj["*"];
+
+      handlerFunc({ method, request_id, params }, (message) => {
+        const responseMessage = JSON.stringify({
+          request_id,
+          ...message,
+          rtype: 0,
+          type: 1,
+        });
+        ws.send(responseMessage);
+        isLogLevelVerbose && console.log("message sent", responseMessage);
+        webSocketServer.clients.forEach(function each(client) {
+          if (client !== ws && client.readyState === WebSocket.OPEN) {
+            client.send(responseMessage);
+          }
+        });
+      });
+    });
+  });
+
+  return webSocketServer;
+}
+
+export default main;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "build-all": "yarn build",
     "build": "CYPRESS_INSTALL_BINARY=0 yarn install && react-scripts build",
+    "build-demo": "CYPRESS_INSTALL_BINARY=0 yarn install && REACT_APP_STATIC_DEMO=true react-scripts build",
     "clean-all": "yarn clean",
     "clean": "rm -rf node_modules build",
     "cleanbuild": "yarn clean-all && yarn build",
@@ -26,9 +27,12 @@
     "serve-react": "BROWSER=none PORT=8401 react-scripts start",
     "serve-static-demo": "STATIC_DEMO=true PROXY_PORT=80 nodemon ./scripts/proxy.js",
     "serve": "yarn start",
+    "start-mock-server": "nodemon ./mock-server/index.js",
     "show-ready": "wait-on http-get://0.0.0.0:8401 && nodemon ./scripts/proxy-ready.js",
     "sitespeed": "docker run -v \"$(pwd)/sitespeed.io:/sitespeed.io\" --network=host sitespeedio/sitespeed.io:25.2.1 --config /sitespeed.io/config.json /sitespeed.io/scripts/machines.js --multi --spa",
     "start": "concurrently \"yarn serve-proxy\" \"yarn serve-react\" \"yarn show-ready\"",
+    "start-mock-server-and-serve": "concurrently \"yarn start-mock-server\" \"yarn start\"",
+    "serve-demo": "concurrently \"yarn start-mock-server\" \"REACT_APP_STATIC_DEMO=true PROXY_PORT=80 MAAS_URL=http://localhost:8080/ yarn serve-proxy\"",
     "test-cypress": "start-server-and-test start '8401' serve-base 'tcp:8400' cypress-run",
     "test-ui": "TZ=UTC react-scripts test --testURL http://example.com/MAAS/r --watchAll=false",
     "test": "yarn test-ui",
@@ -121,7 +125,8 @@
     "redux-saga-test-plan": "4.0.5",
     "sass": "1.53.0",
     "start-server-and-test": "1.14.0",
-    "wait-on": "6.0.1"
+    "wait-on": "6.0.1",
+    "ws": "8.8.0"
   },
   "browserslist": {
     "production": [

--- a/scripts/proxy.js
+++ b/scripts/proxy.js
@@ -48,7 +48,7 @@ app.use(
 );
 
 // Proxy to the React client.
-if (process.env.STATIC_DEMO !== "true") {
+if (process.env.REACT_APP_STATIC_DEMO !== "true") {
   app.use(
     createProxyMiddleware("/", {
       target: `http://localhost:${REACT_PORT}/`,
@@ -56,7 +56,7 @@ if (process.env.STATIC_DEMO !== "true") {
   );
 }
 
-if (process.env.STATIC_DEMO === "true") {
+if (process.env.REACT_APP_STATIC_DEMO === "true") {
   app.use(`${BASENAME}${REACT_BASENAME}`, express.static("./build"));
   app.use(`*`, express.static("./build"));
 }

--- a/scripts/proxy.js
+++ b/scripts/proxy.js
@@ -2,65 +2,141 @@ require("dotenv-flow").config();
 var express = require("express");
 var { createProxyMiddleware } = require("http-proxy-middleware");
 
-const BASENAME = process.env.BASENAME;
-const REACT_BASENAME = process.env.REACT_BASENAME;
+const DEFAULT_OPTIONS = {
+  MAAS_URL: process.env.MAAS_URL,
+  BASENAME: process.env.BASENAME,
+  REACT_BASENAME: process.env.REACT_BASENAME,
+  PROXY_PORT: process.env.PROXY_PORT || 8400,
+  REACT_PORT: 8401,
+  DEVTOOLS_PORT: 8402,
+};
 
-var app = express();
+function startDevtools(proxyServer) {
+  var app = express(DEFAULT_OPTIONS.PROXY_PORT);
+  let maasUrl = DEFAULT_OPTIONS.MAAS_URL;
+  let _proxyServer = proxyServer;
 
-const PROXY_PORT = process.env.PROXY_PORT || 8400;
-const REACT_PORT = 8401;
+  app.post("/devtools/options", function (request, response) {
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+    request.on("end", async () => {
+      const params = new URLSearchParams(body);
+      const url = params.get("url");
+      console.log("devtools called with ", url);
+      maasUrl = url;
+      response.end();
+      _proxyServer.close(() => {
+        console.info("Restarting server with new MAAS_URL " + maasUrl);
+        _proxyServer = startProxy({ MAAS_URL: maasUrl });
+      });
+    });
+  });
 
-app.get(BASENAME, (req, res) => res.redirect(`${BASENAME}${REACT_BASENAME}`));
-app.get("/", (req, res) => res.redirect(`${BASENAME}${REACT_BASENAME}`));
-app.get(`${BASENAME}/`, (req, res) =>
-  res.redirect(`${BASENAME}${REACT_BASENAME}`)
-);
+  app.get("/devtools/options", function (_request, response) {
+    console.log("devtools endpoint called");
+    response.setHeader("Content-Type", "application/json");
+    response.writeHead(200);
+    response.end(JSON.stringify({ url: maasUrl }));
+  });
 
-// Proxy API endpoints to the MAAS.
-app.use(
-  createProxyMiddleware([`${BASENAME}/api`, `${BASENAME}/accounts`], {
-    changeOrigin: true,
-    onProxyReq(proxyReq) {
-      // Django's CSRF protection requires requests to come from the correct
-      // protocol, so this makes XHR requests work when using TLS certs.
-      proxyReq.setHeader("Referer", `${process.env.MAAS_URL}${proxyReq.path}`);
-    },
-    secure: false,
-    target: process.env.MAAS_URL,
-  })
-);
+  app.listen(DEFAULT_OPTIONS.DEVTOOLS_PORT);
 
-// Proxy the WebSocket API endpoint to the MAAS.
-app.use(
-  createProxyMiddleware(`${BASENAME}/ws`, {
-    secure: false,
-    target: process.env.MAAS_URL,
-    ws: true,
-  })
-);
+  console.log(`Serving devtools on port ${DEFAULT_OPTIONS.DEVTOOLS_PORT}`);
+}
 
-// Proxy the HMR endpoint to the React client.
-app.use(
-  createProxyMiddleware("/sockjs-node", {
-    target: `http://localhost:${REACT_PORT}/`,
-    ws: true,
-  })
-);
+function startProxy(options) {
+  const {
+    DEVTOOLS_PORT,
+    MAAS_URL,
+    BASENAME,
+    REACT_BASENAME,
+    PROXY_PORT,
+    REACT_PORT,
+  } = Object.assign({}, DEFAULT_OPTIONS, options);
 
-// Proxy to the React client.
-if (process.env.REACT_APP_STATIC_DEMO !== "true") {
+  var app = express();
+  app.get(BASENAME, (req, res) => res.redirect(`${BASENAME}${REACT_BASENAME}`));
+  app.get("/", (req, res) => res.redirect(`${BASENAME}${REACT_BASENAME}`));
+  app.get(`${BASENAME}/`, (req, res) =>
+    res.redirect(`${BASENAME}${REACT_BASENAME}`)
+  );
+
+  // Proxy API endpoints to the MAAS.
   app.use(
-    createProxyMiddleware("/", {
-      target: `http://localhost:${REACT_PORT}/`,
+    createProxyMiddleware([`${BASENAME}/api`, `${BASENAME}/accounts`], {
+      changeOrigin: true,
+      onProxyReq(proxyReq) {
+        // Django's CSRF protection requires requests to come from the correct
+        // protocol, so this makes XHR requests work when using TLS certs.
+        proxyReq.setHeader("Referer", `${MAAS_URL}${proxyReq.path}`);
+      },
+      secure: false,
+      target: MAAS_URL,
     })
   );
+
+  // Proxy the WebSocket API endpoint to the MAAS.
+  app.use(
+    createProxyMiddleware(`${BASENAME}/ws`, {
+      secure: false,
+      target: MAAS_URL,
+      ws: true,
+    })
+  );
+
+  // Proxy the HMR endpoint to the React client.
+  app.use(
+    createProxyMiddleware("/sockjs-node", {
+      target: `http://localhost:${REACT_PORT}/`,
+      ws: true,
+    })
+  );
+
+  // Proxy to the devtools server
+  app.use(
+    createProxyMiddleware("/devtools", {
+      target: `http://localhost:${DEVTOOLS_PORT}/`,
+    })
+  );
+
+  // proxy to the mock server devtools server
+  app.use(
+    createProxyMiddleware(`/mock-server-devtools`, {
+      changeOrigin: true,
+      onProxyReq(proxyReq) {
+        // Django's CSRF protection requires requests to come from the correct
+        // protocol, so this makes XHR requests work when using TLS certs.
+        proxyReq.setHeader(
+          "Referer",
+          `${DEFAULT_OPTIONS.MAAS_URL}${proxyReq.path}`
+        );
+      },
+      secure: false,
+      target: DEFAULT_OPTIONS.MAAS_URL,
+    })
+  );
+
+  // Proxy to the React client.
+  if (process.env.REACT_APP_STATIC_DEMO !== "true") {
+    app.use(
+      createProxyMiddleware("/", {
+        target: `http://localhost:${REACT_PORT}/`,
+      })
+    );
+  }
+
+  if (process.env.REACT_APP_STATIC_DEMO === "true") {
+    app.use(`${BASENAME}${REACT_BASENAME}`, express.static("./build"));
+    app.use(`*`, express.static("./build"));
+  }
+
+  const server = app.listen(PROXY_PORT);
+
+  console.log(`Serving on port ${PROXY_PORT}`);
+
+  return server;
 }
 
-if (process.env.REACT_APP_STATIC_DEMO === "true") {
-  app.use(`${BASENAME}${REACT_BASENAME}`, express.static("./build"));
-  app.use(`*`, express.static("./build"));
-}
-
-app.listen(PROXY_PORT);
-
-console.log(`Serving on port ${PROXY_PORT}`);
+startDevtools(startProxy());

--- a/src/app/base/components/Devtools/Devtools.tsx
+++ b/src/app/base/components/Devtools/Devtools.tsx
@@ -1,12 +1,17 @@
 import { useEffect, useState } from "react";
 
-import { Button, Input } from "@canonical/react-components";
+import { Button, Input, Switch } from "@canonical/react-components";
 
 const DevTools = (): JSX.Element => {
-  const [scenario, setScenario] = useState("");
+  const [mockUrl, setMockUrl] = useState("");
+  const [savedMockUrl, setSavedMockUrl] = useState("");
+  const [maasUrl, setMaasUrl] = useState("");
+  const [savedMaasUrl, setSavedMaasUrl] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const handleSend = (url: string) =>
-    fetch("/MAAS/accounts/devtools/scenario", {
+  const [shouldUseMockServer, setShouldUseMockServer] = useState(false);
+
+  const handleMaasUrlSend = (url: string) => {
+    return fetch(`/devtools/options`, {
       method: "POST",
       headers: new Headers({
         Accept: "application/json",
@@ -15,42 +20,105 @@ const DevTools = (): JSX.Element => {
       }),
       body: new URLSearchParams({ url }),
     });
+  };
 
-  useEffect(() => {
-    fetch("/MAAS/accounts/devtools/scenario").then((response) => {
-      response.json().then(({ url }) => setScenario(url));
-    });
-  }, []);
-
-  const handleScenarioChange = (value: string) => {
-    setIsLoading(true);
-    handleSend(value).then((response) => {
-      if (response.ok) {
-        window.location.reload();
-      } else {
-        console.error(response);
-        setIsLoading(false);
-      }
+  const handleMockUrlSend = (url: string) => {
+    return fetch(`/mock-server-devtools/options`, {
+      method: "POST",
+      headers: new Headers({
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "X-Requested-With": "XMLHttpRequest",
+      }),
+      body: new URLSearchParams({ url }),
     });
   };
 
+  useEffect(() => {
+    fetch("/mock-server-devtools/options").then((response) => {
+      response.json().then(({ url }) => {
+        setMockUrl(url);
+        setSavedMockUrl(url);
+      });
+    });
+    fetch("/devtools/options").then((response) => {
+      response.json().then(({ url }) => {
+        setMaasUrl(url);
+        setSavedMaasUrl(url);
+      });
+    });
+  }, []);
+
+  const handleSubmit = () => {
+    setIsLoading(true);
+    if (mockUrl !== savedMockUrl) {
+      handleMockUrlSend(mockUrl).then((response) => {
+        if (response.ok) {
+          window.location.reload();
+        } else {
+          console.error(response);
+          setIsLoading(false);
+        }
+      });
+    }
+    if (maasUrl !== savedMaasUrl) {
+      handleMaasUrlSend(maasUrl).then((response) => {
+        if (response.ok) {
+          window.location.reload();
+        } else {
+          console.error(response);
+          setIsLoading(false);
+        }
+      });
+    }
+  };
+
   return (
-    <section aria-label="MAAS UI Devtools" className="row">
-      <div className="col-6 p-footer__nav">
-        <hr />
-        <Input
-          label="JSON file URL"
-          onChange={(event) => setScenario(event.target.value)}
-          stacked
-          type="text"
-          value={scenario}
-        />
-        <Button
-          disabled={isLoading}
-          onClick={() => handleScenarioChange(scenario)}
-        >
-          Set custom scenario
-        </Button>
+    <section aria-label="MAAS UI Devtools" className="p-strip">
+      <div className="row">
+        <div className="col-3">
+          <h4 className="u-no-margin--bottom">Developer Tools</h4>
+        </div>
+        <div className="col-6">
+          <div className="row">
+            <div className="col-6">
+              <Switch
+                checked={shouldUseMockServer}
+                label="Enable mock server"
+                onChange={() => {
+                  setShouldUseMockServer(!shouldUseMockServer);
+                }}
+              />
+              {!shouldUseMockServer ? (
+                <Input
+                  help="The URL of the MAAS server to use for the UI"
+                  label="MAAS URL"
+                  onChange={(event) => setMaasUrl(event.target.value)}
+                  stacked
+                  type="text"
+                  value={maasUrl}
+                />
+              ) : null}
+            </div>
+            <div className="col-6">
+              {shouldUseMockServer ? (
+                <Input
+                  help="The URL of the JSON file to be used by the mock server"
+                  label="JSON file URL"
+                  onChange={(event) => setMockUrl(event.target.value)}
+                  stacked
+                  type="text"
+                  value={mockUrl}
+                />
+              ) : null}
+            </div>
+          </div>
+          <div className="u-align--right">
+            <Button disabled={isLoading} onClick={handleSubmit}>
+              Update
+            </Button>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/src/app/base/components/Devtools/Devtools.tsx
+++ b/src/app/base/components/Devtools/Devtools.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from "react";
+
+import { Button, Input } from "@canonical/react-components";
+
+const DevTools = (): JSX.Element => {
+  const [scenario, setScenario] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const handleSend = (url: string) =>
+    fetch("/MAAS/accounts/devtools/scenario", {
+      method: "POST",
+      headers: new Headers({
+        Accept: "application/json",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "X-Requested-With": "XMLHttpRequest",
+      }),
+      body: new URLSearchParams({ url }),
+    });
+
+  useEffect(() => {
+    fetch("/MAAS/accounts/devtools/scenario").then((response) => {
+      response.json().then(({ url }) => setScenario(url));
+    });
+  }, []);
+
+  const handleScenarioChange = (value: string) => {
+    setIsLoading(true);
+    handleSend(value).then((response) => {
+      if (response.ok) {
+        window.location.reload();
+      } else {
+        console.error(response);
+        setIsLoading(false);
+      }
+    });
+  };
+
+  return (
+    <section aria-label="MAAS UI Devtools" className="row">
+      <div className="col-6 p-footer__nav">
+        <hr />
+        <Input
+          label="JSON file URL"
+          onChange={(event) => setScenario(event.target.value)}
+          stacked
+          type="text"
+          value={scenario}
+        />
+        <Button
+          disabled={isLoading}
+          onClick={() => handleScenarioChange(scenario)}
+        >
+          Set custom scenario
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default DevTools;

--- a/src/app/base/components/Devtools/index.ts
+++ b/src/app/base/components/Devtools/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./Devtools";

--- a/src/app/base/components/Footer/Footer.tsx
+++ b/src/app/base/components/Footer/Footer.tsx
@@ -1,12 +1,20 @@
+import { useState } from "react";
+
 import { Button } from "@canonical/react-components";
 
+import DevTools from "app/base/components/Devtools";
 import { useUsabilla } from "app/base/hooks";
 
 export const Footer = (): JSX.Element => {
   const allowUsabilla = useUsabilla();
+  const isDevtoolsEnabled =
+    process.env.NODE_ENV === "development" ||
+    process.env.REACT_APP_STATIC_DEMO === "true";
+  const [isDevtoolsVisible, setIsDevtoolsVisible] = useState(false);
 
   return (
     <footer className="p-strip--light is-shallow p-footer">
+      {isDevtoolsEnabled && isDevtoolsVisible ? <DevTools /> : null}
       <div className="row">
         <div className="col-10 p-footer__nav">
           <ul className="p-inline-list--middot">
@@ -44,6 +52,11 @@ export const Footer = (): JSX.Element => {
           <svg
             aria-label="Canonical"
             className="p-footer__logo u-float--right"
+            onClick={
+              !isDevtoolsEnabled
+                ? undefined
+                : () => setIsDevtoolsVisible(!isDevtoolsVisible)
+            }
             viewBox="-0.835 -0.92 761 101"
             xmlns="http://www.w3.org/2000/svg"
           >

--- a/yarn.lock
+++ b/yarn.lock
@@ -13633,6 +13633,11 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
+ws@8.8.0, ws@^8.4.2:
+  version "8.8.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
+  integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
+
 ws@^7.4.6:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.4.tgz#56bfa20b167427e138a7795de68d134fe92e21f9"
@@ -13642,11 +13647,6 @@ ws@^8.0.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.5.0.tgz#bfb4be96600757fe5382de12c670dab984a1ed4f"
   integrity sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==
-
-ws@^8.4.2:
-  version "8.8.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.8.0.tgz#8e71c75e2f6348dbf8d78005107297056cb77769"
-  integrity sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Done

- add mock websocket server
- add devtools in the footer allowing to swap the mock JSON file used as a source of data 
  - only enabled in development and in demos (you can activate it by clicking on the canonical logo in the footer)
  - JSON files can be generated using https://github.com/canonical-web-and-design/maas-websocket-scraper 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the demo URL linked in the comment below.
- Verify you can log in to MAAS UI using login `admin` and password `test1`
- Click on the Canonical logo in the footer and enter an alternative JSON URL, e.g. `https://assets.ubuntu.com/v1/d71c5c07-responses.json` or `https://assets.ubuntu.com/v1/cfc9affb-responses.json`.
- Confirm with "Set custom scenario"
- Verify the page has been reloaded and new data is displayed.
- All pages should load.

## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/1143

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
<img width="1510" alt="image" src="https://user-images.githubusercontent.com/7452681/177571754-a90a0b17-631f-4dc9-96bd-878d9f396a67.png">
