### PR TITLE
feat: clean up machine requests

### DIFF
--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1239,7 +1239,7 @@ const machineSlice = createSlice({
         state: MachineState,
         action: PayloadAction<null, string, GenericMeta>
       ) => {
-        if (action.meta.callId) {
+        if (action.meta.callId && action.meta.callId in state.details) {
           delete state.details[action.meta.callId];
         }
       },

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1228,6 +1228,22 @@ const machineSlice = createSlice({
       state.filtersLoading = false;
       state.filtersLoaded = true;
     },
+    cleanupRequest: {
+      prepare: (callId: string) => ({
+        meta: {
+          callId,
+        },
+        payload: null,
+      }),
+      reducer: (
+        state: MachineState,
+        action: PayloadAction<null, string, GenericMeta>
+      ) => {
+        if (action.meta.callId) {
+          delete state.details[action.meta.callId];
+        }
+      },
+    },
     get: {
       prepare: (machineID: Machine[MachineMeta.PK], callId: string) => ({
         meta: {


### PR DESCRIPTION
## Done

- clean up machine requests on unmount and id change
- add cleanupRequest action

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to `/MAAS/r/subnet/3` using bolla back-end
- open redux devtools and ensure only latest machine details requests are in the store (for the page above that would be the total of 2)
- verify all machine details requests get removed from the store when you navigate to a different page (e.g. Settings)

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1165

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
