### PR TITLE
Migrate to RTL - app/pools

### DIFF
--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -1,8 +1,7 @@
 import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
-import { MemoryRouter, Router } from "react-router-dom";
+import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
@@ -16,7 +15,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, renderWithMockStore } from "testing/utils";
+import { renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -112,19 +112,9 @@ describe("PoolForm", () => {
       .getActions()
       .find((action) => action.type === "resourcepool/create");
 
-    expect(action).toEqual({
-      type: "resourcepool/create",
-      payload: {
-        params: {
-          name: "test name",
-          description: "test description",
-        },
-      },
-      meta: {
-        model: "resourcepool",
-        method: "create",
-      },
-    });
+    expect(action).toEqual(
+      actions.create({ name: "test name", description: "test description" })
+    );
   });
 
   it("can update a resource pool", async () => {

--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -16,7 +16,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { renderWithBrowserRouter, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -35,14 +35,10 @@ describe("PoolForm", () => {
   });
 
   it("can render", () => {
-    renderWithMockStore(
-      <MemoryRouter initialEntries={["/"]}>
-        <CompatRouter>
-          <PoolForm />
-        </CompatRouter>
-      </MemoryRouter>,
-      { state }
-    );
+    renderWithBrowserRouter(<PoolForm />, {
+      route: "/",
+      wrapperProps: { state },
+    });
 
     expect(screen.getByRole("form", { name: PoolFormLabels.AddPoolTitle }));
   });
@@ -67,18 +63,14 @@ describe("PoolForm", () => {
 
   it("redirects when the resource pool is saved", () => {
     state.resourcepool.saved = true;
-    const history = createMemoryHistory({
-      initialEntries: ["/"],
+    renderWithBrowserRouter(<PoolForm />, {
+      route: urls.pools.add,
+      wrapperProps: {
+        state,
+        routePattern: `${urls.pools.index}/*`,
+      },
     });
-    renderWithMockStore(
-      <Router history={history}>
-        <CompatRouter>
-          <PoolForm />
-        </CompatRouter>
-      </Router>,
-      { state }
-    );
-    expect(history.location.pathname).toBe(urls.pools.index);
+    expect(window.location.pathname).toBe(urls.pools.index);
   });
 
   it("can create a resource pool", async () => {

--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -1,11 +1,12 @@
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
+import { screen, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
-import { PoolForm } from "./PoolForm";
+import { PoolForm, Labels as PoolFormLabels } from "./PoolForm";
 
 import urls from "app/base/urls";
 import { actions } from "app/store/resourcepool";
@@ -15,7 +16,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { submitFormikForm } from "testing/utils";
+import { renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -34,25 +35,22 @@ describe("PoolForm", () => {
   });
 
   it("can render", () => {
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
-          <CompatRouter>
-            <PoolForm />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={["/"]}>
+        <CompatRouter>
+          <PoolForm />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
 
-    expect(wrapper.find("PoolForm").exists()).toBe(true);
+    expect(screen.getByRole("form", { name: PoolFormLabels.AddPoolTitle }));
   });
 
   it("cleans up when unmounting", async () => {
     const store = mockStore(state);
 
-    const wrapper = mount(
+    const { unmount } = render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
           <CompatRouter>
@@ -62,36 +60,31 @@ describe("PoolForm", () => {
       </Provider>
     );
 
-    act(() => {
-      wrapper.unmount();
-    });
+    unmount();
 
     expect(store.getActions()[0]).toEqual(actions.cleanup());
   });
 
   it("redirects when the resource pool is saved", () => {
     state.resourcepool.saved = true;
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/pool/add"]}>
-          <CompatRouter>
-            <PoolForm />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    const history = createMemoryHistory({
+      initialEntries: ["/"],
+    });
+    renderWithMockStore(
+      <Router history={history}>
+        <CompatRouter>
+          <PoolForm />
+        </CompatRouter>
+      </Router>,
+      { state }
     );
-    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
-      urls.pools.index
-    );
+    expect(history.location.pathname).toBe(urls.pools.index);
   });
 
-  it("can create a resource pool", () => {
+  it("can create a resource pool", async () => {
     const store = mockStore(state);
-    const pool = resourcePoolFactory();
 
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/pools/add"]}>
           <CompatRouter>
@@ -100,16 +93,45 @@ describe("PoolForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    submitFormikForm(wrapper, pool);
 
-    expect(store.getActions()[1]).toEqual(actions.create(pool));
+    await userEvent.type(
+      screen.getByRole("textbox", { name: PoolFormLabels.PoolName }),
+      "test name"
+    );
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: PoolFormLabels.PoolDescription }),
+      "test description"
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: PoolFormLabels.SubmitLabel })
+    );
+
+    const action = store
+      .getActions()
+      .find((action) => action.type === "resourcepool/create");
+
+    expect(action).toEqual({
+      type: "resourcepool/create",
+      payload: {
+        params: {
+          name: "test name",
+          description: "test description",
+        },
+      },
+      meta: {
+        model: "resourcepool",
+        method: "create",
+      },
+    });
   });
 
-  it("can update a resource pool", () => {
+  it("can update a resource pool", async () => {
     const store = mockStore(state);
     const pool = resourcePoolFactory({ id: 1 });
 
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/pools/", key: "testKey" }]}
@@ -120,10 +142,24 @@ describe("PoolForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    submitFormikForm(wrapper, {
-      name: "newName",
-      description: "newDescription",
+
+    const name_textbox = screen.getByRole("textbox", {
+      name: PoolFormLabels.PoolName,
     });
+    const description_textbox = screen.getByRole("textbox", {
+      name: PoolFormLabels.PoolDescription,
+    });
+
+    await userEvent.clear(name_textbox);
+    await userEvent.clear(description_textbox);
+
+    await userEvent.type(name_textbox, "newName");
+    await userEvent.type(description_textbox, "newDescription");
+
+    await userEvent.click(
+      screen.getByRole("button", { name: PoolFormLabels.SubmitLabel })
+    );
+
     const action = store
       .getActions()
       .find((action) => action.type === "resourcepool/update");
@@ -137,7 +173,7 @@ describe("PoolForm", () => {
     state.resourcepool.saved = true;
     const store = mockStore(state);
 
-    mount(
+    render(
       <Provider store={store}>
         <MemoryRouter initialEntries={["/"]}>
           <CompatRouter>

--- a/src/app/pools/components/PoolForm/PoolForm.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.tsx
@@ -22,6 +22,14 @@ type PoolFormValues = {
   name: ResourcePool["name"];
 };
 
+export enum Labels {
+  AddPoolTitle = "Add pool",
+  EditPoolTitle = "Edit pool",
+  SubmitLabel = "Save pool",
+  PoolName = "Name (required)",
+  PoolDescription = "Description",
+}
+
 const PoolSchema = Yup.object().shape({
   name: Yup.string().required("name is required"),
   description: Yup.string(),
@@ -45,13 +53,13 @@ export const PoolForm = ({ pool, ...props }: Props): JSX.Element => {
   let initialValues: PoolFormValues;
   let title: string;
   if (pool) {
-    title = "Edit pool";
+    title = Labels.EditPoolTitle;
     initialValues = {
       name: pool.name,
       description: pool.description,
     };
   } else {
-    title = "Add pool";
+    title = Labels.AddPoolTitle;
     initialValues = {
       name: "",
       description: "",
@@ -63,6 +71,7 @@ export const PoolForm = ({ pool, ...props }: Props): JSX.Element => {
   return (
     <FormCard sidebar={false} title={title}>
       <FormikForm
+        aria-label={title}
         cleanup={poolActions.cleanup}
         errors={errors}
         initialValues={initialValues}
@@ -89,12 +98,16 @@ export const PoolForm = ({ pool, ...props }: Props): JSX.Element => {
         saved={saved}
         savedRedirect={urls.pools.index}
         saving={saving}
-        submitLabel="Save pool"
+        submitLabel={Labels.SubmitLabel}
         validationSchema={PoolSchema}
         {...props}
       >
-        <FormikField label="Name (required)" name="name" type="text" />
-        <FormikField label="Description" name="description" type="text" />
+        <FormikField label={Labels.PoolName} name="name" type="text" />
+        <FormikField
+          label={Labels.PoolDescription}
+          name="description"
+          type="text"
+        />
       </FormikForm>
     </FormCard>
   );

--- a/src/app/pools/views/PoolAdd/PoolAdd.test.tsx
+++ b/src/app/pools/views/PoolAdd/PoolAdd.test.tsx
@@ -1,15 +1,12 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
+import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
 
-import { PoolAdd } from "./PoolAdd";
+import { PoolAdd, Label as PoolAddLabel } from "./PoolAdd";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithMockStore } from "testing/utils";
 
 describe("PoolAdd", () => {
   let state: RootState;
@@ -19,18 +16,16 @@ describe("PoolAdd", () => {
   });
 
   it("can render", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/pool/add", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <PoolAdd />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter
+        initialEntries={[{ pathname: "/pool/add", key: "testKey" }]}
+      >
+        <CompatRouter>
+          <PoolAdd />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
-    expect(wrapper.find("PoolAdd").exists()).toBe(true);
+    expect(screen.getByRole("form", { name: PoolAddLabel.Title }));
   });
 });

--- a/src/app/pools/views/PoolList/PoolList.test.tsx
+++ b/src/app/pools/views/PoolList/PoolList.test.tsx
@@ -1,4 +1,5 @@
-import { mount } from "enzyme";
+import { screen, render, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +13,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -29,56 +31,51 @@ describe("PoolList", () => {
 
   it("displays a loading component if pools are loading", () => {
     state.resourcepool.loading = true;
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
 
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("disables the edit button without permissions", () => {
     state.resourcepool.items = [resourcePoolFactory({ permissions: [] })];
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
 
-    expect(wrapper.find("Button").first().props().disabled).toBe(true);
+    expect(screen.getByRole("link", { name: "Edit" })).toHaveClass(
+      "is-disabled"
+    );
   });
 
   it("enables the edit button with correct permissions", () => {
     state.resourcepool.items = [resourcePoolFactory({ permissions: ["edit"] })];
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
 
-    expect(wrapper.find("Button").first().props().disabled).toBe(false);
+    expect(screen.getByRole("link", { name: "Edit" })).not.toHaveClass(
+      "is-disabled"
+    );
   });
 
-  it("can show a delete confirmation", () => {
+  it("can show a delete confirmation", async () => {
     state.resourcepool.items = [
       resourcePoolFactory({
         id: 0,
@@ -89,29 +86,31 @@ describe("PoolList", () => {
         permissions: ["delete"],
       }),
     ];
-    const store = mockStore(state);
-
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
 
-    expect(wrapper.find("TableRow").at(1).hasClass("is-active")).toBe(false);
+    const row = screen.getByRole("row", { name: "squambo" });
+
+    expect(row).not.toHaveClass("is-active");
+
     // Click on the delete button:
-    wrapper
-      .find("TableRow")
-      .at(1)
-      .find("Button[data-testid='table-actions-delete']")
-      .simulate("click");
-    expect(wrapper.find("TableRow").at(1).hasClass("is-active")).toBe(true);
+    await userEvent.click(within(row).getByRole("button", { name: "Delete" }));
+
+    expect(row).toHaveClass("is-active");
+    expect(
+      screen.getByText(
+        'Are you sure you want to delete resourcepool "squambo"?'
+      )
+    ).toBeInTheDocument();
   });
 
-  it("can delete a pool", () => {
+  it("can delete a pool", async () => {
     state.resourcepool.items = [
       resourcePoolFactory({
         id: 2,
@@ -124,7 +123,7 @@ describe("PoolList", () => {
     ];
     const store = mockStore(state);
 
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
           <CompatRouter>
@@ -133,18 +132,19 @@ describe("PoolList", () => {
         </MemoryRouter>
       </Provider>
     );
+    const row = screen.getByRole("row", { name: "squambo" });
+
     // Click on the delete button:
-    wrapper
-      .find("TableRow")
-      .at(1)
-      .find("Button[data-testid='table-actions-delete']")
-      .simulate("click");
+    await userEvent.click(within(row).getByRole("button", { name: "Delete" }));
+
     // Click on the delete confirm button
-    wrapper
-      .find("TableRow")
-      .at(1)
-      .find("ActionButton[data-testid='action-confirm']")
-      .simulate("click");
+    await userEvent.click(
+      within(
+        within(row).getByRole("gridcell", {
+          name: 'Are you sure you want to delete resourcepool "squambo"? This action is permanent and can not be undone. Cancel Delete',
+        })
+      ).getByRole("button", { name: "Delete" })
+    );
 
     expect(store.getActions()[2]).toEqual({
       type: "resourcepool/delete",
@@ -161,7 +161,6 @@ describe("PoolList", () => {
   });
 
   it("disables the delete button for default pools", () => {
-    const store = mockStore(state);
     state.resourcepool.items = [
       resourcePoolFactory({
         id: 0,
@@ -171,20 +170,18 @@ describe("PoolList", () => {
         permissions: ["edit", "delete"],
       }),
     ];
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
-    expect(wrapper.find("Button").at(1).props().disabled).toBe(true);
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
   });
 
   it("disables the delete button for pools that contain machines", () => {
-    const store = mockStore(state);
     state.resourcepool.items = [
       resourcePoolFactory({
         id: 0,
@@ -195,72 +192,60 @@ describe("PoolList", () => {
         machine_total_count: 1,
       }),
     ];
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
-    expect(wrapper.find("Button").at(1).props().disabled).toBe(true);
+    expect(screen.getByRole("button", { name: "Delete" })).toBeDisabled();
   });
 
   it("does not show a machine link for empty pools", () => {
     state.resourcepool.items[0].machine_total_count = 0;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
-    const name = wrapper.find("TableRow").at(1).find("TableCell").at(1);
-    expect(name.text()).toBe("Empty pool");
+    const row = screen.getByRole("row", { name: "default" });
+    expect(within(row).getByText("Empty pool")).toBeInTheDocument();
   });
 
   it("can show a machine link for non-empty pools", () => {
     state.resourcepool.items[0].machine_total_count = 5;
     state.resourcepool.items[0].machine_ready_count = 1;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
-    const link = wrapper
-      .find("TableRow")
-      .at(1)
-      .find("TableCell")
-      .at(1)
-      .find("Link");
-    expect(link.exists()).toBe(true);
-    expect(link.prop("to")).toBe("/machines?pool=%3Ddefault");
-    expect(link.text()).toBe("1 of 5 ready");
+    const link = within(screen.getByRole("row", { name: "default" })).getByRole(
+      "link",
+      { name: "1 of 5 ready" }
+    );
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/machines?pool=%3Ddefault");
   });
 
   it("displays state errors in a notification", () => {
     state.resourcepool.errors = "Pools are not for swimming.";
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
-          <CompatRouter>
-            <PoolList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/pools", key: "testKey" }]}>
+        <CompatRouter>
+          <PoolList />
+        </CompatRouter>
+      </MemoryRouter>,
+      { state }
     );
-    expect(wrapper.find("Notification p").text()).toEqual(
-      "Pools are not for swimming."
-    );
+    expect(screen.getByText("Pools are not for swimming.")).toBeInTheDocument();
   });
 });

--- a/src/app/pools/views/PoolList/PoolList.tsx
+++ b/src/app/pools/views/PoolList/PoolList.tsx
@@ -55,6 +55,7 @@ const generateRows = (
   rows.map((row) => {
     const expanded = expandedId === row.id;
     return {
+      "aria-label": row.name,
       className: expanded ? "p-table__row is-active" : null,
       columns: [
         {
@@ -91,6 +92,7 @@ const generateRows = (
       expanded: expanded,
       expandedContent: expanded && (
         <TableDeleteConfirm
+          aria-label="Confirm pool deletion"
           deleted={saved}
           deleting={saving}
           modelName={row.name}


### PR DESCRIPTION
## Done

Migrated the following tests to RTL:
- [src/app/pools/components/PoolForm/PoolForm.test.tsx](https://github.com/canonical/maas-ui/compare/main...ndv99:rtlMigration_pools?expand=1#diff-d6a591db18400d410511a4fff1a233e3ebf487df1f2b4cc0ba973e6519eaa737)
- [src/app/pools/views/PoolAdd/PoolAdd.test.tsx](https://github.com/canonical/maas-ui/compare/main...ndv99:rtlMigration_pools?expand=1#diff-c916501a4435731b1f1fa9668217502086439b0a9aa3d7b9ed20388a3c3ecf0a)
- [src/app/pools/views/PoolList/PoolList.test.tsx](https://github.com/canonical/maas-ui/compare/main...ndv99:rtlMigration_pools?expand=1#diff-31d15a73b940bc94d81dfb409ea6390f6b6a5831e2762dd93bd13441bf95bc91)

## Fixes

Fixes https://github.com/canonical/app-tribe/issues/1061 
