### PR TITLE
feat(machines): parse search DSL and send to new API

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -97,7 +97,6 @@ module.exports = {
           },
         ],
         "react/jsx-sort-props": "error",
-        "react/no-multi-comp": ["error", { ignoreStateless: false }],
       },
       settings: {
         "import/resolver": {
@@ -115,6 +114,12 @@ module.exports = {
       files: ["src/**/*.js?(x)"],
       rules: {
         "no-unused-vars": 2,
+      },
+    },
+    {
+      files: ["src/**/*.tsx"],
+      rules: {
+        "react/no-multi-comp": ["error", { ignoreStateless: false }],
       },
     },
     {

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -28,8 +28,9 @@ import {
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState, {}>();
 
 jest.useFakeTimers();
 
@@ -374,6 +375,7 @@ describe("MachineList", () => {
       </Provider>
     );
     expect(wrapper.find("Notification").exists()).toBe(true);
+    // eslint-disable-next-line testing-library/no-node-access
     expect(wrapper.find("Notification").props().children).toBe("Uh oh!");
   });
 
@@ -393,6 +395,7 @@ describe("MachineList", () => {
       </Provider>
     );
     expect(wrapper.find("Notification").exists()).toBe(true);
+    // eslint-disable-next-line testing-library/no-node-access
     expect(wrapper.find("Notification").props().children).toBe(
       "tag: No such constraint."
     );
@@ -415,6 +418,7 @@ describe("MachineList", () => {
       </Provider>
     );
     expect(wrapper.find("Notification").exists()).toBe(true);
+    // eslint-disable-next-line testing-library/no-node-access
     expect(wrapper.find("Notification").props().children).toBe(
       "Uh oh! It broke"
     );
@@ -435,6 +439,7 @@ describe("MachineList", () => {
       </Provider>
     );
     expect(wrapper.find("Notification").exists()).toBe(true);
+    // eslint-disable-next-line testing-library/no-node-access
     expect(wrapper.find("Notification").props().children).toBe(
       "machine: Uh oh! network: It broke"
     );
@@ -514,6 +519,30 @@ describe("MachineList", () => {
       type: "machine/setSelected",
       payload: [],
     });
+  });
+
+  it("can search", () => {
+    const store = mockStore(state);
+    renderWithBrowserRouter(
+      <MachineList
+        searchFilter="free text workload-service:prod"
+        setSearchFilter={jest.fn()}
+      />,
+      { wrapperProps: { store } }
+    );
+    const filter = {
+      free_text: ["free text"],
+      workloads: ["service:prod"],
+    };
+    const expected = machineActions.fetch("123456", {
+      filter,
+    });
+    const fetches = store
+      .getActions()
+      .filter((action) => action.type === expected.type);
+    expect(fetches[fetches.length - 1].payload.params.filter).toStrictEqual(
+      filter
+    );
   });
 
   it("can change pages", () => {

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
-import cloneDeep from "clone-deep";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
@@ -14,11 +13,9 @@ import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter, SortDirection } from "app/base/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-import type { FetchFilters } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
-import { FilterMachines, mapSortDirection } from "app/store/machine/utils";
+import { mapSortDirection, FilterMachineItems } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
-import type { Filters } from "app/utils/search/filter-handlers";
 
 type Props = {
   headerFormOpen?: boolean;
@@ -27,17 +24,6 @@ type Props = {
 };
 
 const PAGE_SIZE = DEFAULTS.pageSize;
-
-// TODO: this should construct the full set of filters once the API has been
-// updated: https://github.com/canonical/app-tribe/issues/1125
-export const parseFilters = (filters: Filters): FetchFilters => {
-  const fetchFilters = cloneDeep(filters);
-  // Remove the in:selected filter as this is done client side.
-  delete fetchFilters.in;
-  // The API doesn't currently support free search.
-  delete fetchFilters.q;
-  return fetchFilters;
-};
 
 const MachineList = ({
   headerFormOpen,
@@ -55,7 +41,6 @@ const MachineList = ({
   const [sortDirection, setSortDirection] = useState<
     ValueOf<typeof SortDirection>
   >(DEFAULTS.sortDirection);
-  const filters = FilterMachines.getCurrentFilters(searchFilter);
   const [grouping, setGrouping] = useStorageState<FetchGroupKey | null>(
     localStorage,
     "grouping",
@@ -64,7 +49,7 @@ const MachineList = ({
   const { callId, loading, machineCount, machines, machinesErrors } =
     useFetchMachines({
       currentPage,
-      filters: parseFilters(filters),
+      filters: FilterMachineItems.parseFetchFilters(searchFilter),
       grouping,
       pageSize: PAGE_SIZE,
       sortDirection: mapSortDirection(sortDirection),

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -11,8 +11,6 @@ import classNames from "classnames";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
-import { parseFilters } from "../MachineList";
-
 import AllCheckbox from "./AllCheckbox";
 import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
@@ -41,7 +39,7 @@ import type {
   MachineMeta,
   MachineStateListGroup,
 } from "app/store/machine/types";
-import { FilterMachines } from "app/store/machine/utils";
+import { FilterMachineItems } from "app/store/machine/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
@@ -603,7 +601,7 @@ export const MachineListTable = ({
             <AllCheckbox
               callId={callId}
               data-testid="all-machines-checkbox"
-              filter={parseFilters(FilterMachines.getCurrentFilters(filter))}
+              filter={FilterMachineItems.parseFetchFilters(filter)}
             />
           )}
           <div>

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -253,58 +253,59 @@ export enum FetchSortDirection {
 
 type ArrayOrValue<T> = { [P in keyof T]: T[P] | Array<T[P]> };
 
-type Filters = ArrayOrValue<{
-  [FilterGroupKey.FreeText]: string;
-  [FilterGroupKey.SystemId]: Machine["system_id"];
-  [FilterGroupKey.Hostname]: Machine["hostname"];
+type Filters = {
+  [FilterGroupKey.AgentName]: string;
+  [FilterGroupKey.Arch]: Machine["architecture"];
+  [FilterGroupKey.CpuCount]: Machine["cpu_count"];
+  [FilterGroupKey.CpuSpeed]: Machine["cpu_speed"];
   [FilterGroupKey.Description]: Machine["description"];
   [FilterGroupKey.DistroSeries]: Machine["distro_series"];
-  [FilterGroupKey.Osystem]: Machine["osystem"];
-  [FilterGroupKey.ErrorDescription]: Machine["error_description"];
-  [FilterGroupKey.MacAddress]: NetworkInterface["mac_address"];
   [FilterGroupKey.Domain]: Domain["name"];
-  [FilterGroupKey.AgentName]: string;
+  [FilterGroupKey.ErrorDescription]: Machine["error_description"];
   [FilterGroupKey.FabricClasses]: Fabric["class_type"];
   [FilterGroupKey.Fabrics]: Machine["fabrics"];
-  [FilterGroupKey.Zone]: Machine["zone"]["name"];
-  [FilterGroupKey.Pool]: ResourcePool["name"];
-  [FilterGroupKey.Arch]: Machine["architecture"];
-  [FilterGroupKey.Tags]: Tag["name"];
-  [FilterGroupKey.Vlans]: NodeVlan["name"];
+  [FilterGroupKey.FreeText]: string;
+  [FilterGroupKey.Hostname]: Machine["hostname"];
+  [FilterGroupKey.IpAddresses]: NodeIpAddress["ip"];
+  [FilterGroupKey.LinkSpeed]: Machine["link_speeds"][0];
+  [FilterGroupKey.MacAddress]: NetworkInterface["mac_address"];
+  [FilterGroupKey.Mem]: Machine["memory"];
+  [FilterGroupKey.Osystem]: Machine["osystem"];
+  [FilterGroupKey.Owner]: Machine["owner"];
   [FilterGroupKey.Pod]: ModelRef["name"];
   [FilterGroupKey.PodType]: Pod["type"];
-  [FilterGroupKey.Owner]: Machine["owner"];
-  [FilterGroupKey.Subnets]: Subnet["name"];
-  [FilterGroupKey.IpAddresses]: NodeIpAddress["ip"];
+  [FilterGroupKey.Pool]: ResourcePool["name"];
   [FilterGroupKey.Spaces]: Space["name"];
-  [FilterGroupKey.Workloads]: string;
   [FilterGroupKey.Status]: FetchNodeStatus;
-}> & {
-  [FilterGroupKey.Mem]: string;
-  [FilterGroupKey.CpuCount]: string;
-  [FilterGroupKey.CpuSpeed]: string;
-  [FilterGroupKey.LinkSpeed]: string;
+  [FilterGroupKey.Subnets]: Subnet["name"];
+  [FilterGroupKey.SystemId]: Machine["system_id"];
+  [FilterGroupKey.Tags]: Tag["name"];
+  [FilterGroupKey.Vlans]: NodeVlan["name"];
+  [FilterGroupKey.Workloads]: string;
+  [FilterGroupKey.Zone]: Machine["zone"]["name"];
 };
 
-type ExcludeFilters = ArrayOrValue<{
+type ExcludeFilters = {
+  [FilterGroupKey.NotArch]: Filters["arch"];
+  [FilterGroupKey.NotDistroSeries]: Filters["distro_series"];
   [FilterGroupKey.NotFabricClasses]: Filters["fabric_classes"];
   [FilterGroupKey.NotFabrics]: Filters["fabrics"];
-  [FilterGroupKey.NotInZone]: Filters["zone"];
   [FilterGroupKey.NotInPool]: Filters["pool"];
-  [FilterGroupKey.NotArch]: Filters["arch"];
-  [FilterGroupKey.NotTags]: Filters["tags"];
-  [FilterGroupKey.NotSystemId]: Filters["system_id"];
+  [FilterGroupKey.NotInZone]: Filters["zone"];
+  [FilterGroupKey.NotIpAddresses]: Filters["ip_addresses"];
+  [FilterGroupKey.NotOsystem]: Filters["osystem"];
+  [FilterGroupKey.NotOwner]: Filters["owner"];
   [FilterGroupKey.NotPod]: Filters["pod"];
   [FilterGroupKey.NotPodType]: Filters["pod_type"];
-  [FilterGroupKey.NotOwner]: Filters["owner"];
   [FilterGroupKey.NotSubnets]: Filters["subnets"];
+  [FilterGroupKey.NotSystemId]: Filters["system_id"];
+  [FilterGroupKey.NotTags]: Filters["tags"];
   [FilterGroupKey.NotVlans]: Filters["vlans"];
-  [FilterGroupKey.NotIpAddresses]: Filters["ip_addresses"];
-  [FilterGroupKey.NotDistroSeries]: Filters["distro_series"];
-  [FilterGroupKey.NotOsystem]: Filters["osystem"];
-}>;
+};
 
-export type FetchFilters = Partial<Filters & ExcludeFilters>;
+export type FetchFilters = Partial<
+  ArrayOrValue<Filters> & ArrayOrValue<ExcludeFilters>
+>;
 
 export enum FetchGroupKey {
   AddressTtl = "address_ttl",

--- a/src/app/store/machine/utils/index.ts
+++ b/src/app/store/machine/utils/index.ts
@@ -20,6 +20,7 @@ export {
   FilterMachines,
   getMachineValue,
   WORKLOAD_FILTER_PREFIX,
+  FilterMachineItems,
 } from "./search";
 
 export { isTransientStatus } from "./status";

--- a/src/app/store/machine/utils/search.ts
+++ b/src/app/store/machine/utils/search.ts
@@ -134,7 +134,7 @@ const searchAPIMappings: SearchAPIMappings = {
   ram: mapNumber("mem"),
   release: (releases) => {
     // Map release strings in the format osystem/distro_series (e.g.
-    // "ubuntu/jammy") to the 'osystem' and ædistro_series' filters.
+    // "ubuntu/jammy") to the 'osystem' and distro_series' filters.
     const newFilters: {
       distro_series: string[];
       osystem: string[];

--- a/src/app/store/machine/utils/search.ts
+++ b/src/app/store/machine/utils/search.ts
@@ -1,9 +1,9 @@
 import { MachineMeta } from "app/store/machine/types";
-import type { Machine } from "app/store/machine/types";
+import type { Machine, FetchFilters } from "app/store/machine/types";
 import type { Tag } from "app/store/tag/types";
 import { getTagNamesForIds } from "app/store/tag/utils";
 import type { FilterValue } from "app/utils/search/filter-handlers";
-import {
+import FilterHandlers, {
   isFilterValue,
   isFilterValueArray,
 } from "app/utils/search/filter-handlers";
@@ -88,6 +88,9 @@ export const getMachineValue = (
   return value;
 };
 
+// TODO: remove this once the machine lists have all been migrated to the
+// new search API and methods:
+// https://github.com/canonical/app-tribe/issues/1279
 export const FilterMachines = new FilterItems<
   Machine,
   MachineMeta.PK,
@@ -95,3 +98,170 @@ export const FilterMachines = new FilterItems<
 >(MachineMeta.PK, getMachineValue, [
   { filter: "workload_annotations", prefix: "workload" },
 ]);
+
+type APIFilters = Record<string, (number | string)[]>;
+
+type SearchMappingFunc = (filter: FilterValue[]) => APIFilters | null;
+
+type SearchAPIMappings = {
+  [x: string]: string | SearchMappingFunc;
+};
+
+/**
+ * Generates a function to map a list of numbers to the highest value. This is
+ * required as they are matched by 'greater than or equal to' and don't support
+ * an array of values.
+ * @param The API filter key that the value should be mapped to.
+ * @returns A function to map to the min value.
+ */
+const mapNumber = (newKey: string) => (filter: FilterValue[]) => {
+  return filter
+    ? {
+        [newKey]: filter.map((filterValue) =>
+          typeof filterValue === "number"
+            ? filterValue
+            : parseInt(filterValue, 10)
+        ),
+      }
+    : null;
+};
+
+// A mapping of search DSL names and values to API keys.
+const searchAPIMappings: SearchAPIMappings = {
+  cores: mapNumber("cpu_count"),
+  cpu: mapNumber("cpu_count"),
+  mac: "mac_address",
+  ram: mapNumber("mem"),
+  release: (releases) => {
+    // Map release strings in the format osystem/distro_series (e.g.
+    // "ubuntu/jammy") to the 'osystem' and ædistro_series' filters.
+    const newFilters: {
+      distro_series: string[];
+      osystem: string[];
+    } = {
+      distro_series: [],
+      osystem: [],
+    };
+    releases.forEach((release) => {
+      const [osystem, distro_series] = release.toString().split("/");
+      newFilters.distro_series.push(distro_series);
+      newFilters.osystem.push(osystem);
+    });
+    return newFilters;
+  },
+  q: (query) => (query.length > 0 ? { free_text: [query.join(" ")] } : null),
+  vlan: "vlans",
+};
+
+class FilterMachineHandlers extends FilterHandlers {
+  prefixedFilters = [{ filter: "workloads", prefix: "workload" }];
+
+  /**
+   * Parse the search DSL into filters to be sent to the API.
+   * @param search A search DSL string.
+   */
+  parseFetchFilters = (search: string): FetchFilters => {
+    // Parse the DSL into an object of values.
+    const filters = this.getCurrentFilters(search);
+    // Map the filters from the DSL names/filters to the API filters.
+    const mappedValues = Object.entries(filters).reduce<APIFilters>(
+      (fetchFilters, [filterName, filterValues]) => {
+        // Get the mapping if there is one.
+        const mapping =
+          filterName in searchAPIMappings
+            ? searchAPIMappings[filterName]
+            : null;
+        if (!mapping) {
+          // Check if this is a filter that uses a prefix.
+          const prefixedFilter = this.prefixedFilters.find(({ prefix }) =>
+            filterName.startsWith(`${prefix}-`)
+          );
+          if (prefixedFilter) {
+            // Prefixed filters are passed as key value string pairs e.g. {"workloads": "role:prod"}.
+            fetchFilters = this._mergeFilters(
+              {
+                [prefixedFilter.filter]: [
+                  // Remove the prefix from the start of the key.
+                  `${filterName.replace(
+                    `${prefixedFilter.prefix}-`,
+                    ""
+                  )}:${filterValues}`,
+                ],
+              },
+              fetchFilters
+            );
+          } else {
+            fetchFilters = this._mergeFilters(
+              { [filterName]: filterValues },
+              fetchFilters
+            );
+          }
+        } else if (typeof mapping === "string") {
+          // String mappings only require a name change.
+          fetchFilters = this._mergeFilters(
+            { [mapping]: filterValues },
+            fetchFilters
+          );
+        } else {
+          // Use a mapping function to get the new names and values.
+          const newFilters = mapping(filterValues);
+          if (newFilters) {
+            // The mapping function returns an object containing new key names
+            // and values, so this needs to be merged into the object of filters.
+            fetchFilters = this._mergeFilters(newFilters, fetchFilters);
+          }
+        }
+        return fetchFilters;
+      },
+      {}
+    );
+    // Map the filters from '!' to 'not_[key-name]'.
+    return Object.entries(mappedValues).reduce<APIFilters>(
+      (fetchFilters, [filterName, filterValues]) => {
+        const includeValues = filterValues.filter(
+          (filterValue) =>
+            !(typeof filterValue === "string" && filterValue.startsWith("!"))
+        );
+        const excludeValues = filterValues.filter(
+          (filterValue) =>
+            typeof filterValue === "string" && filterValue.startsWith("!")
+        );
+        if (includeValues.length) {
+          fetchFilters[filterName] = includeValues;
+        }
+        if (excludeValues.length) {
+          fetchFilters[`not_${filterName}`] = excludeValues.map((filter) =>
+            // Remove the starting '!'.
+            typeof filter === "string" ? filter.substring(1) : filter
+          );
+        }
+        return fetchFilters;
+      },
+      {}
+    );
+  };
+
+  /**
+   * Merge a new filter into the existing list of filters. This is required
+   * because multiple DSL filter names can be mapped to the same API key name.
+   * @param newFilters The filters to be merged.
+   * @param parsedFilters The existing object of parsed filters.
+   */
+  _mergeFilters = (
+    newFilters: APIFilters,
+    parsedFilters: APIFilters
+  ): APIFilters => {
+    Object.entries(newFilters).forEach(([newFilterName, newFilterValue]) => {
+      if (newFilterName in parsedFilters) {
+        const existingFilters = parsedFilters[newFilterName];
+        // Combine the new and old filters.
+        parsedFilters[newFilterName] = existingFilters.concat(newFilterValue);
+      } else {
+        parsedFilters[newFilterName] = newFilterValue;
+      }
+    }, {});
+    return parsedFilters;
+  };
+}
+
+export const FilterMachineItems = new FilterMachineHandlers();


### PR DESCRIPTION
## Done

- Parse the search DSL string and send the filters to the API call.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Type in some text that will match some param of a machine e.g. part of a hostname, a user's name etc. and the table should update with the results.
- Type in a search for a specific param e.g. status: new, tags:..., hostname:... etc. and the table should update.
- Add a workload annotation (if using the demo service I've added an annotation so you can skip to the last step):
  - go to the network tab and find the websocket URL.
  - Open the console and run the following with the websocket URL: `const websocket = new WebSocket("<MAAS_WEBSOCKET_URL>");`
  - Find the system id of a machine.
  - Now run the following with the system id:
```
websocket.send(
  JSON.stringify({
    method: "machine.set_workload_annotations",
    params: {
      workload_annotations: {
        type: "production",
      },
      system_id: "<SYSTEM_ID_OF_MACHINE>",
    },
    request_id: 999,
    type: 0,
  })
);
```
  - Now go to the machine list and type `workload-type:prod` and you should see the machine.


## Fixes

Fixes: canonical/app-tribe#1263.