### PR TITLE
refactor(machines): remove count request

### DIFF
--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -1338,4 +1338,17 @@ describe("machine reducer", () => {
       })
     );
   });
+
+  it("reduces removeRequest for a count request", () => {
+    const initialState = machineStateFactory({
+      counts: {
+        123456: machineStateCountFactory(),
+      },
+    });
+    expect(reducers(initialState, actions.removeRequest("123456"))).toEqual(
+      machineStateFactory({
+        counts: {},
+      })
+    );
+  });
 });

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1530,6 +1530,8 @@ const machineSlice = createSlice({
             delete state.details[callId];
           } else if (callId in state.lists) {
             delete state.lists[callId];
+          } else if (callId in state.counts) {
+            delete state.counts[callId];
           }
         }
       },


### PR DESCRIPTION
## Done

- remove count request

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Verify there are counts in the machine redux slice via Redux Devtools
- Navigate to another page (e.g. Settings)
- make sure all counts requests were removed from the Redux store

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1259

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
