### PR TITLE
feat(redux): add filter options

### DIFF
--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -1684,4 +1684,15 @@ describe("machine actions", () => {
       payload: null,
     });
   });
+
+  it("can handle filter options", () => {
+    expect(actions.filterOptions(FetchGroupKey.Owner)).toEqual({
+      type: "machine/filterOptions",
+      meta: {
+        model: "machine",
+        method: "filter_options",
+      },
+      payload: null,
+    });
+  });
 });

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -1692,7 +1692,11 @@ describe("machine actions", () => {
         model: "machine",
         method: "filter_options",
       },
-      payload: null,
+      payload: {
+        params: {
+          group_key: FetchGroupKey.Owner,
+        },
+      },
     });
   });
 });

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -1,4 +1,6 @@
 import reducers, { actions } from "./slice";
+import { FetchGroupKey } from "./types/actions";
+import { FilterGroupType } from "./types/base";
 
 import { NodeActions } from "app/store/types/node";
 import {
@@ -331,6 +333,286 @@ describe("machine reducer", () => {
           }),
         ],
         filtersLoading: false,
+      })
+    );
+  });
+
+  it("reduces filterOptionsStart", () => {
+    const initialState = machineStateFactory({
+      filters: [
+        filterGroupFactory({
+          key: FetchGroupKey.Owner,
+          loading: false,
+        }),
+      ],
+    });
+    expect(
+      reducers(initialState, actions.filterOptionsStart(FetchGroupKey.Owner))
+    ).toEqual(
+      machineStateFactory({
+        filters: [
+          filterGroupFactory({
+            key: FetchGroupKey.Owner,
+            loading: true,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("reduces filterOptionsError", () => {
+    const initialState = machineStateFactory({
+      eventErrors: [],
+      filters: [
+        filterGroupFactory({
+          key: FetchGroupKey.Owner,
+          loading: true,
+        }),
+      ],
+    });
+    expect(
+      reducers(
+        initialState,
+        actions.filterOptionsError(
+          FetchGroupKey.Owner,
+          "Could not fetch filter groups"
+        )
+      )
+    ).toEqual(
+      machineStateFactory({
+        eventErrors: [
+          machineEventErrorFactory({
+            error: "Could not fetch filter groups",
+            event: "filterOptions",
+            id: undefined,
+          }),
+        ],
+        filters: [
+          filterGroupFactory({
+            errors: "Could not fetch filter groups",
+            key: FetchGroupKey.Owner,
+            loading: false,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("reduces filterOptionsSuccess for bool options", () => {
+    const initialState = machineStateFactory({
+      filters: [
+        filterGroupFactory({
+          key: FetchGroupKey.PowerState,
+          options: null,
+          loaded: false,
+          loading: true,
+          type: FilterGroupType.Bool,
+        }),
+      ],
+    });
+    const fetchedOptions = [
+      { key: true, label: "On" },
+      { key: false, label: "Off" },
+    ];
+    expect(
+      reducers(
+        initialState,
+        actions.filterOptionsSuccess(FetchGroupKey.PowerState, fetchedOptions)
+      )
+    ).toEqual(
+      machineStateFactory({
+        filters: [
+          filterGroupFactory({
+            key: FetchGroupKey.PowerState,
+            options: fetchedOptions,
+            loaded: true,
+            loading: false,
+            type: FilterGroupType.Bool,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("reduces filterOptionsSuccess for float options", () => {
+    const initialState = machineStateFactory({
+      filters: [
+        filterGroupFactory({
+          key: FetchGroupKey.Memory,
+          options: null,
+          loaded: false,
+          loading: true,
+          type: FilterGroupType.Float,
+        }),
+      ],
+    });
+    const fetchedOptions = [
+      { key: 1024.1, label: "1024.1" },
+      { key: 1024.2, label: "2024.2" },
+    ];
+    expect(
+      reducers(
+        initialState,
+        actions.filterOptionsSuccess(FetchGroupKey.Memory, fetchedOptions)
+      )
+    ).toEqual(
+      machineStateFactory({
+        filters: [
+          filterGroupFactory({
+            key: FetchGroupKey.Memory,
+            options: fetchedOptions,
+            loaded: true,
+            loading: false,
+            type: FilterGroupType.Float,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("reduces filterOptionsSuccess for int options", () => {
+    const initialState = machineStateFactory({
+      filters: [
+        filterGroupFactory({
+          key: FetchGroupKey.Status,
+          options: null,
+          loaded: false,
+          loading: true,
+          type: FilterGroupType.Int,
+        }),
+      ],
+    });
+    const fetchedOptions = [
+      { key: 1, label: "New" },
+      { key: 2, label: "Ready" },
+    ];
+    expect(
+      reducers(
+        initialState,
+        actions.filterOptionsSuccess(FetchGroupKey.Status, fetchedOptions)
+      )
+    ).toEqual(
+      machineStateFactory({
+        filters: [
+          filterGroupFactory({
+            key: FetchGroupKey.Status,
+            options: fetchedOptions,
+            loaded: true,
+            loading: false,
+            type: FilterGroupType.Int,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("reduces filterOptionsSuccess for string options", () => {
+    const initialState = machineStateFactory({
+      filters: [
+        filterGroupFactory({
+          key: FetchGroupKey.Tags,
+          options: null,
+          loaded: false,
+          loading: true,
+          type: FilterGroupType.List,
+        }),
+      ],
+    });
+    const fetchedOptions = [
+      { key: "tag1", label: "Tag 1" },
+      { key: "tag2", label: "Tag 2" },
+    ];
+    expect(
+      reducers(
+        initialState,
+        actions.filterOptionsSuccess(FetchGroupKey.Tags, fetchedOptions)
+      )
+    ).toEqual(
+      machineStateFactory({
+        filters: [
+          filterGroupFactory({
+            key: FetchGroupKey.Tags,
+            options: fetchedOptions,
+            loaded: true,
+            loading: false,
+            type: FilterGroupType.List,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("reduces filterOptionsSuccess for dict options", () => {
+    const initialState = machineStateFactory({
+      filters: [
+        filterGroupFactory({
+          key: FetchGroupKey.BootInterface,
+          options: null,
+          loaded: false,
+          loading: true,
+          type: FilterGroupType.Dict,
+        }),
+      ],
+    });
+    const fetchedOptions = [
+      { key: "iface:name=eth0", label: "name=eth0" },
+      { key: "iface:name=eth1", label: "name=eth1" },
+    ];
+    expect(
+      reducers(
+        initialState,
+        actions.filterOptionsSuccess(
+          FetchGroupKey.BootInterface,
+          fetchedOptions
+        )
+      )
+    ).toEqual(
+      machineStateFactory({
+        filters: [
+          filterGroupFactory({
+            key: FetchGroupKey.BootInterface,
+            options: fetchedOptions,
+            loaded: true,
+            loading: false,
+            type: FilterGroupType.Dict,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("reduces filterOptionsSuccess for list options", () => {
+    const initialState = machineStateFactory({
+      filters: [
+        filterGroupFactory({
+          key: FetchGroupKey.Owner,
+          options: null,
+          loaded: false,
+          loading: true,
+          type: FilterGroupType.String,
+        }),
+      ],
+    });
+    const fetchedOptions = [
+      { key: "admin", label: "Admin" },
+      { key: "admin2", label: "Admin2" },
+    ];
+    expect(
+      reducers(
+        initialState,
+        actions.filterOptionsSuccess(FetchGroupKey.Owner, fetchedOptions)
+      )
+    ).toEqual(
+      machineStateFactory({
+        filters: [
+          filterGroupFactory({
+            key: FetchGroupKey.Owner,
+            options: fetchedOptions,
+            loaded: true,
+            loading: false,
+            type: FilterGroupType.String,
+          }),
+        ],
       })
     );
   });

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -213,19 +213,45 @@ export type MachineStateList = {
 
 export type MachineStateLists = Record<string, MachineStateList>;
 
+export type FilterGroupOptionType = boolean | number | string[] | string;
+
+export type FilterGroupOption<K = FilterGroupOptionType> = {
+  key: K;
+  label: string;
+};
+
+export enum FilterGroupType {
+  Bool = "bool",
+  Dict = "dict[string,string]",
+  Float = "float",
+  Int = "int",
+  // Only multichoice strings are currently supported:
+  // https://github.com/maas/maas/blob/a9e9029d0153a938e5a73b9d1de5b59252e64c6a/src/maasserver/node_constraint_filter_forms.py#L688
+  List = "list[string]",
+  String = "string",
+}
+
 export type FilterGroup = {
+  errors: APIError;
   key: string;
   label: string;
+  loaded: boolean;
+  loading: boolean;
   dynamic: boolean;
   for_grouping: boolean;
 } & (
-  | { options: boolean | null; type: "bool" }
-  | { options: Record<string, string> | null; type: "dict[string, string]" }
-  | { options: number | null; type: "float" | "int" }
-  | { options: number[] | null; type: "list[float]" | "list[int]" }
-  | { options: boolean[] | null; type: "list[bool]" }
-  | { options: string[] | null; type: "list[string]" }
-  | { options: string | null; type: "string" }
+  | { options: FilterGroupOption<boolean>[] | null; type: FilterGroupType.Bool }
+  | {
+      options: FilterGroupOption<string>[] | null;
+      type:
+        | FilterGroupType.Dict
+        | FilterGroupType.List
+        | FilterGroupType.String;
+    }
+  | {
+      options: FilterGroupOption<number>[] | null;
+      type: FilterGroupType.Float | FilterGroupType.Int;
+    }
 );
 
 export type MachineEventErrors = CloneError;

--- a/src/app/store/machine/types/index.ts
+++ b/src/app/store/machine/types/index.ts
@@ -47,6 +47,10 @@ export { FetchGroupKey, FetchSortDirection } from "./actions";
 export type {
   BaseMachine,
   Machine,
+  FilterGroup,
+  FilterGroupType,
+  FilterGroupOption,
+  FilterGroupOptionType,
   MachineActions,
   MachineDetails,
   MachineEventErrors,

--- a/src/testing/factories/nodes.ts
+++ b/src/testing/factories/nodes.ts
@@ -1,5 +1,7 @@
 import { define, extend, random, sequence } from "cooky-cutter";
 
+import { FilterGroupType } from "../../app/store/machine/types/base";
+
 import { model, modelRef, timestampedModel } from "./model";
 
 import type {
@@ -241,11 +243,14 @@ const node = extend<SimpleNode, BaseNode>(simpleNode, {
 
 export const filterGroup = define<FilterGroup>({
   dynamic: false,
+  errors: null,
   for_grouping: true,
   key: "arch",
   label: "Architecture",
+  loaded: false,
+  loading: false,
   options: null,
-  type: "string",
+  type: FilterGroupType.String,
 });
 
 export const machine = extend<BaseNode, Machine>(node, {


### PR DESCRIPTION
## Done

- Add support for fetching filter options.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open the redux dev tools and dispatch both of the following actions:
```
{
    type: "machine/filterGroups",
    meta: {
        model: "machine",
        method: "filter_groups",
    },
    payload: null,
}
```

```
{
    type: "machine/filterOptions",
    meta: {
        model: "machine",
        method: "filter_options",
    },
    payload: { params: {group_key: "tags"} },
}
```
- No look in state for machines -> filters -> find the group for tags
- The options array should be populated.



## Fixes

Fixes: canonical/app-tribe#1217.