### PR TITLE
Fix vanishing radio button dot for theme selector

### DIFF
--- a/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/_index.scss
+++ b/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/_index.scss
@@ -67,6 +67,8 @@
             transform: scale(0);
             transition: 120ms transform ease-in-out;
             box-shadow: inset 0.52rem 0.52rem #fff;
+            // 0.52 is used since 0.5 causes the white dot to vanish at 80% and 100% zoom, and 0.51 also causes disappearances.
+            // The dot appears identical in any of these sizes
         }
 
         .general-form__radio:checked::before {

--- a/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/_index.scss
+++ b/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/_index.scss
@@ -49,8 +49,8 @@
 
         .general-form__radio {
             color: currentColor;
-            width: 24px;
-            height: 24px;
+            width: 1.5rem;
+            height: 1.5rem;
             border: 0;
             border-radius: 50%;
             display: grid;
@@ -61,12 +61,12 @@
 
         .general-form__radio::before {
             content: "";
-            width: 8px;
-            height: 8px;
+            width: 0.5rem;
+            height: 0.5rem;
             border-radius: 50%;
             transform: scale(0);
             transition: 120ms transform ease-in-out;
-            box-shadow: inset 8px 8px #fff;
+            box-shadow: inset 0.52rem 0.52rem #fff;
         }
 
         .general-form__radio:checked::before {


### PR DESCRIPTION
## Done

- Changed the size of the box shadow (radio button dot) to 0.52rem. _Note: the size appears identical in the browser, but this ensures that the dot shows at all zoom levels._

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

1. Log in and navigate to settings/configuration/general
2. Zoom in and out to all available levels
3. Ensure that the white dot remains visible on the selected theme

## Fixes

Fixes https://github.com/canonical/app-tribe/issues/1267

## Screenshots

### 100% Zoom
#### Before
![image](https://user-images.githubusercontent.com/35104482/184875212-378d22e3-5e33-4c96-a28a-30881938c700.png)
#### After
![image](https://user-images.githubusercontent.com/35104482/184875594-75211702-4ee9-4d1c-add7-03bef90715b1.png)

### 80% Zoom
#### Before 
![image](https://user-images.githubusercontent.com/35104482/184875468-76d82b35-ae1b-4850-a1cf-71797fe9eadd.png)
#### After
![image](https://user-images.githubusercontent.com/35104482/184875551-43d7ee40-c254-4fc7-9412-2b5c72cef29e.png)

