### PR TITLE
feat(machines): add skeleton while machines are loading

### DIFF
--- a/src/app/base/components/Placeholder/Placeholder.tsx
+++ b/src/app/base/components/Placeholder/Placeholder.tsx
@@ -17,6 +17,7 @@ const Placeholder = ({
   if (loading) {
     return (
       <span
+        aria-hidden={true}
         className={classNames("p-placeholder", className)}
         data-testid="placeholder"
         style={{ animationDelay: `${delay}ms` }}

--- a/src/app/base/components/Placeholder/__snapshots__/Placeholder.test.tsx.snap
+++ b/src/app/base/components/Placeholder/__snapshots__/Placeholder.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Placeholder renders 1`] = `
 <span
+  aria-hidden={true}
   className="p-placeholder"
   data-testid="placeholder"
   style={

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import MachineListPagination, { Label } from "./MachineListPagination";
+
+it("displays pagination if there are machines", () => {
+  render(
+    <MachineListPagination
+      currentPage={1}
+      itemsPerPage={20}
+      machineCount={100}
+      machinesLoading={false}
+      paginate={jest.fn()}
+    />
+  );
+  expect(
+    screen.getByRole("navigation", { name: Label.Pagination })
+  ).toBeInTheDocument();
+});
+
+it("does not display pagination if there are no machines", () => {
+  render(
+    <MachineListPagination
+      currentPage={1}
+      itemsPerPage={20}
+      machineCount={0}
+      machinesLoading={false}
+      paginate={jest.fn()}
+    />
+  );
+  expect(
+    screen.queryByRole("navigation", { name: Label.Pagination })
+  ).not.toBeInTheDocument();
+});
+
+it("displays pagination while refetching machines", () => {
+  // Set up shared props to make it clear what's changing on rerenders.
+  const props = {
+    currentPage: 1,
+    itemsPerPage: 20,
+    machineCount: 100,
+    machinesLoading: false,
+    paginate: jest.fn(),
+  };
+  const { rerender } = render(<MachineListPagination {...props} />);
+  expect(
+    screen.getByRole("navigation", { name: Label.Pagination })
+  ).toBeInTheDocument();
+  rerender(<MachineListPagination {...props} machinesLoading={true} />);
+  expect(
+    screen.getByRole("navigation", { name: Label.Pagination })
+  ).toBeInTheDocument();
+});
+
+it("hides pagination if there are no refetched machines", () => {
+  // Set up shared props to make it clear what's changing on rerenders.
+  const props = {
+    currentPage: 1,
+    itemsPerPage: 20,
+    machineCount: 100,
+    machinesLoading: false,
+    paginate: jest.fn(),
+  };
+  const { rerender } = render(<MachineListPagination {...props} />);
+  expect(
+    screen.getByRole("navigation", { name: Label.Pagination })
+  ).toBeInTheDocument();
+  rerender(<MachineListPagination {...props} machinesLoading={true} />);
+  expect(
+    screen.getByRole("navigation", { name: Label.Pagination })
+  ).toBeInTheDocument();
+  rerender(
+    <MachineListPagination
+      {...props}
+      machineCount={0}
+      machinesLoading={false}
+    />
+  );
+  expect(
+    screen.queryByRole("navigation", { name: Label.Pagination })
+  ).not.toBeInTheDocument();
+});

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
 import MachineListPagination, { Label } from "./MachineListPagination";
 

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from "react";
+
+import type {
+  PaginationProps,
+  PropsWithSpread,
+} from "@canonical/react-components";
+import { Pagination } from "@canonical/react-components";
+
+export enum Label {
+  Pagination = "Table pagination",
+}
+
+type Props = PropsWithSpread<
+  {
+    currentPage: PaginationProps["currentPage"];
+    itemsPerPage: PaginationProps["itemsPerPage"];
+    machineCount: number | null;
+    machinesLoading?: boolean | null;
+    paginate: PaginationProps["paginate"];
+  },
+  Partial<PaginationProps>
+>;
+
+const MachineListPagination = ({
+  machineCount,
+  machinesLoading,
+  ...props
+}: Props): JSX.Element | null => {
+  const [previousCount, setPreviousCount] = useState(machineCount);
+  const count = (machinesLoading ? previousCount : machineCount) ?? 0;
+
+  useEffect(() => {
+    // The pagination needs to be displayed while the new list is being fetched
+    // so this stores the previous machine count while the request is in progress.
+    if (
+      (machineCount || machineCount === 0) &&
+      previousCount !== machineCount
+    ) {
+      setPreviousCount(machineCount);
+    }
+  }, [machineCount, previousCount]);
+
+  return count > 0 ? (
+    <Pagination
+      aria-label={Label.Pagination}
+      className="u-nudge-down"
+      totalItems={count}
+      {...props}
+    />
+  ) : null;
+};
+
+export default MachineListPagination;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/index.ts
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineListPagination";

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -6,7 +6,7 @@ import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
-import { MachineListTable } from "./MachineListTable";
+import { MachineListTable, Label } from "./MachineListTable";
 
 import { SortDirection } from "app/base/types";
 import { MachineColumns, columnLabels } from "app/machines/constants";
@@ -265,6 +265,11 @@ describe("MachineListTable", () => {
         })[0]
       ).getByText("xxxxxxxxx.xxxx")
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("grid", {
+        name: Label.Loading,
+      })
+    ).toHaveClass("machine-list--loading");
   });
 
   it("includes groups", () => {

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -1,15 +1,15 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen } from "@testing-library/react";
+import { screen, within } from "@testing-library/react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
-import { MachineListTable, Label } from "./MachineListTable";
+import { MachineListTable } from "./MachineListTable";
 
 import { SortDirection } from "app/base/types";
-import urls from "app/base/urls";
+import { MachineColumns, columnLabels } from "app/machines/constants";
 import type { Machine } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -35,7 +35,7 @@ import {
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -236,38 +236,35 @@ describe("MachineListTable", () => {
     localStorage.clear();
   });
 
-  it("displays a loading component if machines are loading", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <MachineListTable
-              callId="123456"
-              currentPage={1}
-              filter=""
-              grouping={FetchGroupKey.Status}
-              hiddenGroups={[]}
-              machineCount={10}
-              machines={machines}
-              machinesLoading
-              pageSize={20}
-              setCurrentPage={jest.fn()}
-              setHiddenGroups={jest.fn()}
-              setSearchFilter={jest.fn()}
-              setSortDirection={jest.fn()}
-              setSortKey={jest.fn()}
-              sortDirection="none"
-              sortKey={null}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+  it("displays skeleton rows when loading", () => {
+    renderWithMockStore(
+      <MachineListTable
+        callId="123456"
+        currentPage={1}
+        filter=""
+        grouping={FetchGroupKey.Status}
+        hiddenGroups={[]}
+        machineCount={10}
+        machines={machines}
+        machinesLoading
+        pageSize={20}
+        setCurrentPage={jest.fn()}
+        setHiddenGroups={jest.fn()}
+        setSearchFilter={jest.fn()}
+        setSortDirection={jest.fn()}
+        setSortKey={jest.fn()}
+        sortDirection="none"
+        sortKey={null}
+      />,
+      { state }
     );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
-    expect(wrapper.find("MachineListTable").exists()).toBe(true);
+    expect(
+      within(
+        screen.getAllByRole("gridcell", {
+          name: columnLabels[MachineColumns.FQDN],
+        })[0]
+      ).getByText("xxxxxxxxx.xxxx")
+    ).toBeInTheDocument();
   });
 
   it("includes groups", () => {
@@ -1392,55 +1389,5 @@ describe("MachineListTable", () => {
       expect(wrapper.find('[data-testid="fqdn-header"]').exists()).toBe(false);
       expect(wrapper.find('[data-testid="fqdn-column"]').exists()).toBe(false);
     });
-  });
-
-  it("displays pagination if there are machines", () => {
-    renderWithBrowserRouter(
-      <MachineListTable
-        callId="123456"
-        currentPage={1}
-        machineCount={100}
-        machines={machines}
-        pageSize={20}
-        setCurrentPage={jest.fn()}
-        setSortDirection={jest.fn()}
-        setSortKey={jest.fn()}
-        showActions={false}
-        sortDirection="none"
-        sortKey={null}
-      />,
-      {
-        route: urls.machines.index,
-        wrapperProps: { state },
-      }
-    );
-    expect(
-      screen.getByRole("navigation", { name: Label.Pagination })
-    ).toBeInTheDocument();
-  });
-
-  it("does not display pagination if there are no machines", () => {
-    renderWithBrowserRouter(
-      <MachineListTable
-        callId="123456"
-        currentPage={1}
-        machineCount={0}
-        machines={[]}
-        pageSize={20}
-        setCurrentPage={jest.fn()}
-        setSortDirection={jest.fn()}
-        setSortKey={jest.fn()}
-        showActions={false}
-        sortDirection="none"
-        sortKey={null}
-      />,
-      {
-        route: urls.machines.index,
-        wrapperProps: { state },
-      }
-    );
-    expect(
-      screen.queryByRole("navigation", { name: Label.Pagination })
-    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { memo, useCallback, useEffect, useState } from "react";
+import { useMemo, memo, useCallback, useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
 import { Button, MainTable } from "@canonical/react-components";
@@ -55,6 +55,11 @@ export const DEFAULTS = {
   // https://github.com/canonical/app-tribe/issues/1268
   sortKey: FetchGroupKey.Hostname,
 };
+
+export enum Label {
+  Loading = "Loading machines",
+  Machines = "Machines",
+}
 
 type Props = {
   callId?: string | null;
@@ -860,12 +865,18 @@ export const MachineListTable = ({
     ...rowProps,
   });
 
+  const skeletonRows = useMemo(
+    () => generateSkeletonRows(hiddenColumns, showActions),
+    [hiddenColumns, showActions]
+  );
+
   return (
     <>
       <MainTable
-        aria-label="Machines"
+        aria-label={machinesLoading ? Label.Loading : Label.Machines}
         className={classNames("p-table-expanding--light", "machine-list", {
           "machine-list--grouped": grouping,
+          "machine-list--loading": machinesLoading,
         })}
         emptyStateMsg={
           !machinesLoading && filter
@@ -873,11 +884,7 @@ export const MachineListTable = ({
             : null
         }
         headers={filterColumns(headers, hiddenColumns, showActions)}
-        rows={
-          machinesLoading
-            ? generateSkeletonRows(hiddenColumns, showActions)
-            : rows
-        }
+        rows={machinesLoading ? skeletonRows : rows}
         {...props}
       />
       <MachineListPagination

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -1,12 +1,8 @@
+import type { ReactNode } from "react";
 import { memo, useCallback, useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
-import {
-  Button,
-  MainTable,
-  Pagination,
-  Spinner,
-} from "@canonical/react-components";
+import { Button, MainTable } from "@canonical/react-components";
 import type {
   MainTableCell,
   MainTableRow,
@@ -18,6 +14,7 @@ import { useDispatch, useSelector } from "react-redux";
 import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
 import FabricColumn from "./FabricColumn";
+import MachineListPagination from "./MachineListPagination";
 import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
 import PoolColumn from "./PoolColumn";
@@ -29,6 +26,7 @@ import ZoneColumn from "./ZoneColumn";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import GroupCheckbox from "app/base/components/GroupCheckbox";
+import Placeholder from "app/base/components/Placeholder";
 import TableHeader from "app/base/components/TableHeader";
 import { SortDirection } from "app/base/types";
 import { columnLabels, columns, MachineColumns } from "app/machines/constants";
@@ -57,10 +55,6 @@ export const DEFAULTS = {
   // https://github.com/canonical/app-tribe/issues/1268
   sortKey: FetchGroupKey.Hostname,
 };
-
-export enum Label {
-  Pagination = "Table pagination",
-}
 
 type Props = {
   callId?: string | null;
@@ -97,6 +91,20 @@ type GenerateRowParams = {
   selectedIDs: NonNullable<Props["selectedIDs"]>;
   showActions: Props["showActions"];
   showMAC: boolean;
+};
+
+type RowContent = {
+  [MachineColumns.FQDN]: ReactNode;
+  [MachineColumns.POWER]: ReactNode;
+  [MachineColumns.STATUS]: ReactNode;
+  [MachineColumns.OWNER]: ReactNode;
+  [MachineColumns.POOL]: ReactNode;
+  [MachineColumns.ZONE]: ReactNode;
+  [MachineColumns.FABRIC]: ReactNode;
+  [MachineColumns.CPU]: ReactNode;
+  [MachineColumns.MEMORY]: ReactNode;
+  [MachineColumns.DISKS]: ReactNode;
+  [MachineColumns.STORAGE]: ReactNode;
 };
 
 const getGroupSecondaryString = (
@@ -143,6 +151,179 @@ const filterColumns = (
   );
 };
 
+const generateRow = ({
+  key,
+  content,
+  hiddenColumns,
+  showActions,
+  classes,
+}: {
+  key: string | number;
+  content: RowContent;
+  hiddenColumns: NonNullable<Props["hiddenColumns"]>;
+  showActions: GenerateRowParams["showActions"];
+  classes: string;
+}) => {
+  const columns = [
+    {
+      "aria-label": columnLabels[MachineColumns.FQDN],
+      key: MachineColumns.FQDN,
+      className: "fqdn-col",
+      content: content[MachineColumns.FQDN],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.POWER],
+      key: MachineColumns.POWER,
+      className: "power-col",
+      content: content[MachineColumns.POWER],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.STATUS],
+      key: MachineColumns.STATUS,
+      className: "status-col",
+      content: content[MachineColumns.STATUS],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.OWNER],
+      key: MachineColumns.OWNER,
+      className: "owner-col",
+      content: content[MachineColumns.OWNER],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.POOL],
+      key: MachineColumns.POOL,
+      className: "pool-col",
+      content: content[MachineColumns.POOL],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.ZONE],
+      key: MachineColumns.ZONE,
+      className: "zone-col",
+      content: content[MachineColumns.ZONE],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.FABRIC],
+      key: MachineColumns.FABRIC,
+      className: "fabric-col",
+      content: content[MachineColumns.FABRIC],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.CPU],
+      key: MachineColumns.CPU,
+      className: "cores-col",
+      content: content[MachineColumns.CPU],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.MEMORY],
+      key: MachineColumns.MEMORY,
+      className: "ram-col",
+      content: content[MachineColumns.MEMORY],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.DISKS],
+      key: MachineColumns.DISKS,
+      className: "disks-col",
+      content: content[MachineColumns.DISKS],
+    },
+    {
+      "aria-label": columnLabels[MachineColumns.STORAGE],
+      key: MachineColumns.STORAGE,
+      className: "storage-col",
+      content: content[MachineColumns.STORAGE],
+    },
+  ];
+
+  return {
+    key,
+    className: classNames(
+      "machine-list__machine",
+      {
+        "truncated-border": showActions,
+      },
+      classes
+    ),
+    columns: filterColumns(columns, hiddenColumns, showActions),
+  };
+};
+
+const generateSkeletonRows = (
+  hiddenColumns: NonNullable<Props["hiddenColumns"]>,
+  showActions: GenerateRowParams["showActions"]
+) => {
+  return Array.from(Array(5)).map((_, i) => {
+    const content = {
+      [MachineColumns.FQDN]: (
+        <DoubleRow
+          primary={<Placeholder>xxxxxxxxx.xxxx</Placeholder>}
+          secondary={<Placeholder>xxx.xxx.xx.x</Placeholder>}
+        />
+      ),
+      [MachineColumns.POWER]: (
+        <DoubleRow
+          primary={<Placeholder>Xxxxxxxxxxx</Placeholder>}
+          secondary={<Placeholder>Xxxxxxx</Placeholder>}
+        />
+      ),
+      [MachineColumns.STATUS]: (
+        <DoubleRow primary={<Placeholder>XXXXX XXXXX</Placeholder>} />
+      ),
+      [MachineColumns.OWNER]: (
+        <DoubleRow
+          primary={<Placeholder>Xxxx</Placeholder>}
+          secondary={<Placeholder>XXXX, XXX</Placeholder>}
+        />
+      ),
+      [MachineColumns.POOL]: (
+        <DoubleRow primary={<Placeholder>Xxxxx</Placeholder>} />
+      ),
+      [MachineColumns.ZONE]: (
+        <DoubleRow
+          primary={<Placeholder>Xxxxxxx</Placeholder>}
+          secondary={<Placeholder>Xxxxxxx</Placeholder>}
+        />
+      ),
+      [MachineColumns.FABRIC]: (
+        <DoubleRow
+          primary={<Placeholder>Xxxxxxx-X</Placeholder>}
+          secondary={<Placeholder>Xxxxx</Placeholder>}
+        />
+      ),
+      [MachineColumns.CPU]: (
+        <DoubleRow
+          primary={<Placeholder>XX</Placeholder>}
+          primaryClassName="u-align--right"
+          secondary={<Placeholder>xxxXX</Placeholder>}
+          secondaryClassName="u-align--right"
+        />
+      ),
+      [MachineColumns.MEMORY]: (
+        <DoubleRow
+          primary={<Placeholder>XX xxx</Placeholder>}
+          primaryClassName="u-align--right"
+        />
+      ),
+      [MachineColumns.DISKS]: (
+        <DoubleRow
+          primary={<Placeholder>XX</Placeholder>}
+          primaryClassName="u-align--right"
+        />
+      ),
+      [MachineColumns.STORAGE]: (
+        <DoubleRow
+          primary={<Placeholder>X.XX</Placeholder>}
+          primaryClassName="u-align--right"
+        />
+      ),
+    };
+    return generateRow({
+      key: i,
+      content,
+      hiddenColumns,
+      showActions,
+      classes: "machine-list__machine--inactive",
+    });
+  });
+};
 const generateRows = ({
   activeRow,
   handleRowCheckbox,
@@ -158,138 +339,80 @@ const generateRows = ({
   return machines.map((row) => {
     const isActive = activeRow === row.system_id;
 
-    const columns = [
-      {
-        "aria-label": columnLabels[MachineColumns.FQDN],
-        key: MachineColumns.FQDN,
-        className: "fqdn-col",
-        content: (
-          <NameColumn
-            data-testid="fqdn-column"
-            handleCheckbox={
-              showActions
-                ? () => handleRowCheckbox(row.system_id, selectedIDs)
-                : undefined
-            }
-            selected={selectedIDs}
-            showMAC={showMAC}
-            systemId={row.system_id}
-          />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.POWER],
-        key: MachineColumns.POWER,
-        className: "power-col",
-        content: (
-          <PowerColumn
-            data-testid="power-column"
-            onToggleMenu={menuCallback}
-            systemId={row.system_id}
-          />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.STATUS],
-        key: MachineColumns.STATUS,
-        className: "status-col",
-        content: (
-          <StatusColumn
-            data-testid="status-column"
-            onToggleMenu={menuCallback}
-            systemId={row.system_id}
-          />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.OWNER],
-        key: MachineColumns.OWNER,
-        className: "owner-col",
-        content: (
-          <OwnerColumn
-            data-testid="owner-column"
-            onToggleMenu={menuCallback}
-            systemId={row.system_id}
-          />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.POOL],
-        key: MachineColumns.POOL,
-        className: "pool-col",
-        content: (
-          <PoolColumn
-            data-testid="pool-column"
-            onToggleMenu={menuCallback}
-            systemId={row.system_id}
-          />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.ZONE],
-        key: MachineColumns.ZONE,
-        className: "zone-col",
-        content: (
-          <ZoneColumn
-            data-testid="zone-column"
-            onToggleMenu={menuCallback}
-            systemId={row.system_id}
-          />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.FABRIC],
-        key: MachineColumns.FABRIC,
-        className: "fabric-col",
-        content: (
-          <FabricColumn data-testid="fabric-column" systemId={row.system_id} />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.CPU],
-        key: MachineColumns.CPU,
-        className: "cores-col",
-        content: (
-          <CoresColumn data-testid="cpu-column" systemId={row.system_id} />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.MEMORY],
-        key: MachineColumns.MEMORY,
-        className: "ram-col",
-        content: (
-          <RamColumn data-testid="memory-column" systemId={row.system_id} />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.DISKS],
-        key: MachineColumns.DISKS,
-        className: "disks-col",
-        content: (
-          <DisksColumn data-testid="disks-column" systemId={row.system_id} />
-        ),
-      },
-      {
-        "aria-label": columnLabels[MachineColumns.STORAGE],
-        key: MachineColumns.STORAGE,
-        className: "storage-col",
-        content: (
-          <StorageColumn
-            data-testid="storage-column"
-            systemId={row.system_id}
-          />
-        ),
-      },
-    ];
-
-    return {
-      key: row.system_id,
-      className: classNames("machine-list__machine", {
-        "machine-list__machine--active": isActive,
-        "truncated-border": showActions,
-      }),
-      columns: filterColumns(columns, hiddenColumns, showActions),
+    const content = {
+      [MachineColumns.FQDN]: (
+        <NameColumn
+          data-testid="fqdn-column"
+          handleCheckbox={
+            showActions
+              ? () => handleRowCheckbox(row.system_id, selectedIDs)
+              : undefined
+          }
+          selected={selectedIDs}
+          showMAC={showMAC}
+          systemId={row.system_id}
+        />
+      ),
+      [MachineColumns.POWER]: (
+        <PowerColumn
+          data-testid="power-column"
+          onToggleMenu={menuCallback}
+          systemId={row.system_id}
+        />
+      ),
+      [MachineColumns.STATUS]: (
+        <StatusColumn
+          data-testid="status-column"
+          onToggleMenu={menuCallback}
+          systemId={row.system_id}
+        />
+      ),
+      [MachineColumns.OWNER]: (
+        <OwnerColumn
+          data-testid="owner-column"
+          onToggleMenu={menuCallback}
+          systemId={row.system_id}
+        />
+      ),
+      [MachineColumns.POOL]: (
+        <PoolColumn
+          data-testid="pool-column"
+          onToggleMenu={menuCallback}
+          systemId={row.system_id}
+        />
+      ),
+      [MachineColumns.ZONE]: (
+        <ZoneColumn
+          data-testid="zone-column"
+          onToggleMenu={menuCallback}
+          systemId={row.system_id}
+        />
+      ),
+      [MachineColumns.FABRIC]: (
+        <FabricColumn data-testid="fabric-column" systemId={row.system_id} />
+      ),
+      [MachineColumns.CPU]: (
+        <CoresColumn data-testid="cpu-column" systemId={row.system_id} />
+      ),
+      [MachineColumns.MEMORY]: (
+        <RamColumn data-testid="memory-column" systemId={row.system_id} />
+      ),
+      [MachineColumns.DISKS]: (
+        <DisksColumn data-testid="disks-column" systemId={row.system_id} />
+      ),
+      [MachineColumns.STORAGE]: (
+        <StorageColumn data-testid="storage-column" systemId={row.system_id} />
+      ),
     };
+    return generateRow({
+      key: row.system_id,
+      content,
+      hiddenColumns,
+      showActions,
+      classes: classNames({
+        "machine-list__machine--active": isActive,
+      }),
+    });
   });
 };
 
@@ -745,30 +868,25 @@ export const MachineListTable = ({
           "machine-list--grouped": grouping,
         })}
         emptyStateMsg={
-          machinesLoading ? (
-            <Spinner text="Loading..." />
-          ) : filter ? (
-            "No machines match the search criteria."
-          ) : null
+          !machinesLoading && filter
+            ? "No machines match the search criteria."
+            : null
         }
         headers={filterColumns(headers, hiddenColumns, showActions)}
         rows={
-          // Pass undefined if there are no rows as the MainTable prop doesn't
-          // allow null.
-          rows ? rows : undefined
+          machinesLoading
+            ? generateSkeletonRows(hiddenColumns, showActions)
+            : rows
         }
         {...props}
       />
-      {(machineCount ?? 0) > 0 && (
-        <Pagination
-          aria-label={Label.Pagination}
-          currentPage={currentPage}
-          itemsPerPage={pageSize}
-          paginate={setCurrentPage}
-          style={{ marginTop: "1rem" }}
-          totalItems={machineCount ?? 0}
-        />
-      )}
+      <MachineListPagination
+        currentPage={currentPage}
+        itemsPerPage={pageSize}
+        machineCount={machineCount}
+        machinesLoading={machinesLoading}
+        paginate={setCurrentPage}
+      />
     </>
   );
 };

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -61,6 +61,11 @@
     }
   }
 
+  .machine-list--loading .u-truncate {
+    // When loading the skeleton placeholders should get cut off and not show an ellipsis.
+    text-overflow: clip !important;
+  }
+
   .machine-list__machine .p-table-menu {
     display: none;
   }

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -71,7 +71,7 @@
     min-height: 1px;
   }
 
-  .machine-list__machine:hover,
+  .machine-list__machine:hover:not(.machine-list__machine--inactive),
   .machine-list__machine--active {
     background-color: $color-x-light;
 


### PR DESCRIPTION
## Done

- Display the loading skeleton while the machine list is fetching machines.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- You should see the loading skeleton appear.
- Try changing the page, the sort order, do a search or change the grouping and you should see the skeleton.

## Fixes

Fixes: canonical/app-tribe#1100.

## Screenshots
![Screen Recording 2022-08-29 at 9 56 29 am](https://user-images.githubusercontent.com/361637/187100322-2c05c873-7548-4b20-9349-93f722ef543f.gif)

