### PR TITLE
refactor(machines): remove in:selected from machines DSL

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -18,7 +18,6 @@ import { FilterMachines } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import { actions as tagActions } from "app/store/tag";
 import type { Filters } from "app/utils/search/filter-handlers";
-import { getSelectedValue } from "app/utils/search/filter-items";
 
 type Props = {
   headerFormOpen?: boolean;
@@ -54,8 +53,7 @@ const MachineList = ({
   );
   const { machines, machinesErrors } = useFetchMachines(
     parseFilters(filters),
-    grouping,
-    "in" in filters ? getSelectedValue(filters.in) : null
+    grouping
   );
   const [hiddenGroups, setHiddenGroups] = useStorageState<string[]>(
     localStorage,

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -2,7 +2,6 @@ import machine from "./selectors";
 
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import { NodeActions, NodeStatus, NodeStatusCode } from "app/store/types/node";
-import { FilterSelected } from "app/utils/search/filter-items";
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
@@ -503,76 +502,7 @@ describe("machine selectors", () => {
         },
       }),
     });
-    expect(machine.list(state, "123456", null)).toStrictEqual(machines);
-  });
-
-  it("can get selected items in a list", () => {
-    const machines = [machineFactory(), machineFactory()];
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [...machines, machineFactory()],
-        lists: {
-          "123456": machineStateListFactory({
-            loading: true,
-            groups: [
-              machineStateListGroupFactory({
-                items: machines.map(({ system_id }) => system_id),
-              }),
-            ],
-          }),
-        },
-        selected: [machines[0].system_id],
-      }),
-    });
-    expect(
-      machine.list(state, "123456", FilterSelected.Selected)
-    ).toStrictEqual([machines[0]]);
-  });
-
-  it("can get unselected items in a list", () => {
-    const machines = [machineFactory(), machineFactory()];
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [...machines, machineFactory()],
-        lists: {
-          "123456": machineStateListFactory({
-            loading: true,
-            groups: [
-              machineStateListGroupFactory({
-                items: machines.map(({ system_id }) => system_id),
-              }),
-            ],
-          }),
-        },
-        selected: [machines[0].system_id],
-      }),
-    });
-    expect(
-      machine.list(state, "123456", FilterSelected.NotSelected)
-    ).toStrictEqual([machines[1]]);
-  });
-
-  it("can get selected and unselected items in a list", () => {
-    const machines = [machineFactory(), machineFactory()];
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        items: [...machines, machineFactory()],
-        lists: {
-          "123456": machineStateListFactory({
-            loading: true,
-            groups: [
-              machineStateListGroupFactory({
-                items: machines.map(({ system_id }) => system_id),
-              }),
-            ],
-          }),
-        },
-        selected: [machines[0].system_id],
-      }),
-    });
-    expect(machine.list(state, "123456", FilterSelected.All)).toStrictEqual(
-      machines
-    );
+    expect(machine.list(state, "123456")).toStrictEqual(machines);
   });
 
   it("can get an interface by id", () => {

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -22,7 +22,6 @@ import {
   getInterfaceById as getInterfaceByIdUtil,
 } from "app/store/utils";
 import { isId } from "app/utils";
-import { FilterSelected } from "app/utils/search/filter-items";
 
 const defaultSelectors = generateBaseSelectors<
   MachineState,
@@ -387,17 +386,11 @@ const list = createSelector(
   [
     machineState,
     defaultSelectors.all,
-    selectedIDs,
-    (
-      _state: RootState,
-      callId: string | null | undefined,
-      filterSelected: FilterSelected | null | undefined
-    ) => ({
+    (_state: RootState, callId: string | null | undefined) => ({
       callId,
-      filterSelected,
     }),
   ],
-  (machineState, allMachines, selectedIDs, { callId, filterSelected }) => {
+  (machineState, allMachines, { callId }) => {
     const machines: Machine[] = [];
     getList(machineState, callId)?.groups?.forEach((group) => {
       group.items.forEach((systemId) => {
@@ -405,15 +398,7 @@ const list = createSelector(
           ({ system_id }) => system_id === systemId
         );
         if (machine) {
-          const inSelected = selectedIDs.includes(machine.system_id);
-          if (
-            filterSelected === FilterSelected.All ||
-            (filterSelected === FilterSelected.Selected && inSelected) ||
-            (filterSelected === FilterSelected.NotSelected && !inSelected) ||
-            !filterSelected
-          ) {
-            machines.push(machine);
-          }
+          machines.push(machine);
         }
       });
     });

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -32,7 +32,6 @@ import {
 } from "app/store/utils";
 import vlanSelectors from "app/store/vlan/selectors";
 import { isId } from "app/utils";
-import type { FilterSelected } from "app/utils/search/filter-items";
 
 export const useFetchMachineCount = (
   filters?: FetchFilters
@@ -89,8 +88,7 @@ export const useFetchMachineCount = (
  */
 export const useFetchMachines = (
   filters?: FetchFilters | null,
-  grouping?: FetchGroupKey | null,
-  filterSelected?: FilterSelected | null
+  grouping?: FetchGroupKey | null
 ): {
   machines: Machine[];
   machinesErrors: APIError;
@@ -101,7 +99,7 @@ export const useFetchMachines = (
   const previousGrouping = usePrevious(grouping, false);
   const dispatch = useDispatch();
   const machines = useSelector((state: RootState) =>
-    machineSelectors.list(state, callId, filterSelected)
+    machineSelectors.list(state, callId)
   );
   const machinesErrors = useSelector((state: RootState) =>
     machineSelectors.listErrors(state, callId)


### PR DESCRIPTION
## Done

- Remove support for in:selected from the machines DSL as it's not possible with the server side
search API.

## QA

n/a

## Fixes

Fixes: canonical/app-tribe#1265.