### PR TITLE
feat(machines): sort the machine list via the API

### DIFF
--- a/src/app/kvm/components/VmResources/VmResources.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.tsx
@@ -23,6 +23,8 @@ const VmResources = ({ loading = false, vms }: Props): JSX.Element => {
             toggleDisabled={vms.length === 0}
             toggleLabel={`Total VMs: ${vms.length}`}
           >
+            {/* TODO: update to use the new API: 
+            https://github.com/canonical/app-tribe/issues/1117 */}
             <MachineListTable
               hiddenColumns={[
                 "owner",
@@ -34,7 +36,11 @@ const VmResources = ({ loading = false, vms }: Props): JSX.Element => {
               ]}
               machines={vms}
               paginateLimit={5}
+              setSortDirection={() => null}
+              setSortKey={() => null}
               showActions={false}
+              sortDirection="none"
+              sortKey={null}
             />
           </ContextualMenu>
         )}

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,15 +1,19 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
+import type { ValueOf } from "@canonical/react-components";
 import cloneDeep from "clone-deep";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
+import { FetchSortDirection } from "../../../store/machine/types/actions";
+
 import ErrorsNotification from "./ErrorsNotification";
 import MachineListControls from "./MachineListControls";
-import MachineListTable from "./MachineListTable";
+import MachineListTable, { DEFAULTS } from "./MachineListTable";
 
 import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
+import { SortDirection } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { FetchFilters } from "app/store/machine/types";
@@ -36,6 +40,19 @@ const parseFilters = (filters: Filters): FetchFilters => {
   return fetchFilters;
 };
 
