### PR TITLE
fix: IP address tooltip 

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.tsx
@@ -137,7 +137,7 @@ describe("NameColumn", () => {
     expect(wrapper.find('[data-testid="ip-addresses"]').text()).toBe(
       "127.0.0.1"
     );
-    expect(wrapper.find("Button").text()).toBe("(+1)");
+    expect(wrapper.find("Button").text()).toBe("+1");
     // Shows a tooltip.
     expect(wrapper.find("Tooltip").exists()).toBe(true);
   });

--- a/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.test.tsx
@@ -135,8 +135,9 @@ describe("NameColumn", () => {
       </Provider>
     );
     expect(wrapper.find('[data-testid="ip-addresses"]').text()).toBe(
-      "127.0.0.1 (+1)"
+      "127.0.0.1"
     );
+    expect(wrapper.find("Button").text()).toBe("(+1)");
     // Shows a tooltip.
     expect(wrapper.find("Tooltip").exists()).toBe(true);
   });

--- a/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
@@ -85,12 +85,12 @@ const generateIPAddresses = (machine: Machine) => {
         >
           {ipAddresses.length > 1 ? (
             <>
-              {"("}
+              (
               <Button
                 appearance="link"
                 className="p-double-row__button u-no-border u-no-margin u-no-padding"
               >{`+${ipAddresses.length - 1}`}</Button>
-              {")"}
+              )
             </>
           ) : null}
         </Tooltip>

--- a/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 
-import { Tooltip } from "@canonical/react-components";
+import { Button, Tooltip } from "@canonical/react-components";
+import classNames from "classnames";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 
@@ -51,35 +52,44 @@ const generateIPAddresses = (machine: Machine) => {
 
   if (ipAddresses.length) {
     const ipAddressesLine = (
-      <span
-        data-testid="ip-addresses"
-        title={ipAddresses.length === 1 ? ipAddresses[0] : ""}
-      >
-        {bootIP || ipAddresses[0]}
-        {ipAddresses.length > 1 ? ` (+${ipAddresses.length - 1})` : null}
-      </span>
+      <>
+        <span
+          className="u-truncate"
+          data-testid="ip-addresses"
+          title={ipAddresses.length === 1 ? ipAddresses[0] : ""}
+        >
+          {bootIP || ipAddresses[0]}
+        </span>
+      </>
     );
 
     if (ipAddresses.length === 1) {
       return ipAddressesLine;
     }
     return (
-      <Tooltip
-        message={
-          <>
-            <strong>{ipAddresses.length} interfaces:</strong>
-            <ul className="p-list u-no-margin--bottom">
-              {ipAddresses.map((address) => (
-                <li key={address}>{address}</li>
-              ))}
-            </ul>
-          </>
-        }
-        position="btm-left"
-        positionElementClassName="p-double-row__tooltip-inner"
-      >
+      <>
         {ipAddressesLine}
-      </Tooltip>
+        <Tooltip
+          message={
+            <>
+              <strong>{ipAddresses.length} interfaces:</strong>
+              <ul className="p-list u-no-margin--bottom">
+                {ipAddresses.map((address) => (
+                  <li key={address}>{address}</li>
+                ))}
+              </ul>
+            </>
+          }
+          position="right"
+        >
+          {ipAddresses.length > 1 ? (
+            <Button
+              appearance="base"
+              className="p-double-row__button u-no-border u-no-margin u-no-padding"
+            >{`(+${ipAddresses.length - 1})`}</Button>
+          ) : null}
+        </Tooltip>
+      </>
     );
   }
   return "";
@@ -133,9 +143,10 @@ export const NameColumn = ({
       }
       // fallback to non-breaking space to keep equal height of all rows
       secondary={secondaryRow || <NonBreakingSpace />}
-      secondaryClassName={
-        handleCheckbox && "u-nudge--secondary-row u-align--left"
-      }
+      secondaryClassName={classNames([
+        "u-flex",
+        { "u-flex u-nudge--secondary-row u-align--left": handleCheckbox },
+      ])}
     />
   );
 };

--- a/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
@@ -81,12 +81,17 @@ const generateIPAddresses = (machine: Machine) => {
             </>
           }
           position="right"
+          positionElementClassName="p-double-row__tooltip-inner"
         >
           {ipAddresses.length > 1 ? (
-            <Button
-              appearance="base"
-              className="p-double-row__button u-no-border u-no-margin u-no-padding"
-            >{`(+${ipAddresses.length - 1})`}</Button>
+            <>
+              {"("}
+              <Button
+                appearance="link"
+                className="p-double-row__button u-no-border u-no-margin u-no-padding"
+              >{`+${ipAddresses.length - 1}`}</Button>
+              {")"}
+            </>
           ) : null}
         </Tooltip>
       </>
@@ -145,7 +150,7 @@ export const NameColumn = ({
       secondary={secondaryRow || <NonBreakingSpace />}
       secondaryClassName={classNames([
         "u-flex",
-        { "u-flex u-nudge--secondary-row u-align--left": handleCheckbox },
+        { "u-nudge--secondary-row u-align--left": handleCheckbox },
       ])}
     />
   );

--- a/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
+++ b/src/app/machines/views/MachineList/MachineListTable/NameColumn/__snapshots__/NameColumn.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`NameColumn renders 1`] = `
       />
     }
     secondary={<NonBreakingSpace />}
-    secondaryClassName="u-nudge--secondary-row u-align--left"
+    secondaryClassName="u-flex u-nudge--secondary-row u-align--left"
   >
     <div
       className="p-double-row"
@@ -210,7 +210,7 @@ exports[`NameColumn renders 1`] = `
           </div>
         </div>
         <div
-          className="p-double-row__secondary-row u-truncate u-nudge--secondary-row u-align--left"
+          className="p-double-row__secondary-row u-truncate u-flex u-nudge--secondary-row u-align--left"
           data-testid="secondary"
         >
           <NonBreakingSpace>

--- a/src/scss/_patterns_double-row.scss
+++ b/src/scss/_patterns_double-row.scss
@@ -33,8 +33,6 @@
 
   button.p-double-row__button {
     @extend %small-text;
-    margin-left: $sph--x-small !important;
-    color: $color-mid-dark;
   }
 
   .p-double-row__icon-space {
@@ -51,5 +49,6 @@
 
   .p-double-row__tooltip-inner {
     display: inline !important;
+    margin-left: $sph--x-small !important;
   }
 }

--- a/src/scss/_patterns_double-row.scss
+++ b/src/scss/_patterns_double-row.scss
@@ -31,6 +31,12 @@
     margin-bottom: 0;
   }
 
+  button.p-double-row__button {
+    @extend %small-text;
+    margin-left: $sph--x-small !important;
+    color: $color-mid-dark;
+  }
+
   .p-double-row__icon-space {
     width: $icon-space;
   }


### PR DESCRIPTION
## Done

- fix IP address tooltip positioning

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Ensure each machine that has multiple IP addresses has a (+1) button displayed which opens a tooltip on click/hover.
- Ensure if IP strings are truncated the (+1) button is still visible

## Fixes

Fixes: #4221 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
<img width="605" alt="image" src="https://user-images.githubusercontent.com/7452681/182809300-3e578e2d-9108-4bdc-9464-193dcf98729e.png">

### After
![image](https://user-images.githubusercontent.com/7452681/182824621-cb119ff0-e2b3-4a1a-b5e3-ef955a209c39.png)


