### PR TITLE
feat: create hook to unsubscribe machines

### DIFF
--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -10,6 +10,8 @@ import type {
   MachineState,
   MachineStatus,
   MachineStatuses,
+  MachineStateDetails,
+  MachineStateLists,
 } from "app/store/machine/types";
 import { FilterMachines, isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
@@ -82,6 +84,32 @@ ACTIONS.forEach(({ status }) => {
       )
   );
 });
+
+const lists = (state: RootState): MachineStateLists => state.machine.lists;
+
+const details = (state: RootState): MachineStateDetails =>
+  state.machine.details;
+
+const machineIdsInDetails = (state: RootState): Machine[MachineMeta.PK][] =>
+  Object.values(state.machine.details).reduce((acc, curr) => {
+    if (curr.system_id) {
+      acc.push(curr.system_id);
+    }
+    return acc;
+  }, [] as Machine[MachineMeta.PK][]);
+
+const machineIdsInLists = (state: RootState): Machine[MachineMeta.PK][] =>
+  Object.values(state.machine.lists).reduce((acc, curr) => {
+    if (curr.groups && curr.groups.length) {
+      curr.groups.reduce((acc, curr) => {
+        if (curr.items.length > 0) {
+          return acc.concat(curr.items);
+        }
+        return acc;
+      }, [] as Machine[MachineMeta.PK][]);
+    }
+    return acc;
+  }, [] as Machine[MachineMeta.PK][]);
 
 /**
  * Get the machines that are either tagging or untagging.
@@ -368,8 +396,10 @@ const selectors = {
   deleting: statusSelectors["deleting"],
   deletingInterface: statusSelectors["deletingInterface"],
   deploying: statusSelectors["deploying"],
+  details,
   detailsLoaded,
   detailsLoading,
+  machineIdsInDetails,
   enteringRescueMode: statusSelectors["enteringRescueMode"],
   eventErrors,
   eventErrorsForIds,
@@ -380,6 +410,7 @@ const selectors = {
   getStatuses,
   getStatusForMachine,
   linkingSubnet: statusSelectors["linkingSubnet"],
+  lists,
   locking: statusSelectors["locking"],
   markingBroken: statusSelectors["markingBroken"],
   markingFixed: statusSelectors["markingFixed"],
@@ -389,6 +420,7 @@ const selectors = {
   search,
   selected,
   selectedIDs,
+  machineIdsInLists,
   settingPool: statusSelectors["settingPool"],
   settingZone: statusSelectors["settingZone"],
   statuses,

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -44,6 +44,19 @@ export const useFetchMachines = (): void => {
   // https://github.com/canonical-web-and-design/app-tribe/issues/1128
 };
 
+// TODO: Maybe in the hook for getting a machine it should check for whether the machine details exist in the store,
+// or otherwise it could check if there is another request in the store for the same id.
+// We still need to store a details request for each place that is using it so that we know when it is safe to unsubscribe from the machine.
+
+// do we need a hook? I don't think so. We can just dispatch the cleanup on unmount.
+// TODO: hook for cleaning up machine requests
+// check if any machine.list or machine.get requests are using the machine(s)
+// if not it should:
+// 1. remove the machine(s) from the items list
+// 2. remove the list or get entry
+// 3. , clean up any other references e.g. errors and statuses
+// dispatch the machine.unsubscribe action to unsubscribe from the machine
+
 /**
  * Get a machine via the API.
  * @param id - A machine's system id.
@@ -85,8 +98,11 @@ export const useGetMachine = (
   useEffect(() => {
     if (isId(id) && callId && callId !== previousCallId) {
       dispatch(machineActions.get(id, callId));
+      if (previousCallId) {
+        cleanup(previousCallId);
+      }
     }
-  }, [dispatch, id, callId, previousCallId]);
+  }, [dispatch, id, callId, previousCallId, cleanup]);
 
   useEffect(() => {
     return () => {
@@ -96,6 +112,7 @@ export const useGetMachine = (
 
   // TODO: clean up the previous request if the id changes or the component is unmounted:
   // https://github.com/canonical-web-and-design/app-tribe/issues/1151
+
   return { machine, loading, loaded };
 };
 


### PR DESCRIPTION
## Done

- create hook to unsubscribe machines

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to `/MAAS/r/subnet/3` using bolla back-end
- open redux devtools
- navigate to another page (e.g. Settings)
- verify associated machine items have been removed from the store via the unsubscribe action

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1141

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
