### PR TITLE
feat(machines): machine listing count API

### DIFF
--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -10,6 +11,8 @@ import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
+  machineStateCount as machineStateCountFactory,
+  machineStateCounts as machineStateCountsFactory,
   machineStatus as machineStatusFactory,
   resourcePool as resourcePoolFactory,
   resourcePoolState as resourcePoolStateFactory,
@@ -24,9 +27,17 @@ describe("MachinesHeader", () => {
   let state: RootState;
 
   beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
     state = rootStateFactory({
       machine: machineStateFactory({
         loaded: true,
+        counts: machineStateCountsFactory({
+          "mocked-nanoid": machineStateCountFactory({
+            count: 2,
+            loaded: true,
+            loading: false,
+          }),
+        }),
         items: [
           machineFactory({ system_id: "abc123" }),
           machineFactory({ system_id: "def456" }),

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
@@ -8,8 +8,10 @@ import { matchPath, Link } from "react-router-dom-v5-compat";
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
 import SectionHeader from "app/base/components/SectionHeader";
 import urls from "app/base/urls";
-import machineSelectors from "app/store/machine/selectors";
-import { useFetchMachines } from "app/store/machine/utils/hooks";
+import {
+  useFetchMachineCount,
+  useFetchMachines,
+} from "app/store/machine/utils/hooks";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { actions as tagActions } from "app/store/tag";
@@ -20,9 +22,9 @@ type Props = SectionHeaderProps;
 export const MachinesHeader = (props: Props): JSX.Element => {
   const dispatch = useDispatch();
   const location = useLocation();
-  const machineCount = useSelector(machineSelectors.count);
   const poolCount = useSelector(resourcePoolSelectors.count);
   const tagCount = useSelector(tagSelectors.count);
+  const { machineCount } = useFetchMachineCount();
   useFetchMachines();
 
   useEffect(() => {

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -1,4 +1,5 @@
 import { ContextualMenu } from "@canonical/react-components";
+import reduxToolkit from "@reduxjs/toolkit";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -12,6 +13,8 @@ import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
   machine as machineFactory,
+  machineStateCount as machineStateCountFactory,
+  machineStateCounts as machineStateCountsFactory,
   machineState as machineStateFactory,
   machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
@@ -23,9 +26,17 @@ describe("MachineListHeader", () => {
   let state: RootState;
 
   beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
     state = rootStateFactory({
       machine: machineStateFactory({
         loaded: true,
+        counts: machineStateCountsFactory({
+          "mocked-nanoid": machineStateCountFactory({
+            count: 2,
+            loaded: true,
+            loading: false,
+          }),
+        }),
         items: [
           machineFactory({ system_id: "abc123" }),
           machineFactory({ system_id: "def456" }),

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -19,7 +19,10 @@ import type {
 } from "app/machines/types";
 import { getHeaderTitle } from "app/machines/utils";
 import machineSelectors from "app/store/machine/selectors";
-import { useFetchMachines } from "app/store/machine/utils/hooks";
+import {
+  useFetchMachineCount,
+  useFetchMachines,
+} from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 
@@ -35,7 +38,6 @@ export const MachineListHeader = ({
   setHeaderContent,
 }: Props): JSX.Element => {
   const location = useLocation();
-  const machines = useSelector(machineSelectors.all);
   const machinesLoaded = useSelector(machineSelectors.loaded);
   const selectedMachines = useSelector(machineSelectors.selected);
   const [tagsSeen, setTagsSeen] = useStorageState(
@@ -43,6 +45,7 @@ export const MachineListHeader = ({
     "machineViewTagsSeen",
     false
   );
+  const { machineCount } = useFetchMachineCount();
   useFetchMachines();
 
   useEffect(() => {
@@ -108,7 +111,7 @@ export const MachineListHeader = ({
       }
       subtitle={
         <ModelListSubtitle
-          available={machines.length}
+          available={machineCount}
           filterSelected={() => setSearchFilter("in:(Selected)")}
           modelName="machine"
           selected={selectedMachines.length}

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -23,9 +23,6 @@ import {
 } from "testing/factories";
 
 describe("machine selectors", () => {
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
   it("can get all items", () => {
     const items = [machineFactory(), machineFactory()];
     const state = rootStateFactory({
@@ -473,7 +470,6 @@ describe("machine selectors", () => {
   });
 
   it("can get machine count", () => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid");
     const machines = [machineFactory(), machineFactory()];
     const state = rootStateFactory({
       machine: machineStateFactory({

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -1,5 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
-
 import machine from "./selectors";
 
 import { NetworkInterfaceTypes } from "app/store/types/enum";

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -1,3 +1,5 @@
+import reduxToolkit from "@reduxjs/toolkit";
+
 import machine from "./selectors";
 
 import { NetworkInterfaceTypes } from "app/store/types/enum";
@@ -10,6 +12,8 @@ import {
   machineInterface as machineInterfaceFactory,
   machineState as machineStateFactory,
   machineStateDetailsItem as machineStateDetailsItemFactory,
+  machineStateCount as machineStateCountFactory,
+  machineStateCounts as machineStateCountsFactory,
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
   machineStatus as machineStatusFactory,
@@ -19,6 +23,9 @@ import {
 } from "testing/factories";
 
 describe("machine selectors", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
   it("can get all items", () => {
     const items = [machineFactory(), machineFactory()];
     const state = rootStateFactory({
@@ -463,6 +470,26 @@ describe("machine selectors", () => {
     expect(
       machine.eventErrorsForIds(state, ["abc123", "def456"], null)
     ).toStrictEqual([machineEventErrors[0], machineEventErrors[1]]);
+  });
+
+  it("can get machine count", () => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid");
+    const machines = [machineFactory(), machineFactory()];
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        items: [...machines, machineFactory()],
+        counts: machineStateCountsFactory({
+          "mocked-nanoid": machineStateCountFactory({
+            count: 2,
+            loaded: true,
+            loading: false,
+          }),
+        }),
+      }),
+    });
+    expect(machine.count(state, "mocked-nanoid")).toStrictEqual(2);
+    expect(machine.countLoaded(state, "mocked-nanoid")).toStrictEqual(true);
+    expect(machine.countLoading(state, "mocked-nanoid")).toStrictEqual(false);
   });
 
   it("can get items in a list", () => {

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -3,6 +3,8 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import type { Tag, TagMeta } from "../tag/types";
 
+import type { MachineStateCount } from "./types/base";
+
 import { ACTIONS } from "app/store/machine/slice";
 import { MachineMeta } from "app/store/machine/types";
 import type {
@@ -269,6 +271,36 @@ const getByStatusCode = createSelector(
     machines.filter(({ status_code }) => status_code === statusCode)
 );
 
+const getCount = (
+  machine: MachineState,
+  callId: string | null | undefined
+): MachineStateCount | null =>
+  callId && callId in machine.counts ? machine.counts[callId] : null;
+
+const count = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => getCount(machineState, callId)?.count
+);
+
+const countLoaded = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => !!getCount(machineState, callId)?.loaded
+);
+
+const countLoading = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => !!getCount(machineState, callId)?.loading
+);
+
 /**
  * Get the deployed machines with the provided tag.
  * @param state - The redux state.
@@ -455,6 +487,9 @@ const selectors = {
   eventErrorsForIds,
   exitingRescueMode: statusSelectors["exitingRescueMode"],
   getByStatusCode,
+  count,
+  countLoaded,
+  countLoading,
   getDeployedWithTag,
   getInterfaceById,
   getStatuses,

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -607,10 +607,14 @@ const machineSlice = createSlice({
         action: PayloadAction<null, string, GenericMeta>
       ) => {
         if (action.meta.callId) {
-          if (!(action.meta.callId in state.counts)) {
-            state.counts[action.meta.callId] = DEFAULT_COUNT_STATE;
+          if (action.meta.callId in state.counts) {
+            state.counts[action.meta.callId].loading = true;
+          } else {
+            state.counts[action.meta.callId] = {
+              ...DEFAULT_COUNT_STATE,
+              loading: true,
+            };
           }
-          state.counts[action.meta.callId].loading = true;
         }
       },
     },

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -412,7 +412,7 @@ describe("machine hook utils", () => {
       });
       const store = mockStore(state);
       const { result } = renderHook(
-        ({ id }: { children?: ReactNode; id: string }) => useGetMachine(id),
+        ({ id }: { children?: ReactNode; id: string }) => useFetchMachine(id),
         {
           initialProps: {
             id: "abc123",

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -14,6 +14,7 @@ import {
   useIsLimitedEditingAllowed,
   useFetchMachine,
   useFetchMachines,
+  useFetchMachineCount,
 } from "./hooks";
 
 import { actions as machineActions } from "app/store/machine";
@@ -32,6 +33,8 @@ import {
   machineStateDetailsItem as machineStateDetailsItemFactory,
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
+  machineStateCount as machineStateCountFactory,
+  machineStateCounts as machineStateCountsFactory,
   osInfo as osInfoFactory,
   osInfoState as osInfoStateFactory,
   powerType as powerTypeFactory,
@@ -79,6 +82,109 @@ describe("machine hook utils", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  describe("useFetchMachineCount", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(reduxToolkit, "nanoid")
+        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce("mocked-nanoid-2")
+        .mockReturnValueOnce("mocked-nanoid-3");
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const generateWrapper =
+      (store: MockStoreEnhanced<unknown>) =>
+      ({ children }: { children?: ReactNode; filters?: FetchFilters }) =>
+        <Provider store={store}>{children}</Provider>;
+
+    it("can dispatch machine count action", () => {
+      const store = mockStore(state);
+      renderHook(() => useFetchMachineCount(), {
+        wrapper: generateWrapper(store),
+      });
+      const expected = machineActions.count("mocked-nanoid-1");
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected);
+    });
+
+    it("returns the machine count", async () => {
+      jest.restoreAllMocks();
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid");
+      const machineCount = 2;
+      const counts = machineStateCountsFactory({
+        "mocked-nanoid": machineStateCountFactory({
+          count: machineCount,
+          loaded: true,
+          loading: false,
+        }),
+      });
+      state.machine = machineStateFactory({
+        loaded: true,
+        counts,
+      });
+      const store = mockStore(state);
+      const { result } = renderHook(() => useFetchMachineCount(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current.machineCountLoaded).toBe(true);
+      expect(result.current.machineCount).toStrictEqual(machineCount);
+    });
+
+    it("does not fetch again with no params", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(() => useFetchMachineCount(), {
+        wrapper: generateWrapper(store),
+      });
+      rerender();
+      const expected = machineActions.count("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
+    it("does not fetch again if the filters haven't changed", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        () => useFetchMachineCount({ hostname: "spotted-quoll" }),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ filters: { hostname: "spotted-quoll" } });
+      const expected = machineActions.count("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
+    it("fetches again if the filters change", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({ filters }) => useFetchMachineCount(filters),
+        {
+          initialProps: {
+            filters: {
+              hostname: "spotted-quoll",
+            },
+          },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ filters: { hostname: "eastern-quoll" } });
+      const expected = machineActions.count("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(2);
+    });
   });
 
   describe("useFetchMachines", () => {
@@ -217,6 +323,12 @@ describe("machine hook utils", () => {
   });
 
   describe("useFetchMachine", () => {
+    beforeEach(() => {
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+    });
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
       ({ children }: { children?: ReactNode; id: string }) =>

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -54,21 +54,28 @@ export const useFetchMachineCount = (
   );
 
   useEffect(() => {
-    if (!callId) {
+    // undefined, null and {} are all equivalent i.e. no filters so compare the
+    // current and previous filters using an empty object if the filters are falsy.
+    if (!fastDeepEqual(filters || {}, previousFilters || {}) || !callId) {
       setCallId(nanoid());
     }
+  }, [callId, dispatch, filters, previousFilters]);
+  
+  useEffect(() => {
+    return () => {
+      if (callId) {
+        dispatch(machineActions.removeRequest(callId));
+      }
+    };
   }, [callId, dispatch]);
 
   useEffect(() => {
-    if (
-      (callId && callId !== previousCallId) ||
-      (callId &&
-        (filters || previousFilters) &&
-        !fastDeepEqual(filters, previousFilters))
-    ) {
-      dispatch(machineActions.count(callId, filters));
+    if (callId && callId !== previousCallId) {
+      dispatch(
+        machineActions.count(callId, filters)
+      );
     }
-  }, [dispatch, callId, previousCallId, filters, previousFilters]);
+  }, [dispatch, filters, callId, previousCallId]);
 
   return {
     machineCount: machineCount || 0,

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -32,6 +32,51 @@ import vlanSelectors from "app/store/vlan/selectors";
 import { isId } from "app/utils";
 import type { FilterSelected } from "app/utils/search/filter-items";
 
+export const useFetchMachineCount = (
+  filters?: FetchFilters
+): {
+  machineCount: number;
+  machineCountLoading: boolean;
+  machineCountLoaded: boolean;
+} => {
+  const [callId, setCallId] = useState<string | null>(null);
+  const previousCallId = usePrevious(callId);
+  const previousFilters = usePrevious(filters);
+  const dispatch = useDispatch();
+  const machineCount = useSelector((state: RootState) =>
+    machineSelectors.count(state, callId)
+  );
+  const machineCountLoading = useSelector((state: RootState) =>
+    machineSelectors.countLoading(state, callId)
+  );
+  const machineCountLoaded = useSelector((state: RootState) =>
+    machineSelectors.countLoaded(state, callId)
+  );
+
+  useEffect(() => {
+    if (!callId) {
+      setCallId(nanoid());
+    }
+  }, [callId, dispatch]);
+
+  useEffect(() => {
+    if (
+      (callId && callId !== previousCallId) ||
+      (callId &&
+        (filters || previousFilters) &&
+        !fastDeepEqual(filters, previousFilters))
+    ) {
+      dispatch(machineActions.count(callId, filters));
+    }
+  }, [dispatch, callId, previousCallId, filters, previousFilters]);
+
+  return {
+    machineCount: machineCount || 0,
+    machineCountLoading,
+    machineCountLoaded,
+  };
+};
+
 /**
  * Fetch machines via the API.
  */

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -60,7 +60,7 @@ export const useFetchMachineCount = (
       setCallId(nanoid());
     }
   }, [callId, dispatch, filters, previousFilters]);
-  
+
   useEffect(() => {
     return () => {
       if (callId) {
@@ -71,9 +71,7 @@ export const useFetchMachineCount = (
 
   useEffect(() => {
     if (callId && callId !== previousCallId) {
-      dispatch(
-        machineActions.count(callId, filters)
-      );
+      dispatch(machineActions.count(callId, filters));
     }
   }, [dispatch, filters, callId, previousCallId]);
 

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -32,6 +32,7 @@ export {
   machineEventError,
   machineState,
   machineStateCount,
+  machineStateCounts,
   machineStateDetails,
   machineStateDetailsItem,
   machineStateListGroup,


### PR DESCRIPTION
## Done

- use machine count API on the machine listing page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing page and ensure the machine count is correct

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1110

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
