### PR TITLE
refactor(machines): use count API in tag delete form

### DIFF
--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -91,7 +91,7 @@ describe("machine actions", () => {
         method: "count",
         callId: "123456",
       },
-      payload: { params: { filters: { owner: "admin" } } },
+      payload: { params: { filter: { owner: "admin" } } },
     });
   });
 

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -564,7 +564,7 @@ const machineSlice = createSlice({
         },
         payload: filters
           ? {
-              params: { filters },
+              params: { filter: filters },
             }
           : null,
       }),

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -1,4 +1,5 @@
 import { NotificationSeverity } from "@canonical/react-components";
+import reduxToolkit from "@reduxjs/toolkit";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
@@ -17,6 +18,7 @@ import { NodeStatus } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
+  machineStateCount as machineStateCountFactory,
   rootState as rootStateFactory,
   tag as tagFactory,
   tagState as tagStateFactory,
@@ -28,6 +30,7 @@ let state: RootState;
 let scrollToSpy: jest.Mock;
 
 beforeEach(() => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
   state = rootStateFactory({
     machine: machineStateFactory({
       items: [
@@ -183,6 +186,12 @@ it("can return to the details on cancel", async () => {
       name: "tag1",
     }),
   ];
+  state.machine.counts = {
+    "mocked-nanoid": machineStateCountFactory({
+      count: 1,
+      loaded: true,
+    }),
+  };
   const path = urls.tags.tag.machines({ id: 1 });
   const history = createMemoryHistory({
     initialEntries: [{ pathname: path }],

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -14,6 +15,7 @@ import {
   machineState as machineStateFactory,
   tag as tagFactory,
   rootState as rootStateFactory,
+  machineStateCount as machineStateCountFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
 
@@ -22,6 +24,7 @@ const mockStore = configureStore();
 let state: RootState;
 
 beforeEach(() => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
   state = rootStateFactory({
     machine: machineStateFactory({
       items: [
@@ -56,6 +59,12 @@ it("does not display a kernel options warning for non-deployed machines", async 
       tags: [1],
     }),
   ];
+  state.machine.counts = {
+    "mocked-nanoid": machineStateCountFactory({
+      count: 0,
+      loaded: true,
+    }),
+  };
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -80,6 +89,12 @@ it("displays warning when deleting a tag with kernel options", async () => {
       name: "tag1",
     }),
   ];
+  state.machine.counts = {
+    "mocked-nanoid": machineStateCountFactory({
+      count: 1,
+      loaded: true,
+    }),
+  };
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -110,6 +125,12 @@ it("displays a kernel options warning with multiple machines", async () => {
       name: "tag1",
     }),
   ];
+  state.machine.counts = {
+    "mocked-nanoid": machineStateCountFactory({
+      count: 2,
+      loaded: true,
+    }),
+  };
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -134,6 +155,12 @@ it("displays a kernel options warning with one machine", async () => {
       name: "tag1",
     }),
   ];
+  state.machine.counts = {
+    "mocked-nanoid": machineStateCountFactory({
+      count: 1,
+      loaded: true,
+    }),
+  };
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -158,6 +185,12 @@ it("links to a page to display deployed machines", async () => {
       name: "tag1",
     }),
   ];
+  state.machine.counts = {
+    "mocked-nanoid": machineStateCountFactory({
+      count: 1,
+      loaded: true,
+    }),
+  };
   const store = mockStore(state);
   render(
     <Provider store={store}>

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.tsx
@@ -4,10 +4,11 @@ import { useSelector } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 
 import urls from "app/base/urls";
-import machineSelectors from "app/store/machine/selectors";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
+import { NodeStatus } from "app/store/types/node";
 
 type Props = {
   id: Tag[TagMeta.PK];
@@ -32,10 +33,11 @@ export const DeleteTagFormWarnings = ({ id }: Props): JSX.Element | null => {
   const tag = useSelector((state: RootState) =>
     tagSelectors.getById(state, id)
   );
-  const deployedMachines = useSelector((state: RootState) =>
-    machineSelectors.getDeployedWithTag(state, id)
-  );
-  const deployedCount = deployedMachines.length;
+  const { machineCount: deployedCount } = useFetchMachineCount({
+    // TODO: update with filter types in https://github.com/canonical/app-tribe/issues/1149
+    status: [NodeStatus.DEPLOYED.toLowerCase()],
+    ...(tag?.id ? { tags: [tag.name] } : {}),
+  });
   if (!tag) {
     return null;
   }


### PR DESCRIPTION
## Done

- use count API in tag delete form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the tags list
- Select automatic tags
- Click on delete icon
- Check the count websocket request with correct parameters has been made in the developer tools Network tab
- Verify the number of deployed machines with a selected tag is correct in the UI

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1119

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
