### PR TITLE
feat(machines): add machine.count API support

### DIFF
--- a/src/__snapshots__/root-reducer.test.ts.snap
+++ b/src/__snapshots__/root-reducer.test.ts.snap
@@ -202,6 +202,7 @@ Object {
   },
   "machine": Object {
     "active": null,
+    "counts": Object {},
     "details": Object {},
     "errors": null,
     "eventErrors": Array [],

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -71,6 +71,30 @@ describe("machine actions", () => {
     });
   });
 
+  it("can get a count of machines", () => {
+    expect(actions.count("123456")).toEqual({
+      type: "machine/count",
+      meta: {
+        model: "machine",
+        method: "count",
+        requestId: "123456",
+      },
+      payload: null,
+    });
+  });
+
+  it("can get a count of filtered machines", () => {
+    expect(actions.count("123456", { owner: "admin" })).toEqual({
+      type: "machine/count",
+      meta: {
+        model: "machine",
+        method: "count",
+        requestId: "123456",
+      },
+      payload: { params: { filters: { owner: "admin" } } },
+    });
+  });
+
   it("can set an active machine", () => {
     expect(actions.setActive("abc123")).toEqual({
       type: "machine/setActive",

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -9,6 +9,7 @@ import {
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
   machineState as machineStateFactory,
+  machineStateCount as machineStateCountFactory,
   machineStateDetailsItem as machineStateDetailsItemFactory,
   machineStatus as machineStatusFactory,
 } from "testing/factories";
@@ -18,6 +19,7 @@ describe("machine reducer", () => {
     expect(reducers(undefined, { type: "" })).toEqual({
       active: null,
       errors: null,
+      counts: {},
       details: {},
       eventErrors: [],
       filters: [],
@@ -32,6 +34,80 @@ describe("machine reducer", () => {
       selected: [],
       statuses: {},
     });
+  });
+
+  it("reduces countStart", () => {
+    const initialState = machineStateFactory({ loading: false });
+    expect(reducers(initialState, actions.countStart("123456"))).toEqual(
+      machineStateFactory({
+        counts: {
+          "123456": machineStateCountFactory({
+            loading: true,
+          }),
+        },
+      })
+    );
+  });
+
+  it("reduces countSuccess", () => {
+    const initialState = machineStateFactory({
+      counts: {
+        "123456": machineStateCountFactory({
+          loaded: true,
+          loading: true,
+        }),
+      },
+    });
+    expect(
+      reducers(
+        initialState,
+        actions.countSuccess("123456", {
+          count: 11,
+        })
+      )
+    ).toEqual(
+      machineStateFactory({
+        counts: {
+          "123456": machineStateCountFactory({
+            count: 11,
+            loaded: true,
+            loading: false,
+          }),
+        },
+      })
+    );
+  });
+
+  it("reduces countError", () => {
+    const initialState = machineStateFactory({
+      counts: {
+        "123456": machineStateCountFactory({
+          loading: true,
+        }),
+      },
+    });
+    expect(
+      reducers(
+        initialState,
+        actions.countError("123456", "Could not count machines")
+      )
+    ).toEqual(
+      machineStateFactory({
+        counts: {
+          "123456": machineStateCountFactory({
+            errors: "Could not count machines",
+            loading: false,
+          }),
+        },
+        eventErrors: [
+          machineEventErrorFactory({
+            error: "Could not count machines",
+            event: "count",
+            id: null,
+          }),
+        ],
+      })
+    );
   });
 
   it("reduces fetchStart", () => {

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1,8 +1,6 @@
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
-import type { GenericMeta } from "../utils/slice";
-
 import { MachineMeta } from "./types";
 import type {
   Action,

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -230,8 +230,18 @@ export type FilterGroup = {
 
 export type MachineEventErrors = CloneError;
 
+export type MachineStateCount = {
+  count: number | null;
+  errors: APIError;
+  loaded: boolean;
+  loading: boolean;
+};
+
+export type MachineStateCounts = Record<string, MachineStateCount>;
+
 export type MachineState = {
   active: Machine[MachineMeta.PK] | null;
+  counts: MachineStateCounts;
   details: MachineStateDetails;
   eventErrors: EventError<
     Machine,

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -32,6 +32,11 @@ export type GenericItemMeta<I> = {
 export type GenericMeta = {
   requestId?: string;
   identifier?: number | string;
+} & GenericMeta;
+
+export type GenericMeta = {
+  requestId?: string;
+  identifier?: number | string;
 };
 
 // Get the models that follow the generic shape. The following models are excluded:

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -32,11 +32,6 @@ export type GenericItemMeta<I> = {
 export type GenericMeta = {
   requestId?: string;
   identifier?: number | string;
-} & GenericMeta;
-
-export type GenericMeta = {
-  requestId?: string;
-  identifier?: number | string;
 };
 
 // Get the models that follow the generic shape. The following models are excluded:

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -31,6 +31,7 @@ export {
   machineActionsState,
   machineEventError,
   machineState,
+  machineStateCount,
   machineStateDetails,
   machineStateDetailsItem,
   machineStateListGroup,

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -59,6 +59,8 @@ import type {
 } from "app/store/machine/types";
 import type {
   MachineEventErrors,
+  MachineStateCount,
+  MachineStateCounts,
   MachineStateDetails,
   MachineStateDetailsItem,
   MachineStateList,
@@ -274,6 +276,17 @@ export const machineStatuses = define<MachineStatuses>({
   testNode: machineStatus,
 });
 
+export const machineStateCount = define<MachineStateCount>({
+  count: null,
+  errors: null,
+  loaded: false,
+  loading: false,
+});
+
+export const machineStateCounts = define<MachineStateCounts>({
+  testId: machineStateCount,
+});
+
 export const machineStateDetailsItem = define<MachineStateDetailsItem>({
   errors: null,
   loaded: false,
@@ -296,6 +309,7 @@ export const machineEventError = define<
 export const machineState = define<MachineState>({
   ...defaultState,
   active: null,
+  counts: () => ({}),
   details: () => ({}),
   eventErrors: () => [],
   filters: () => [],


### PR DESCRIPTION
## Done

- Add handlers for the machine.count API to the machine slice.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the redux devtools.
- Dispatch the following and the result should appear in the machine -> counts list:
```
{
  type: "machine/count",
  meta: {
    model: "machine",
    method: "count",
    requestId: "123456",
  },
  payload: {
    params: {filter: {owner: "admin"}},
  },
}
```

## Fixes

Fixes: canonical-web-and-design/app-tribe#1108.