### PR TITLE
feat(machines): pass loading states to machine list

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -464,14 +464,7 @@ describe("MachineList", () => {
     state.machine.lists = {
       "123456": machineStateListFactory({
         count: 0,
-        groups: [
-          machineStateListGroupFactory({
-            collapsed: true,
-            count: 4,
-            items: [],
-            name: "admin",
-          }),
-        ],
+        groups: [],
       }),
     };
     const store = mockStore(state);

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -185,11 +185,10 @@ describe("MachineList", () => {
         },
       }),
       machine: machineStateFactory({
-        loaded: true,
         items: machines,
         lists: {
           "123456": machineStateListFactory({
-            loading: true,
+            loaded: true,
             groups: [
               machineStateListGroupFactory({
                 items: [machines[0].system_id, machines[2].system_id],
@@ -465,8 +464,14 @@ describe("MachineList", () => {
     state.machine.lists = {
       "123456": machineStateListFactory({
         count: 0,
-        loading: true,
-        groups: [],
+        groups: [
+          machineStateListGroupFactory({
+            collapsed: true,
+            count: 4,
+            items: [],
+            name: "admin",
+          }),
+        ],
       }),
     };
     const store = mockStore(state);

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -74,14 +74,15 @@ const MachineList = ({
     FetchGroupKey.Status
   );
   const pageSize = DEFAULTS.pageSize;
-  const { callId, machineCount, machines, machinesErrors } = useFetchMachines(
-    parseFilters(filters),
-    grouping,
-    pageSize,
-    currentPage,
-    sortKey,
-    mapSortDirection(sortDirection)
-  );
+  const { callId, loading, machineCount, machines, machinesErrors } =
+    useFetchMachines(
+      parseFilters(filters),
+      grouping,
+      pageSize,
+      currentPage,
+      sortKey,
+      mapSortDirection(sortDirection)
+    );
   const [hiddenGroups, setHiddenGroups] = useStorageState<(string | null)[]>(
     localStorage,
     "hiddenGroups",
@@ -125,6 +126,7 @@ const MachineList = ({
         hiddenGroups={hiddenGroups}
         machineCount={machineCount}
         machines={machines}
+        machinesLoading={loading}
         pageSize={pageSize}
         selectedIDs={selectedIDs}
         setCurrentPage={setCurrentPage}

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -29,7 +29,6 @@ describe("MachineListHeader", () => {
     jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
     state = rootStateFactory({
       machine: machineStateFactory({
-        loaded: true,
         counts: machineStateCountsFactory({
           "mocked-nanoid": machineStateCountFactory({
             count: 2,
@@ -54,7 +53,13 @@ describe("MachineListHeader", () => {
   });
 
   it("displays a loader if machines have not loaded", () => {
-    state.machine.loaded = false;
+    state.machine.counts = machineStateCountsFactory({
+      "mocked-nanoid": machineStateCountFactory({
+        count: 2,
+        loaded: false,
+        loading: true,
+      }),
+    });
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -19,10 +19,7 @@ import type {
 } from "app/machines/types";
 import { getHeaderTitle } from "app/machines/utils";
 import machineSelectors from "app/store/machine/selectors";
-import {
-  useFetchMachineCount,
-  useFetchMachines,
-} from "app/store/machine/utils/hooks";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 
@@ -38,15 +35,13 @@ export const MachineListHeader = ({
   setHeaderContent,
 }: Props): JSX.Element => {
   const location = useLocation();
-  const machinesLoaded = useSelector(machineSelectors.loaded);
   const selectedMachines = useSelector(machineSelectors.selected);
   const [tagsSeen, setTagsSeen] = useStorageState(
     localStorage,
     "machineViewTagsSeen",
     false
   );
-  const { machineCount } = useFetchMachineCount();
-  useFetchMachines();
+  const { machineCount, machineCountLoading } = useFetchMachineCount();
 
   useEffect(() => {
     if (location.pathname !== urls.machines.index) {
@@ -117,7 +112,7 @@ export const MachineListHeader = ({
           selected={selectedMachines.length}
         />
       }
-      subtitleLoading={!machinesLoaded}
+      subtitleLoading={machineCountLoading}
       title={getHeaderTitle("Machines", headerContent)}
     />
   );

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -187,7 +187,6 @@ describe("MachineListTable", () => {
         }),
       }),
       machine: machineStateFactory({
-        loaded: true,
         items: machines,
         lists: {
           "123456": machineStateListFactory({
@@ -238,7 +237,6 @@ describe("MachineListTable", () => {
   });
 
   it("displays a loading component if machines are loading", () => {
-    state.machine.loaded = false;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -254,6 +252,7 @@ describe("MachineListTable", () => {
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
+              machinesLoading
               pageSize={20}
               setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -71,6 +71,7 @@ type Props = {
   hiddenGroups?: (string | null)[];
   machineCount: number | null;
   machines: Machine[];
+  machinesLoading?: boolean | null;
   pageSize: number;
   selectedIDs?: Machine[MachineMeta.PK][];
   setCurrentPage: (currentPage: number) => void;
@@ -415,6 +416,7 @@ export const MachineListTable = ({
   hiddenGroups = [],
   machineCount,
   machines,
+  machinesLoading,
   pageSize,
   selectedIDs = [],
   setCurrentPage,
@@ -428,7 +430,6 @@ export const MachineListTable = ({
   ...props
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const machinesLoaded = useSelector(machineSelectors.loaded);
   const groups = useSelector((state: RootState) =>
     machineSelectors.listGroups(state, callId)
   );
@@ -744,7 +745,7 @@ export const MachineListTable = ({
           "machine-list--grouped": grouping,
         })}
         emptyStateMsg={
-          !machinesLoaded ? (
+          machinesLoading ? (
             <Spinner text="Loading..." />
           ) : filter ? (
             "No machines match the search criteria."

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -594,6 +594,32 @@ describe("machine selectors", () => {
     expect(machine.listGroup(state, "123456", "")).toStrictEqual(groups[1]);
   });
 
+  it("can get the loaded state for a list", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        lists: {
+          "123456": machineStateListFactory({
+            loaded: true,
+          }),
+        },
+      }),
+    });
+    expect(machine.listLoaded(state, "123456")).toBe(true);
+  });
+
+  it("can get the loading state for a list", () => {
+    const state = rootStateFactory({
+      machine: machineStateFactory({
+        lists: {
+          "123456": machineStateListFactory({
+            loading: true,
+          }),
+        },
+      }),
+    });
+    expect(machine.listLoading(state, "123456")).toBe(true);
+  });
+
   it("can get an interface by id", () => {
     const nic = machineInterfaceFactory({
       type: NetworkInterfaceTypes.PHYSICAL,

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -431,6 +431,28 @@ const listGroups = createSelector(
 );
 
 /**
+ * Get the loaded state for a machine list request with a given callId.
+ */
+const listLoaded = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => getList(machineState, callId)?.loaded ?? null
+);
+
+/**
+ * Get the loading stateo for a machine list request with a given callId.
+ */
+const listLoading = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => getList(machineState, callId)?.loading ?? null
+);
+
+/**
  * Get machines in a list request.
  * @param state - The redux state.
  * @param callId - A list request id.
@@ -551,6 +573,8 @@ const selectors = {
   listErrors,
   listGroup,
   listGroups,
+  listLoaded,
+  listLoading,
   locking: statusSelectors["locking"],
   markingBroken: statusSelectors["markingBroken"],
   markingFixed: statusSelectors["markingFixed"],

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -438,7 +438,7 @@ const listLoaded = createSelector(
     machineState,
     (_state: RootState, callId: string | null | undefined) => callId,
   ],
-  (machineState, callId) => getList(machineState, callId)?.loaded ?? null
+  (machineState, callId) => getList(machineState, callId)?.loaded ?? false
 );
 
 /**
@@ -449,7 +449,7 @@ const listLoading = createSelector(
     machineState,
     (_state: RootState, callId: string | null | undefined) => callId,
   ],
-  (machineState, callId) => getList(machineState, callId)?.loading ?? null
+  (machineState, callId) => getList(machineState, callId)?.loading ?? false
 );
 
 /**

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -253,6 +253,23 @@ describe("machine hook utils", () => {
       expect(result.current.machines).toStrictEqual(machines);
     });
 
+    it("returns the loaded and loading states", () => {
+      state.machine = machineStateFactory({
+        lists: {
+          "mocked-nanoid-1": machineStateListFactory({
+            loaded: false,
+            loading: true,
+          }),
+        },
+      });
+      const store = mockStore(state);
+      const { result } = renderHook(() => useFetchMachines(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current.loaded).toBe(false);
+      expect(result.current.loading).toBe(true);
+    });
+
     it("does not fetch again with no params", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(() => useFetchMachines(), {

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -97,8 +97,8 @@ export const useFetchMachines = (
   sortDirection?: FetchSortDirection | null
 ): {
   callId: string | null;
-  loaded: boolean | null;
-  loading: boolean | null;
+  loaded: boolean;
+  loading: boolean;
   machineCount: number | null;
   machines: Machine[];
   machinesErrors: APIError;

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -97,6 +97,8 @@ export const useFetchMachines = (
   sortDirection?: FetchSortDirection | null
 ): {
   callId: string | null;
+  loaded: boolean | null;
+  loading: boolean | null;
   machineCount: number | null;
   machines: Machine[];
   machinesErrors: APIError;
@@ -118,6 +120,12 @@ export const useFetchMachines = (
   );
   const machinesErrors = useSelector((state: RootState) =>
     machineSelectors.listErrors(state, callId)
+  );
+  const loaded = useSelector((state: RootState) =>
+    machineSelectors.listLoaded(state, callId)
+  );
+  const loading = useSelector((state: RootState) =>
+    machineSelectors.listLoading(state, callId)
   );
   useCleanup(callId);
 
@@ -189,7 +197,7 @@ export const useFetchMachines = (
     sortKey,
   ]);
 
-  return { callId, machineCount, machines, machinesErrors };
+  return { callId, loaded, loading, machineCount, machines, machinesErrors };
 };
 
 /**


### PR DESCRIPTION
## Done

- Pass the loading state from the list request to the machine list header and table.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- You should see a spinner in the header and table while the list and counts load.
- Do a search (e.g. `owner:admin`). You should see a spinner in the table (this will be replaced by the loading skeleton in https://github.com/canonical/app-tribe/issues/1100.).

## Fixes

Fixes: canonical/app-tribe#1280.