### PR TITLE
refactor(ui): update machine link

### DIFF
--- a/src/app/base/components/MachineLink/MachineLink.test.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.test.tsx
@@ -17,11 +17,8 @@ import {
 
 const mockStore = configureStore();
 
-beforeEach(() => {
-  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
-});
-
 it("handles when machines are loading", async () => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
   const state = rootStateFactory({
     machine: machineStateFactory({
       items: [
@@ -51,6 +48,7 @@ it("handles when machines are loading", async () => {
   await waitFor(() =>
     expect(screen.getByLabelText(Labels.Loading)).toBeInTheDocument()
   );
+  jest.restoreAllMocks();
 });
 
 it("handles when a machine does not exist", () => {

--- a/src/app/base/components/MachineLink/MachineLink.test.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from "@testing-library/react";
+import reduxToolkit from "@reduxjs/toolkit";
+import { render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -11,13 +12,30 @@ import {
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
+  machineStateDetailsItem as machineStateDetailsItemFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
 
-it("handles when machines are loading", () => {
+beforeEach(() => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+});
+
+it("handles when machines are loading", async () => {
   const state = rootStateFactory({
-    machine: machineStateFactory({ items: [], loading: true }),
+    machine: machineStateFactory({
+      items: [
+        machineFactory({
+          system_id: "abc123",
+        }),
+      ],
+      details: {
+        123456: machineStateDetailsItemFactory({
+          loading: true,
+          system_id: "abc123",
+        }),
+      },
+    }),
   });
   const store = mockStore(state);
   render(
@@ -30,7 +48,9 @@ it("handles when machines are loading", () => {
     </Provider>
   );
 
-  expect(screen.getByLabelText(Labels.Loading)).toBeInTheDocument();
+  await waitFor(() =>
+    expect(screen.getByLabelText(Labels.Loading)).toBeInTheDocument()
+  );
 });
 
 it("handles when a machine does not exist", () => {

--- a/src/app/base/components/MachineLink/MachineLink.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.tsx
@@ -1,12 +1,9 @@
 import { Spinner } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 
 import urls from "app/base/urls";
-import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
 import { useGetMachine } from "app/store/machine/utils/hooks";
-import type { RootState } from "app/store/root/types";
 
 type Props = {
   systemId?: Machine[MachineMeta.PK] | null;
@@ -17,13 +14,9 @@ export enum Labels {
 }
 
 const MachineLink = ({ systemId }: Props): JSX.Element | null => {
-  const machine = useSelector((state: RootState) =>
-    machineSelectors.getById(state, systemId)
-  );
-  const machinesLoading = useSelector(machineSelectors.loading);
-  useGetMachine(systemId);
+  const { machine, loading } = useGetMachine(systemId);
 
-  if (machinesLoading) {
+  if (loading) {
     return <Spinner aria-label={Labels.Loading} />;
   }
   if (!machine) {

--- a/src/app/base/components/MachineLink/MachineLink.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom-v5-compat";
 import urls from "app/base/urls";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
-import { useFetchMachines } from "app/store/machine/utils/hooks";
+import { useGetMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
@@ -21,7 +21,7 @@ const MachineLink = ({ systemId }: Props): JSX.Element | null => {
     machineSelectors.getById(state, systemId)
   );
   const machinesLoading = useSelector(machineSelectors.loading);
-  useFetchMachines();
+  useGetMachine(systemId);
 
   if (machinesLoading) {
     return <Spinner aria-label={Labels.Loading} />;

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -43,10 +43,7 @@ export const CloneFormFields = ({
   const loadingVlans = !useSelector(vlanSelectors.loaded);
   const loadingData =
     loadingFabrics || loadingMachines || loadingSubnets || loadingVlans;
-  const requestId = useGetMachine(values.source);
-  const loadingMachineDetails = useSelector((state: RootState) =>
-    machineSelectors.detailsLoading(state, requestId)
-  );
+  const { loading: loadingMachineDetails } = useGetMachine(values.source);
   useFetchMachines();
 
   useEffect(() => {

--- a/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 import { Redirect, useLocation } from "react-router-dom";
 import { Route, Routes } from "react-router-dom-v5-compat";
 
@@ -26,10 +26,8 @@ import { useGetURLId } from "app/base/hooks/urls";
 import urls from "app/base/urls";
 import type { MachineHeaderContent } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
 import { MachineMeta } from "app/store/machine/types";
 import { useGetMachine } from "app/store/machine/utils/hooks";
-import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { getRelativeRoute, isId } from "app/utils";
 
@@ -37,13 +35,7 @@ const MachineDetails = (): JSX.Element => {
   const dispatch = useDispatch();
   const id = useGetURLId(MachineMeta.PK);
   const { pathname } = useLocation();
-  const machine = useSelector((state: RootState) =>
-    machineSelectors.getById(state, id)
-  );
-  const requestId = useGetMachine(id);
-  const detailsLoaded = useSelector((state: RootState) =>
-    machineSelectors.detailsLoaded(state, requestId)
-  );
+  const { machine, loaded: detailsLoaded } = useGetMachine(id);
   const [headerContent, setHeaderContent] =
     useState<MachineHeaderContent | null>(null);
 

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -49,7 +49,6 @@ describe("machine hook utils", () => {
   let machine: Machine | null;
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
     machine = machineFactory({
       architecture: "amd64",
       events: [machineEventFactory()],
@@ -124,6 +123,7 @@ describe("machine hook utils", () => {
         <Provider store={store}>{children}</Provider>;
 
     it("can get a machine", () => {
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
       const store = mockStore(state);
       renderHook(
         ({ id }: { children?: ReactNode; id: string }) => useGetMachine(id),
@@ -160,6 +160,10 @@ describe("machine hook utils", () => {
     });
 
     it("gets a machine if the id changes", () => {
+      jest
+        .spyOn(reduxToolkit, "nanoid")
+        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce("mocked-nanoid-2");
       const store = mockStore(state);
       const { rerender } = renderHook(
         ({ id }: { children?: ReactNode; id: string }) => useGetMachine(id),
@@ -171,7 +175,7 @@ describe("machine hook utils", () => {
         }
       );
       rerender({ id: "ghi789" });
-      const expected = machineActions.get("ghi789", "mocked-nanoid");
+      const expected = machineActions.get("ghi789", "mocked-nanoid-2");
       const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { nanoid } from "@reduxjs/toolkit";
@@ -51,24 +51,31 @@ export const useFetchMachines = (): void => {
 export const useGetMachine = (
   id?: Machine[MachineMeta.PK] | null
 ): { machine: Machine | null; loading?: boolean; loaded?: boolean } => {
-  const callId = useRef<string | null>(null);
+  const [callId, setCallId] = useState<string | null>(null);
+  const previousCallId = usePrevious(callId);
   const previousId = usePrevious(id, false);
   const dispatch = useDispatch();
   const loaded = useSelector((state: RootState) =>
-    machineSelectors.detailsLoaded(state, callId.current)
+    machineSelectors.detailsLoaded(state, callId)
   );
   const loading = useSelector((state: RootState) =>
-    machineSelectors.detailsLoading(state, callId.current)
+    machineSelectors.detailsLoading(state, callId)
   );
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
+
   useEffect(() => {
     if (isId(id) && id !== previousId) {
-      callId.current = nanoid();
-      dispatch(machineActions.get(id, callId.current));
+      setCallId(nanoid());
     }
   }, [dispatch, id, previousId]);
+
+  useEffect(() => {
+    if (isId(id) && callId && callId !== previousCallId) {
+      dispatch(machineActions.get(id, callId));
+    }
+  }, [dispatch, id, callId, previousCallId]);
   // TODO: clean up the previous request if the id changes or the component is unmounted:
   // https://github.com/canonical-web-and-design/app-tribe/issues/1151
   return { machine, loading, loaded };

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -11,6 +11,7 @@ import {
   osInfo as osInfoSelectors,
 } from "app/store/general/selectors";
 import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
@@ -49,10 +50,19 @@ export const useFetchMachines = (): void => {
  */
 export const useGetMachine = (
   id?: Machine[MachineMeta.PK] | null
-): string | null => {
+): { machine: Machine | null; loading?: boolean; loaded?: boolean } => {
   const callId = useRef<string | null>(null);
   const previousId = usePrevious(id, false);
   const dispatch = useDispatch();
+  const loaded = useSelector((state: RootState) =>
+    machineSelectors.detailsLoaded(state, callId.current)
+  );
+  const loading = useSelector((state: RootState) =>
+    machineSelectors.detailsLoading(state, callId.current)
+  );
+  const machine = useSelector((state: RootState) =>
+    machineSelectors.getById(state, id)
+  );
   useEffect(() => {
     if (isId(id) && id !== previousId) {
       callId.current = nanoid();
@@ -61,7 +71,7 @@ export const useGetMachine = (
   }, [dispatch, id, previousId]);
   // TODO: clean up the previous request if the id changes or the component is unmounted:
   // https://github.com/canonical-web-and-design/app-tribe/issues/1151
-  return callId.current;
+  return { machine, loading, loaded };
 };
 
 /**


### PR DESCRIPTION
## Done

- update machine link 
- refactor `useGetMachine` to return status and machine (consistent with `useDhcpTarget`)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- using bolla back-end, go to /MAAS/r/subnet/3 
- in the Used IP addresses section verify machine links in the NODE column are displayed correctly 
- click on a link and verify a machine details page is displayed 


## Fixes

Fixes: https://github.com/canonical-web-and-design/app-tribe/issues/1107

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
