### PR TITLE
refactor(machines): useFetchMachine

### DIFF
--- a/src/app/base/components/MachineLink/MachineLink.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom-v5-compat";
 
 import urls from "app/base/urls";
 import type { Machine, MachineMeta } from "app/store/machine/types";
-import { useGetMachine } from "app/store/machine/utils/hooks";
+import { useFetchMachine } from "app/store/machine/utils/hooks";
 
 type Props = {
   systemId?: Machine[MachineMeta.PK] | null;
@@ -14,7 +14,7 @@ export enum Labels {
 }
 
 const MachineLink = ({ systemId }: Props): JSX.Element | null => {
-  const { machine, loading } = useGetMachine(systemId);
+  const { machine, loading } = useFetchMachine(systemId);
 
   if (loading) {
     return <Spinner aria-label={Labels.Loading} />;

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -15,7 +15,10 @@ import fabricSelectors from "app/store/fabric/selectors";
 import machineSelectors from "app/store/machine/selectors";
 import type { MachineDetails } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
-import { useGetMachine, useFetchMachines } from "app/store/machine/utils/hooks";
+import {
+  useFetchMachine,
+  useFetchMachines,
+} from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -43,7 +46,7 @@ export const CloneFormFields = ({
   const loadingVlans = !useSelector(vlanSelectors.loaded);
   const loadingData =
     loadingFabrics || loadingMachines || loadingSubnets || loadingVlans;
-  const { loading: loadingMachineDetails } = useGetMachine(values.source);
+  const { loading: loadingMachineDetails } = useFetchMachine(values.source);
   useFetchMachines();
 
   useEffect(() => {

--- a/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -27,7 +27,7 @@ import urls from "app/base/urls";
 import type { MachineHeaderContent } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import { MachineMeta } from "app/store/machine/types";
-import { useGetMachine } from "app/store/machine/utils/hooks";
+import { useFetchMachine } from "app/store/machine/utils/hooks";
 import { actions as tagActions } from "app/store/tag";
 import { getRelativeRoute, isId } from "app/utils";
 
@@ -35,7 +35,7 @@ const MachineDetails = (): JSX.Element => {
   const dispatch = useDispatch();
   const id = useGetURLId(MachineMeta.PK);
   const { pathname } = useLocation();
-  const { machine, loaded: detailsLoaded } = useGetMachine(id);
+  const { machine, loaded: detailsLoaded } = useFetchMachine(id);
   const [headerContent, setHeaderContent] =
     useState<MachineHeaderContent | null>(null);
 

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -24,7 +24,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
-import { useGetMachine } from "app/store/machine/utils/hooks";
+import { useFetchMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { ScriptResultStatus } from "app/store/scriptresult/types";
 import { NodeActions } from "app/store/types/node";
@@ -55,7 +55,7 @@ const MachineHeader = ({
     NodeActions.ON,
   ]);
   const isDetails = isMachineDetails(machine);
-  useGetMachine(systemId);
+  useFetchMachine(systemId);
 
   if (!machine || !isDetails) {
     return <SectionHeader loading />;

--- a/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -17,7 +17,7 @@ import type { MachineSetHeaderContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import { MachineMeta } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
-import { useGetMachine } from "app/store/machine/utils/hooks";
+import { useFetchMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { NodeStatusCode } from "app/store/types/node";
 import { isId } from "app/utils";
@@ -31,7 +31,7 @@ const MachineSummary = ({ setHeaderContent }: Props): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
-  useGetMachine(id);
+  useFetchMachine(id);
   useWindowTitle(`${`${machine?.fqdn} ` || "Machine"} details`);
 
   if (!isId(id) || !isMachineDetails(machine)) {

--- a/src/app/settings/hooks.ts
+++ b/src/app/settings/hooks.ts
@@ -10,7 +10,7 @@ import deviceSelectors from "app/store/device/selectors";
 import type { Device } from "app/store/device/types";
 import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
 import type { Machine } from "app/store/machine/types";
-import { useGetMachine } from "app/store/machine/utils/hooks";
+import { useFetchMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -46,7 +46,7 @@ export const useDhcpTarget = (
     machine,
     loaded: machineLoaded = false,
     loading: machineLoading = false,
-  } = useGetMachine(nodeId);
+  } = useFetchMachine(nodeId);
 
   const isLoading =
     (!!subnetId && subnetLoading) ||

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -12,7 +12,7 @@ import {
   useFormattedOS,
   useHasInvalidArchitecture,
   useIsLimitedEditingAllowed,
-  useGetMachine,
+  useFetchMachine,
   useFetchMachines,
 } from "./hooks";
 
@@ -183,7 +183,7 @@ describe("machine hook utils", () => {
     });
   });
 
-  describe("useGetMachine", () => {
+  describe("useFetchMachine", () => {
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
       ({ children }: { children?: ReactNode; id: string }) =>
@@ -193,7 +193,7 @@ describe("machine hook utils", () => {
       jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
       const store = mockStore(state);
       renderHook(
-        ({ id }: { children?: ReactNode; id: string }) => useGetMachine(id),
+        ({ id }: { children?: ReactNode; id: string }) => useFetchMachine(id),
         {
           initialProps: {
             id: "def456",
@@ -210,7 +210,7 @@ describe("machine hook utils", () => {
     it("does not fetch again if the id hasn't changed", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({ id }: { children?: ReactNode; id: string }) => useGetMachine(id),
+        ({ id }: { children?: ReactNode; id: string }) => useFetchMachine(id),
         {
           initialProps: {
             id: "def456",
@@ -233,7 +233,7 @@ describe("machine hook utils", () => {
         .mockReturnValueOnce("mocked-nanoid-2");
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({ id }: { children?: ReactNode; id: string }) => useGetMachine(id),
+        ({ id }: { children?: ReactNode; id: string }) => useFetchMachine(id),
         {
           initialProps: {
             id: "def456",
@@ -254,7 +254,7 @@ describe("machine hook utils", () => {
       jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid-1");
       const store = mockStore(state);
       renderHook(
-        ({ id }: { children?: ReactNode; id: string }) => useGetMachine(id),
+        ({ id }: { children?: ReactNode; id: string }) => useFetchMachine(id),
         {
           initialProps: {
             id: "def456",
@@ -276,7 +276,7 @@ describe("machine hook utils", () => {
         .mockReturnValueOnce("mocked-nanoid-2");
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({ id }: { children?: ReactNode; id: string }) => useGetMachine(id),
+        ({ id }: { children?: ReactNode; id: string }) => useFetchMachine(id),
         {
           initialProps: {
             id: "def123",

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -75,10 +75,10 @@ export const useFetchMachines = (
 };
 
 /**
- * Get a machine via the API.
+ * Fetch a machine via the API.
  * @param id - A machine's system id.
  */
-export const useGetMachine = (
+export const useFetchMachine = (
   id?: Machine[MachineMeta.PK] | null
 ): { machine: Machine | null; loading?: boolean; loaded?: boolean } => {
   const [callId, setCallId] = useState<string | null>(null);


### PR DESCRIPTION
## Done

- rename useGetMachine to useFetchMachine for consistency with related hooks (e.g. `useFetchMachines`)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


### QA steps

- Ensure machine details page loads correctly

### Fixes
Fixes: https://github.com/canonical/app-tribe/issues/1255

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
