### PR TITLE
feat(machines): add group to fetch calls

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -13,6 +13,7 @@ import type { SetSearchFilter } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { FetchFilters } from "app/store/machine/types";
+import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import { actions as tagActions } from "app/store/tag";
@@ -46,14 +47,15 @@ const MachineList = ({
   const errors = useSelector(machineSelectors.errors);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
   const filters = FilterMachines.getCurrentFilters(searchFilter);
-  const { machines, machinesErrors } = useFetchMachines(
-    parseFilters(filters),
-    "in" in filters ? getSelectedValue(filters.in) : null
-  );
-  const [grouping, setGrouping] = useStorageState(
+  const [grouping, setGrouping] = useStorageState<FetchGroupKey | null>(
     localStorage,
     "grouping",
-    "status"
+    FetchGroupKey.Status
+  );
+  const { machines, machinesErrors } = useFetchMachines(
+    parseFilters(filters),
+    grouping,
+    "in" in filters ? getSelectedValue(filters.in) : null
   );
   const [hiddenGroups, setHiddenGroups] = useStorageState<string[]>(
     localStorage,

--- a/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.test.tsx
@@ -6,7 +6,7 @@ describe("GroupSelect ", () => {
   it("renders", () => {
     const wrapper = shallow(
       <GroupSelect
-        grouping="none"
+        grouping={null}
         setGrouping={jest.fn()}
         setHiddenGroups={jest.fn()}
       />
@@ -19,7 +19,7 @@ describe("GroupSelect ", () => {
     const setHiddenGroups = jest.fn();
     const wrapper = shallow(
       <GroupSelect
-        grouping="none"
+        grouping={null}
         setGrouping={setGrouping}
         setHiddenGroups={setHiddenGroups}
       />

--- a/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.tsx
@@ -1,34 +1,36 @@
 import { Select } from "@canonical/react-components";
 
+import { FetchGroupKey } from "app/store/machine/types";
+
 type Props = {
-  grouping: string;
-  setGrouping: (group: string) => void;
+  grouping: FetchGroupKey | null;
+  setGrouping: (group: FetchGroupKey | null) => void;
   setHiddenGroups: (groups: string[]) => void;
 };
 
 const groupOptions = [
   {
-    value: "none",
+    value: "",
     label: "No grouping",
   },
   {
-    value: "owner",
+    value: FetchGroupKey.Owner,
     label: "Group by owner",
   },
   {
-    value: "pool",
+    value: FetchGroupKey.Pool,
     label: "Group by pool",
   },
   {
-    value: "power_state",
+    value: FetchGroupKey.PowerState,
     label: "Group by power state",
   },
   {
-    value: "status",
+    value: FetchGroupKey.Status,
     label: "Group by status",
   },
   {
-    value: "zone",
+    value: FetchGroupKey.Zone,
     label: "Group by zone",
   },
 ];
@@ -40,10 +42,10 @@ const GroupSelect = ({
 }: Props): JSX.Element => {
   return (
     <Select
-      defaultValue={grouping}
+      defaultValue={grouping ?? ""}
       name="machine-groupings"
       onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
-        setGrouping(e.target.value);
+        setGrouping((e.target.value as FetchGroupKey) ?? null);
         setHiddenGroups([]);
       }}
       options={groupOptions}

--- a/src/app/machines/views/MachineList/MachineListControls/GroupSelect/__snapshots__/GroupSelect.test.tsx.snap
+++ b/src/app/machines/views/MachineList/MachineListControls/GroupSelect/__snapshots__/GroupSelect.test.tsx.snap
@@ -2,14 +2,14 @@
 
 exports[`GroupSelect  renders 1`] = `
 <Select
-  defaultValue="none"
+  defaultValue=""
   name="machine-groupings"
   onChange={[Function]}
   options={
     Array [
       Object {
         "label": "No grouping",
-        "value": "none",
+        "value": "",
       },
       Object {
         "label": "Group by owner",

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
@@ -37,7 +37,7 @@ describe("MachineListControls", () => {
         >
           <MachineListControls
             filter=""
-            grouping="none"
+            grouping={null}
             hiddenColumns={[]}
             setFilter={setFilter}
             setGrouping={jest.fn()}

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -6,12 +6,13 @@ import GroupSelect from "./GroupSelect";
 import MachinesFilterAccordion from "./MachinesFilterAccordion";
 
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
+import type { FetchGroupKey } from "app/store/machine/types";
 
 type Props = {
   filter: string;
-  grouping: string;
+  grouping: FetchGroupKey | null;
   setFilter: (filter: string) => void;
-  setGrouping: (group: string) => void;
+  setGrouping: (group: FetchGroupKey | null) => void;
   setHiddenGroups: (groups: string[]) => void;
   hiddenColumns?: string[];
   toggleHiddenColumn?: (column: string) => void;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 import { MachineListTable } from "./MachineListTable";
 
 import type { Machine } from "app/store/machine/types";
+import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
   NodeStatus,
@@ -224,7 +225,7 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter=""
-              grouping="status"
+              grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
               machines={machines}
               setHiddenGroups={jest.fn()}
@@ -248,7 +249,7 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter=""
-              grouping="status"
+              grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
               machines={machines}
               setHiddenGroups={jest.fn()}
@@ -277,7 +278,7 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter=""
-              grouping="status"
+              grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
               machines={machines}
               setHiddenGroups={jest.fn()}
@@ -314,7 +315,6 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter=""
-              grouping="none"
               hiddenGroups={[]}
               machines={machines}
               setHiddenGroups={jest.fn()}
@@ -361,7 +361,6 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter=""
-              grouping="none"
               hiddenGroups={[]}
               machines={machines}
               setHiddenGroups={jest.fn()}
@@ -424,7 +423,7 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter=""
-              grouping="status"
+              grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
               machines={machines}
               selectedIDs={[machines[0].system_id]}
@@ -454,7 +453,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={["abc123"]}
@@ -481,7 +480,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={["abc123", "ghi789"]}
@@ -514,7 +513,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={["abc123", "def456", "ghi789"]}
@@ -547,7 +546,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 setHiddenGroups={jest.fn()}
@@ -584,7 +583,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={["abc123"]}
@@ -622,7 +621,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={[]}
@@ -660,7 +659,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={["abc123", "def456", "ghi789"]}
@@ -698,7 +697,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={["abc123"]}
@@ -727,7 +726,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={[]}
@@ -765,7 +764,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={machines}
                 selectedIDs={["abc123", "def456", "ghi789"]}
@@ -803,7 +802,7 @@ describe("MachineListTable", () => {
             <CompatRouter>
               <MachineListTable
                 filter=""
-                grouping="status"
+                grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
                 machines={[]}
                 setHiddenGroups={jest.fn()}
@@ -836,7 +835,7 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter=""
-              grouping="status"
+              grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
               machines={machines}
               selectedIDs={["abc123"]}
@@ -866,7 +865,7 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter="in:selected"
-              grouping="status"
+              grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
               machines={machines}
               selectedIDs={["abc123"]}
@@ -897,7 +896,7 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter="in:selected"
-              grouping="status"
+              grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
               machines={machines}
               selectedIDs={["abc123"]}
@@ -928,7 +927,7 @@ describe("MachineListTable", () => {
           <CompatRouter>
             <MachineListTable
               filter="in:selected"
-              grouping="status"
+              grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
               machines={machines}
               selectedIDs={["abc123", "def456", "ghi789"]}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -31,7 +31,11 @@ import { columnLabels, columns, MachineColumns } from "app/machines/constants";
 import { actions as generalActions } from "app/store/general";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-import type { Machine, MachineMeta } from "app/store/machine/types";
+import type {
+  Machine,
+  MachineMeta,
+  FetchGroupKey,
+} from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import { actions as tagActions } from "app/store/tag";
@@ -49,7 +53,7 @@ import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
 type Props = {
   filter?: string;
-  grouping?: string;
+  grouping?: FetchGroupKey | null;
   hiddenColumns?: string[];
   hiddenGroups?: string[];
   machines: Machine[];
@@ -530,7 +534,7 @@ const generateGroupRows = ({
 
 export const MachineListTable = ({
   filter = "",
-  grouping = "none",
+  grouping,
   hiddenColumns = [],
   hiddenGroups = [],
   machines,
@@ -831,7 +835,7 @@ export const MachineListTable = ({
 
   let rows: MainTableRow[] | null = null;
 
-  if (grouping === "none") {
+  if (!grouping) {
     rows = generateRows({
       machines,
       selectedIDs,
@@ -855,7 +859,7 @@ export const MachineListTable = ({
       <MainTable
         aria-label="Machines"
         className={classNames("p-table-expanding--light", "machine-list", {
-          "machine-list--grouped": grouping !== "none",
+          "machine-list--grouped": grouping,
         })}
         emptyStateMsg={
           !machinesLoaded ? (

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -407,7 +407,7 @@ export enum FetchGroupKey {
 }
 
 export type FetchParams = {
-  filter?: FetchFilters;
+  filter?: FetchFilters | null;
   group_key?: FetchGroupKey | null;
   group_collapsed?: string[];
   page_size?: number;

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -216,10 +216,7 @@ describe("machine hook utils", () => {
       renderHook(() => useFetchMachines(), {
         wrapper: generateWrapper(store),
       });
-      const expected = machineActions.fetch("mocked-nanoid-1", {
-        filter: null,
-        group_key: null,
-      });
+      const expected = machineActions.fetch("mocked-nanoid-1");
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -19,6 +19,7 @@ import {
 
 import { actions as machineActions } from "app/store/machine";
 import type { FetchFilters, Machine } from "app/store/machine/types";
+import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import { NodeStatus, NodeStatusCode } from "app/store/types/node";
@@ -44,6 +45,11 @@ import {
 } from "testing/factories";
 
 const mockStore = configureStore();
+
+type UseFetchMachinesProps = {
+  filters?: FetchFilters | null;
+  grouping?: FetchGroupKey | null;
+};
 
 const generateWrapper =
   (store: MockStoreEnhanced<unknown>) =>
@@ -210,7 +216,10 @@ describe("machine hook utils", () => {
       renderHook(() => useFetchMachines(), {
         wrapper: generateWrapper(store),
       });
-      const expected = machineActions.fetch("mocked-nanoid-1");
+      const expected = machineActions.fetch("mocked-nanoid-1", {
+        filter: null,
+        group_key: null,
+      });
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
@@ -255,8 +264,9 @@ describe("machine hook utils", () => {
     it("does not fetch again if the filters haven't changed", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        () => useFetchMachines({ hostname: "spotted-quoll" }),
+        ({ filters }: UseFetchMachinesProps) => useFetchMachines(filters),
         {
+          initialProps: { filters: { hostname: "spotted-quoll" } },
           wrapper: generateWrapper(store),
         }
       );
@@ -268,14 +278,30 @@ describe("machine hook utils", () => {
       expect(getDispatches).toHaveLength(1);
     });
 
+    it("does not fetch again if the grouping hasn't changed", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({ filters, grouping }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping),
+        {
+          initialProps: { grouping: FetchGroupKey.Owner },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ grouping: FetchGroupKey.Owner });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
     it("does not fetch again if the filters haven't changed including empty objects", () => {
       const store = mockStore(state);
-      const initialProps: { filters: FetchFilters | null } = { filters: null };
       const { rerender } = renderHook(
-        ({ filters }: { filters: FetchFilters | null }) =>
-          useFetchMachines(filters),
+        ({ filters }: UseFetchMachinesProps) => useFetchMachines(filters),
         {
-          initialProps,
+          initialProps: { filters: null },
           wrapper: generateWrapper(store),
         }
       );
@@ -290,7 +316,8 @@ describe("machine hook utils", () => {
     it("fetches again if the filters change", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({ filters }) => useFetchMachines(filters),
+        ({ filters, grouping }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping),
         {
           initialProps: {
             filters: {
@@ -301,6 +328,26 @@ describe("machine hook utils", () => {
         }
       );
       rerender({ filters: { hostname: "eastern-quoll" } });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(2);
+    });
+
+    it("fetches again if the grouping changes", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({ filters, grouping }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping),
+        {
+          initialProps: {
+            grouping: FetchGroupKey.Owner,
+          },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ grouping: FetchGroupKey.Status });
       const expected = machineActions.fetch("mocked-nanoid-1");
       const getDispatches = store
         .getActions()

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -125,10 +125,15 @@ export const useFetchMachines = (
   useEffect(() => {
     if (callId && callId !== previousCallId) {
       dispatch(
-        machineActions.fetch(callId, {
-          filter: filters ?? null,
-          group_key: grouping ?? null,
-        })
+        machineActions.fetch(
+          callId,
+          filters || grouping
+            ? {
+                filter: filters ?? null,
+                group_key: grouping ?? null,
+              }
+            : null
+        )
       );
     }
   }, [callId, dispatch, filters, grouping, previousCallId]);


### PR DESCRIPTION
## Done

- Update the machine list group selector to pass the group with the API call.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and change the value of the "Group by..." select box (some values don't currently work: https://bugs.launchpad.net/maas/+bug/1984994).
- Open redux and look in machine -> list -> whichever call id is for the list -> groups
- You should see groups for the key you selected (they might not match what you see in the machine list, that needs to be updated: https://github.com/canonical/app-tribe/issues/1261).

## Fixes

Fixes: canonical/app-tribe#1122.