### PR TITLE
feat(machines): paginate using the new API

### DIFF
--- a/src/app/kvm/components/VmResources/VmResources.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.tsx
@@ -26,6 +26,7 @@ const VmResources = ({ loading = false, vms }: Props): JSX.Element => {
             {/* TODO: update to use the new API: 
             https://github.com/canonical/app-tribe/issues/1117 */}
             <MachineListTable
+              currentPage={1}
               hiddenColumns={[
                 "owner",
                 "pool",
@@ -34,8 +35,10 @@ const VmResources = ({ loading = false, vms }: Props): JSX.Element => {
                 "disks",
                 "storage",
               ]}
+              machineCount={vms.length}
               machines={vms}
-              paginateLimit={5}
+              pageSize={5}
+              setCurrentPage={() => null}
               setSortDirection={() => null}
               setSortKey={() => null}
               showActions={false}

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -75,7 +75,7 @@ const MachineList = ({
     "grouping",
     FetchGroupKey.Status
   );
-  const pageSize = DEFAULT_PAGE_SIZE;
+  const pageSize = DEFAULTS.pageSize;
   const { machineCount, machines, machinesErrors } = useFetchMachines(
     parseFilters(filters),
     grouping,

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -62,6 +62,7 @@ const MachineList = ({
   const dispatch = useDispatch();
   const errors = useSelector(machineSelectors.errors);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
+  const [currentPage, setCurrentPage] = useState(1);
   const [sortKey, setSortKey] = useState<FetchGroupKey | null>(
     DEFAULTS.sortKey
   );
@@ -74,9 +75,12 @@ const MachineList = ({
     "grouping",
     FetchGroupKey.Status
   );
-  const { machines, machinesErrors } = useFetchMachines(
+  const pageSize = DEFAULT_PAGE_SIZE;
+  const { machineCount, machines, machinesErrors } = useFetchMachines(
     parseFilters(filters),
     grouping,
+    pageSize,
+    currentPage,
     sortKey,
     mapSortDirection(sortDirection)
   );
@@ -116,11 +120,15 @@ const MachineList = ({
         setHiddenGroups={setHiddenGroups}
       />
       <MachineListTable
+        currentPage={currentPage}
         filter={searchFilter}
         grouping={grouping}
         hiddenGroups={hiddenGroups}
+        machineCount={machineCount}
         machines={machines}
+        pageSize={pageSize}
         selectedIDs={selectedIDs}
+        setCurrentPage={setCurrentPage}
         setHiddenGroups={setHiddenGroups}
         setSearchFilter={setSearchFilter}
         setSortDirection={setSortDirection}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -1344,7 +1344,7 @@ describe("MachineListTable", () => {
     renderWithBrowserRouter(
       <MachineListTable
         currentPage={1}
-        machineCount={100}
+        machineCount={0}
         machines={[]}
         pageSize={20}
         setCurrentPage={jest.fn()}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -1,12 +1,14 @@
+import { screen } from "@testing-library/react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
-import { MachineListTable } from "./MachineListTable";
+import { MachineListTable, Label } from "./MachineListTable";
 
 import { SortDirection } from "app/base/types";
+import urls from "app/base/urls";
 import type { Machine } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -30,6 +32,7 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -225,10 +228,14 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={jest.fn()}
@@ -253,10 +260,14 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={jest.fn()}
@@ -286,10 +297,14 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={jest.fn()}
@@ -329,9 +344,13 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={setSortDirection}
@@ -363,9 +382,13 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={setSortDirection}
@@ -397,9 +420,13 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={setSortDirection}
@@ -431,9 +458,13 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={setSortDirection}
@@ -465,9 +496,13 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={setSortDirection}
@@ -498,11 +533,15 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
               selectedIDs={[machines[0].system_id]}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={jest.fn()}
@@ -532,11 +571,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={["abc123"]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -563,11 +606,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={["abc123", "ghi789"]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -600,11 +647,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={["abc123", "def456", "ghi789"]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -637,10 +688,14 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -678,11 +733,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={["abc123"]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -720,11 +779,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={[]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -762,11 +825,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={["abc123", "def456", "ghi789"]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -804,11 +871,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={["abc123"]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -837,11 +908,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={[]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -879,11 +954,15 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
                 selectedIDs={["abc123", "def456", "ghi789"]}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -921,10 +1000,14 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 filter=""
                 grouping={FetchGroupKey.Status}
                 hiddenGroups={[]}
+                machineCount={10}
                 machines={[]}
+                pageSize={20}
+                setCurrentPage={jest.fn()}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
                 setSortDirection={jest.fn()}
@@ -958,11 +1041,15 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
               selectedIDs={["abc123"]}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
               setSortDirection={jest.fn()}
@@ -992,11 +1079,15 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter="in:selected"
               grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
               selectedIDs={["abc123"]}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={setSearchFilter}
               setSortDirection={jest.fn()}
@@ -1027,11 +1118,15 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter="in:selected"
               grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
               selectedIDs={["abc123"]}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={setSearchFilter}
               setSortDirection={jest.fn()}
@@ -1062,11 +1157,15 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
               filter="in:selected"
               grouping={FetchGroupKey.Status}
               hiddenGroups={[]}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
               selectedIDs={["abc123", "def456", "ghi789"]}
+              setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSearchFilter={setSearchFilter}
               setSortDirection={jest.fn()}
@@ -1096,7 +1195,11 @@ describe("MachineListTable", () => {
         >
           <CompatRouter>
             <MachineListTable
+              currentPage={1}
+              machineCount={10}
               machines={machines}
+              pageSize={20}
+              setCurrentPage={jest.fn()}
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}
               showActions={false}
@@ -1128,8 +1231,12 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 hiddenColumns={["power", "zone"]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
+                setCurrentPage={jest.fn()}
                 setSortDirection={jest.fn()}
                 setSortKey={jest.fn()}
                 sortDirection="none"
@@ -1157,8 +1264,12 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 hiddenColumns={["fqdn"]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
+                setCurrentPage={jest.fn()}
                 setSortDirection={jest.fn()}
                 setSortKey={jest.fn()}
                 showActions
@@ -1183,8 +1294,12 @@ describe("MachineListTable", () => {
           >
             <CompatRouter>
               <MachineListTable
+                currentPage={1}
                 hiddenColumns={["fqdn"]}
+                machineCount={10}
                 machines={machines}
+                pageSize={20}
+                setCurrentPage={jest.fn()}
                 setSortDirection={jest.fn()}
                 setSortKey={jest.fn()}
                 showActions={false}
@@ -1199,5 +1314,53 @@ describe("MachineListTable", () => {
       expect(wrapper.find('[data-testid="fqdn-header"]').exists()).toBe(false);
       expect(wrapper.find('[data-testid="fqdn-column"]').exists()).toBe(false);
     });
+  });
+
+  it("displays pagination if there are machines", () => {
+    renderWithBrowserRouter(
+      <MachineListTable
+        currentPage={1}
+        machineCount={100}
+        machines={machines}
+        pageSize={20}
+        setCurrentPage={jest.fn()}
+        setSortDirection={jest.fn()}
+        setSortKey={jest.fn()}
+        showActions={false}
+        sortDirection="none"
+        sortKey={null}
+      />,
+      {
+        route: urls.machines.index,
+        wrapperProps: { state },
+      }
+    );
+    expect(
+      screen.getByRole("navigation", { name: Label.Pagination })
+    ).toBeInTheDocument();
+  });
+
+  it("does not display pagination if there are no machines", () => {
+    renderWithBrowserRouter(
+      <MachineListTable
+        currentPage={1}
+        machineCount={100}
+        machines={[]}
+        pageSize={20}
+        setCurrentPage={jest.fn()}
+        setSortDirection={jest.fn()}
+        setSortKey={jest.fn()}
+        showActions={false}
+        sortDirection="none"
+        sortKey={null}
+      />,
+      {
+        route: urls.machines.index,
+        wrapperProps: { state },
+      }
+    );
+    expect(
+      screen.queryByRole("navigation", { name: Label.Pagination })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -1,7 +1,12 @@
 import { memo, useCallback, useEffect, useMemo, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
-import { Button, MainTable, Spinner } from "@canonical/react-components";
+import {
+  Button,
+  MainTable,
+  Pagination,
+  Spinner,
+} from "@canonical/react-components";
 import type {
   MainTableCell,
   MainTableRow,
@@ -47,20 +52,28 @@ import {
 import type { CheckboxHandlers } from "app/utils/generateCheckboxHandlers";
 
 export const DEFAULTS = {
+  pageSize: 50,
   sortDirection: SortDirection.DESCENDING,
   // TODO: change this to fqdn when the API supports it:
   // https://github.com/canonical/app-tribe/issues/1268
   sortKey: FetchGroupKey.Hostname,
 };
 
+export enum Label {
+  Pagination = "Table pagination",
+}
+
 type Props = {
+  currentPage: number;
   filter?: string;
   grouping?: FetchGroupKey | null;
   hiddenColumns?: string[];
   hiddenGroups?: string[];
+  machineCount: number | null;
   machines: Machine[];
-  paginateLimit?: number;
+  pageSize: number;
   selectedIDs?: Machine[MachineMeta.PK][];
+  setCurrentPage: (currentPage: number) => void;
   setHiddenGroups?: (hiddenGroups: string[]) => void;
   setSearchFilter?: (filter: string) => void;
   showActions?: boolean;
@@ -517,13 +530,16 @@ const generateGroupRows = ({
 };
 
 export const MachineListTable = ({
+  currentPage,
   filter = "",
   grouping,
   hiddenColumns = [],
   hiddenGroups = [],
+  machineCount,
   machines,
-  paginateLimit = 50,
+  pageSize,
   selectedIDs = [],
+  setCurrentPage,
   setHiddenGroups,
   setSearchFilter,
   showActions = true,
@@ -867,7 +883,6 @@ export const MachineListTable = ({
           ) : null
         }
         headers={filterColumns(headers, hiddenColumns, showActions)}
-        paginate={paginateLimit}
         rows={
           // Pass undefined if there are no rows as the MainTable prop doesn't
           // allow null.
@@ -875,6 +890,16 @@ export const MachineListTable = ({
         }
         {...props}
       />
+      {machines.length > 0 && (
+        <Pagination
+          aria-label={Label.Pagination}
+          currentPage={currentPage}
+          itemsPerPage={pageSize}
+          paginate={setCurrentPage}
+          style={{ marginTop: "1rem" }}
+          totalItems={machineCount ?? 0}
+        />
+      )}
     </>
   );
 };

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -890,7 +890,7 @@ export const MachineListTable = ({
         }
         {...props}
       />
-      {machines.length > 0 && (
+      {(machineCount ?? 0) > 0 && (
         <Pagination
           aria-label={Label.Pagination}
           currentPage={currentPage}

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -505,6 +505,19 @@ describe("machine selectors", () => {
     expect(machine.list(state, "123456")).toStrictEqual(machines);
   });
 
+  it("can get the count for a list", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        lists: {
+          "123456": machineStateListFactory({
+            count: 5,
+          }),
+        },
+      }),
+    });
+    expect(machine.listCount(state, "123456")).toBe(5);
+  });
+
   it("can get an interface by id", () => {
     const nic = machineInterfaceFactory({
       type: NetworkInterfaceTypes.PHYSICAL,

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -376,6 +376,17 @@ const listErrors = createSelector(
 );
 
 /**
+ * Get the count for a machine list request with a given callId.
+ */
+const listCount = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => getList(machineState, callId)?.count || null
+);
+
+/**
  * Get machines in a list request.
  * @param state - The redux state.
  * @param callId - A list request id.
@@ -492,6 +503,7 @@ const selectors = {
   getStatusForMachine,
   linkingSubnet: statusSelectors["linkingSubnet"],
   list,
+  listCount,
   listErrors,
   locking: statusSelectors["locking"],
   markingBroken: statusSelectors["markingBroken"],

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -51,6 +51,8 @@ type UseFetchMachinesProps = {
   grouping?: FetchGroupKey | null;
   sortKey?: FetchGroupKey | null;
   sortDirection?: FetchSortDirection | null;
+  pageSize?: number;
+  currentPage?: number;
 };
 
 const generateWrapper =
@@ -210,7 +212,11 @@ describe("machine hook utils", () => {
 
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
-      ({ children }: { children?: ReactNode; filters?: FetchFilters | null }) =>
+      ({
+        children,
+      }: UseFetchMachinesProps & {
+        children?: ReactNode;
+      }) =>
         <Provider store={store}>{children}</Provider>;
 
     it("can fetch machines", () => {
@@ -283,10 +289,19 @@ describe("machine hook utils", () => {
         ({
           filters,
           grouping,
+          pageSize,
+          currentPage,
           sortKey,
           sortDirection,
         }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping, sortKey, sortDirection),
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
         {
           initialProps: { grouping: FetchGroupKey.Owner },
           wrapper: generateWrapper(store),
@@ -306,10 +321,19 @@ describe("machine hook utils", () => {
         ({
           filters,
           grouping,
+          pageSize,
+          currentPage,
           sortKey,
           sortDirection,
         }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping, sortKey, sortDirection),
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
         {
           initialProps: { sortKey: FetchGroupKey.Bmc },
           wrapper: generateWrapper(store),
@@ -323,22 +347,95 @@ describe("machine hook utils", () => {
       expect(getDispatches).toHaveLength(1);
     });
 
+    it("does not fetch again if the current page hasn't changed", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({
+          filters,
+          grouping,
+          pageSize,
+          currentPage,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
+        {
+          initialProps: { currentPage: 4 },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ currentPage: 4 });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
     it("does not fetch again if the sort direction hasn't changed", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
         ({
           filters,
           grouping,
+          pageSize,
+          currentPage,
           sortKey,
           sortDirection,
         }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping, sortKey, sortDirection),
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
         {
           initialProps: { sortDirection: FetchSortDirection.Ascending },
           wrapper: generateWrapper(store),
         }
       );
       rerender({ sortDirection: FetchSortDirection.Ascending });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
+    it("does not fetch again if the page size hasn't changed", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({
+          filters,
+          grouping,
+          pageSize,
+          currentPage,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
+        {
+          initialProps: { pageSize: 22 },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ pageSize: 22 });
       const expected = machineActions.fetch("mocked-nanoid-1");
       const getDispatches = store
         .getActions()
@@ -369,10 +466,19 @@ describe("machine hook utils", () => {
         ({
           filters,
           grouping,
+          pageSize,
+          currentPage,
           sortKey,
           sortDirection,
         }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping, sortKey, sortDirection),
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
         {
           initialProps: {
             filters: {
@@ -382,9 +488,13 @@ describe("machine hook utils", () => {
           wrapper: generateWrapper(store),
         }
       );
-      rerender({ filters: { hostname: "eastern-quoll" } });
       const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
+      let getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+      rerender({ filters: { hostname: "eastern-quoll" } });
+      getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
       expect(getDispatches).toHaveLength(2);
@@ -396,10 +506,19 @@ describe("machine hook utils", () => {
         ({
           filters,
           grouping,
+          pageSize,
+          currentPage,
           sortKey,
           sortDirection,
         }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping, sortKey, sortDirection),
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
         {
           initialProps: {
             grouping: FetchGroupKey.Owner,
@@ -407,9 +526,89 @@ describe("machine hook utils", () => {
           wrapper: generateWrapper(store),
         }
       );
-      rerender({ grouping: FetchGroupKey.Status });
       const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
+      let getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+      rerender({ grouping: FetchGroupKey.Status });
+      getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(2);
+    });
+
+    it("fetches again if the page size changes", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({
+          filters,
+          grouping,
+          pageSize,
+          currentPage,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
+        {
+          initialProps: {
+            pageSize: 22,
+          },
+          wrapper: generateWrapper(store),
+        }
+      );
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      let getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+      rerender({ pageSize: 44 });
+      getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(2);
+    });
+
+    it("fetches again if the current page changes", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({
+          filters,
+          grouping,
+          pageSize,
+          currentPage,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
+        {
+          initialProps: {
+            currentPage: 3,
+          },
+          wrapper: generateWrapper(store),
+        }
+      );
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      let getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+      rerender({ currentPage: 6 });
+      getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
       expect(getDispatches).toHaveLength(2);
@@ -421,10 +620,19 @@ describe("machine hook utils", () => {
         ({
           filters,
           grouping,
+          pageSize,
+          currentPage,
           sortKey,
           sortDirection,
         }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping, sortKey, sortDirection),
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
         {
           initialProps: {
             sortKey: FetchGroupKey.Bmc,
@@ -446,10 +654,19 @@ describe("machine hook utils", () => {
         ({
           filters,
           grouping,
+          pageSize,
+          currentPage,
           sortKey,
           sortDirection,
         }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping, sortKey, sortDirection),
+          useFetchMachines(
+            filters,
+            grouping,
+            pageSize,
+            currentPage,
+            sortKey,
+            sortDirection
+          ),
         {
           initialProps: {
             sortDirection: FetchSortDirection.Descending,

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -91,9 +91,12 @@ export const useFetchMachineCount = (
 export const useFetchMachines = (
   filters?: FetchFilters | null,
   grouping?: FetchGroupKey | null,
+  pageSize?: number,
+  currentPage?: number,
   sortKey?: FetchGroupKey | null,
   sortDirection?: FetchSortDirection | null
 ): {
+  machineCount: number | null;
   machines: Machine[];
   machinesErrors: APIError;
 } => {
@@ -103,9 +106,14 @@ export const useFetchMachines = (
   const previousGrouping = usePrevious(grouping, false);
   const previousSortDirection = usePrevious(sortDirection, false);
   const previousSortKey = usePrevious(sortKey, false);
+  const previousPage = usePrevious(currentPage, false);
+  const previousPageSize = usePrevious(pageSize, false);
   const dispatch = useDispatch();
   const machines = useSelector((state: RootState) =>
     machineSelectors.list(state, callId)
+  );
+  const machineCount = useSelector((state: RootState) =>
+    machineSelectors.listCount(state, callId)
   );
   const machinesErrors = useSelector((state: RootState) =>
     machineSelectors.listErrors(state, callId)
@@ -122,21 +130,27 @@ export const useFetchMachines = (
       !callId ||
       grouping !== previousGrouping ||
       sortKey !== previousSortKey ||
-      sortDirection !== previousSortDirection
+      sortDirection !== previousSortDirection ||
+      currentPage !== previousPage ||
+      pageSize !== previousPageSize
     ) {
       setCallId(nanoid());
     }
   }, [
     callId,
+    currentPage,
     dispatch,
     filters,
     grouping,
+    pageSize,
     previousFilters,
     previousGrouping,
+    previousPage,
+    previousPageSize,
     previousSortDirection,
     previousSortKey,
-    sortKey,
     sortDirection,
+    sortKey,
   ]);
 
   useEffect(() => {
@@ -144,10 +158,17 @@ export const useFetchMachines = (
       dispatch(
         machineActions.fetch(
           callId,
-          filters || grouping || sortKey || sortDirection
+          filters ||
+            grouping ||
+            sortKey ||
+            sortDirection ||
+            grouping ||
+            pageSize
             ? {
                 filter: filters ?? null,
                 group_key: grouping ?? null,
+                page_number: currentPage,
+                page_size: pageSize,
                 sort_direction: sortDirection ?? null,
                 sort_key: sortKey ?? null,
               }
@@ -157,15 +178,17 @@ export const useFetchMachines = (
     }
   }, [
     callId,
+    currentPage,
     dispatch,
     filters,
     grouping,
+    pageSize,
     previousCallId,
-    sortKey,
     sortDirection,
+    sortKey,
   ]);
 
-  return { machines, machinesErrors };
+  return { machineCount, machines, machinesErrors };
 };
 
 /**

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -8,7 +8,7 @@ import { useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
 import urls from "app/base/urls";
 import MachineListTable, {
-  DEFAULT_PAGE_SIZE,
+  DEFAULTS,
 } from "app/machines/views/MachineList/MachineListTable";
 import machineSelectors from "app/store/machine/selectors";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
@@ -56,7 +56,7 @@ const TagMachines = (): JSX.Element => {
       currentPage={1}
       machineCount={deployedMachines.length}
       machines={deployedMachines}
-      pageSize={DEFAULT_PAGE_SIZE}
+      pageSize={DEFAULTS.pageSize}
       setCurrentPage={() => null}
       setSortDirection={() => null}
       setSortKey={() => null}

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -7,7 +7,9 @@ import ModelNotFound from "app/base/components/ModelNotFound";
 import { useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
 import urls from "app/base/urls";
-import MachineListTable from "app/machines/views/MachineList/MachineListTable";
+import MachineListTable, {
+  DEFAULT_PAGE_SIZE,
+} from "app/machines/views/MachineList/MachineListTable";
 import machineSelectors from "app/store/machine/selectors";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
@@ -51,7 +53,11 @@ const TagMachines = (): JSX.Element => {
   return (
     <MachineListTable
       aria-label={Label.Machines}
+      currentPage={1}
+      machineCount={deployedMachines.length}
       machines={deployedMachines}
+      pageSize={DEFAULT_PAGE_SIZE}
+      setCurrentPage={() => null}
       setSortDirection={() => null}
       setSortKey={() => null}
       showActions={false}


### PR DESCRIPTION
## Done

- Add pagination to the machine list using the new API.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

To test this you either need more than one page of machines using [sampledata](https://github.com/canonical/maas-ui/blob/main/docs/HACKING.md#sample-data) or change [`const pageSize = DEFAULT_PAGE_SIZE;`](https://github.com/canonical/maas-ui/pull/4344/files#diff-2b86f4686bb74434cdb1fafb6f4ee8837c1cfa1afaf9d92934a85ee1a90072c8R56) in `MachineList.tsx` to something smaller than the number of machines you have.
- Go to the machine list.
- Scroll down and should see the pagination.
- Open the redux dev tools and go to `machine` -> `lists` and you should see a few requests.
- Clicking on the pagination buttons should navigate through the list and you should see one of the requests getting removed and replaced with a new one.

## Fixes

Fixes: canonical/app-tribe#1101.
Fixes: canonical/app-tribe#1121.