### PR TITLE
refactor(machines): ignore removed count requests

### DIFF
--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -81,6 +81,24 @@ describe("machine reducer", () => {
     );
   });
 
+  it("ignores calls that don't exist when reducing countSuccess", () => {
+    const initialState = machineStateFactory({
+      counts: {},
+    });
+    expect(
+      reducers(
+        initialState,
+        actions.countSuccess("123456", {
+          count: 11,
+        })
+      )
+    ).toEqual(
+      machineStateFactory({
+        counts: {},
+      })
+    );
+  });
+
   it("reduces countError", () => {
     const initialState = machineStateFactory({
       counts: {

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -641,7 +641,10 @@ const machineSlice = createSlice({
         state: MachineState,
         action: PayloadAction<{ count: number }, string, GenericMeta>
       ) => {
-        if (action.meta.callId) {
+        // Only update state if this call exists in the store. This check is required
+        // because the call may have been cleaned up in the time the API takes
+        // to respond.
+        if (action.meta.callId && action.meta.callId in state.counts) {
           state.counts[action.meta.callId] = {
             ...(action.meta.callId in state.counts
               ? state.counts[action.meta.callId]


### PR DESCRIPTION
## Done

- refactor(machines): ignore removed count requests

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1264

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
