### PR TITLE
test: add react no-multi-comp rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,6 +97,7 @@ module.exports = {
           },
         ],
         "react/jsx-sort-props": "error",
+        "react/no-multi-comp": ["error", { ignoreStateless: false }],
       },
       settings: {
         "import/resolver": {
@@ -132,6 +133,7 @@ module.exports = {
             allowedMethods: ["change"],
           },
         ],
+        "react/no-multi-comp": "off",
       },
     },
     {

--- a/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
+++ b/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";

--- a/src/app/base/components/SideNav/SideNav.tsx
+++ b/src/app/base/components/SideNav/SideNav.tsx
@@ -87,6 +87,7 @@ const _generateSection = (
   );
 };
 
+// eslint-disable-next-line react/no-multi-comp
 export const SideNav = ({
   closeToggleText = "Toggle side navigation",
   items,

--- a/src/app/base/components/TitledSection/TitledSection.tsx
+++ b/src/app/base/components/TitledSection/TitledSection.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React from "react";
 import type { ReactNode } from "react";
 

--- a/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import { useMemo } from "react";
 
 import { ModularTable } from "@canonical/react-components";

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import type { ReactNode } from "react";
 import { useState, useMemo } from "react";
 

--- a/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import { Col, Row, Textarea } from "@canonical/react-components";
 import type { TextareaProps } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/app/subnets/views/FormActions/components/AddSubnet.tsx
+++ b/src/app/subnets/views/FormActions/components/AddSubnet.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import { Row, Col, Input } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import type { PropsWithChildren } from "react";
 import { useState } from "react";
 

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import type { ValueOf } from "@canonical/react-components";
 import type { RenderOptions, RenderResult } from "@testing-library/react";
 import { render } from "@testing-library/react";


### PR DESCRIPTION
## Done

- add react no-multi-comp rule
  - (we already have a 1 component per file rule in MAAS but it wasn't enforced by eslint - https://github.com/canonical/maas-ui/pull/4333#discussion_r943008337)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1266

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
