### PR TITLE
refactor(machines): pass an options object to useFetchMachines

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -18,7 +18,6 @@ import type { FetchFilters } from "app/store/machine/types";
 import { FetchSortDirection, FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
-import { actions as tagActions } from "app/store/tag";
 import type { Filters } from "app/utils/search/filter-handlers";
 
 type Props = {
@@ -75,22 +74,19 @@ const MachineList = ({
   );
   const pageSize = DEFAULTS.pageSize;
   const { callId, loading, machineCount, machines, machinesErrors } =
-    useFetchMachines(
-      parseFilters(filters),
+    useFetchMachines({
+      currentPage,
+      filters: parseFilters(filters),
       grouping,
       pageSize,
-      currentPage,
+      sortDirection: mapSortDirection(sortDirection),
       sortKey,
-      mapSortDirection(sortDirection)
-    );
+    });
   const [hiddenGroups, setHiddenGroups] = useStorageState<(string | null)[]>(
     localStorage,
     "hiddenGroups",
     []
   );
-  useEffect(() => {
-    dispatch(tagActions.fetch());
-  }, [dispatch]);
 
   useEffect(
     () => () => {

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -6,6 +6,7 @@ import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import type { MockStoreEnhanced } from "redux-mock-store";
 
+import type { UseFetchMachinesOptions } from "./hooks";
 import {
   useCanAddVLAN,
   useCanEditStorage,
@@ -19,7 +20,6 @@ import {
 
 import { actions as machineActions } from "app/store/machine";
 import type { FetchFilters, Machine } from "app/store/machine/types";
-import { FetchGroupKey, FetchSortDirection } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import { NodeStatus, NodeStatusCode } from "app/store/types/node";
@@ -45,15 +45,6 @@ import {
 } from "testing/factories";
 
 const mockStore = configureStore();
-
-type UseFetchMachinesProps = {
-  filters?: FetchFilters | null;
-  grouping?: FetchGroupKey | null;
-  sortKey?: FetchGroupKey | null;
-  sortDirection?: FetchSortDirection | null;
-  pageSize?: number;
-  currentPage?: number;
-};
 
 const generateWrapper =
   (store: MockStoreEnhanced<unknown>) =>
@@ -212,11 +203,7 @@ describe("machine hook utils", () => {
 
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
-      ({
-        children,
-      }: UseFetchMachinesProps & {
-        children?: ReactNode;
-      }) =>
+      ({ children }: { children?: ReactNode }) =>
         <Provider store={store}>{children}</Provider>;
 
     it("can fetch machines", () => {
@@ -283,10 +270,10 @@ describe("machine hook utils", () => {
       expect(getDispatches).toHaveLength(1);
     });
 
-    it("does not fetch again if the filters haven't changed", () => {
+    it("does not fetch again if the options haven't changed", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({ filters }: UseFetchMachinesProps) => useFetchMachines(filters),
+        (options: UseFetchMachinesOptions) => useFetchMachines(options),
         {
           initialProps: { filters: { hostname: "spotted-quoll" } },
           wrapper: generateWrapper(store),
@@ -300,31 +287,16 @@ describe("machine hook utils", () => {
       expect(getDispatches).toHaveLength(1);
     });
 
-    it("does not fetch again if the grouping hasn't changed", () => {
+    it("does not fetch again if the options haven't changed including empty objects", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
+        (options: UseFetchMachinesOptions | null) => useFetchMachines(options),
         {
-          initialProps: { grouping: FetchGroupKey.Owner },
+          initialProps: {},
           wrapper: generateWrapper(store),
         }
       );
-      rerender({ grouping: FetchGroupKey.Owner });
+      rerender(null);
       const expected = machineActions.fetch("mocked-nanoid-1");
       const getDispatches = store
         .getActions()
@@ -332,170 +304,10 @@ describe("machine hook utils", () => {
       expect(getDispatches).toHaveLength(1);
     });
 
-    it("does not fetch again if the sort key hasn't changed", () => {
+    it("fetches again if the options change", () => {
       const store = mockStore(state);
       const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: { sortKey: FetchGroupKey.Bmc },
-          wrapper: generateWrapper(store),
-        }
-      );
-      rerender({ sortKey: FetchGroupKey.Bmc });
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(1);
-    });
-
-    it("does not fetch again if the current page hasn't changed", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: { currentPage: 4 },
-          wrapper: generateWrapper(store),
-        }
-      );
-      rerender({ currentPage: 4 });
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(1);
-    });
-
-    it("does not fetch again if the sort direction hasn't changed", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: { sortDirection: FetchSortDirection.Ascending },
-          wrapper: generateWrapper(store),
-        }
-      );
-      rerender({ sortDirection: FetchSortDirection.Ascending });
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(1);
-    });
-
-    it("does not fetch again if the page size hasn't changed", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: { pageSize: 22 },
-          wrapper: generateWrapper(store),
-        }
-      );
-      rerender({ pageSize: 22 });
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(1);
-    });
-
-    it("does not fetch again if the filters haven't changed including empty objects", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({ filters }: UseFetchMachinesProps) => useFetchMachines(filters),
-        {
-          initialProps: { filters: null },
-          wrapper: generateWrapper(store),
-        }
-      );
-      rerender({ filters: {} });
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(1);
-    });
-
-    it("fetches again if the filters change", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
+        (options: UseFetchMachinesOptions) => useFetchMachines(options),
         {
           initialProps: {
             filters: {
@@ -512,188 +324,6 @@ describe("machine hook utils", () => {
       expect(getDispatches).toHaveLength(1);
       rerender({ filters: { hostname: "eastern-quoll" } });
       getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(2);
-    });
-
-    it("fetches again if the grouping changes", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: {
-            grouping: FetchGroupKey.Owner,
-          },
-          wrapper: generateWrapper(store),
-        }
-      );
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      let getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(1);
-      rerender({ grouping: FetchGroupKey.Status });
-      getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(2);
-    });
-
-    it("fetches again if the page size changes", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: {
-            pageSize: 22,
-          },
-          wrapper: generateWrapper(store),
-        }
-      );
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      let getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(1);
-      rerender({ pageSize: 44 });
-      getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(2);
-    });
-
-    it("fetches again if the current page changes", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: {
-            currentPage: 3,
-          },
-          wrapper: generateWrapper(store),
-        }
-      );
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      let getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(1);
-      rerender({ currentPage: 6 });
-      getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(2);
-    });
-
-    it("fetches again if the sort key changes", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: {
-            sortKey: FetchGroupKey.Bmc,
-          },
-          wrapper: generateWrapper(store),
-        }
-      );
-      rerender({ sortKey: FetchGroupKey.AgentName });
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
-        .getActions()
-        .filter((action) => action.type === expected.type);
-      expect(getDispatches).toHaveLength(2);
-    });
-
-    it("fetches again if the sort direction changes", () => {
-      const store = mockStore(state);
-      const { rerender } = renderHook(
-        ({
-          filters,
-          grouping,
-          pageSize,
-          currentPage,
-          sortKey,
-          sortDirection,
-        }: UseFetchMachinesProps) =>
-          useFetchMachines(
-            filters,
-            grouping,
-            pageSize,
-            currentPage,
-            sortKey,
-            sortDirection
-          ),
-        {
-          initialProps: {
-            sortDirection: FetchSortDirection.Descending,
-          },
-          wrapper: generateWrapper(store),
-        }
-      );
-      rerender({ sortDirection: FetchSortDirection.Ascending });
-      const expected = machineActions.fetch("mocked-nanoid-1");
-      const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
       expect(getDispatches).toHaveLength(2);


### PR DESCRIPTION
## Done

- Pass the options as an object to the useFectchMachines hook.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Change the sort order or do a search.
- The table should update with the new machines.

## Fixes

Fixes: canonical/app-tribe#1283.