### PR TITLE
feat(machines): display fetch machines errors

### DIFF
--- a/src/app/machines/views/MachineList/ErrorsNotification/ErrorsNotification.test.tsx
+++ b/src/app/machines/views/MachineList/ErrorsNotification/ErrorsNotification.test.tsx
@@ -1,0 +1,22 @@
+import { screen, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ErrorsNotification from "./ErrorsNotification";
+
+it("can display and close an error message", async () => {
+  render(<ErrorsNotification errors={{ title: "error message" }} />);
+  expect(screen.getByText("title: error message")).toBeInTheDocument();
+  await userEvent.click(screen.getByLabelText("Close notification"));
+  expect(screen.queryByText("title: error message")).not.toBeInTheDocument();
+});
+
+it("reopens the notification with a new error when previously dismissed", async () => {
+  const { rerender } = render(
+    <ErrorsNotification errors={{ title: "error message" }} />
+  );
+  expect(screen.getByText("title: error message")).toBeInTheDocument();
+  await userEvent.click(screen.getByLabelText("Close notification"));
+  expect(screen.queryByText("title: error message")).not.toBeInTheDocument();
+  rerender(<ErrorsNotification errors={{ title: "another error message" }} />);
+  expect(screen.getByText("title: another error message")).toBeInTheDocument();
+});

--- a/src/app/machines/views/MachineList/ErrorsNotification/ErrorsNotification.tsx
+++ b/src/app/machines/views/MachineList/ErrorsNotification/ErrorsNotification.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from "react";
+
+import { Notification, usePrevious } from "@canonical/react-components";
+
+import type { APIError } from "app/base/types";
+import { formatErrors } from "app/utils";
+
+const ErrorsNotification = ({
+  errors,
+  onAfterDismiss,
+}: {
+  errors: APIError;
+  onAfterDismiss?: () => void;
+}): JSX.Element | null => {
+  const [isOpen, setIsOpen] = useState(true);
+  const previousErrors = usePrevious(errors);
+  const handleDismiss = () => {
+    setIsOpen(false);
+    onAfterDismiss?.();
+  };
+
+  useEffect(() => {
+    if (errors !== previousErrors) {
+      setIsOpen(true);
+    }
+  }, [errors, previousErrors]);
+
+  return errors && isOpen ? (
+    <Notification onDismiss={handleDismiss} severity="negative">
+      {formatErrors(errors)}
+    </Notification>
+  ) : null;
+};
+
+export default ErrorsNotification;

--- a/src/app/machines/views/MachineList/ErrorsNotification/index.ts
+++ b/src/app/machines/views/MachineList/ErrorsNotification/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ErrorsNotification";

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -344,6 +344,28 @@ describe("MachineList", () => {
     expect(wrapper.find("Notification").props().children).toBe("Uh oh!");
   });
 
+  it("can display and close an error from machine list", () => {
+    state.machine.lists["123456"].errors = { tag: "No such constraint." };
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CompatRouter>
+            <MachineList searchFilter="" setSearchFilter={jest.fn()} />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("Notification").exists()).toBe(true);
+    expect(wrapper.find("Notification").props().children).toBe(
+      "tag: No such constraint."
+    );
+    wrapper.find("Notification button").simulate("click");
+    expect(wrapper.find("Notification").exists()).toBe(false);
+  });
+
   it("can display a list of errors", () => {
     state.machine.errors = ["Uh oh!", "It broke"];
     const store = mockStore(state);

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -345,6 +345,7 @@ describe("MachineList", () => {
   });
 
   it("can display and close an error from machine list", () => {
+    state.machine.errors = null;
     state.machine.lists["123456"].errors = { tag: "No such constraint." };
     const store = mockStore(state);
     const wrapper = mount(

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,6 +1,5 @@
 import { useEffect } from "react";
 
-import { Notification } from "@canonical/react-components";
 import cloneDeep from "clone-deep";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { Notification } from "@canonical/react-components";
 import cloneDeep from "clone-deep";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
+import ErrorsNotification from "./ErrorsNotification";
 import MachineListControls from "./MachineListControls";
 import MachineListTable from "./MachineListTable";
 
@@ -16,7 +17,6 @@ import type { FetchFilters } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import { actions as tagActions } from "app/store/tag";
-import { formatErrors } from "app/utils";
 import type { Filters } from "app/utils/search/filter-handlers";
 import { getSelectedValue } from "app/utils/search/filter-items";
 
@@ -43,7 +43,6 @@ const MachineList = ({
   setSearchFilter,
 }: Props): JSX.Element => {
   useWindowTitle("Machines");
-  const [machinesErrorsOpen, setMachinesErrorsOpen] = useState(true);
   const dispatch = useDispatch();
   const errors = useSelector(machineSelectors.errors);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
@@ -52,7 +51,6 @@ const MachineList = ({
     parseFilters(filters),
     "in" in filters ? getSelectedValue(filters.in) : null
   );
-  const errorMessage = formatErrors(errors);
   const [grouping, setGrouping] = useStorageState(
     localStorage,
     "grouping",
@@ -79,22 +77,13 @@ const MachineList = ({
 
   return (
     <>
-      {errorMessage && !headerFormOpen ? (
-        <Notification
-          onDismiss={() => dispatch(machineActions.cleanup())}
-          severity="negative"
-        >
-          {errorMessage}
-        </Notification>
+      {errors && !headerFormOpen ? (
+        <ErrorsNotification
+          errors={errors}
+          onAfterDismiss={() => dispatch(machineActions.cleanup())}
+        />
       ) : null}
-      {machinesErrors && machinesErrorsOpen && !headerFormOpen ? (
-        <Notification
-          onDismiss={() => setMachinesErrorsOpen(false)}
-          severity="negative"
-        >
-          {formatErrors(machinesErrors)}
-        </Notification>
-      ) : null}
+      {!headerFormOpen ? <ErrorsNotification errors={machinesErrors} /> : null}
       <MachineListControls
         filter={searchFilter}
         grouping={grouping}

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { Notification } from "@canonical/react-components";
 import cloneDeep from "clone-deep";
@@ -43,11 +43,12 @@ const MachineList = ({
   setSearchFilter,
 }: Props): JSX.Element => {
   useWindowTitle("Machines");
+  const [machinesErrorsOpen, setMachinesErrorsOpen] = useState(true);
   const dispatch = useDispatch();
   const errors = useSelector(machineSelectors.errors);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
   const filters = FilterMachines.getCurrentFilters(searchFilter);
-  const { machines } = useFetchMachines(
+  const { machines, machinesErrors } = useFetchMachines(
     parseFilters(filters),
     "in" in filters ? getSelectedValue(filters.in) : null
   );
@@ -62,7 +63,6 @@ const MachineList = ({
     "hiddenGroups",
     []
   );
-
   useEffect(() => {
     dispatch(tagActions.fetch());
   }, [dispatch]);
@@ -85,6 +85,14 @@ const MachineList = ({
           severity="negative"
         >
           {errorMessage}
+        </Notification>
+      ) : null}
+      {machinesErrors && machinesErrorsOpen && !headerFormOpen ? (
+        <Notification
+          onDismiss={() => setMachinesErrorsOpen(false)}
+          severity="negative"
+        >
+          {formatErrors(machinesErrors)}
         </Notification>
       ) : null}
       <MachineListControls

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -365,6 +365,9 @@ const getList = (
 ) =>
   callId && callId in machineState.lists ? machineState.lists[callId] : null;
 
+/**
+ * Get the errors for a machine list request with a given callId
+ */
 const listErrors = createSelector(
   [
     machineState,

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -365,6 +365,14 @@ const getList = (
 ) =>
   callId && callId in machineState.lists ? machineState.lists[callId] : null;
 
+const listErrors = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => getList(machineState, callId)?.errors || null
+);
+
 /**
  * Get machines in a list request.
  * @param state - The redux state.
@@ -496,6 +504,7 @@ const selectors = {
   getStatusForMachine,
   linkingSubnet: statusSelectors["linkingSubnet"],
   list,
+  listErrors,
   locking: statusSelectors["locking"],
   markingBroken: statusSelectors["markingBroken"],
   markingFixed: statusSelectors["markingFixed"],

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -6,6 +6,7 @@ import fastDeepEqual from "fast-deep-equal";
 import { useDispatch, useSelector } from "react-redux";
 
 import { useCanEdit } from "app/base/hooks";
+import type { APIError } from "app/base/types";
 import { actions as generalActions } from "app/store/general";
 import {
   architectures as architecturesSelectors,
@@ -90,6 +91,7 @@ export const useFetchMachines = (
   filterSelected?: FilterSelected | null
 ): {
   machines: Machine[];
+  machinesErrors: APIError;
 } => {
   const [callId, setCallId] = useState<string | null>(null);
   const previousCallId = usePrevious(callId);
@@ -97,6 +99,9 @@ export const useFetchMachines = (
   const dispatch = useDispatch();
   const machines = useSelector((state: RootState) =>
     machineSelectors.list(state, callId, filterSelected)
+  );
+  const machinesErrors = useSelector((state: RootState) =>
+    machineSelectors.listErrors(state, callId)
   );
   useCleanup(callId);
 
@@ -118,7 +123,7 @@ export const useFetchMachines = (
     }
   }, [dispatch, filters, callId, previousCallId]);
 
-  return { machines };
+  return { machines, machinesErrors };
 };
 
 /**


### PR DESCRIPTION
## Done

-  display fetch machines errors

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Enter invalid search constraint into the search field (e.g. `tag1:(test)`)
- verify an error message has been shown and can be dismissed on click

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1247

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
