### PR TITLE
refactor(machines): update edit tag warning

### DIFF
--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
@@ -62,6 +62,10 @@ describe("MachinesHeader", () => {
     });
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("displays machine, resource pool and tag counts if loaded", () => {
     state.machine.loaded = true;
     state.resourcepool.loaded = true;

--- a/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
+++ b/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
@@ -4,8 +4,8 @@ import { useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
 import docsUrls from "app/base/docsUrls";
-import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import type {
@@ -14,6 +14,7 @@ import type {
   TagMeta,
   UpdateParams,
 } from "app/store/tag/types";
+import { FetchNodeStatus } from "app/store/types/node";
 import { isId } from "app/utils";
 
 export enum Label {
@@ -39,12 +40,12 @@ export const KernelOptionsField = ({
   const tag = useSelector((state: RootState) =>
     tagSelectors.getById(state, id)
   );
-  const deployedMachinesForTag = useSelector((state: RootState) =>
-    machineSelectors.getDeployedWithTag(state, id)
-  );
-  const deployedMachines = suppliedDeployedMachines ?? deployedMachinesForTag;
+  const { machineCount } = useFetchMachineCount({
+    status: FetchNodeStatus.DEPLOYED,
+    ...(tag?.id ? { tags: [tag.name] } : {}),
+  });
+  const deployedCount = suppliedDeployedMachines?.length ?? machineCount;
   const { values } = useFormikContext<CreateParams | UpdateParams>();
-  const deployedCount = deployedMachines.length;
   const changedExistingOptions =
     isId(id) && values.kernel_opts !== tag?.kernel_opts;
   const setNewOptions = !isId(id) && values.kernel_opts;


### PR DESCRIPTION
## Done

- update edit tag warning to use the count API

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing and select Tags
- Edit a tag that has kernel options
- Type in the kernel options field
- Make sure the number of machines in the warning message is correct

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1118

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
