### PR TITLE
fix(machines): fix deploy with mismatched default release and kernel

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import * as React from "react";
 
 import {
@@ -22,7 +22,10 @@ import docsUrls from "app/base/docsUrls";
 import urls from "app/base/urls";
 import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
-import { osInfo as osInfoSelectors } from "app/store/general/selectors";
+import {
+  osInfo as osInfoSelectors,
+  defaultMinHweKernel as defaultMinHweKernelSelectors,
+} from "app/store/general/selectors";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
 import { timeSpanToMinutes } from "app/utils";
@@ -35,6 +38,7 @@ export const DeployFormFields = (): JSX.Element => {
 
   const user = useSelector(authSelectors.get);
   const osOptions = useSelector(configSelectors.defaultOSystemOptions);
+  const defaultMinHweKernel = useSelector(defaultMinHweKernelSelectors.get);
   const { osystems = [], releases = [] } =
     useSelector(osInfoSelectors.get) || {};
   const allReleaseOptions = useSelector(osInfoSelectors.getAllOsReleases) || {};
@@ -52,6 +56,18 @@ export const DeployFormFields = (): JSX.Element => {
   const hardwareSyncInterval = useSelector(
     configSelectors.hardwareSyncInterval
   );
+
+  // When the kernel options change then reset the selected kernel. If the
+  // selected release contains the default kernel then select it.
+  useEffect(() => {
+    if (defaultMinHweKernel) {
+      if (kernelOptions.find(({ value }) => value === defaultMinHweKernel)) {
+        setFieldValue("kernel", defaultMinHweKernel);
+      } else {
+        setFieldValue("kernel", "");
+      }
+    }
+  }, [defaultMinHweKernel, kernelOptions, setFieldValue]);
 
   return (
     <>


### PR DESCRIPTION
## Done

- Handle deploying machines when the default kernel is not in the default release.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to Settings ->  Commissioning and select a default release and minimum kernel and save.
- Go to Settings -> Deploy and choose a different release and save.
- Go to the Machine list and tick a deployable machine and open the deploy form via the take action menu.
- Submit the form without changing the release or kernel and you should not get any errors about the kernel not being available for the release.
- Abort the deploy and open the deploy form again and change the release to the one that contains the default kernel and the default kernel should get selected.

## Fixes

Fixes: #4342.