### PR TITLE
feat(machines): search machines using the new API

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "classnames": "2.3.1",
     "clone-deep": "4.0.1",
     "date-fns": "2.29.1",
+    "fast-deep-equal": "3.1.3",
     "formik": "2.2.9",
     "http-proxy-middleware": "2.0.6",
     "js-file-download": "0.4.12",

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
@@ -21,6 +22,8 @@ import {
   osInfo as osInfoFactory,
   rootState as rootStateFactory,
   testStatus as testStatusFactory,
+  machineStateList as machineStateListFactory,
+  machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -31,6 +34,135 @@ describe("MachineList", () => {
   let state: RootState;
 
   beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+    const machines = [
+      machineFactory({
+        actions: [],
+        architecture: "amd64/generic",
+        cpu_count: 4,
+        cpu_test_status: testStatusFactory({
+          status: TestStatusStatus.RUNNING,
+        }),
+        distro_series: "bionic",
+        domain: modelRefFactory({
+          name: "example",
+        }),
+        extra_macs: [],
+        fqdn: "koala.example",
+        hostname: "koala",
+        ip_addresses: [],
+        memory: 8,
+        memory_test_status: testStatusFactory({
+          status: TestStatusStatus.PASSED,
+        }),
+        network_test_status: testStatusFactory({
+          status: TestStatusStatus.PASSED,
+        }),
+        osystem: "ubuntu",
+        owner: "admin",
+        permissions: ["edit", "delete"],
+        physical_disk_count: 1,
+        pool: modelRefFactory(),
+        pxe_mac: "00:11:22:33:44:55",
+        spaces: [],
+        status: NodeStatus.DEPLOYED,
+        status_code: NodeStatusCode.DEPLOYED,
+        status_message: "",
+        storage: 8,
+        storage_test_status: testStatusFactory({
+          status: TestStatusStatus.PASSED,
+        }),
+        testing_status: testStatusFactory({
+          status: TestStatusStatus.PASSED,
+        }),
+        system_id: "abc123",
+        zone: modelRefFactory(),
+      }),
+      machineFactory({
+        actions: [],
+        architecture: "amd64/generic",
+        cpu_count: 2,
+        cpu_test_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        distro_series: "xenial",
+        domain: modelRefFactory({
+          name: "example",
+        }),
+        extra_macs: [],
+        fqdn: "other.example",
+        hostname: "other",
+        ip_addresses: [],
+        memory: 6,
+        memory_test_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        network_test_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        osystem: "ubuntu",
+        owner: "user",
+        permissions: ["edit", "delete"],
+        physical_disk_count: 2,
+        pool: modelRefFactory(),
+        pxe_mac: "66:77:88:99:00:11",
+        spaces: [],
+        status: NodeStatus.RELEASING,
+        status_code: NodeStatusCode.RELEASING,
+        status_message: "",
+        storage: 16,
+        storage_test_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        testing_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        system_id: "def456",
+        zone: modelRefFactory(),
+      }),
+      machineFactory({
+        actions: [],
+        architecture: "amd64/generic",
+        cpu_count: 2,
+        cpu_test_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        distro_series: "xenial",
+        domain: modelRefFactory({
+          name: "example",
+        }),
+        extra_macs: [],
+        fqdn: "other.example",
+        hostname: "other",
+        ip_addresses: [],
+        memory: 6,
+        memory_test_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        network_test_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        osystem: "ubuntu",
+        owner: "user",
+        permissions: ["edit", "delete"],
+        physical_disk_count: 2,
+        pool: modelRefFactory(),
+        pxe_mac: "66:77:88:99:00:11",
+        spaces: [],
+        status: NodeStatus.RELEASING,
+        status_code: NodeStatusCode.DEPLOYED,
+        status_message: "",
+        storage: 16,
+        storage_test_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        testing_status: testStatusFactory({
+          status: TestStatusStatus.FAILED,
+        }),
+        system_id: "ghi789",
+        zone: modelRefFactory(),
+      }),
+    ];
     state = rootStateFactory({
       general: generalStateFactory({
         machineActions: {
@@ -51,158 +183,24 @@ describe("MachineList", () => {
       }),
       machine: machineStateFactory({
         loaded: true,
-        items: [
-          machineFactory({
-            actions: [],
-            architecture: "amd64/generic",
-            cpu_count: 4,
-            cpu_test_status: testStatusFactory({
-              status: TestStatusStatus.RUNNING,
-            }),
-            distro_series: "bionic",
-            domain: modelRefFactory({
-              name: "example",
-            }),
-            extra_macs: [],
-            fqdn: "koala.example",
-            hostname: "koala",
-            ip_addresses: [],
-            memory: 8,
-            memory_test_status: testStatusFactory({
-              status: TestStatusStatus.PASSED,
-            }),
-            network_test_status: testStatusFactory({
-              status: TestStatusStatus.PASSED,
-            }),
-            osystem: "ubuntu",
-            owner: "admin",
-            permissions: ["edit", "delete"],
-            physical_disk_count: 1,
-            pool: modelRefFactory(),
-            pxe_mac: "00:11:22:33:44:55",
-            spaces: [],
-            status: NodeStatus.DEPLOYED,
-            status_code: NodeStatusCode.DEPLOYED,
-            status_message: "",
-            storage: 8,
-            storage_test_status: testStatusFactory({
-              status: TestStatusStatus.PASSED,
-            }),
-            testing_status: testStatusFactory({
-              status: TestStatusStatus.PASSED,
-            }),
-            system_id: "abc123",
-            zone: modelRefFactory(),
+        items: machines,
+        lists: {
+          "123456": machineStateListFactory({
+            loading: true,
+            groups: [
+              machineStateListGroupFactory({
+                items: machines.map(({ system_id }) => system_id),
+              }),
+            ],
           }),
-          machineFactory({
-            actions: [],
-            architecture: "amd64/generic",
-            cpu_count: 2,
-            cpu_test_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            distro_series: "xenial",
-            domain: modelRefFactory({
-              name: "example",
-            }),
-            extra_macs: [],
-            fqdn: "other.example",
-            hostname: "other",
-            ip_addresses: [],
-            memory: 6,
-            memory_test_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            network_test_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            osystem: "ubuntu",
-            owner: "user",
-            permissions: ["edit", "delete"],
-            physical_disk_count: 2,
-            pool: modelRefFactory(),
-            pxe_mac: "66:77:88:99:00:11",
-            spaces: [],
-            status: NodeStatus.RELEASING,
-            status_code: NodeStatusCode.RELEASING,
-            status_message: "",
-            storage: 16,
-            storage_test_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            testing_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            system_id: "def456",
-            zone: modelRefFactory(),
-          }),
-          machineFactory({
-            actions: [],
-            architecture: "amd64/generic",
-            cpu_count: 2,
-            cpu_test_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            distro_series: "xenial",
-            domain: modelRefFactory({
-              name: "example",
-            }),
-            extra_macs: [],
-            fqdn: "other.example",
-            hostname: "other",
-            ip_addresses: [],
-            memory: 6,
-            memory_test_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            network_test_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            osystem: "ubuntu",
-            owner: "user",
-            permissions: ["edit", "delete"],
-            physical_disk_count: 2,
-            pool: modelRefFactory(),
-            pxe_mac: "66:77:88:99:00:11",
-            spaces: [],
-            status: NodeStatus.RELEASING,
-            status_code: NodeStatusCode.DEPLOYED,
-            status_message: "",
-            storage: 16,
-            storage_test_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            testing_status: testStatusFactory({
-              status: TestStatusStatus.FAILED,
-            }),
-            system_id: "ghi789",
-            zone: modelRefFactory(),
-          }),
-        ],
+        },
       }),
     });
   });
 
   afterEach(() => {
     localStorage.clear();
-  });
-
-  it("displays a loading component if machines are loading", () => {
-    state.machine.loading = true;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <MachineList searchFilter="" setSearchFilter={jest.fn()} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
-    expect(wrapper.find("Memo(MachineListTable)").exists()).toBe(true);
+    jest.restoreAllMocks();
   });
 
   it("can filter groups", () => {
@@ -407,6 +405,19 @@ describe("MachineList", () => {
   });
 
   it("displays a message if there are no search results", () => {
+    state.machine.lists = {
+      "123456": machineStateListFactory({
+        loading: true,
+        groups: [
+          machineStateListGroupFactory({
+            collapsed: true,
+            count: 4,
+            items: [],
+            name: "admin",
+          }),
+        ],
+      }),
+    };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { Notification } from "@canonical/react-components";
+import cloneDeep from "clone-deep";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
@@ -11,14 +12,29 @@ import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-import type { RootState } from "app/store/root/types";
+import type { FetchFilters } from "app/store/machine/types";
+import { FilterMachines } from "app/store/machine/utils";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import { actions as tagActions } from "app/store/tag";
 import { formatErrors } from "app/utils";
+import type { Filters } from "app/utils/search/filter-handlers";
+import { getSelectedValue } from "app/utils/search/filter-items";
 
 type Props = {
   headerFormOpen?: boolean;
   searchFilter: string;
   setSearchFilter: SetSearchFilter;
+};
+
+// TODO: this should construct the full set of filters once the API has been
+// updated: https://github.com/canonical/app-tribe/issues/1125
+const parseFilters = (filters: Filters): FetchFilters => {
+  const fetchFilters = cloneDeep(filters);
+  // Remove the in:selected filter as this is done client side.
+  delete fetchFilters.in;
+  // The API doesn't currently support free search.
+  delete fetchFilters.q;
+  return fetchFilters;
 };
 
 const MachineList = ({
@@ -30,8 +46,10 @@ const MachineList = ({
   const dispatch = useDispatch();
   const errors = useSelector(machineSelectors.errors);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
-  const filteredMachines = useSelector((state: RootState) =>
-    machineSelectors.search(state, searchFilter || null, selectedIDs)
+  const filters = FilterMachines.getCurrentFilters(searchFilter);
+  const { machines } = useFetchMachines(
+    parseFilters(filters),
+    "in" in filters ? getSelectedValue(filters.in) : null
   );
   const errorMessage = formatErrors(errors);
   const [grouping, setGrouping] = useStorageState(
@@ -80,7 +98,7 @@ const MachineList = ({
         filter={searchFilter}
         grouping={grouping}
         hiddenGroups={hiddenGroups}
-        machines={filteredMachines}
+        machines={machines}
         selectedIDs={selectedIDs}
         setHiddenGroups={setHiddenGroups}
         setSearchFilter={setSearchFilter}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -213,6 +213,31 @@ describe("MachineListTable", () => {
     localStorage.clear();
   });
 
+  it("displays a loading component if machines are loading", () => {
+    state.machine.loaded = false;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              grouping="status"
+              hiddenGroups={[]}
+              machines={machines}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+            />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(wrapper.find("MachineListTable").exists()).toBe(true);
+  });
+
   it("includes groups", () => {
     const store = mockStore(state);
     const wrapper = mount(

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1098,7 +1098,7 @@ const machineSlice = createSlice({
     exitRescueModeStart: statusHandlers.exitRescueMode.start,
     exitRescueModeSuccess: statusHandlers.exitRescueMode.success,
     fetch: {
-      prepare: (callId: string, params?: FetchParams) => ({
+      prepare: (callId: string, params?: FetchParams | null) => ({
         meta: {
           model: MachineMeta.MODEL,
           method: "list",

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -17,7 +17,7 @@ import {
 } from "./hooks";
 
 import { actions as machineActions } from "app/store/machine";
-import type { Machine } from "app/store/machine/types";
+import type { FetchFilters, Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import { NodeStatus, NodeStatusCode } from "app/store/types/node";
@@ -35,6 +35,8 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
   vlan as vlanFactory,
+  machineStateList as machineStateListFactory,
+  machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -80,39 +82,104 @@ describe("machine hook utils", () => {
 
   describe("useFetchMachines", () => {
     beforeEach(() => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+      jest
+        .spyOn(reduxToolkit, "nanoid")
+        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce("mocked-nanoid-2")
+        .mockReturnValueOnce("mocked-nanoid-3");
     });
 
     afterEach(() => {
       jest.restoreAllMocks();
     });
+
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
-      ({ children }: { children?: ReactNode; id: string }) =>
+      ({ children }: { children?: ReactNode; filters?: FetchFilters }) =>
         <Provider store={store}>{children}</Provider>;
 
-    it("can get a machine", () => {
+    it("can fetch machines", () => {
       const store = mockStore(state);
       renderHook(() => useFetchMachines(), {
         wrapper: generateWrapper(store),
       });
-      const expected = machineActions.fetch("mocked-nanoid");
+      const expected = machineActions.fetch("mocked-nanoid-1");
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
     });
 
-    it("does not fetch again", () => {
+    it("returns the fetched machines", () => {
+      const machines = [machineFactory(), machineFactory(), machineFactory()];
+      state.machine = machineStateFactory({
+        loaded: true,
+        items: [...machines, machineFactory()],
+        lists: {
+          "123456": machineStateListFactory({
+            loading: true,
+            groups: [
+              machineStateListGroupFactory({
+                items: machines.map(({ system_id }) => system_id),
+              }),
+            ],
+          }),
+        },
+      });
+      const store = mockStore(state);
+      const { result } = renderHook(() => useFetchMachines(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result).toStrictEqual(result);
+    });
+
+    it("does not fetch again with no params", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(() => useFetchMachines(), {
         wrapper: generateWrapper(store),
       });
-      rerender({ id: "def456" });
-      const expected = machineActions.fetch("mocked-nanoid");
+      rerender();
+      const expected = machineActions.fetch("mocked-nanoid-1");
       const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
       expect(getDispatches).toHaveLength(1);
+    });
+
+    it("does not fetch again if the filters haven't changed", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        () => useFetchMachines({ hostname: "spotted-quoll" }),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ filters: { hostname: "spotted-quoll" } });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
+    it("fetches again if the filters change", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({ filters }) => useFetchMachines(filters),
+        {
+          initialProps: {
+            filters: {
+              hostname: "spotted-quoll",
+            },
+          },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ filters: { hostname: "eastern-quoll" } });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(2);
     });
   });
 

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -115,7 +115,7 @@ describe("machine hook utils", () => {
         loaded: true,
         items: [...machines, machineFactory()],
         lists: {
-          "123456": machineStateListFactory({
+          "mocked-nanoid-1": machineStateListFactory({
             loading: true,
             groups: [
               machineStateListGroupFactory({
@@ -129,7 +129,7 @@ describe("machine hook utils", () => {
       const { result } = renderHook(() => useFetchMachines(), {
         wrapper: generateWrapper(store),
       });
-      expect(result).toStrictEqual(result);
+      expect(result.current.machines).toStrictEqual(machines);
     });
 
     it("does not fetch again with no params", () => {

--- a/src/app/utils/search/filter-items.ts
+++ b/src/app/utils/search/filter-items.ts
@@ -7,6 +7,25 @@ export type GetValue<I, D = void> = (
   extraData?: D
 ) => FilterValue | FilterValue[] | null;
 
+export enum FilterSelected {
+  All,
+  Selected,
+  NotSelected,
+}
+
+export const getSelectedValue = (terms: FilterValue[]): FilterSelected => {
+  // The terms will be an array, but it is invalid to have more than
+  // one of 'selected' or '!selected'.
+  const term = terms[0].toString().toLowerCase();
+  if (term === "selected") {
+    return FilterSelected.Selected;
+  }
+  if (term === "!selected") {
+    return FilterSelected.NotSelected;
+  }
+  return FilterSelected.All;
+};
+
 export default class FilterItems<
   I,
   PK extends keyof I,
@@ -94,10 +113,11 @@ export default class FilterItems<
           const selected = selectedIDs.includes(item[this.primaryKey]);
           // The terms will be an array, but it is invalid to have more than
           // one of 'selected' or '!selected'.
-          const term = terms[0].toString().toLowerCase();
-          const onlySelected = term === "selected";
-          const onlyNotSelected = term === "!selected";
-          if ((selected && onlySelected) || (!selected && onlyNotSelected)) {
+          const selectedValue = getSelectedValue(terms);
+          if (
+            (selected && selectedValue === FilterSelected.Selected) ||
+            (!selected && selectedValue === FilterSelected.NotSelected)
+          ) {
             matched = true;
           } else {
             exclude = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,7 +6626,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@3.1.3, fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
## Done

- Update the machine list to search using the new API.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Enter in a search term that machines some machines e.g. `hostname:abc` (free text won't work until the API supports it: followup here: https://github.com/canonical/app-tribe/issues/1149).
- The list should update with the matching machines.
- Tick some machines and add `in:selected` and just the selected machines should be visible.
- Change to not selected: `in:!selected` and just the unselected machines should be visible.

## Fixes

Fixes: canonical/app-tribe#1125.