### PR TITLE
feat(actions): remove take action counts and show all options

### DIFF
--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
@@ -9,7 +9,9 @@ import { machine as machineFactory } from "testing/factories";
 
 describe("NodeActionMenu", () => {
   const openMenu = async () =>
-    await userEvent.click(screen.getByRole("button", { name: Label.Toggle }));
+    await userEvent.click(
+      screen.getByRole("button", { name: Label.TakeAction })
+    );
 
   const getActionButton = (action: NodeActions) =>
     screen.getByRole("button", {
@@ -34,7 +36,9 @@ describe("NodeActionMenu", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: Label.Toggle })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: Label.TakeAction })
+    ).toBeDisabled();
   });
 
   it("is enabled if nodes are selected", async () => {
@@ -49,7 +53,7 @@ describe("NodeActionMenu", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: Label.Toggle })
+      screen.getByRole("button", { name: Label.TakeAction })
     ).not.toBeDisabled();
   });
 
@@ -228,7 +232,7 @@ describe("NodeActionMenu", () => {
       />
     );
 
-    expect(screen.getByRole("button", { name: Label.Toggle })).toHaveClass(
+    expect(screen.getByRole("button", { name: Label.TakeAction })).toHaveClass(
       "p-button--negative"
     );
   });

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
@@ -1,88 +1,113 @@
-import type { ReactWrapper } from "enzyme";
-import { mount } from "enzyme";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
-import NodeActionMenu from "./NodeActionMenu";
+import NodeActionMenu, { Label } from "./NodeActionMenu";
 
 import { NodeActions } from "app/store/types/node";
