### PR TITLE
Add unsubscribe hook and saga

### DIFF
--- a/src/app/base/sagas/actions.ts
+++ b/src/app/base/sagas/actions.ts
@@ -178,24 +178,26 @@ export const generateNextDeleteRecordAction = (
 export function* deleteDomainRecord(
   socketClient: WebSocketClient,
   sendMessage: SendMessage,
-  { payload }: PayloadAction<{ params: DeleteRecordParams }>
+  { payload }: PayloadAction<{ params: DeleteRecordParams } | null>
 ): SagaGenerator<void> {
-  const { domain, rrset } = payload.params;
-  const initialAction = isAddressRecord(rrset.rrtype)
-    ? domainActions.deleteAddressRecord({
-        dnsresource_id: rrset.dnsresource_id,
-        domain,
-        rrdata: rrset.rrdata,
-      })
-    : domainActions.deleteDNSData({
-        dnsdata_id: rrset.dnsdata_id,
-        domain,
-      });
-  const nextAction = yield* call(
-    generateNextDeleteRecordAction,
-    payload.params
-  );
-  yield* call(sendMessage, socketClient, initialAction, nextAction);
+  if (payload?.params) {
+    const { domain, rrset } = payload?.params;
+    const initialAction = isAddressRecord(rrset.rrtype)
+      ? domainActions.deleteAddressRecord({
+          dnsresource_id: rrset.dnsresource_id,
+          domain,
+          rrdata: rrset.rrdata,
+        })
+      : domainActions.deleteDNSData({
+          dnsdata_id: rrset.dnsdata_id,
+          domain,
+        });
+    const nextAction = yield* call(
+      generateNextDeleteRecordAction,
+      payload.params
+    );
+    yield* call(sendMessage, socketClient, initialAction, nextAction);
+  }
 }
 
 const deleteRecordHandler: MessageHandler<DeleteRecordParams> = {

--- a/src/app/base/sagas/websockets.test.ts
+++ b/src/app/base/sagas/websockets.test.ts
@@ -1,6 +1,7 @@
 import { eventChannel } from "redux-saga";
 import { expectSaga } from "redux-saga-test-plan";
 import * as matchers from "redux-saga-test-plan/matchers";
+import { select } from "redux-saga-test-plan/matchers";
 import { call, put, take } from "redux-saga/effects";
 
 import type {
@@ -11,7 +12,9 @@ import WebSocketClient, {
   WebSocketMessageType,
   WebSocketResponseType,
 } from "../../../websocket-client";
+import machine from "../../store/machine/selectors";
 
+import type { WebSocketChannel } from "./websockets";
 import {
   createConnection,
   handleFileContextRequest,
@@ -25,12 +28,24 @@ import {
   storeFileContextActions,
   watchMessages,
   watchWebSockets,
+  handleUnsubscribe,
 } from "./websockets";
-import type { WebSocketChannel } from "./websockets";
 
+import { actions as machineActions } from "app/store/machine";
+import machineSelectors from "app/store/machine/selectors";
 import { getCookie } from "app/utils";
+import {
+  machineState as machineStateFactory,
+  rootState as rootStateFactory,
+  machineStateDetailsItem as machineStateDetailsItemFactory,
+  machineStateList as machineStateListFactory,
+  machineStateListGroup as machineStateListGroupFactory,
+} from "testing/factories";
 
-jest.mock("app/utils");
+jest.mock("app/utils", () => ({
+  ...jest.requireActual("app/utils"),
+  getCookie: jest.fn(),
+}));
 
 describe("websocket sagas", () => {
   let socketChannel: WebSocketChannel;
@@ -524,6 +539,53 @@ describe("websocket sagas", () => {
         payload: null,
       })
     );
+  });
+
+  it("can unsubscribe from unused machines", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        lists: {
+          123456: machineStateListFactory({
+            groups: [
+              machineStateListGroupFactory({
+                items: ["abc123"],
+              }),
+            ],
+          }),
+        },
+      }),
+    });
+    return expectSaga(
+      handleUnsubscribe,
+      machineActions.cleanupRequest("123456")
+    )
+      .withState(state)
+      .put(machineActions.unsubscribe(["abc123"]))
+      .put(machineActions.removeRequest("123456"))
+      .run();
+  });
+
+  it("removes request when machines are in use", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        lists: {
+          123456: machineStateListFactory({
+            groups: [
+              machineStateListGroupFactory({
+                items: ["abc123"],
+              }),
+            ],
+          }),
+        },
+      }),
+    });
+    return expectSaga(
+      handleUnsubscribe,
+      machineActions.cleanupRequest("123456")
+    )
+      .withState(state)
+      .put(machineActions.removeRequest("123456"))
+      .run();
   });
 
   describe("polling", () => {

--- a/src/app/base/sagas/websockets.test.ts
+++ b/src/app/base/sagas/websockets.test.ts
@@ -1,7 +1,6 @@
 import { eventChannel } from "redux-saga";
 import { expectSaga } from "redux-saga-test-plan";
 import * as matchers from "redux-saga-test-plan/matchers";
-import { select } from "redux-saga-test-plan/matchers";
 import { call, put, take } from "redux-saga/effects";
 
 import type {
@@ -12,7 +11,6 @@ import WebSocketClient, {
   WebSocketMessageType,
   WebSocketResponseType,
 } from "../../../websocket-client";
-import machine from "../../store/machine/selectors";
 
 import type { WebSocketChannel } from "./websockets";
 import {
@@ -32,12 +30,10 @@ import {
 } from "./websockets";
 
 import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
 import { getCookie } from "app/utils";
 import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
-  machineStateDetailsItem as machineStateDetailsItemFactory,
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -1674,6 +1674,28 @@ describe("machine actions", () => {
     });
   });
 
+  it("can handle cleaning up requests", () => {
+    expect(actions.cleanupRequest("123456")).toEqual({
+      meta: {
+        callId: "123456",
+        model: "machine",
+        unsubscribe: true,
+      },
+      payload: null,
+      type: "machine/cleanupRequest",
+    });
+  });
+
+  it("can handle removing requests", () => {
+    expect(actions.removeRequest("123456")).toEqual({
+      meta: {
+        callId: "123456",
+      },
+      payload: null,
+      type: "machine/removeRequest",
+    });
+  });
+
   it("can handle filter groups", () => {
     expect(actions.filterGroups()).toEqual({
       type: "machine/filterGroups",

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -131,7 +131,7 @@ describe("machine reducer", () => {
       items: [],
       lists: {
         "123456": machineStateListFactory({
-          loaded: true,
+          loaded: false,
           loading: true,
         }),
       },
@@ -187,6 +187,43 @@ describe("machine reducer", () => {
     );
   });
 
+  it("ignores calls that don't exist when reducing fetchSuccess", () => {
+    const initialState = machineStateFactory({
+      items: [],
+      lists: {},
+      statuses: {},
+    });
+    const fetchedMachines = [
+      machineFactory({ system_id: "abc123" }),
+      machineFactory({ system_id: "def456" }),
+    ];
+
+    expect(
+      reducers(
+        initialState,
+        actions.fetchSuccess("123456", {
+          count: 1,
+          cur_page: 2,
+          groups: [
+            {
+              collapsed: true,
+              count: 4,
+              items: fetchedMachines,
+              name: "admin",
+            },
+          ],
+          num_pages: 3,
+        })
+      )
+    ).toEqual(
+      machineStateFactory({
+        items: [],
+        lists: {},
+        statuses: {},
+      })
+    );
+  });
+
   it("does not update existing items when reducing fetchSuccess", () => {
     const existingMachine = machineDetailsFactory({
       id: 1,
@@ -194,6 +231,9 @@ describe("machine reducer", () => {
     });
     const initialState = machineStateFactory({
       items: [existingMachine],
+      lists: {
+        "123456": machineStateListFactory(),
+      },
       statuses: {
         abc123: machineStatusFactory(),
       },
@@ -750,6 +790,28 @@ describe("machine reducer", () => {
           abc123: machineStatusFactory(),
           def456: machineStatusFactory(),
         },
+      })
+    );
+  });
+
+  it("ignores calls that don't exist when reducing getSuccess", () => {
+    const initialState = machineStateFactory({
+      details: {},
+      items: [],
+      statuses: {},
+    });
+    const newMachine = machineDetailsFactory({ system_id: "def456" });
+
+    expect(
+      reducers(
+        initialState,
+        actions.getSuccess({ system_id: "abc123" }, "123456", newMachine)
+      )
+    ).toEqual(
+      machineStateFactory({
+        details: {},
+        items: [],
+        statuses: {},
       })
     );
   });

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -1250,4 +1250,30 @@ describe("machine reducer", () => {
       })
     );
   });
+
+  it("reduces removeRequest for a details request", () => {
+    const initialState = machineStateFactory({
+      details: {
+        123456: machineStateDetailsItemFactory(),
+      },
+    });
+    expect(reducers(initialState, actions.removeRequest("123456"))).toEqual(
+      machineStateFactory({
+        details: {},
+      })
+    );
+  });
+
+  it("reduces removeRequest for a list request", () => {
+    const initialState = machineStateFactory({
+      lists: {
+        123456: machineStateListFactory(),
+      },
+    });
+    expect(reducers(initialState, actions.removeRequest("123456"))).toEqual(
+      machineStateFactory({
+        lists: {},
+      })
+    );
+  });
 });

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -378,6 +378,68 @@ const list = createSelector(
   }
 );
 
+const getList = (
+  machineState: MachineState,
+  callId: string | null | undefined
+) =>
+  callId && callId in machineState.lists ? machineState.lists[callId] : null;
+
+/**
+ * Get the ids of machines in a list or details call that are not being used
+ * by other calls.
+ * @param state - The redux state.
+ * @param callId - A list request id.
+ * @returns A list of unused machine ids.
+ */
+const unusedIdsInCall = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => {
+    const usedIds: Machine[MachineMeta.PK][] = [];
+    // Get the ids for all machines in list and details requests, ignoring the
+    // current request.
+    Object.entries(machineState.details).forEach(
+      ([detailsCallId, { system_id }]) => {
+        if (detailsCallId !== callId) {
+          usedIds.push(system_id);
+        }
+      }
+    );
+    Object.entries(machineState.lists).forEach(
+      ([detailsCallId, { groups }]) => {
+        if (detailsCallId !== callId) {
+          groups?.forEach((group) => {
+            group.items.forEach((systemId) => {
+              usedIds.push(systemId);
+            });
+          });
+        }
+      }
+    );
+    const unusedIds: Machine[MachineMeta.PK][] = [];
+    const details = getDetails(machineState, callId);
+    const list = getList(machineState, callId);
+    if (details) {
+      // Check if the machine in the details request is used by any other requests.
+      if (!usedIds.includes(details.system_id)) {
+        unusedIds.push(details.system_id);
+      }
+    } else if (list) {
+      // Find any machines in the list request that are not used by any other requests.
+      list.groups?.forEach((group) => {
+        group.items.forEach((systemId) => {
+          if (!usedIds.includes(systemId)) {
+            unusedIds.push(systemId);
+          }
+        });
+      });
+    }
+    return unusedIds;
+  }
+);
+
 const selectors = {
   ...defaultSelectors,
   aborting: statusSelectors["aborting"],
@@ -422,8 +484,9 @@ const selectors = {
   turningOn: statusSelectors["turningOn"],
   unlocking: statusSelectors["unlocking"],
   unlinkingSubnet: statusSelectors["unlinkingSubnet"],
-  untagging: statusSelectors["untagging"],
   unselected,
+  untagging: statusSelectors["untagging"],
+  unusedIdsInCall,
   updatingTags,
 };
 

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -378,12 +378,6 @@ const list = createSelector(
   }
 );
 
-const getList = (
-  machineState: MachineState,
-  callId: string | null | undefined
-) =>
-  callId && callId in machineState.lists ? machineState.lists[callId] : null;
-
 /**
  * Get the ids of machines in a list or details call that are not being used
  * by other calls.

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1263,16 +1263,13 @@ const machineSlice = createSlice({
       prepare: (callId: string) => ({
         meta: {
           callId,
+          model: MachineMeta.MODEL,
+          unsubscribe: true,
         },
         payload: null,
       }),
-      reducer: (
-        state: MachineState,
-        action: PayloadAction<null, string, GenericMeta>
-      ) => {
-        if (action.meta.callId && action.meta.callId in state.details) {
-          delete state.details[action.meta.callId];
-        }
+      reducer: () => {
+        // No state changes need to be handled for this action.
       },
     },
     get: {
@@ -1512,6 +1509,27 @@ const machineSlice = createSlice({
     [`${NodeActions.RELEASE}Error`]: statusHandlers.release.error,
     [`${NodeActions.RELEASE}Start`]: statusHandlers.release.start,
     [`${NodeActions.RELEASE}Success`]: statusHandlers.release.success,
+    removeRequest: {
+      prepare: (callId: string) => ({
+        meta: {
+          callId,
+        },
+        payload: null,
+      }),
+      reducer: (
+        state: MachineState,
+        action: PayloadAction<null, string, GenericMeta>
+      ) => {
+        const { callId } = action.meta;
+        if (callId) {
+          if (callId in state.details) {
+            delete state.details[callId];
+          } else if (callId in state.lists) {
+            delete state.lists[callId];
+          }
+        }
+      },
+    },
     rescueMode: generateActionParams<BaseNodeActionParams>(
       NodeActions.RESCUE_MODE
     ),

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -96,7 +96,7 @@ describe("machine hook utils", () => {
 
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
-      ({ children }: { children?: ReactNode; filters?: FetchFilters }) =>
+      ({ children }: { children?: ReactNode; filters?: FetchFilters | null }) =>
         <Provider store={store}>{children}</Provider>;
 
     it("can fetch machines", () => {
@@ -155,6 +155,25 @@ describe("machine hook utils", () => {
         }
       );
       rerender({ filters: { hostname: "spotted-quoll" } });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
+    it("does not fetch again if the filters haven't changed including empty objects", () => {
+      const store = mockStore(state);
+      const initialProps: { filters: FetchFilters | null } = { filters: null };
+      const { rerender } = renderHook(
+        ({ filters }: { filters: FetchFilters | null }) =>
+          useFetchMachines(filters),
+        {
+          initialProps,
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ filters: {} });
       const expected = machineActions.fetch("mocked-nanoid-1");
       const getDispatches = store
         .getActions()

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -53,6 +53,8 @@ export const useFetchMachines = (
   useEffect(() => {
     // TODO: request the machines again if the provided options change (
     // ordering, pagination etc.)
+    // undefined, null and {} are all equivalent i.e. no filters so compare the
+    // current and previous filters using an empty object if the filters are falsy.
     if (!fastDeepEqual(filters || {}, previousFilters || {}) || !callId) {
       setCallId(nanoid());
     }

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -53,11 +53,7 @@ export const useFetchMachines = (
   useEffect(() => {
     // TODO: request the machines again if the provided options change (
     // ordering, pagination etc.)
-    if (
-      ((filters || previousFilters) &&
-        !fastDeepEqual(filters, previousFilters)) ||
-      !callId
-    ) {
+    if (!fastDeepEqual(filters || {}, previousFilters || {}) || !callId) {
       setCallId(nanoid());
     }
   }, [callId, dispatch, filters, previousFilters]);

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -59,7 +59,7 @@ export type WebSocketActionParams = AnyObject | AnyObject[];
 export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
   {
     params: P;
-  },
+  } | null,
   string,
   {
     // Whether the request should only be fetched the first time.
@@ -73,7 +73,7 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
     // key of a model in order to track a its loading/success/error states.
     identifier?: number | string;
     // The endpoint method e.g. "list".
-    method: string;
+    method?: string;
     // The endpoint model e.g. "machine".
     model: string;
     // Whether the request should be fetched every time.
@@ -89,6 +89,8 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
     callId?: string;
     // Whether polling should be stopped for the request.
     pollStop?: boolean;
+    // Whether the request should unsubscribe from unused entities.
+    unsubscribe?: boolean;
     // Whether the response should be stored in the file context.
     useFileContext?: boolean;
   }


### PR DESCRIPTION
## Done

- Add support for unsubscribing to the websocket sagas.
- Add clean up and unsub to fetch and get hooks.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Look in `machine` in the redux store and you should see the `lists` requests.
- Navigate away from the machine list, preferably to somewhere that doesn't have machines.
- You should see the dispatches for `machine/unsubscribe` and state should no longer have the lists requests.
- Go to a machine details page and navigate away.
- You should see the dispatches for `machine/unsubscribe` and state should no longer have the details requests.

## Fixes

Fixes: canonical/app-tribe#1141.
Fixes: canonical/app-tribe#1128.
