### PR TITLE
fix(UI): node overview

### DIFF
--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -44,26 +44,6 @@ beforeEach(() => {
   });
 });
 
-it("renders the domain", () => {
-  const machine = machineDetailsFactory({ domain: { id: 1, name: "maas" } });
-  state.machine.items = [machine];
-
-  const store = mockStore(state);
-  const wrapper = mount(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-      >
-        <CompatRouter>
-          <DetailsCard node={machine} />
-        </CompatRouter>
-      </MemoryRouter>
-    </Provider>
-  );
-
-  expect(wrapper.find("[data-testid='domain']").text()).toEqual("maas");
-});
-
 it("renders a link to zone configuration with edit permissions", () => {
   const machine = machineDetailsFactory({
     permissions: ["edit"],

--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -59,7 +59,7 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
       })}
     >
       {isMachine && (
-        <div>
+        <div className="overview-card__details-item">
           <div className="u-text--muted">Owner</div>
           <span data-testid="owner" title={node.owner || "-"}>
             {node.owner || "-"}
@@ -67,7 +67,7 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
         </div>
       )}
       {isMachine && (
-        <div>
+        <div className="overview-card__details-item">
           <div className="u-text--muted">Host</div>
           <span data-testid="host">
             {node.pod ? (
@@ -86,7 +86,7 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
           </span>
         </div>
       )}
-      <div data-testid="zone">
+      <div className="overview-card__details-item" data-testid="zone">
         <div>
           {canEdit ? (
             <Link
@@ -108,7 +108,10 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
         <span title={node.zone.name}>{node.zone.name}</span>
       </div>
       {isMachine && (
-        <div data-testid="resource-pool">
+        <div
+          className="overview-card__details-item"
+          data-testid="resource-pool"
+        >
           <div>
             {canEdit ? (
               <Link
@@ -130,7 +133,7 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
           <span title={node.pool.name}>{node.pool.name}</span>
         </div>
       )}
-      <div>
+      <div className="overview-card__details-item">
         <div>
           {canEdit ? (
             <Link

--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -59,7 +59,7 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
       })}
     >
       {isMachine && (
-        <div className="overview-card__details-item">
+        <div>
           <div className="u-text--muted">Owner</div>
           <span data-testid="owner" title={node.owner || "-"}>
             {node.owner || "-"}
@@ -67,11 +67,12 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
         </div>
       )}
       {isMachine && (
-        <div className="overview-card__details-item">
+        <div>
           <div className="u-text--muted">Host</div>
           <span data-testid="host">
             {node.pod ? (
               <Link
+                className="p-link__chevron"
                 to={
                   node.power_type === PowerTypeNames.LXD
                     ? urls.kvm.lxd.single.index({ id: node.pod.id })
@@ -86,10 +87,11 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
           </span>
         </div>
       )}
-      <div className="overview-card__details-item" data-testid="zone">
+      <div data-testid="zone">
         <div>
           {canEdit ? (
             <Link
+              className="p-link__chevron"
               onClick={() =>
                 sendAnalytics(
                   `${node.node_type_display} details`,
@@ -108,13 +110,11 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
         <span title={node.zone.name}>{node.zone.name}</span>
       </div>
       {isMachine && (
-        <div
-          className="overview-card__details-item"
-          data-testid="resource-pool"
-        >
+        <div data-testid="resource-pool">
           <div>
             {canEdit ? (
               <Link
+                className="p-link__chevron"
                 onClick={() =>
                   sendAnalytics(
                     `${node.node_type_display} details`,
@@ -133,10 +133,11 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
           <span title={node.pool.name}>{node.pool.name}</span>
         </div>
       )}
-      <div className="overview-card__details-item">
+      <div>
         <div>
           {canEdit ? (
             <Link
+              className="p-link__chevron"
               onClick={() =>
                 sendAnalytics(
                   `${node.node_type_display} details`,
@@ -160,6 +161,7 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
         <div>
           {canEdit ? (
             <Link
+              className="p-link__chevron"
               onClick={() =>
                 sendAnalytics(
                   `${node.node_type_display} details`,

--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -67,25 +67,25 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
         </div>
       )}
       {isMachine && (
-        <div>
-          <div className="u-text--muted">Host</div>
-          <span data-testid="host">
-            {node.pod ? (
-              <Link
-                className="p-link__chevron"
-                to={
-                  node.power_type === PowerTypeNames.LXD
-                    ? urls.kvm.lxd.single.index({ id: node.pod.id })
-                    : urls.kvm.virsh.details.index({ id: node.pod.id })
-                }
-              >
-                {node.pod.name} ›
-              </Link>
-            ) : (
-              <em>None</em>
-            )}
-          </span>
-        </div>
+        <>
+          {node.pod && (
+            <div>
+              <div className="u-text--muted">Host</div>
+              <span data-testid="host">
+                <Link
+                  className="p-link__chevron"
+                  to={
+                    node.power_type === PowerTypeNames.LXD
+                      ? urls.kvm.lxd.single.index({ id: node.pod.id })
+                      : urls.kvm.virsh.details.index({ id: node.pod.id })
+                  }
+                >
+                  {node.pod.name} ›
+                </Link>
+              </span>
+            </div>
+          )}
+        </>
       )}
       <div data-testid="zone">
         <div>

--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -66,12 +66,6 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
           </span>
         </div>
       )}
-      <div>
-        <div className="u-text--muted">Domain</div>
-        <span data-testid="domain" title={node.domain?.name}>
-          {node.domain?.name}
-        </span>
-      </div>
       {isMachine && (
         <div>
           <div className="u-text--muted">Host</div>

--- a/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.tsx
+++ b/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.tsx
@@ -131,14 +131,17 @@ const MachineStatusCard = ({ machine }: Props): JSX.Element => {
       </div>
       {showFailedTestsWarning(machine) ? (
         <div
-          className="overview-card__test-warning u-flex-bottom"
+          className="overview-card__test-warning u-flex--vertically"
           data-testid="failed-test-warning"
         >
-          <i className="p-icon--warning">Warning:</i>
-          <span className="u-nudge-right--x-small">
-            {" "}
-            Some tests failed, use with caution.
-          </span>
+          <ul className="overview-card__test-warning-text p-inline-list u-no-margin--bottom">
+            <li className="p-inline-list__item">
+              <span>
+                <i className="p-icon--warning">Warning:</i> Some tests failed,
+                use with caution.
+              </span>
+            </li>
+          </ul>
         </div>
       ) : null}
     </>

--- a/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.tsx
+++ b/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.tsx
@@ -134,7 +134,7 @@ const MachineStatusCard = ({ machine }: Props): JSX.Element => {
           className="overview-card__test-warning u-flex--vertically"
           data-testid="failed-test-warning"
         >
-          <ul className="overview-card__test-warning-text p-inline-list u-no-margin--bottom">
+          <ul className="overview-card__test-text p-inline-list u-no-margin--bottom">
             <li className="p-inline-list__item">
               <span>
                 <i className="p-icon--warning">Warning:</i> Some tests failed,

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -72,14 +72,14 @@
       }
 
       &.for-controller {
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(
             0,
             4fr
           );
       }
 
       &.for-machine {
-        grid-template-columns: repeat(7, minmax(0, 1fr));
+        grid-template-columns: minmax(0, 8rem) minmax(0, 8rem) minmax(0, 8rem) minmax(0, 8rem) minmax(0, 8rem) minmax(0, 3fr);
         padding-left: 0;
       }
 

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -174,10 +174,10 @@
           &:last-child {
             grid-column-end: 4;
             grid-column-start: 1;
-            overflow: initial;
+            overflow: ellipsis;
             padding-right: 0;
-            text-overflow: initial;
-            white-space: initial;
+            text-overflow: ellipsis;
+            white-space: nowrap;
           }
         }
       }
@@ -243,6 +243,9 @@
 
         > *:last-child {
           grid-column-end: 3;
+          overflow: ellipsis;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
       }
     }

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -39,12 +39,26 @@
     .overview-card__test-warning {
       grid-area: test-warning;
       padding: $spv--large 0 $spv--large $sph--large;
-      
-      .overview-card__test-warning-text {
-        margin-bottom: 0.1rem;
-        padding-top: calc(0.4rem - 1px);
-      }
+    }
 
+    .overview-card__test-text {
+      margin-bottom: 0.1rem;
+      padding-top: calc(0.4rem - 1px);
+    }
+
+    .overview-card__storage-test-text {
+      margin-bottom: 0.1rem;
+      padding-top: calc(0.4rem - 1px);
+    }
+
+    .overview-card__memory-test-text {
+      margin-bottom: 0.1rem;
+      padding-top: calc(0.4rem - 1px);
+    }
+
+    .overview-card__cpu-test-text {
+      margin-bottom: 0.1rem;
+      padding-top: calc(0.4rem - 1px);
     }
 
     .overview-card__cpu-tests {

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -39,6 +39,12 @@
     .overview-card__test-warning {
       grid-area: test-warning;
       padding: $spv--large 0 $spv--large $sph--large;
+      
+      .overview-card__test-warning-text {
+        margin-bottom: 0.1rem;
+        padding-top: calc(0.4rem - 1px);
+      }
+
     }
 
     .overview-card__cpu-tests {

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -72,7 +72,7 @@
       gap: $sph--large;
       grid-area: details;
       padding: $spv--large 0;
-      margin: 0 1rem 0 1rem ;
+      margin: 0 $spv--large 0 $spv--large ;
 
       > * {
 
@@ -137,13 +137,13 @@
         &::before {
           right: -#{map-get($grid-gutter-widths, default)};
         }
-        margin-left: 1rem;
+        margin-left: $sph--large;
         padding-left: 0;
       }
 
       .overview-card__storage {
         @include pseudo-border(top);
-        margin-right: 1rem;
+        margin-right: $sph--large;
         padding-right: 0;
       }
 
@@ -197,19 +197,19 @@
       }
 
       .overview-card__cpu {
-        padding: 1rem 0 0 0;
-        margin-left: 1rem;
-        margin-right: 1rem;
+        padding: $spv--large 0 0 0;
+        margin-left: $sph--large;
+        margin-right: $sph--large;
       }
 
       .overview-card__memory {
-        padding: 1rem 0 0 0;
-        margin-right: 1rem;
+        padding: $spv--large 0 0 0;
+        margin-right: $sph--large;
       }
 
       .overview-card__storage {
-        padding: 1rem 0 0 0;
-        margin-left: 1rem;
+        padding: $spv--large 0 0 0;
+        margin-left: $sph--large;
       }
 
       .overview-card__test-warning,

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -61,36 +61,22 @@
 
     .overview-card__details {
       @include pseudo-border(top);
-      display: grid;
+      display: flex;
+      flex: 1 0 auto;
+      justify-content: space-between;
+      gap: $sph--large;
       grid-area: details;
-      grid-template-rows: auto;
-      padding: $spv--large $sph--large;
+      padding: $spv--large 0;
       margin: 0 1rem 0 1rem ;
 
-      .overview-card__details-item {
-        padding-right: 1rem;
-      }
-
-      &.for-controller {
-        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(
-            0,
-            4fr
-          );
-      }
-
-      &.for-machine {
-        grid-template-columns: minmax(0, 8rem) minmax(0, 8rem) minmax(0, 8rem) minmax(0, 8rem) minmax(0, 8rem) minmax(0, 3fr);
-        padding-left: 0;
-      }
-
       > * {
-        padding-right: $sph--large;
 
         &:last-child {
           overflow: hidden;
           padding-right: 0;
           text-overflow: ellipsis;
           white-space: nowrap;
+          max-width: 50rem;
         }
       }
     }

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -13,7 +13,9 @@
     }
 
     .overview-card__cpu {
-      @include pseudo-border(left);
+      @media only screen and (min-width: ($breakpoint-small + 1)){
+        @include pseudo-border(left);
+      };
       grid-area: cpu;
       padding: $spv--large 0 0 0;
     }
@@ -63,7 +65,7 @@
       grid-area: details;
       grid-template-rows: auto;
       padding: $spv--large $sph--large;
-      margin: 0 16px 0 16px ;
+      margin: 0 1rem 0 1rem ;
 
       &.for-controller {
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(
@@ -115,7 +117,9 @@
       }
 
       .overview-card__cpu {
-        @include pseudo-border(left);
+        @media only screen and (min-width: ($breakpoint-small + 1)){
+          @include pseudo-border(left);
+        };
         padding: $spv--large $sph--large 0 0;
       }
 
@@ -134,13 +138,13 @@
         &::before {
           right: -#{map-get($grid-gutter-widths, default)};
         }
-        margin-left: 16px;
+        margin-left: 1rem;
         padding-left: 0;
       }
 
       .overview-card__storage {
         @include pseudo-border(top);
-        margin-right: 16px;
+        margin-right: 1rem;
         padding-right: 0;
       }
 
@@ -193,14 +197,20 @@
         }
       }
 
+      .overview-card__cpu {
+        padding: 1rem 0 0 0;
+        margin-left: 1rem;
+        margin-right: 1rem;
+      }
+
       .overview-card__memory {
-        padding: 16px 0 0 0;
-        margin-right: 16px;
+        padding: 1rem 0 0 0;
+        margin-right: 1rem;
       }
 
       .overview-card__storage {
-        padding: 16px 0 0 0;
-        margin-left: 16px;
+        padding: 1rem 0 0 0;
+        margin-left: 1rem;
       }
 
       .overview-card__test-warning,

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -16,27 +16,22 @@
       @include pseudo-border(left);
       grid-area: cpu;
       padding: $spv--large 0 0 0;
-      &::after {
-        top: $spv--large;
-      }
     }
 
     .overview-card__memory {
-      @include pseudo-border(left);
+      @media only screen and (min-width: ($breakpoint-large + 1)){
+        @include pseudo-border(left);
+      };
       grid-area: memory;
       padding: $spv--large 0 0 0;
-      &::after {
-        top: $spv--large;
-      }
     }
 
     .overview-card__storage {
-      @include pseudo-border(left);
+      @media only screen and (min-width: ($breakpoint-small + 1)){
+        @include pseudo-border(left);
+      };
       grid-area: storage;
       padding: $spv--large $sph--large 0 0;
-      &::after {
-        top: $spv--large;
-      }
     }
 
     .overview-card__test-warning {
@@ -48,27 +43,18 @@
       @include pseudo-border(left);
       grid-area: cpu-tests;
       padding: $spv--large 0;
-      &::after {
-        bottom: $spv--large;
-      }
     }
 
     .overview-card__memory-tests {
       @include pseudo-border(left);
       grid-area: memory-tests;
       padding: $spv--large 0;
-      &::after {
-        bottom: $spv--large;
-      }
     }
 
     .overview-card__storage-tests {
       @include pseudo-border(left);
       grid-area: storage-tests;
       padding: $spv--large $sph--large $spv--large 0;
-      &::after {
-        bottom: $spv--large;
-      }
     }
 
     .overview-card__details {
@@ -77,6 +63,7 @@
       grid-area: details;
       grid-template-rows: auto;
       padding: $spv--large $sph--large;
+      margin: 0 16px 0 16px ;
 
       &.for-controller {
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(
@@ -87,6 +74,7 @@
 
       &.for-machine {
         grid-template-columns: repeat(7, minmax(0, 1fr));
+        padding-left: 0;
       }
 
       > * {
@@ -126,22 +114,19 @@
         }
       }
 
-      .overview-card__cpu,
-      .overview-card__storage {
+      .overview-card__cpu {
         @include pseudo-border(left);
         padding: $spv--large $sph--large 0 0;
-        &::after {
-          top: $spv--large;
-        }
+      }
+
+      .overview-card__storage {
+        padding: $spv--large $sph--large 0 0;
       }
 
       .overview-card__cpu-tests,
       .overview-card__storage-tests {
         @include pseudo-border(left);
         padding: $spv--large $sph--large $spv--large 0;
-        &::after {
-          bottom: $spv--large;
-        }
       }
 
       .overview-card__memory {
@@ -149,10 +134,14 @@
         &::before {
           right: -#{map-get($grid-gutter-widths, default)};
         }
+        margin-left: 16px;
+        padding-left: 0;
       }
 
       .overview-card__storage {
         @include pseudo-border(top);
+        margin-right: 16px;
+        padding-right: 0;
       }
 
       .overview-card__details {
@@ -202,6 +191,16 @@
           left: 0;
           right: 0;
         }
+      }
+
+      .overview-card__memory {
+        padding: 16px 0 0 0;
+        margin-right: 16px;
+      }
+
+      .overview-card__storage {
+        padding: 16px 0 0 0;
+        margin-left: 16px;
       }
 
       .overview-card__test-warning,

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -46,21 +46,6 @@
       padding-top: calc(0.4rem - 1px);
     }
 
-    .overview-card__storage-test-text {
-      margin-bottom: 0.1rem;
-      padding-top: calc(0.4rem - 1px);
-    }
-
-    .overview-card__memory-test-text {
-      margin-bottom: 0.1rem;
-      padding-top: calc(0.4rem - 1px);
-    }
-
-    .overview-card__cpu-test-text {
-      margin-bottom: 0.1rem;
-      padding-top: calc(0.4rem - 1px);
-    }
-
     .overview-card__cpu-tests {
       @include pseudo-border(left);
       grid-area: cpu-tests;

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -79,6 +79,10 @@
           max-width: 50rem;
         }
       }
+
+      .p-link__chevron {
+        white-space: nowrap;
+      }
     }
 
     @media only screen and (max-width: $breakpoint-large) {

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -67,6 +67,10 @@
       padding: $spv--large $sph--large;
       margin: 0 1rem 0 1rem ;
 
+      .overview-card__details-item {
+        padding-right: 1rem;
+      }
+
       &.for-controller {
         grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr) minmax(
             0,

--- a/src/app/base/components/node/TestResults/TestResults.tsx
+++ b/src/app/base/components/node/TestResults/TestResults.tsx
@@ -55,7 +55,7 @@ const TestResults = ({
   return (
     <div className={`overview-card__${scriptType}-tests u-flex--vertically`}>
       <ul
-        className={`overview-card__${scriptType}-test-text p-inline-list u-no-margin--bottom`}
+        className={`overview-card__test-text p-inline-list u-no-margin--bottom`}
         data-testid="tests"
       >
         {testStatus.passed ? (

--- a/src/app/base/components/node/TestResults/TestResults.tsx
+++ b/src/app/base/components/node/TestResults/TestResults.tsx
@@ -54,7 +54,10 @@ const TestResults = ({
 
   return (
     <div className={`overview-card__${scriptType}-tests u-flex--vertically`}>
-      <ul className="p-inline-list u-no-margin--bottom" data-testid="tests">
+      <ul
+        className={`overview-card__${scriptType}-test-text p-inline-list u-no-margin--bottom`}
+        data-testid="tests"
+      >
         {testStatus.passed ? (
           <li className="p-inline-list__item">
             <Link
@@ -142,7 +145,7 @@ const TestResults = ({
             >
               <Button
                 appearance="link"
-                className="u-no-margin--bottom"
+                className="u-no-margin--bottom u-no-padding--top"
                 disabled={!machine.actions.includes(NodeActions.TEST)}
                 onClick={() => {
                   setHeaderContent({


### PR DESCRIPTION
## Note

The commits in this PR are being merged by #4377. 

## Done

- Extend vertical grid dividers to top of summary card
- Add padding on either side of horizontal divider on summary card
- Details items (Owner, Host, Zone etc) have a max gap of 1rem
- If there is extra space, tags are allowed to stop truncating first
- Align test failed text to other links in top half of overview
- Redistribute space after tags finish truncating
- Hide "Host" on physical machines that don't have a VM host

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to Machines and click a machine
- Stretch the window horizontally and ensure that the tags are allowed to truncate
- Squeeze the window horizontally and ensure none of the details (labels or info) are wrapping before the layout changes

## Fixes

Fixes https://github.com/canonical/app-tribe/issues/1281

## Screenshots

### Before
![Screenshot from 2022-08-25 09-42-56](https://user-images.githubusercontent.com/35104482/186618653-ecbba007-44e1-4098-ad9a-f542bf1cbdd8.png)

### After
![image](https://user-images.githubusercontent.com/35104482/186905139-dd2d0bb0-7b2d-4778-b94b-769e216e7c5e.png)