+import { getNodeActionTitle } from "app/store/utils";
 import { machine as machineFactory } from "testing/factories";
 
 describe("NodeActionMenu", () => {
-  const openMenu = (wrapper: ReactWrapper) =>
-    wrapper
-      .find("[data-testid='take-action-dropdown'] button")
-      .simulate("click");
+  const openMenu = async () =>
+    await userEvent.click(screen.getByRole("button", { name: Label.Toggle }));
 
-  const getActionButton = (wrapper: ReactWrapper, action: NodeActions) =>
-    wrapper.find(`button[data-testid='action-link-${action}']`);
+  const getActionButton = (action: NodeActions) =>
+    screen.getByRole("button", {
+      name: new RegExp(getNodeActionTitle(action)),
+    });
 
-  const getActionCount = (wrapper: ReactWrapper, action: NodeActions) =>
-    wrapper.find(`[data-testid='action-count-${action}']`);
+  const queryActionButton = (action: NodeActions) =>
+    screen.queryByRole("button", {
+      name: new RegExp(getNodeActionTitle(action)),
+    });
 
-  it("is disabled if no nodes are provided", () => {
-    const wrapper = mount(
-      <NodeActionMenu nodes={[]} onActionClick={jest.fn()} />
+  const getActionCount = (action: NodeActions) =>
+    screen.getByTestId(`action-count-${action}`);
+
+  it("is disabled if no nodes are selected", async () => {
+    render(
+      <NodeActionMenu
+        hasSelection={false}
+        nodes={[]}
+        onActionClick={jest.fn()}
+        showCount
+      />
     );
 
-    expect(
-      wrapper
-        .find('[data-testid="take-action-dropdown"] button')
-        .prop("disabled")
-    ).toBe(true);
+    expect(screen.getByRole("button", { name: Label.Toggle })).toBeDisabled();
   });
 
-  it("is enabled if at least one node is provided", () => {
+  it("is enabled if nodes are selected", async () => {
     const nodes = [machineFactory()];
-    const wrapper = mount(
-      <NodeActionMenu nodes={nodes} onActionClick={jest.fn()} />
+    render(
+      <NodeActionMenu
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount
+      />
     );
 
     expect(
-      wrapper
-        .find('[data-testid="take-action-dropdown"] button')
-        .prop("disabled")
-    ).toBe(false);
+      screen.getByRole("button", { name: Label.Toggle })
+    ).not.toBeDisabled();
   });
 
-  it("only shows actions that can be performed by the nodes", () => {
+  it("can only shows actions that can be performed by the nodes", async () => {
     const nodes = [
       machineFactory({ actions: [NodeActions.DELETE] }),
       machineFactory({ actions: [NodeActions.SET_ZONE] }),
     ];
-    const wrapper = mount(
-      <NodeActionMenu nodes={nodes} onActionClick={jest.fn()} />
-    );
-
-    openMenu(wrapper);
-
-    expect(getActionButton(wrapper, NodeActions.DELETE).exists()).toBe(true);
-    expect(getActionButton(wrapper, NodeActions.SET_ZONE).exists()).toBe(true);
-    expect(getActionButton(wrapper, NodeActions.TEST).exists()).toBe(false);
-  });
-
-  it(`can be made to always show lifecycle actions, disabling the actions that
-      cannot be performed`, () => {
-    const nodes = [machineFactory({ actions: [NodeActions.DEPLOY] })];
-    const wrapper = mount(
+    render(
       <NodeActionMenu
-        alwaysShowLifecycle
+        filterActions
+        hasSelection
         nodes={nodes}
         onActionClick={jest.fn()}
+        showCount
       />
     );
 
-    openMenu(wrapper);
+    await openMenu();
 
-    expect(getActionButton(wrapper, NodeActions.DEPLOY).exists()).toBe(true);
-    expect(getActionButton(wrapper, NodeActions.DEPLOY).prop("disabled")).toBe(
-      false
-    );
-    expect(getActionButton(wrapper, NodeActions.RELEASE).exists()).toBe(true);
-    expect(getActionButton(wrapper, NodeActions.RELEASE).prop("disabled")).toBe(
-      true
-    );
+    expect(getActionButton(NodeActions.DELETE)).toBeInTheDocument();
+    expect(getActionButton(NodeActions.SET_ZONE)).toBeInTheDocument();
+    expect(queryActionButton(NodeActions.TEST)).not.toBeInTheDocument();
   });
 
-  it("correctly calculates number of nodes that can perform each action", () => {
+  it(`can be made to always show lifecycle actions, disabling the actions that
+      cannot be performed`, async () => {
+    const nodes = [machineFactory({ actions: [NodeActions.DEPLOY] })];
+    render(
+      <NodeActionMenu
+        alwaysShowLifecycle
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount
+      />
+    );
+
+    await openMenu();
+
+    expect(getActionButton(NodeActions.DEPLOY)).toBeInTheDocument();
+    expect(queryActionButton(NodeActions.DEPLOY)).not.toBeDisabled();
+    expect(getActionButton(NodeActions.RELEASE)).toBeInTheDocument();
+    expect(getActionButton(NodeActions.RELEASE)).toBeDisabled();
+  });
+
+  it("shows all actions that can be performed when not showing counts", async () => {
+    render(<NodeActionMenu hasSelection onActionClick={jest.fn()} />);
+    await openMenu();
+    expect(getActionButton(NodeActions.DELETE)).toBeInTheDocument();
+    expect(queryActionButton(NodeActions.DELETE)).not.toBeDisabled();
+    expect(getActionButton(NodeActions.SET_ZONE)).toBeInTheDocument();
+    expect(queryActionButton(NodeActions.SET_ZONE)).not.toBeDisabled();
+    expect(getActionButton(NodeActions.TEST)).toBeInTheDocument();
+    expect(queryActionButton(NodeActions.TEST)).not.toBeDisabled();
+  });
+
+  it("correctly calculates number of nodes that can perform each action", async () => {
     const nodes = [
       machineFactory({
         actions: [
@@ -98,137 +123,134 @@ describe("NodeActionMenu", () => {
         actions: [NodeActions.COMMISSION],
       }),
     ];
-    const wrapper = mount(
-      <NodeActionMenu nodes={nodes} onActionClick={jest.fn()} />
+    render(
+      <NodeActionMenu
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount
+      />
     );
 
-    openMenu(wrapper);
+    await openMenu();
 
-    expect(getActionCount(wrapper, NodeActions.COMMISSION).text()).toBe("3");
-    expect(getActionCount(wrapper, NodeActions.RELEASE).text()).toBe("2");
-    expect(getActionCount(wrapper, NodeActions.DEPLOY).text()).toBe("1");
+    expect(within(getActionCount(NodeActions.COMMISSION)).getByText("3"));
+    expect(within(getActionCount(NodeActions.RELEASE)).getByText("2"));
+    expect(within(getActionCount(NodeActions.DEPLOY)).getByText("1"));
   });
 
-  it("does not display count if only one node provided", () => {
-    const nodes = [
-      machineFactory({
-        actions: [NodeActions.DEPLOY],
-      }),
-    ];
-    const wrapper = mount(
-      <NodeActionMenu nodes={nodes} onActionClick={jest.fn()} />
-    );
-
-    openMenu(wrapper);
-
-    expect(getActionCount(wrapper, NodeActions.DEPLOY).exists()).toBe(false);
-  });
-
-  it("fires onActionClick function on action button click", () => {
+  it("fires onActionClick function on action button click", async () => {
     const nodes = [
       machineFactory({
         actions: [NodeActions.DEPLOY],
       }),
     ];
     const onActionClick = jest.fn();
-    const wrapper = mount(
-      <NodeActionMenu nodes={nodes} onActionClick={onActionClick} />
+    render(
+      <NodeActionMenu
+        hasSelection
+        nodes={nodes}
+        onActionClick={onActionClick}
+        showCount
+      />
     );
 
-    openMenu(wrapper);
-    getActionButton(wrapper, NodeActions.DEPLOY).simulate("click");
+    await openMenu();
+    await userEvent.click(getActionButton(NodeActions.DEPLOY));
 
     expect(onActionClick).toHaveBeenCalledWith(NodeActions.DEPLOY);
   });
 
-  it("can exclude actions from being shown", () => {
+  it("can exclude actions from being shown", async () => {
     const nodes = [
       machineFactory({
         actions: [NodeActions.DEPLOY, NodeActions.DELETE],
       }),
     ];
-    const wrapper = mount(
+    render(
       <NodeActionMenu
         excludeActions={[NodeActions.DELETE]}
+        hasSelection
         nodes={nodes}
         onActionClick={jest.fn()}
+        showCount
       />
     );
 
-    openMenu(wrapper);
+    await openMenu();
 
-    expect(getActionButton(wrapper, NodeActions.DEPLOY).exists()).toBe(true);
-    expect(getActionButton(wrapper, NodeActions.DELETE).exists()).toBe(false);
+    expect(getActionButton(NodeActions.DEPLOY)).toBeInTheDocument();
+    expect(queryActionButton(NodeActions.DELETE)).not.toBeInTheDocument();
   });
 
-  it("can change the display text of the nodes in the disabled tooltip", () => {
-    const wrapper = mount(
+  it("can change the display text of the nodes in the disabled tooltip", async () => {
+    render(
       <NodeActionMenu
+        hasSelection={false}
         nodeDisplay="foobar"
         nodes={[]}
         onActionClick={jest.fn()}
+        showCount
       />
     );
 
-    expect(wrapper.find("Tooltip").prop("message")).toBe(
-      "Select foobars below to perform an action."
-    );
+    expect(
+      screen.getByRole("tooltip", {
+        name: "Select foobars below to perform an action.",
+      })
+    ).toBeInTheDocument();
   });
 
-  it("can change the position of the disabled tooltip", () => {
-    const wrapper = mount(
+  it("can change the position of the disabled tooltip", async () => {
+    render(
       <NodeActionMenu
         disabledTooltipPosition="top-left"
+        hasSelection={false}
         nodes={[]}
         onActionClick={jest.fn()}
+        showCount
       />
     );
 
-    expect(wrapper.find("Tooltip").prop("position")).toBe("top-left");
-  });
-
-  it("can change the position of the menu dropdown", () => {
-    const wrapper = mount(
-      <NodeActionMenu
-        menuPosition="left"
-        nodes={[]}
-        onActionClick={jest.fn()}
-      />
+    expect(screen.getByTestId("tooltip-portal")).toHaveClass(
+      "p-tooltip--top-left"
     );
-
-    expect(wrapper.find("ContextualMenu").prop("position")).toBe("left");
   });
 
-  it("can change the appearance of the menu toggle", () => {
-    const wrapper = mount(
+  it("can change the appearance of the menu toggle", async () => {
+    render(
       <NodeActionMenu
+        hasSelection
         nodes={[]}
         onActionClick={jest.fn()}
+        showCount
         toggleAppearance="negative"
       />
     );
 
-    expect(wrapper.find("ContextualMenu").prop("toggleAppearance")).toBe(
-      "negative"
+    expect(screen.getByRole("button", { name: Label.Toggle })).toHaveClass(
+      "p-button--negative"
     );
   });
 
-  it("can override action titles", () => {
+  it("can override action titles", async () => {
     const nodes = [
       machineFactory({
         actions: [NodeActions.TAG],
       }),
     ];
-    const wrapper = mount(
+    render(
       <NodeActionMenu
         getTitle={() => "Overridden"}
+        hasSelection
         nodes={nodes}
         onActionClick={jest.fn()}
+        showCount
       />
     );
-    openMenu(wrapper);
+    await openMenu();
     expect(
-      getActionButton(wrapper, NodeActions.TAG).text().includes("Overridden")
-    ).toBe(true);
+      within(screen.getByTestId("action-link-tag")).getByText(/Overridden/)
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
@@ -13,7 +13,7 @@ import { NodeActions } from "app/store/types/node";
 import { canOpenActionForm, getNodeActionTitle } from "app/store/utils";
 
 export enum Label {
-  Toggle = "Take action",
+  TakeAction = "Take action",
 }
 
 type ActionGroup = {
@@ -188,7 +188,7 @@ export const NodeActionMenu = ({
         toggleAppearance={toggleAppearance}
         toggleClassName={toggleClassName}
         toggleDisabled={!hasSelection}
-        toggleLabel={Label.Toggle}
+        toggleLabel={Label.TakeAction}
       />
     </Tooltip>
   );

--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
@@ -48,6 +48,8 @@ const ControllerDetailsHeader = ({
     <SectionHeader
       buttons={[
         <NodeActionMenu
+          filterActions
+          hasSelection={true}
           key="action-dropdown"
           nodeDisplay="controller"
           nodes={[controller]}

--- a/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.tsx
@@ -42,6 +42,8 @@ const ControllerListHeader = ({
           Add rack controller
         </Button>,
         <NodeActionMenu
+          filterActions
+          hasSelection={selectedControllers.length > 0}
           nodeDisplay="controller"
           nodes={selectedControllers}
           onActionClick={(action) => {
@@ -52,6 +54,7 @@ const ControllerListHeader = ({
               setHeaderContent({ view });
             }
           }}
+          showCount
         />,
       ]}
       headerContent={

--- a/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
@@ -46,6 +46,8 @@ const DeviceDetailsHeader = ({
     <SectionHeader
       buttons={[
         <NodeActionMenu
+          filterActions
+          hasSelection={true}
           nodeDisplay="device"
           nodes={[device]}
           onActionClick={(action) => {

--- a/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
+++ b/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
@@ -42,6 +42,8 @@ const DeviceListHeader = ({
           Add device
         </Button>,
         <NodeActionMenu
+          filterActions
+          hasSelection={selectedDevices.length > 0}
           nodeDisplay="device"
           nodes={selectedDevices}
           onActionClick={(action) => {
@@ -52,6 +54,7 @@ const DeviceListHeader = ({
               setHeaderContent({ view });
             }
           }}
+          showCount
         />,
       ]}
       headerContent={

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -43,9 +43,9 @@ const VMsActionBar = ({
             data-testid="vm-actions"
             disabledTooltipPosition="top-left"
             excludeActions={[NodeActions.DELETE]}
+            hasSelection={selectedMachines.length > 0}
             menuPosition="left"
             nodeDisplay="VM"
-            nodes={selectedMachines}
             onActionClick={(action) => {
               const view = Object.values(MachineHeaderViews).find(
                 ([, actionName]) => actionName === action

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -69,9 +69,10 @@ const MachineHeader = ({
       buttons={[
         <NodeActionMenu
           alwaysShowLifecycle
+          filterActions
+          hasSelection={true}
           key="action-dropdown"
           nodeDisplay="machine"
-          nodes={[machine]}
           onActionClick={(action) => {
             const view = Object.values(MachineHeaderViews).find(
               ([, actionName]) => actionName === action

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -78,9 +78,9 @@ export const MachineListHeader = ({
         <NodeActionMenu
           alwaysShowLifecycle
           getTitle={getTitle}
+          hasSelection={selectedMachines.length > 0}
           key="machine-list-action-menu"
           nodeDisplay="machine"
-          nodes={selectedMachines}
           onActionClick={(action) => {
             if (action === NodeActions.TAG && !tagsSeen) {
               setTagsSeen(true);


### PR DESCRIPTION
## Done

- Update the take action menu to not show counts and display all options on the machine list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- The take action menu should be disabled.
- Tick some machines.
- Open the take action menu and there should not be any counts next to the actions and all should be visible and enabled.
- Got to the controller list.
- Tick some controllers.
- Open the take action menu and there should be counts next to the actions and only some should be visible and enabled.

## Fixes

Fixes: canonical/app-tribe#1285.