+const mapSortDirection = (
+  sortDirection: ValueOf<typeof SortDirection>
+): FetchSortDirection | null => {
+  switch (sortDirection) {
+    case SortDirection.ASCENDING:
+      return FetchSortDirection.Ascending;
+    case SortDirection.DESCENDING:
+      return FetchSortDirection.Descending;
+    default:
+      return null;
+  }
+};
+
 const MachineList = ({
   headerFormOpen,
   searchFilter,
@@ -45,6 +62,12 @@ const MachineList = ({
   const dispatch = useDispatch();
   const errors = useSelector(machineSelectors.errors);
   const selectedIDs = useSelector(machineSelectors.selectedIDs);
+  const [sortKey, setSortKey] = useState<FetchGroupKey | null>(
+    DEFAULTS.sortKey
+  );
+  const [sortDirection, setSortDirection] = useState<
+    ValueOf<typeof SortDirection>
+  >(DEFAULTS.sortDirection);
   const filters = FilterMachines.getCurrentFilters(searchFilter);
   const [grouping, setGrouping] = useStorageState<FetchGroupKey | null>(
     localStorage,
@@ -53,7 +76,9 @@ const MachineList = ({
   );
   const { machines, machinesErrors } = useFetchMachines(
     parseFilters(filters),
-    grouping
+    grouping,
+    sortKey,
+    mapSortDirection(sortDirection)
   );
   const [hiddenGroups, setHiddenGroups] = useStorageState<string[]>(
     localStorage,
@@ -98,6 +123,10 @@ const MachineList = ({
         selectedIDs={selectedIDs}
         setHiddenGroups={setHiddenGroups}
         setSearchFilter={setSearchFilter}
+        setSortDirection={setSortDirection}
+        setSortKey={setSortKey}
+        sortDirection={sortDirection}
+        sortKey={sortKey}
       />
     </>
   );

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -6,6 +6,7 @@ import configureStore from "redux-mock-store";
 
 import { MachineListTable } from "./MachineListTable";
 
+import { SortDirection } from "app/base/types";
 import type { Machine } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -230,6 +231,10 @@ describe("MachineListTable", () => {
               machines={machines}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
@@ -254,6 +259,10 @@ describe("MachineListTable", () => {
               machines={machines}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
@@ -283,6 +292,10 @@ describe("MachineListTable", () => {
               machines={machines}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
@@ -306,6 +319,8 @@ describe("MachineListTable", () => {
   });
 
   it("updates sort on header click", () => {
+    const setSortDirection = jest.fn();
+    const setSortKey = jest.fn();
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -319,39 +334,27 @@ describe("MachineListTable", () => {
               machines={machines}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
+              setSortDirection={setSortDirection}
+              setSortKey={setSortKey}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
-    // First machine has more cores than second machine
-    const [firstMachine, secondMachine] = [machines[0], machines[1]];
-
-    expect(
-      wrapper.find('[data-testid="cores-header"]').find("i").exists()
-    ).toBe(false);
-    expect(
-      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
-    ).toEqual(firstMachine.fqdn);
     // Click the cores table header
     wrapper
       .find('[data-testid="cores-header"]')
       .find("button")
       .simulate("click");
-    expect(
-      wrapper.find('[data-testid="cores-header"]').find("i").exists()
-    ).toBe(true);
-    expect(
-      wrapper
-        .find(".machine-list__machine")
-        .at(0)
-        .find("RowCheckbox")
-        .at(0)
-        .text()
-    ).toEqual(secondMachine.fqdn);
+    expect(setSortKey).toHaveBeenCalledWith(FetchGroupKey.CpuCount);
+    expect(setSortDirection).toHaveBeenCalledWith(SortDirection.DESCENDING);
   });
 
-  it("updates sort direction on multiple header clicks", () => {
+  it("clears the sort when the same header is clicked and is ascending", () => {
+    const setSortDirection = jest.fn();
+    const setSortKey = jest.fn();
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -365,51 +368,124 @@ describe("MachineListTable", () => {
               machines={machines}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
+              setSortDirection={setSortDirection}
+              setSortKey={setSortKey}
+              sortDirection={SortDirection.ASCENDING}
+              sortKey={FetchGroupKey.CpuCount}
             />
           </CompatRouter>
         </MemoryRouter>
       </Provider>
     );
-    const [firstMachine, secondMachine] = [machines[0], machines[1]];
-
-    // Click the status table header
+    // Click the cores table header
     wrapper
-      .find('[data-testid="status-header"]')
+      .find('[data-testid="cores-header"]')
       .find("button")
       .simulate("click");
-    expect(
-      wrapper.find('[data-testid="status-header"]').find("i").exists()
-    ).toBe(true);
-    expect(
-      wrapper.find('[data-testid="status-header"]').find("i").props().className
-    ).toBe("p-icon--chevron-down");
-    expect(
-      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
-    ).toEqual(firstMachine.fqdn);
+    expect(setSortKey).toHaveBeenCalledWith(null);
+    expect(setSortDirection).toHaveBeenCalledWith(SortDirection.NONE);
+  });
 
-    // Click the status table header again to reverse sort order
+  it("updates the sort when the same header is clicked and is descending", () => {
+    const setSortDirection = jest.fn();
+    const setSortKey = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              hiddenGroups={[]}
+              machines={machines}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+              setSortDirection={setSortDirection}
+              setSortKey={setSortKey}
+              sortDirection={SortDirection.DESCENDING}
+              sortKey={FetchGroupKey.CpuCount}
+            />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+    // Click the cores table header
     wrapper
-      .find('[data-testid="status-header"]')
+      .find('[data-testid="cores-header"]')
       .find("button")
       .simulate("click");
-    expect(
-      wrapper.find('[data-testid="status-header"]').find("i").props().className
-    ).toBe("p-icon--chevron-up");
-    expect(
-      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
-    ).toEqual(secondMachine.fqdn);
+    expect(setSortKey).not.toHaveBeenCalled();
+    expect(setSortDirection).toHaveBeenCalledWith(SortDirection.ASCENDING);
+  });
 
-    // Click the FQDN table header again to return to no sort
+  it("updates the sort when the same header is clicked and direction is not set", () => {
+    const setSortDirection = jest.fn();
+    const setSortKey = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              hiddenGroups={[]}
+              machines={machines}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+              setSortDirection={setSortDirection}
+              setSortKey={setSortKey}
+              sortDirection={SortDirection.NONE}
+              sortKey={FetchGroupKey.CpuCount}
+            />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+    // Click the cores table header
     wrapper
-      .find('[data-testid="status-header"]')
+      .find('[data-testid="cores-header"]')
       .find("button")
       .simulate("click");
-    expect(
-      wrapper.find('[data-testid="status-header"]').find("i").exists()
-    ).toBe(false);
-    expect(
-      wrapper.find(".machine-list__machine").at(0).find("RowCheckbox").text()
-    ).toEqual(firstMachine.fqdn);
+    expect(setSortKey).not.toHaveBeenCalled();
+    expect(setSortDirection).toHaveBeenCalledWith(SortDirection.ASCENDING);
+  });
+
+  it("updates the sort when a different header is clicked", () => {
+    const setSortDirection = jest.fn();
+    const setSortKey = jest.fn();
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+        >
+          <CompatRouter>
+            <MachineListTable
+              filter=""
+              hiddenGroups={[]}
+              machines={machines}
+              setHiddenGroups={jest.fn()}
+              setSearchFilter={jest.fn()}
+              setSortDirection={setSortDirection}
+              setSortKey={setSortKey}
+              sortDirection={SortDirection.NONE}
+              sortKey={FetchGroupKey.CpuCount}
+            />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+    // Click the cores table header
+    wrapper
+      .find('[data-testid="power-header"]')
+      .find("button")
+      .simulate("click");
+    expect(setSortKey).toHaveBeenCalledWith(FetchGroupKey.PowerState);
+    expect(setSortDirection).toHaveBeenCalledWith(SortDirection.DESCENDING);
   });
 
   it("displays correct selected string in group header", () => {
@@ -429,6 +505,10 @@ describe("MachineListTable", () => {
               selectedIDs={[machines[0].system_id]}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
@@ -459,6 +539,10 @@ describe("MachineListTable", () => {
                 selectedIDs={["abc123"]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -486,6 +570,10 @@ describe("MachineListTable", () => {
                 selectedIDs={["abc123", "ghi789"]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -519,6 +607,10 @@ describe("MachineListTable", () => {
                 selectedIDs={["abc123", "def456", "ghi789"]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -551,6 +643,10 @@ describe("MachineListTable", () => {
                 machines={machines}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -589,6 +685,10 @@ describe("MachineListTable", () => {
                 selectedIDs={["abc123"]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -627,6 +727,10 @@ describe("MachineListTable", () => {
                 selectedIDs={[]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -665,6 +769,10 @@ describe("MachineListTable", () => {
                 selectedIDs={["abc123", "def456", "ghi789"]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -703,6 +811,10 @@ describe("MachineListTable", () => {
                 selectedIDs={["abc123"]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -732,6 +844,10 @@ describe("MachineListTable", () => {
                 selectedIDs={[]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -770,6 +886,10 @@ describe("MachineListTable", () => {
                 selectedIDs={["abc123", "def456", "ghi789"]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -807,6 +927,10 @@ describe("MachineListTable", () => {
                 machines={[]}
                 setHiddenGroups={jest.fn()}
                 setSearchFilter={jest.fn()}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -841,6 +965,10 @@ describe("MachineListTable", () => {
               selectedIDs={["abc123"]}
               setHiddenGroups={jest.fn()}
               setSearchFilter={jest.fn()}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
@@ -871,6 +999,10 @@ describe("MachineListTable", () => {
               selectedIDs={["abc123"]}
               setHiddenGroups={jest.fn()}
               setSearchFilter={setSearchFilter}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
@@ -902,6 +1034,10 @@ describe("MachineListTable", () => {
               selectedIDs={["abc123"]}
               setHiddenGroups={jest.fn()}
               setSearchFilter={setSearchFilter}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
@@ -933,6 +1069,10 @@ describe("MachineListTable", () => {
               selectedIDs={["abc123", "def456", "ghi789"]}
               setHiddenGroups={jest.fn()}
               setSearchFilter={setSearchFilter}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              sortDirection="none"
+              sortKey={null}
             />
           </CompatRouter>
         </MemoryRouter>
@@ -955,7 +1095,14 @@ describe("MachineListTable", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <CompatRouter>
-            <MachineListTable machines={machines} showActions={false} />
+            <MachineListTable
+              machines={machines}
+              setSortDirection={jest.fn()}
+              setSortKey={jest.fn()}
+              showActions={false}
+              sortDirection="none"
+              sortKey={null}
+            />
           </CompatRouter>
         </MemoryRouter>
       </Provider>
@@ -983,6 +1130,10 @@ describe("MachineListTable", () => {
               <MachineListTable
                 hiddenColumns={["power", "zone"]}
                 machines={machines}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -1008,7 +1159,11 @@ describe("MachineListTable", () => {
               <MachineListTable
                 hiddenColumns={["fqdn"]}
                 machines={machines}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
                 showActions
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>
@@ -1030,7 +1185,11 @@ describe("MachineListTable", () => {
               <MachineListTable
                 hiddenColumns={["fqdn"]}
                 machines={machines}
+                setSortDirection={jest.fn()}
+                setSortKey={jest.fn()}
                 showActions={false}
+                sortDirection="none"
+                sortKey={null}
               />
             </CompatRouter>
           </MemoryRouter>

--- a/src/app/machines/views/MachineList/MachineListTable/index.ts
+++ b/src/app/machines/views/MachineList/MachineListTable/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./MachineListTable";
+export { default, DEFAULTS } from "./MachineListTable";

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -40,7 +40,7 @@ describe("machine actions", () => {
       group_collapsed: [],
       page_size: 20,
       page_number: 5,
-      sort_key: "owner",
+      sort_key: FetchGroupKey.Owner,
       sort_direction: FetchSortDirection.Ascending,
     };
     expect(actions.fetch("123456", params)).toEqual({

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -420,8 +420,8 @@ export type FetchParams = {
   group_collapsed?: string[];
   page_size?: number;
   page_number?: number;
-  sort_key?: string | null;
-  sort_direction?: FetchSortDirection;
+  sort_key?: FetchGroupKey | null;
+  sort_direction?: FetchSortDirection | null;
 };
 
 export type GetSummaryXmlParams = {

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -19,7 +19,7 @@ import {
 
 import { actions as machineActions } from "app/store/machine";
 import type { FetchFilters, Machine } from "app/store/machine/types";
-import { FetchGroupKey } from "app/store/machine/types";
+import { FetchGroupKey, FetchSortDirection } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import { NodeStatus, NodeStatusCode } from "app/store/types/node";
@@ -49,6 +49,8 @@ const mockStore = configureStore();
 type UseFetchMachinesProps = {
   filters?: FetchFilters | null;
   grouping?: FetchGroupKey | null;
+  sortKey?: FetchGroupKey | null;
+  sortDirection?: FetchSortDirection | null;
 };
 
 const generateWrapper =
@@ -278,14 +280,65 @@ describe("machine hook utils", () => {
     it("does not fetch again if the grouping hasn't changed", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({ filters, grouping }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping),
+        ({
+          filters,
+          grouping,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping, sortKey, sortDirection),
         {
           initialProps: { grouping: FetchGroupKey.Owner },
           wrapper: generateWrapper(store),
         }
       );
       rerender({ grouping: FetchGroupKey.Owner });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
+    it("does not fetch again if the sort key hasn't changed", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({
+          filters,
+          grouping,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping, sortKey, sortDirection),
+        {
+          initialProps: { sortKey: FetchGroupKey.Bmc },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ sortKey: FetchGroupKey.Bmc });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(1);
+    });
+
+    it("does not fetch again if the sort direction hasn't changed", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({
+          filters,
+          grouping,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping, sortKey, sortDirection),
+        {
+          initialProps: { sortDirection: FetchSortDirection.Ascending },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ sortDirection: FetchSortDirection.Ascending });
       const expected = machineActions.fetch("mocked-nanoid-1");
       const getDispatches = store
         .getActions()
@@ -313,8 +366,13 @@ describe("machine hook utils", () => {
     it("fetches again if the filters change", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({ filters, grouping }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping),
+        ({
+          filters,
+          grouping,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping, sortKey, sortDirection),
         {
           initialProps: {
             filters: {
@@ -335,8 +393,13 @@ describe("machine hook utils", () => {
     it("fetches again if the grouping changes", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({ filters, grouping }: UseFetchMachinesProps) =>
-          useFetchMachines(filters, grouping),
+        ({
+          filters,
+          grouping,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping, sortKey, sortDirection),
         {
           initialProps: {
             grouping: FetchGroupKey.Owner,
@@ -345,6 +408,56 @@ describe("machine hook utils", () => {
         }
       );
       rerender({ grouping: FetchGroupKey.Status });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(2);
+    });
+
+    it("fetches again if the sort key changes", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({
+          filters,
+          grouping,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping, sortKey, sortDirection),
+        {
+          initialProps: {
+            sortKey: FetchGroupKey.Bmc,
+          },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ sortKey: FetchGroupKey.AgentName });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      const getDispatches = store
+        .getActions()
+        .filter((action) => action.type === expected.type);
+      expect(getDispatches).toHaveLength(2);
+    });
+
+    it("fetches again if the sort direction changes", () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        ({
+          filters,
+          grouping,
+          sortKey,
+          sortDirection,
+        }: UseFetchMachinesProps) =>
+          useFetchMachines(filters, grouping, sortKey, sortDirection),
+        {
+          initialProps: {
+            sortDirection: FetchSortDirection.Descending,
+          },
+          wrapper: generateWrapper(store),
+        }
+      );
+      rerender({ sortDirection: FetchSortDirection.Ascending });
       const expected = machineActions.fetch("mocked-nanoid-1");
       const getDispatches = store
         .getActions()

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -46,11 +46,17 @@ const TagMachines = (): JSX.Element => {
     return <Spinner data-testid="Spinner" />;
   }
 
+  // Update to use the new API:
+  // https://github.com/canonical/app-tribe/issues/1120
   return (
     <MachineListTable
       aria-label={Label.Machines}
       machines={deployedMachines}
+      setSortDirection={() => null}
+      setSortKey={() => null}
       showActions={false}
+      sortDirection="none"
+      sortKey={null}
     />
   );
 };


### PR DESCRIPTION
## Done

- Update the machine list to send the sort params to the API call.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Click some of the table headers and the machines should be refetched.

## Fixes

Fixes: canonical/app-tribe#1262.