### PR TITLE
refactor(machines): move machine select table to a reusable component

### DIFF
--- a/src/app/base/components/LabelledList/LabelledList.tsx
+++ b/src/app/base/components/LabelledList/LabelledList.tsx
@@ -13,9 +13,10 @@ type Props = {
   items: LabelledListItem[];
 };
 
-const LabelledList = ({ className, items }: Props): JSX.Element => {
+const LabelledList = ({ className, items, ...props }: Props): JSX.Element => {
   return (
     <List
+      {...props}
       className={classNames("p-list--labelled", className)}
       items={items.map(({ label, value }) => (
         <>

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -36,7 +36,6 @@ describe("MachineSelectTable", () => {
     state = rootStateFactory({
       machine: machineStateFactory({
         items: machines,
-        loaded: true,
       }),
       tag: tagStateFactory({
         items: [
@@ -48,7 +47,7 @@ describe("MachineSelectTable", () => {
   });
 
   it("shows a spinner while data is loading", () => {
-    state.machine.loaded = false;
+    state.machine.loading = true;
     renderWithMockStore(
       <MachineSelectTable
         machines={machines}
@@ -58,7 +57,7 @@ describe("MachineSelectTable", () => {
       />,
       { state }
     );
-    expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
+    expect(screen.getByText(Label.Loading)).toBeInTheDocument();
   });
 
   it("highlights the substring that matches the search text", async () => {

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -1,0 +1,114 @@
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import MachineSelectTable, { Label } from "./MachineSelectTable";
+
+import type { Machine } from "app/store/machine/types";
+import type { RootState } from "app/store/root/types";
+import {
+  machine as machineFactory,
+  rootState as rootStateFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+  machineState as machineStateFactory,
+} from "testing/factories";
+import { renderWithMockStore } from "testing/utils";
+
+describe("MachineSelectTable", () => {
+  let machines: Machine[];
+  let state: RootState;
+
+  beforeEach(() => {
+    machines = [
+      machineFactory({
+        system_id: "abc123",
+        hostname: "first",
+        owner: "admin",
+        tags: [12],
+      }),
+      machineFactory({
+        system_id: "def456",
+        hostname: "second",
+        owner: "user",
+        tags: [13],
+      }),
+    ];
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        items: machines,
+        loaded: true,
+      }),
+      tag: tagStateFactory({
+        items: [
+          tagFactory({ id: 12, name: "tagA" }),
+          tagFactory({ id: 13, name: "tagB" }),
+        ],
+      }),
+    });
+  });
+
+  it("shows a spinner while data is loading", () => {
+    state.machine.loaded = false;
+    renderWithMockStore(
+      <MachineSelectTable
+        machines={machines}
+        onMachineClick={jest.fn()}
+        searchText=""
+        setSearchText={jest.fn()}
+      />,
+      { state }
+    );
+    expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
+  });
+
+  it("highlights the substring that matches the search text", async () => {
+    renderWithMockStore(
+      <MachineSelectTable
+        machines={[machines[0]]}
+        onMachineClick={jest.fn()}
+        searchText="fir"
+        setSearchText={jest.fn()}
+      />,
+      { state }
+    );
+
+    let hostnameCol = screen.getByRole("gridcell", {
+      name: Label.Hostname,
+    });
+    // eslint-disable-next-line testing-library/no-node-access
+    expect(hostnameCol.querySelector("strong")).toHaveTextContent("fir");
+  });
+
+  it("runs onMachineClick function on row click", async () => {
+    const onMachineClick = jest.fn();
+
+    renderWithMockStore(
+      <MachineSelectTable
+        machines={machines}
+        onMachineClick={onMachineClick}
+        searchText=""
+        setSearchText={jest.fn()}
+      />,
+      { state }
+    );
+
+    await userEvent.click(screen.getByRole("row", { name: "first" }));
+    expect(onMachineClick).toHaveBeenCalledWith(machines[0]);
+  });
+
+  it("displays tag names", () => {
+    renderWithMockStore(
+      <MachineSelectTable
+        machines={machines}
+        onMachineClick={jest.fn()}
+        searchText=""
+        setSearchText={jest.fn()}
+      />,
+      { state }
+    );
+    const ownerCols = screen.getAllByRole("gridcell", {
+      name: Label.Owner,
+    });
+    expect(within(ownerCols[0]).getByText("tagA")).toBeInTheDocument();
+  });
+});

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
@@ -81,14 +81,15 @@ export const MachineSelectTable = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const tags = useSelector(tagSelectors.all);
-  const loadingMachines = !useSelector(machineSelectors.loaded);
+  let loadingMachines = useSelector(machineSelectors.loading);
+  loadingMachines = false;
 
   useEffect(() => {
     dispatch(tagActions.fetch());
   }, [dispatch]);
 
   if (loadingMachines) {
-    return <Spinner aria-label={Label.Loading} text={Label.Loading} />;
+    return <Spinner text={Label.Loading} />;
   }
   return (
     <MainTable

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
@@ -1,0 +1,126 @@
+import { useEffect } from "react";
+
+import { MainTable, Spinner } from "@canonical/react-components";
+import { highlightSubString } from "@canonical/react-components/dist/utils";
+import { useDispatch, useSelector } from "react-redux";
+
+import DoubleRow from "app/base/components/DoubleRow";
+import machineSelectors from "app/store/machine/selectors";
+import type { Machine } from "app/store/machine/types";
+import { actions as tagActions } from "app/store/tag";
+import tagSelectors from "app/store/tag/selectors";
+import type { Tag } from "app/store/tag/types";
+import { getTagNamesForIds } from "app/store/tag/utils";
+
+export enum Label {
+  Loading = "Loading...",
+  Hostname = "Hostname",
+  Owner = "Owner",
+}
+
+type Props = {
+  machines: Machine[];
+  onMachineClick: (machine: Machine | null) => void;
+  searchText: string;
+  setSearchText: (searchText: string) => void;
+};
+
+const generateRows = (
+  machines: Machine[],
+  searchText: string,
+  onRowClick: (machine: Machine) => void,
+  tags: Tag[]
+) => {
+  const highlightedText = (text: string) => (
+    <span
+      dangerouslySetInnerHTML={{
+        __html: highlightSubString(text, searchText).text,
+      }}
+    />
+  );
+  return machines.map((machine) => ({
+    "aria-label": machine.hostname,
+    className: "machine-select-table__row",
+    columns: [
+      {
+        "aria-label": Label.Hostname,
+        content: (
+          <DoubleRow
+            primary={highlightedText(machine.hostname)}
+            secondary={highlightedText(machine.system_id)}
+          />
+        ),
+      },
+      {
+        "aria-label": Label.Owner,
+        content: (
+          <DoubleRow
+            primary={machine.owner || "-"}
+            secondary={
+              machine.tags.length
+                ? highlightedText(
+                    getTagNamesForIds(machine.tags, tags).join(", ")
+                  )
+                : "-"
+            }
+          />
+        ),
+      },
+    ],
+    onClick: () => onRowClick(machine),
+    tabIndex: 0,
+  }));
+};
+
+export const MachineSelectTable = ({
+  machines,
+  onMachineClick,
+  searchText,
+  setSearchText,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const tags = useSelector(tagSelectors.all);
+  const loadingMachines = !useSelector(machineSelectors.loaded);
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
+
+  if (loadingMachines) {
+    return <Spinner aria-label={Label.Loading} text={Label.Loading} />;
+  }
+  return (
+    <MainTable
+      emptyStateMsg="No machines match the search criteria."
+      headers={[
+        {
+          content: (
+            <>
+              <div>{Label.Hostname}</div>
+              <div>system_id</div>
+            </>
+          ),
+        },
+        {
+          content: (
+            <>
+              <div>{Label.Owner}</div>
+              <div>Tags</div>
+            </>
+          ),
+        },
+      ]}
+      rows={generateRows(
+        machines,
+        searchText,
+        (machine) => {
+          setSearchText(machine.hostname);
+          onMachineClick(machine);
+        },
+        tags
+      )}
+    />
+  );
+};
+
+export default MachineSelectTable;

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
@@ -67,6 +67,7 @@ const generateRows = (
         ),
       },
     ],
+    "data-testid": "machine-select-row",
     onClick: () => onRowClick(machine),
     tabIndex: 0,
   }));

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
@@ -81,8 +81,7 @@ export const MachineSelectTable = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const tags = useSelector(tagSelectors.all);
-  let loadingMachines = useSelector(machineSelectors.loading);
-  loadingMachines = false;
+  const loadingMachines = useSelector(machineSelectors.loading);
 
   useEffect(() => {
     dispatch(tagActions.fetch());

--- a/src/app/base/components/MachineSelectTable/_index.scss
+++ b/src/app/base/components/MachineSelectTable/_index.scss
@@ -1,0 +1,15 @@
+@mixin MachineSelectTable {
+  .machine-select-table__row {
+    cursor: pointer;
+
+    &:hover {
+      background-color: $color-light;
+    }
+
+    // The default <strong> font-weight is a bit subtle for highlighting
+    // substrings, so it's increased slightly here.
+    strong {
+      font-weight: 600;
+    }
+  }
+}

--- a/src/app/base/components/MachineSelectTable/index.ts
+++ b/src/app/base/components/MachineSelectTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineSelectTable";

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -76,7 +76,7 @@ describe("CloneForm", () => {
     expect(isSubmitDisabled()).toBe(true);
 
     // Select a source machine - checkbox should be enabled.
-    wrapper.find("[data-testid='source-machine-row']").at(0).simulate("click");
+    wrapper.find("[data-testid='machine-select-row']").at(0).simulate("click");
     await waitForComponentToPaint(wrapper);
     expect(isCheckboxDisabled()).toBe(false);
     expect(isSubmitDisabled()).toBe(true);

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -84,7 +84,7 @@ describe("CloneFormFields", () => {
         </Formik>
       </Provider>
     );
-    wrapper.find("[data-testid='source-machine-row']").at(0).simulate("click");
+    wrapper.find("[data-testid='machine-select-row']").at(0).simulate("click");
     await waitForComponentToPaint(wrapper);
 
     const expectedAction = machineActions.get(

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.tsx
@@ -8,6 +8,10 @@ type Props = {
   machine: MachineDetails | null;
 };
 
+export enum Label {
+  Title = "Source machine details",
+}
+
 export const SourceMachineDetails = ({ machine }: Props): JSX.Element => {
   // Placeholder content is displayed until the machine has loaded.
   let content = {
@@ -55,6 +59,7 @@ export const SourceMachineDetails = ({ machine }: Props): JSX.Element => {
 
   return (
     <LabelledList
+      aria-label={Label.Title}
       data-testid="source-machine-details"
       items={[
         {

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/__snapshots__/SourceMachineDetails.test.tsx.snap
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/__snapshots__/SourceMachineDetails.test.tsx.snap
@@ -1,109 +1,483 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SourceMachineDetails renders a list of the source machine's details 1`] = `
-<LabelledList
-  data-testid="source-machine-details"
-  items={
-    Array [
-      Object {
-        "label": "Status",
-        "value": <Placeholder
-          loading={false}
-        >
-          Ready
-        </Placeholder>,
-      },
-      Object {
-        "label": "CPU",
-        "value": <React.Fragment>
-          <Placeholder
+Array [
+  <LabelledList
+    aria-label="Source machine details"
+    data-testid="source-machine-details"
+    items={
+      Array [
+        Object {
+          "label": "Status",
+          "value": <Placeholder
             loading={false}
           >
-            2 cores, 2 GHz
-          </Placeholder>
-          <br />
-          <Placeholder
+            Ready
+          </Placeholder>,
+        },
+        Object {
+          "label": "CPU",
+          "value": <React.Fragment>
+            <Placeholder
+              loading={false}
+            >
+              2 cores, 2 GHz
+            </Placeholder>
+            <br />
+            <Placeholder
+              loading={false}
+            >
+              CPU model
+            </Placeholder>
+            <br />
+            <Placeholder
+              loading={false}
+            >
+              
+            </Placeholder>
+          </React.Fragment>,
+        },
+        Object {
+          "label": "Memory",
+          "value": <Placeholder
             loading={false}
           >
-            CPU model
-          </Placeholder>
-          <br />
-          <Placeholder
+            8 GiB
+          </Placeholder>,
+        },
+        Object {
+          "label": "Storage",
+          "value": <Placeholder
             loading={false}
           >
-            
-          </Placeholder>
-        </React.Fragment>,
-      },
-      Object {
-        "label": "Memory",
-        "value": <Placeholder
-          loading={false}
-        >
-          8 GiB
-        </Placeholder>,
-      },
-      Object {
-        "label": "Storage",
-        "value": <Placeholder
-          loading={false}
-        >
+            <React.Fragment>
+              8
+               GB
+               
+              <small>
+                over 
+                2 disks
+              </small>
+            </React.Fragment>
+          </Placeholder>,
+        },
+        Object {
+          "label": "Power type",
+          "value": <Placeholder
+            loading={false}
+          >
+            manual
+          </Placeholder>,
+        },
+        Object {
+          "label": "Owner",
+          "value": <Placeholder
+            loading={false}
+          >
+            Owner
+          </Placeholder>,
+        },
+        Object {
+          "label": "Host",
+          "value": <Placeholder
+            loading={false}
+          >
+            pod
+          </Placeholder>,
+        },
+        Object {
+          "label": "Zone",
+          "value": <Placeholder
+            loading={false}
+          >
+            zone
+          </Placeholder>,
+        },
+        Object {
+          "label": "Domain",
+          "value": <Placeholder
+            loading={false}
+          >
+            domain
+          </Placeholder>,
+        },
+      ]
+    }
+  >
+    <List
+      aria-label="Source machine details"
+      className="p-list--labelled"
+      data-testid="source-machine-details"
+      items={
+        Array [
           <React.Fragment>
-            8
-             GB
-             
-            <small>
-              over 
-              2 disks
-            </small>
-          </React.Fragment>
-        </Placeholder>,
-      },
-      Object {
-        "label": "Power type",
-        "value": <Placeholder
-          loading={false}
+            <div
+              className="p-list__item-label"
+            >
+              Status
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <Placeholder
+                loading={false}
+              >
+                Ready
+              </Placeholder>
+            </div>
+          </React.Fragment>,
+          <React.Fragment>
+            <div
+              className="p-list__item-label"
+            >
+              CPU
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <React.Fragment>
+                <Placeholder
+                  loading={false}
+                >
+                  2 cores, 2 GHz
+                </Placeholder>
+                <br />
+                <Placeholder
+                  loading={false}
+                >
+                  CPU model
+                </Placeholder>
+                <br />
+                <Placeholder
+                  loading={false}
+                >
+                  
+                </Placeholder>
+              </React.Fragment>
+            </div>
+          </React.Fragment>,
+          <React.Fragment>
+            <div
+              className="p-list__item-label"
+            >
+              Memory
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <Placeholder
+                loading={false}
+              >
+                8 GiB
+              </Placeholder>
+            </div>
+          </React.Fragment>,
+          <React.Fragment>
+            <div
+              className="p-list__item-label"
+            >
+              Storage
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <Placeholder
+                loading={false}
+              >
+                <React.Fragment>
+                  8
+                   GB
+                   
+                  <small>
+                    over 
+                    2 disks
+                  </small>
+                </React.Fragment>
+              </Placeholder>
+            </div>
+          </React.Fragment>,
+          <React.Fragment>
+            <div
+              className="p-list__item-label"
+            >
+              Power type
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <Placeholder
+                loading={false}
+              >
+                manual
+              </Placeholder>
+            </div>
+          </React.Fragment>,
+          <React.Fragment>
+            <div
+              className="p-list__item-label"
+            >
+              Owner
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <Placeholder
+                loading={false}
+              >
+                Owner
+              </Placeholder>
+            </div>
+          </React.Fragment>,
+          <React.Fragment>
+            <div
+              className="p-list__item-label"
+            >
+              Host
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <Placeholder
+                loading={false}
+              >
+                pod
+              </Placeholder>
+            </div>
+          </React.Fragment>,
+          <React.Fragment>
+            <div
+              className="p-list__item-label"
+            >
+              Zone
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <Placeholder
+                loading={false}
+              >
+                zone
+              </Placeholder>
+            </div>
+          </React.Fragment>,
+          <React.Fragment>
+            <div
+              className="p-list__item-label"
+            >
+              Domain
+            </div>
+            <div
+              className="p-list__item-value"
+            >
+              <Placeholder
+                loading={false}
+              >
+                domain
+              </Placeholder>
+            </div>
+          </React.Fragment>,
+        ]
+      }
+    >
+      <ul
+        aria-label="Source machine details"
+        className="p-list--labelled p-list"
+        data-testid="source-machine-details"
+      >
+        <li
+          className="p-list__item"
+          key="0"
         >
-          manual
-        </Placeholder>,
-      },
-      Object {
-        "label": "Owner",
-        "value": <Placeholder
-          loading={false}
+          <div
+            className="p-list__item-label"
+          >
+            Status
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              Ready
+            </Placeholder>
+          </div>
+        </li>
+        <li
+          className="p-list__item"
+          key="1"
         >
-          Owner
-        </Placeholder>,
-      },
-      Object {
-        "label": "Host",
-        "value": <Placeholder
-          loading={false}
+          <div
+            className="p-list__item-label"
+          >
+            CPU
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              2 cores, 2 GHz
+            </Placeholder>
+            <br />
+            <Placeholder
+              loading={false}
+            >
+              CPU model
+            </Placeholder>
+            <br />
+            <Placeholder
+              loading={false}
+            />
+          </div>
+        </li>
+        <li
+          className="p-list__item"
+          key="2"
         >
-          pod
-        </Placeholder>,
-      },
-      Object {
-        "label": "Zone",
-        "value": <Placeholder
-          loading={false}
+          <div
+            className="p-list__item-label"
+          >
+            Memory
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              8 GiB
+            </Placeholder>
+          </div>
+        </li>
+        <li
+          className="p-list__item"
+          key="3"
         >
-          zone
-        </Placeholder>,
-      },
-      Object {
-        "label": "Domain",
-        "value": <Placeholder
-          loading={false}
+          <div
+            className="p-list__item-label"
+          >
+            Storage
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              8
+               GB
+               
+              <small>
+                over 
+                2 disks
+              </small>
+            </Placeholder>
+          </div>
+        </li>
+        <li
+          className="p-list__item"
+          key="4"
         >
-          domain
-        </Placeholder>,
-      },
-    ]
-  }
->
+          <div
+            className="p-list__item-label"
+          >
+            Power type
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              manual
+            </Placeholder>
+          </div>
+        </li>
+        <li
+          className="p-list__item"
+          key="5"
+        >
+          <div
+            className="p-list__item-label"
+          >
+            Owner
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              Owner
+            </Placeholder>
+          </div>
+        </li>
+        <li
+          className="p-list__item"
+          key="6"
+        >
+          <div
+            className="p-list__item-label"
+          >
+            Host
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              pod
+            </Placeholder>
+          </div>
+        </li>
+        <li
+          className="p-list__item"
+          key="7"
+        >
+          <div
+            className="p-list__item-label"
+          >
+            Zone
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              zone
+            </Placeholder>
+          </div>
+        </li>
+        <li
+          className="p-list__item"
+          key="8"
+        >
+          <div
+            className="p-list__item-label"
+          >
+            Domain
+          </div>
+          <div
+            className="p-list__item-value"
+          >
+            <Placeholder
+              loading={false}
+            >
+              domain
+            </Placeholder>
+          </div>
+        </li>
+      </ul>
+    </List>
+  </LabelledList>,
   <List
+    aria-label="Source machine details"
     className="p-list--labelled"
+    data-testid="source-machine-details"
     items={
       Array [
         <React.Fragment>
@@ -276,7 +650,9 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
     }
   >
     <ul
+      aria-label="Source machine details"
       className="p-list--labelled p-list"
+      data-testid="source-machine-details"
     >
       <li
         className="p-list__item"
@@ -466,6 +842,199 @@ exports[`SourceMachineDetails renders a list of the source machine's details 1`]
         </div>
       </li>
     </ul>
-  </List>
-</LabelledList>
+  </List>,
+  <ul
+    aria-label="Source machine details"
+    className="p-list--labelled p-list"
+    data-testid="source-machine-details"
+  >
+    <li
+      className="p-list__item"
+      key="0"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        Status
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          Ready
+        </Placeholder>
+      </div>
+    </li>
+    <li
+      className="p-list__item"
+      key="1"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        CPU
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          2 cores, 2 GHz
+        </Placeholder>
+        <br />
+        <Placeholder
+          loading={false}
+        >
+          CPU model
+        </Placeholder>
+        <br />
+        <Placeholder
+          loading={false}
+        />
+      </div>
+    </li>
+    <li
+      className="p-list__item"
+      key="2"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        Memory
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          8 GiB
+        </Placeholder>
+      </div>
+    </li>
+    <li
+      className="p-list__item"
+      key="3"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        Storage
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          8
+           GB
+           
+          <small>
+            over 
+            2 disks
+          </small>
+        </Placeholder>
+      </div>
+    </li>
+    <li
+      className="p-list__item"
+      key="4"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        Power type
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          manual
+        </Placeholder>
+      </div>
+    </li>
+    <li
+      className="p-list__item"
+      key="5"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        Owner
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          Owner
+        </Placeholder>
+      </div>
+    </li>
+    <li
+      className="p-list__item"
+      key="6"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        Host
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          pod
+        </Placeholder>
+      </div>
+    </li>
+    <li
+      className="p-list__item"
+      key="7"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        Zone
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          zone
+        </Placeholder>
+      </div>
+    </li>
+    <li
+      className="p-list__item"
+      key="8"
+    >
+      <div
+        className="p-list__item-label"
+      >
+        Domain
+      </div>
+      <div
+        className="p-list__item-value"
+      >
+        <Placeholder
+          loading={false}
+        >
+          domain
+        </Placeholder>
+      </div>
+    </li>
+  </ul>,
+]
 `;

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -1,10 +1,10 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import configureStore from "redux-mock-store";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-import SourceMachineSelect from "./SourceMachineSelect";
+import { Label as SourceMachineDetailsLabel } from "./SourceMachineDetails/SourceMachineDetails";
+import SourceMachineSelect, { Label } from "./SourceMachineSelect";
 
+import { Label as MachineSelectTableLabel } from "app/base/components/MachineSelectTable/MachineSelectTable";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
@@ -14,8 +14,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithMockStore } from "testing/utils";
 
 describe("SourceMachineSelect", () => {
   let machines: Machine[];
@@ -47,201 +46,105 @@ describe("SourceMachineSelect", () => {
   });
 
   it("shows a spinner while data is loading", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <SourceMachineSelect
-            loadingData
-            machines={machines}
-            onMachineClick={jest.fn()}
-          />
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <SourceMachineSelect
+        loadingData
+        machines={machines}
+        onMachineClick={jest.fn()}
+      />,
+      { state }
     );
-
-    expect(wrapper.find("[data-testid='loading-spinner']").exists()).toBe(true);
+    expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
   });
 
   it("shows an error if no machines are available to select", () => {
-    const store = mockStore(state);
-    const Proxy = ({ machines }: { machines: Machine[] }) => (
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <SourceMachineSelect machines={[]} onMachineClick={jest.fn()} />,
+      { state }
     );
-    const wrapper = mount(<Proxy machines={[machineFactory()]} />);
-    expect(wrapper.find("[data-testid='no-source-machines']").exists()).toBe(
-      false
-    );
-
-    wrapper.setProps({ machines: [] });
-    expect(wrapper.find("[data-testid='no-source-machines']").exists()).toBe(
-      true
-    );
+    expect(
+      screen.getByRole("heading", { name: Label.NoSourceMachines })
+    ).toBeInTheDocument();
   });
 
-  it("can filter machines by hostname, system_id and/or tags", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
+  it("does not shows an error if machines are available to select", () => {
+    renderWithMockStore(
+      <SourceMachineSelect
+        machines={[machineFactory()]}
+        onMachineClick={jest.fn()}
+      />,
+      { state }
     );
+    expect(
+      screen.queryByRole("heading", { name: Label.NoSourceMachines })
+    ).not.toBeInTheDocument();
+  });
 
+  it("can filter machines by hostname, system_id and/or tags", async () => {
+    renderWithMockStore(
+      <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />,
+      { state }
+    );
+    const searchbox = screen.getByRole("searchbox");
     // Filter by "first" which matches the hostname of the first machine
-    wrapper
-      .find("[data-testid='source-machine-searchbox'] input")
-      .simulate("change", { target: { value: "first" } });
-    expect(wrapper.find("[data-testid='source-machine-first']").exists()).toBe(
-      true
-    );
-    expect(wrapper.find("[data-testid='source-machine-second']").exists()).toBe(
-      false
-    );
-
+    await userEvent.clear(searchbox);
+    await userEvent.type(searchbox, "first");
+    let hostnameCols = screen.getAllByRole("gridcell", {
+      name: MachineSelectTableLabel.Hostname,
+    });
+    expect(hostnameCols).toHaveLength(1);
+    expect(within(hostnameCols[0]).getByText("first")).toBeInTheDocument();
     // Filter by "def" which matches the system_id of the second machine
-    wrapper
-      .find("[data-testid='source-machine-searchbox'] input")
-      .simulate("change", { target: { value: "def" } });
-    expect(wrapper.find("[data-testid='source-machine-first']").exists()).toBe(
-      false
-    );
-    expect(wrapper.find("[data-testid='source-machine-second']").exists()).toBe(
-      true
-    );
+    await userEvent.clear(searchbox);
+    await userEvent.type(searchbox, "def");
+    hostnameCols = screen.getAllByRole("gridcell", {
+      name: MachineSelectTableLabel.Hostname,
+    });
+    expect(hostnameCols).toHaveLength(1);
+    expect(within(hostnameCols[0]).getByText("def")).toBeInTheDocument();
 
     // Filter by "tag" which matches the tags of the first and second machine
-    wrapper
-      .find("[data-testid='source-machine-searchbox'] input")
-      .simulate("change", { target: { value: "tag" } });
-    expect(wrapper.find("[data-testid='source-machine-first']").exists()).toBe(
-      true
-    );
-    expect(wrapper.find("[data-testid='source-machine-second']").exists()).toBe(
-      true
-    );
-  });
-
-  it("highlights the substring that matches the search text", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    // Filter by "fir" which matches part of the hostname of the first machine
-    wrapper
-      .find("[data-testid='source-machine-searchbox'] input")
-      .simulate("change", { target: { value: "fir" } });
-    expect(
-      wrapper
-        .find("[data-testid='source-machine-first']")
-        .render()
-        .find("strong")
-        .text()
-    ).toBe("fir");
-  });
-
-  it("runs onMachineClick function on row click", () => {
-    const onMachineClick = jest.fn();
-
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <SourceMachineSelect
-            machines={machines}
-            onMachineClick={onMachineClick}
-          />
-        </MemoryRouter>
-      </Provider>
-    );
-
-    wrapper.find("[data-testid='source-machine-row']").at(0).simulate("click");
-    expect(onMachineClick).toHaveBeenCalledWith(machines[0]);
+    await userEvent.clear(searchbox);
+    await userEvent.type(searchbox, "tag");
+    const ownerCols = screen.getAllByRole("gridcell", {
+      name: MachineSelectTableLabel.Owner,
+    });
+    expect(ownerCols).toHaveLength(2);
+    expect(within(ownerCols[0]).getByText("tag")).toBeInTheDocument();
+    expect(within(ownerCols[1]).getByText("tag")).toBeInTheDocument();
   });
 
   it("shows the machine's details when selected", () => {
     const selectedMachine = machineDetailsFactory();
 
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <SourceMachineSelect
-            machines={machines}
-            onMachineClick={jest.fn()}
-            selectedMachine={selectedMachine}
-          />
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <SourceMachineSelect
+        machines={machines}
+        onMachineClick={jest.fn()}
+        selectedMachine={selectedMachine}
+      />,
+      { state }
     );
 
-    expect(wrapper.find("SourceMachineDetails").exists()).toBe(true);
+    expect(
+      screen.getByLabelText(SourceMachineDetailsLabel.Title)
+    ).toBeInTheDocument();
   });
 
-  it("clears the selected machine on search input change", () => {
+  it("clears the selected machine on search input change", async () => {
     const selectedMachine = machineDetailsFactory();
     const onMachineClick = jest.fn();
 
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <SourceMachineSelect
-            machines={machines}
-            onMachineClick={onMachineClick}
-            selectedMachine={selectedMachine}
-          />
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <SourceMachineSelect
+        machines={machines}
+        onMachineClick={onMachineClick}
+        selectedMachine={selectedMachine}
+      />,
+      { state }
     );
 
-    wrapper
-      .find("[data-testid='source-machine-searchbox'] input")
-      .simulate("change", { target: { value: "" } });
+    await userEvent.type(screen.getByRole("searchbox"), " ");
     expect(onMachineClick).toHaveBeenCalledWith(null);
-  });
-
-  it("displays tag names", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <SourceMachineSelect machines={machines} onMachineClick={jest.fn()} />
-        </MemoryRouter>
-      </Provider>
-    );
-    // Filter by "first" which matches the hostname of the first machine
-    wrapper
-      .find("[data-testid='source-machine-searchbox'] input")
-      .simulate("change", { target: { value: "first" } });
-    expect(wrapper.find("[data-testid='source-machine-tagA']").exists()).toBe(
-      true
-    );
   });
 });

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -13,6 +13,7 @@ import {
   rootState as rootStateFactory,
   tag as tagFactory,
   tagState as tagStateFactory,
+  machineState as machineStateFactory,
 } from "testing/factories";
 import { renderWithMockStore } from "testing/utils";
 
@@ -36,6 +37,10 @@ describe("SourceMachineSelect", () => {
       }),
     ];
     state = rootStateFactory({
+      machine: machineStateFactory({
+        items: machines,
+        loaded: true,
+      }),
       tag: tagStateFactory({
         items: [
           tagFactory({ id: 12, name: "tagA" }),

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
@@ -8,19 +8,5 @@
   .source-machine-select__table {
     max-height: 22rem;
     overflow: auto;
-
-    // The default <strong> font-weight is a bit subtle for highlighting
-    // substrings, so it's increased slightly here.
-    strong {
-      font-weight: 600;
-    }
-  }
-
-  .source-machine-select__row {
-    cursor: pointer;
-
-    &:hover {
-      background-color: $color-light;
-    }
   }
 }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -82,6 +82,7 @@
 @import "~app/base/components/Header";
 @import "~app/base/components/LabelledList";
 @import "~app/base/components/Login";
+@import "~app/base/components/MachineSelectTable";
 @import "~app/base/components/Meter";
 @import "~app/base/components/node/networking/NetworkTable";
 @import "~app/base/components/node/NodeDevices";
@@ -115,6 +116,7 @@
 @include Header;
 @include LabelledList;
 @include Login;
+@include MachineSelectTable;
 @include Meter;
 @include NetworkCardTable;
 @include NetworkTable;


### PR DESCRIPTION
## Done

- Make the machine selection table a reusable component.
- Migrate tests to RTL.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open [CloneFormFields.tsx](https://github.com/canonical/maas-ui/blob/3ea99f1d1202cd425eb5e59b2ad4d84e2c34b318/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx#L41) and change `const loadingMachines ...` to `const loadingMachines = true` (this isn't working as this form hasn't been updated to use the new API).
- Open [MachineSelectTable.tsx](https://github.com/canonical/maas-ui/blob/3ea99f1d1202cd425eb5e59b2ad4d84e2c34b318/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx#L84) and change `const loadingMachines ...` to `const loadingMachines = true`.
- Start the UI.
- Go to the machine list and tick some machines to clone.
- In the take action menu select "Clone from..."
- In the form you should see some machines to clone from.
- Search and the list should get updated.
- Select a machine and the details should appear.

Fixes: canonical/app-tribe#1224.