### PR TITLE
feat(machines): remove "update selection" link

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -18,14 +18,28 @@ import { renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 
+let html: HTMLHtmlElement | null;
+const originalScrollTo = global.scrollTo;
+
+beforeEach(() => {
+  global.innerHeight = 500;
+  // eslint-disable-next-line testing-library/no-node-access
+  html = document.querySelector("html");
+  global.scrollTo = jest.fn();
+});
+
 afterEach(() => {
+  if (html) {
+    html.scrollTop = 0;
+  }
   jest.restoreAllMocks();
 });
 
+afterAll(() => {
+  global.scrollTo = originalScrollTo;
+});
+
 it("scrolls to the top of the window when opening the form", async () => {
-  global.scrollTo = jest.fn();
-  // eslint-disable-next-line testing-library/no-node-access
-  const html = document.querySelector("html");
   if (html) {
     // Move the page down so that the hook will fire.
     html.scrollTop = 10;

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -7,7 +6,6 @@ import configureStore from "redux-mock-store";
 
 import ActionFormWrapper from "./ActionFormWrapper";
 
-import { actions as machineActions } from "app/store/machine";
 import { NodeActions } from "app/store/types/node";
 import {
   machineEventError as machineEventErrorFactory,
@@ -16,42 +14,31 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 
-it("can set selected machines to those that can perform action", async () => {
-  const state = rootStateFactory();
-  const machines = [
-    machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
-    machineFactory({ system_id: "def456", actions: [] }),
-  ];
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-      >
-        <CompatRouter>
-          <ActionFormWrapper
-            action={NodeActions.ABORT}
-            clearHeaderContent={jest.fn()}
-            machines={machines}
-            viewingDetails={false}
-          />
-        </CompatRouter>
-      </MemoryRouter>
-    </Provider>
-  );
+afterEach(() => {
+  jest.restoreAllMocks();
+});
 
-  await userEvent.click(
-    screen.getByRole("button", { name: /update your selection/ })
+it("scrolls to the top of the window when opening the form", async () => {
+  global.scrollTo = jest.fn();
+  // eslint-disable-next-line testing-library/no-node-access
+  const html = document.querySelector("html");
+  if (html) {
+    // Move the page down so that the hook will fire.
+    html.scrollTop = 10;
+  }
+  renderWithBrowserRouter(
+    <ActionFormWrapper
+      action={NodeActions.ABORT}
+      clearHeaderContent={jest.fn()}
+      machines={[]}
+      viewingDetails={false}
+    />
   );
-
-  const expectedAction = machineActions.setSelected(["abc123"]);
-  const actualActions = store.getActions();
-  expect(
-    actualActions.find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+  expect(global.scrollTo).toHaveBeenCalled();
 });
 
 it("can show untag errors when the tag form is open", async () => {

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.tsx
@@ -11,10 +11,10 @@ import TagForm from "./TagForm";
 
 import DeleteForm from "app/base/components/node/DeleteForm";
 import FieldlessForm from "app/base/components/node/FieldlessForm";
-import NodeActionFormWrapper from "app/base/components/node/NodeActionFormWrapper";
 import SetZoneForm from "app/base/components/node/SetZoneForm";
 import TestForm from "app/base/components/node/TestForm";
 import type { HardwareType } from "app/base/enum";
+import { useScrollOnRender } from "app/base/hooks";
 import type { ClearHeaderContent, SetSearchFilter } from "app/base/types";
 import urls from "app/base/urls";
 import { actions as machineActions } from "app/store/machine";
@@ -79,6 +79,7 @@ export const ActionFormWrapper = ({
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const onRenderRef = useScrollOnRender<HTMLDivElement>();
   const processingMachines = useSelector(getProcessingSelector(action));
   // When updating tags we want to surface both "tag" and "untag" errors.
   const errorEvents = isTagUpdateAction(action)
@@ -207,21 +208,7 @@ export const ActionFormWrapper = ({
     }
   };
 
-  return (
-    <NodeActionFormWrapper
-      action={action}
-      clearHeaderContent={clearHeaderContent}
-      nodeType="machine"
-      nodes={machines}
-      onUpdateSelected={(machineIDs) =>
-        dispatch(machineActions.setSelected(machineIDs))
-      }
-      processingCount={processingCount}
-      viewingDetails={viewingDetails}
-    >
-      {getFormComponent()}
-    </NodeActionFormWrapper>
-  );
+  return <div ref={onRenderRef}>{getFormComponent()}</div>;
 };
 
 export default ActionFormWrapper;

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -158,16 +158,16 @@ const WithMockStoreProvider = ({
 
 export const renderWithBrowserRouter = (
   ui: React.ReactElement,
-  options: RenderOptions & {
+  options?: RenderOptions & {
     wrapperProps?: WrapperProps;
     route?: string;
   }
 ): RenderResult => {
-  window.history.pushState({}, "", options.route);
+  window.history.pushState({}, "", options?.route);
 
   return render(ui, {
     wrapper: (props) => (
-      <BrowserRouterWithProvider {...props} {...options.wrapperProps} />
+      <BrowserRouterWithProvider {...props} {...options?.wrapperProps} />
     ),
     ...options,
   });
@@ -175,12 +175,12 @@ export const renderWithBrowserRouter = (
 
 export const renderWithMockStore = (
   ui: React.ReactElement,
-  options: RenderOptions & {
+  options?: RenderOptions & {
     state?: RootState;
     store?: WrapperProps["store"];
   }
 ): RenderResult => {
-  const { state, store, ...renderOptions } = options;
+  const { state, store, ...renderOptions } = options ?? {};
   const rendered = render(ui, {
     wrapper: (props) => (
       <WithMockStoreProvider {...props} state={state} store={store} />


### PR DESCRIPTION
## Done

- Update the machine list action forms to not show an "update selection" link.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list and select a few machines.
- Open the take action menu.
- Scroll down the page a little.
- Click on an action in the take action menu that not all machines can perform (while still scrolled).
- You should get scrolled to the top off the screen and see the form (instead of the "update selection" link).

## Fixes

Fixes: canonical/app-tribe#1287.