### PR TITLE
feat(dhcp): update dhcp hook to get machines

### DIFF
--- a/src/app/settings/hooks.test.tsx
+++ b/src/app/settings/hooks.test.tsx
@@ -1,0 +1,179 @@
+import type { ReactNode } from "react";
+
+import reduxToolkit from "@reduxjs/toolkit";
+import { renderHook } from "@testing-library/react-hooks";
+import { Provider } from "react-redux";
+import configureStore from "redux-mock-store";
+import type { MockStoreEnhanced } from "redux-mock-store";
+
+import { useDhcpTarget } from "./hooks";
+
+import type { RootState } from "app/store/root/types";
+import {
+  controller as controllerFactory,
+  controllerState as controllerStateFactory,
+  device as deviceFactory,
+  deviceState as deviceStateFactory,
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  machineStateDetailsItem as machineStateDetailsItemFactory,
+} from "testing/factories";
+
+const mockStore = configureStore();
+
+const generateWrapper =
+  (store: MockStoreEnhanced<unknown>) =>
+  ({ children }: { children: ReactNode }) =>
+    <Provider store={store}>{children}</Provider>;
+
+let state: RootState;
+
+beforeEach(() => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+  state = rootStateFactory({
+    controller: controllerStateFactory({
+      items: [
+        controllerFactory({
+          system_id: "abc123",
+        }),
+      ],
+      loaded: true,
+    }),
+    device: deviceStateFactory({
+      items: [
+        deviceFactory({
+          system_id: "def456",
+        }),
+      ],
+      loaded: true,
+    }),
+    machine: machineStateFactory({
+      items: [
+        machineFactory({
+          system_id: "ghi789",
+        }),
+      ],
+    }),
+    subnet: subnetStateFactory({
+      loaded: true,
+      items: [subnetFactory({ id: 1 })],
+    }),
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it("handles loading for a subnet", () => {
+  state.subnet.loading = true;
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget(null, 1), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.loading).toBe(true);
+});
+
+it("handles loaded for a subnet", () => {
+  state.subnet.loaded = true;
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget(null, 1), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.loaded).toBe(true);
+});
+
+it("can return a subnet", () => {
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget(null, 1), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.target).toStrictEqual(state.subnet.items[0]);
+  expect(result.current.type).toBe("subnet");
+});
+
+it("handles loading for a controller", () => {
+  state.controller.loading = true;
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget("abc123"), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.loading).toBe(true);
+});
+
+it("handles loading for a device", () => {
+  state.device.loading = true;
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget("def456"), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.loading).toBe(true);
+});
+
+it("handles loaded for a device or controller", () => {
+  state.controller.loaded = true;
+  state.device.loaded = true;
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget("abc123"), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.loaded).toBe(true);
+});
+
+it("can return a controller", () => {
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget("abc123"), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.target).toStrictEqual(state.controller.items[0]);
+  expect(result.current.type).toBe("controller");
+});
+
+it("can return a device", () => {
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget("def456"), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.target).toStrictEqual(state.device.items[0]);
+  expect(result.current.type).toBe("device");
+});
+
+it("handles loading for a machine", () => {
+  state.machine.details = {
+    123456: machineStateDetailsItemFactory({
+      loading: true,
+      system_id: "ghi789",
+    }),
+  };
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget("ghi789"), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.loading).toBe(true);
+});
+
+it("handles loaded for a machine", () => {
+  state.machine.details = {
+    123456: machineStateDetailsItemFactory({
+      loaded: true,
+      system_id: "ghi789",
+    }),
+  };
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget("ghi789"), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.loaded).toBe(true);
+});
+
+it("can return a machine", () => {
+  const store = mockStore(state);
+  const { result } = renderHook(() => useDhcpTarget("ghi789"), {
+    wrapper: generateWrapper(store),
+  });
+  expect(result.current.target).toStrictEqual(state.machine.items[0]);
+  expect(result.current.type).toBe("machine");
+});

--- a/src/app/settings/hooks.ts
+++ b/src/app/settings/hooks.ts
@@ -9,9 +9,8 @@ import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device } from "app/store/device/types";
 import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
-import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
-import { useFetchMachines } from "app/store/machine/utils/hooks";
+import { useGetMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -43,18 +42,19 @@ export const useDhcpTarget = (
   const device = useSelector((state: RootState) =>
     deviceSelectors.getById(state, nodeId)
   );
-  const machineLoading = useSelector(machineSelectors.loading);
-  const machineLoaded = useSelector(machineSelectors.loaded);
-  const machine = useSelector((state: RootState) =>
-    machineSelectors.getById(state, nodeId)
-  );
-  useFetchMachines();
+  const {
+    machine,
+    loaded: machineLoaded = false,
+    loading: machineLoading = false,
+  } = useGetMachine(nodeId);
+
   const isLoading =
     (!!subnetId && subnetLoading) ||
     (!!nodeId && (controllerLoading || deviceLoading || machineLoading));
   const hasLoaded =
     (!!subnetId && subnetLoaded) ||
-    (!!nodeId && controllerLoaded && deviceLoaded && machineLoaded);
+    // The machine loaded state will only be true if a machine was found.
+    (!!nodeId && ((controllerLoaded && deviceLoaded) || machineLoaded));
 
   useEffect(() => {
     dispatch(subnetActions.fetch());

--- a/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
+++ b/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
@@ -29,7 +29,6 @@ import type {
 } from "app/store/dhcpsnippet/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
-import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -204,7 +203,6 @@ const DhcpList = (): JSX.Element => {
   const devices = useSelector(deviceSelectors.all);
   const machines = useSelector(machineSelectors.all);
   const dispatch = useDispatch();
-  useFetchMachines();
 
   useWindowTitle("DHCP snippets");
 


### PR DESCRIPTION




## Done

- Update the useDhcpTarget hook to get the required machine.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Settings -> DHCP snippets.
- Add snippets that target a machine and a controller or device (if you don't don't already have some - I've added some on Bolla).
- Check that the table displays the node names.
- Click the links to the nodes and go to the network tab and the nodes should appear in the DHCP table.

## Fixes

Fixes: canonical/app-tribe#1114. Fixes: canonical/app-tribe#1115.