### PR TITLE
feat(kvm): update KVM tables to use new selected state

### DIFF
--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -49,6 +49,7 @@ const LXDVMsTable = ({
     ValueOf<typeof SortDirection>
   >(DEFAULTS.sortDirection);
   const {
+    callId,
     loading,
     machineCount,
     machines: vms,
@@ -85,7 +86,7 @@ const LXDVMsTable = ({
         vmCount={machineCount ?? 0}
       />
       <VMsTable
-        currentPage={currentPage}
+        callId={callId}
         displayForCluster={displayForCluster}
         getHostColumn={getHostColumn}
         getResources={getResources}

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
@@ -41,7 +41,7 @@ describe("VMsActionBar", () => {
   it("disables VM actions if none are selected", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
-        selected: [],
+        selectedMachines: null,
       }),
     });
     const store = mockStore(state);
@@ -71,7 +71,7 @@ describe("VMsActionBar", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: vms,
-        selected: ["abc123"],
+        selectedMachines: { items: ["abc123"] },
       }),
     });
     const store = mockStore(state);

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -1,5 +1,4 @@
 import { Button, Icon, Tooltip } from "@canonical/react-components";
-import { useSelector } from "react-redux";
 
 import ActionBar from "app/base/components/ActionBar";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
@@ -7,7 +6,7 @@ import type { SetSearchFilter } from "app/base/types";
 import { VMS_PER_PAGE } from "app/kvm/components/LXDVMsTable";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import { MachineHeaderViews } from "app/machines/constants";
-import machineSelectors from "app/store/machine/selectors";
+import { useHasSelection } from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
 
 type Props = {
@@ -31,8 +30,8 @@ const VMsActionBar = ({
   setHeaderContent,
   vmCount,
 }: Props): JSX.Element | null => {
-  const selectedMachines = useSelector(machineSelectors.selected);
-  const vmActionsDisabled = selectedMachines.length === 0;
+  const hasSelection = useHasSelection();
+  const vmActionsDisabled = !hasSelection;
 
   return (
     <ActionBar
@@ -43,7 +42,7 @@ const VMsActionBar = ({
             data-testid="vm-actions"
             disabledTooltipPosition="top-left"
             excludeActions={[NodeActions.DELETE]}
-            hasSelection={selectedMachines.length > 0}
+            hasSelection={hasSelection}
             menuPosition="left"
             nodeDisplay="VM"
             onActionClick={(action) => {

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/NameColumn/NameColumn.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/NameColumn/NameColumn.tsx
@@ -1,30 +1,22 @@
 import { Spinner } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import RowCheckbox from "app/base/components/RowCheckbox";
 import urls from "app/base/urls";
-import { actions as machineActions } from "app/store/machine";
+import MachineCheckbox from "app/machines/views/MachineList/MachineListTable/MachineCheckbox";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-import { generateCheckboxHandlers } from "app/utils";
 
 type Props = {
+  callId?: string | null;
   systemId: Machine["system_id"];
 };
 
-const NameColumn = ({ systemId }: Props): JSX.Element => {
-  const dispatch = useDispatch();
+const NameColumn = ({ callId, systemId }: Props): JSX.Element => {
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
-  );
-  const selectedIDs = useSelector(machineSelectors.selectedIDs);
-  const { handleRowCheckbox } = generateCheckboxHandlers<Machine["system_id"]>(
-    (machineIDs) => {
-      dispatch(machineActions.setSelected(machineIDs));
-    }
   );
 
   if (!machine) {
@@ -34,18 +26,14 @@ const NameColumn = ({ systemId }: Props): JSX.Element => {
     <DoubleRow
       data-testid="name-col"
       primary={
-        <RowCheckbox
-          checked={selectedIDs.includes(machine.system_id)}
-          handleRowCheckbox={() =>
-            handleRowCheckbox(machine.system_id, selectedIDs)
-          }
-          inputLabel={
+        <MachineCheckbox
+          callId={callId}
+          label={
             <Link to={urls.machines.machine.index({ id: machine.system_id })}>
               <strong>{machine.hostname}</strong>
             </Link>
           }
-          item={systemId}
-          items={[]}
+          systemId={systemId}
         />
       }
       primaryTitle={machine.hostname}

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -43,7 +43,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               getResources={getResources}
               machinesLoading={true}
               searchFilter=""
@@ -92,7 +91,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               getResources={getResources}
               machinesLoading={false}
               searchFilter=""
@@ -135,7 +133,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               getResources={getResources}
               machinesLoading={false}
               searchFilter=""
@@ -186,7 +183,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               getResources={getResources}
               machinesLoading={false}
               searchFilter=""
@@ -228,7 +224,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               getResources={getResources}
               machinesLoading={false}
               searchFilter="system_id:(=ghi789)"
@@ -263,7 +258,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               displayForCluster
               getResources={getResources}
               machinesLoading={false}
@@ -295,7 +289,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               getHostColumn={jest.fn()}
               getResources={getResources}
               machinesLoading={false}
@@ -324,7 +317,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               getHostColumn={undefined}
               getResources={getResources}
               machinesLoading={false}
@@ -364,7 +356,6 @@ describe("VMsTable", () => {
         >
           <CompatRouter>
             <VMsTable
-              currentPage={1}
               getResources={getResources}
               machinesLoading={false}
               searchFilter=""

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -124,7 +124,7 @@ describe("VMsTable", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: vms,
-        selected: [],
+        selectedMachines: null,
       }),
     });
     const store = mockStore(state);
@@ -150,14 +150,16 @@ describe("VMsTable", () => {
       </Provider>
     );
 
-    wrapper.find("GroupCheckbox input").simulate("change", {
-      target: { name: "group-checkbox", value: "checked" },
+    wrapper.find("AllCheckbox input").simulate("change", {
+      target: { checked: "checked" },
     });
     expect(
-      store.getActions().find((action) => action.type === "machine/setSelected")
+      store
+        .getActions()
+        .find((action) => action.type === "machine/setSelectedMachines")
     ).toStrictEqual({
-      type: "machine/setSelected",
-      payload: ["abc123", "def456"],
+      type: "machine/setSelectedMachines",
+      payload: { filter: {} },
     });
   });
 
@@ -173,7 +175,7 @@ describe("VMsTable", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: vms,
-        selected: ["abc123", "def456"],
+        selectedMachines: { filter: {} },
       }),
     });
     const store = mockStore(state);
@@ -199,14 +201,16 @@ describe("VMsTable", () => {
       </Provider>
     );
 
-    wrapper.find("GroupCheckbox input").simulate("change", {
-      target: { name: "group-checkbox", value: "checked" },
+    wrapper.find("AllCheckbox input").simulate("change", {
+      target: { checked: "" },
     });
     expect(
-      store.getActions().find((action) => action.type === "machine/setSelected")
+      store
+        .getActions()
+        .find((action) => action.type === "machine/setSelectedMachines")
     ).toStrictEqual({
-      type: "machine/setSelected",
-      payload: [],
+      type: "machine/setSelectedMachines",
+      payload: null,
     });
   });
 

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
 import { MainTable, Spinner, Strip } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 
 import CoresColumn from "./CoresColumn";
 import HugepagesColumn from "./HugepagesColumn";
@@ -11,17 +11,16 @@ import NameColumn from "./NameColumn";
 import StatusColumn from "./StatusColumn";
 
 import DoubleRow from "app/base/components/DoubleRow";
-import GroupCheckbox from "app/base/components/GroupCheckbox";
 import TableHeader from "app/base/components/TableHeader";
 import { SortDirection } from "app/base/types";
-import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
+import AllCheckbox from "app/machines/views/MachineList/MachineListTable/AllCheckbox";
 import type { Machine } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
+import { FilterMachineItems } from "app/store/machine/utils";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag } from "app/store/tag/types";
 import { getTagNamesForIds } from "app/store/tag/utils";
-import { formatBytes, generateCheckboxHandlers } from "app/utils";
+import { formatBytes } from "app/utils";
 
 export type GetHostColumn = (vm: Machine) => ReactNode;
 
@@ -32,7 +31,7 @@ export type GetResources = (vm: Machine) => {
 };
 
 type Props = {
-  currentPage: number;
+  callId?: string | null;
   displayForCluster?: boolean;
   getHostColumn?: GetHostColumn;
   getResources: GetResources;
@@ -49,7 +48,8 @@ const generateRows = (
   vms: Machine[],
   getResources: GetResources,
   tags: Tag[],
-  getHostColumn?: GetHostColumn
+  getHostColumn?: GetHostColumn,
+  callId?: string | null
 ) =>
   vms.map((vm) => {
     const memory = formatBytes(vm.memory, "GiB", { binary: true });
@@ -60,7 +60,7 @@ const generateRows = (
       columns: [
         {
           className: "name-col",
-          content: <NameColumn systemId={vm.system_id} />,
+          content: <NameColumn callId={callId} systemId={vm.system_id} />,
         },
         {
           className: "status-col",
@@ -126,6 +126,7 @@ const generateRows = (
   });
 
 const VMsTable = ({
+  callId,
   displayForCluster,
   getHostColumn,
   getResources,
@@ -137,15 +138,7 @@ const VMsTable = ({
   sortKey,
   vms,
 }: Props): JSX.Element => {
-  const dispatch = useDispatch();
-  const selectedIDs = useSelector(machineSelectors.selectedIDs);
   const tags = useSelector(tagSelectors.all);
-  const machineIDs = vms.map((vm) => vm.system_id);
-  const { handleGroupCheckbox } = generateCheckboxHandlers<
-    Machine["system_id"]
-  >((machineIDs) => {
-    dispatch(machineActions.setSelected(machineIDs));
-  });
   const currentSort = {
     direction: sortDirection,
     key: sortKey,
@@ -186,10 +179,9 @@ const VMsTable = ({
             className: "name-col",
             content: (
               <div className="u-flex">
-                <GroupCheckbox
-                  handleGroupCheckbox={handleGroupCheckbox}
-                  items={machineIDs}
-                  selectedItems={selectedIDs}
+                <AllCheckbox
+                  callId={callId}
+                  filter={FilterMachineItems.parseFetchFilters(searchFilter)}
                 />
                 <div>
                   <TableHeader
@@ -276,7 +268,7 @@ const VMsTable = ({
             ),
           },
         ]}
-        rows={generateRows(vms, getResources, tags, getHostColumn)}
+        rows={generateRows(vms, getResources, tags, getHostColumn, callId)}
       />
     </>
   );

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.tsx
@@ -44,13 +44,19 @@ type Props = {
   vms: Machine[];
 };
 
-const generateRows = (
-  vms: Machine[],
-  getResources: GetResources,
-  tags: Tag[],
-  getHostColumn?: GetHostColumn,
-  callId?: string | null
-) =>
+const generateRows = ({
+  vms,
+  getResources,
+  tags,
+  getHostColumn,
+  callId,
+}: {
+  vms: Machine[];
+  getResources: GetResources;
+  tags: Tag[];
+  getHostColumn?: GetHostColumn;
+  callId?: string | null;
+}) =>
   vms.map((vm) => {
     const memory = formatBytes(vm.memory, "GiB", { binary: true });
     const storage = formatBytes(vm.storage, "GB");
@@ -268,7 +274,7 @@ const VMsTable = ({
             ),
           },
         ]}
-        rows={generateRows(vms, getResources, tags, getHostColumn, callId)}
+        rows={generateRows({ vms, getResources, tags, getHostColumn, callId })}
       />
     </>
   );

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -104,7 +104,11 @@ describe("MachineListHeader", () => {
 
   it("displays a selected machine filter button if some machines have been selected", () => {
     state.machine.loaded = true;
+    // TODO: This state can be remove once the count has been updated to use the
+    // new API:
+    // https://github.com/canonical/app-tribe/issues/1102
     state.machine.selected = ["abc123"];
+    state.machine.selectedMachines = { items: ["abc123"] };
     const setSearchFilter = jest.fn();
     const store = mockStore(state);
     const wrapper = mount(
@@ -133,7 +137,11 @@ describe("MachineListHeader", () => {
 
   it("displays a message when all machines have been selected", () => {
     state.machine.loaded = true;
+    // TODO: This state can be remove once the count has been updated to use the
+    // new API:
+    // https://github.com/canonical/app-tribe/issues/1102
     state.machine.selected = ["abc123", "def456"];
+    state.machine.selectedMachines = { items: ["abc123", "def456"] };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -156,7 +164,7 @@ describe("MachineListHeader", () => {
   });
 
   it("disables the add hardware menu when machines are selected", () => {
-    state.machine.selected = ["abc123"];
+    state.machine.selectedMachines = { items: ["abc123"] };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -205,7 +213,7 @@ describe("MachineListHeader", () => {
 
   it("displays a new label for the tag action", () => {
     // Set a selected machine so the take action menu becomes enabled.
-    state.machine.selected = ["abc123"];
+    state.machine.selectedMachines = { items: ["abc123"] };
     // A machine needs the tag action for it to appear in the menu.
     state.machine.items = [
       machineFactory({ system_id: "abc123", actions: [NodeActions.TAG] }),
@@ -242,7 +250,7 @@ describe("MachineListHeader", () => {
 
   it("hides the tag action's new label after it has been clicked", () => {
     // Set a selected machine so the take action menu becomes enabled.
-    state.machine.selected = ["abc123"];
+    state.machine.selectedMachines = { items: ["abc123"] };
     // A machine needs the tag action for it to appear in the menu.
     state.machine.items = [
       machineFactory({ system_id: "abc123", actions: [NodeActions.TAG] }),

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -19,7 +19,10 @@ import type {
 } from "app/machines/types";
 import { getHeaderTitle } from "app/machines/utils";
 import machineSelectors from "app/store/machine/selectors";
-import { useFetchMachineCount } from "app/store/machine/utils/hooks";
+import {
+  useFetchMachineCount,
+  useHasSelection,
+} from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 
@@ -36,6 +39,7 @@ export const MachineListHeader = ({
 }: Props): JSX.Element => {
   const location = useLocation();
   const selectedMachines = useSelector(machineSelectors.selected);
+  const hasSelection = useHasSelection();
   const [tagsSeen, setTagsSeen] = useStorageState(
     localStorage,
     "machineViewTagsSeen",
@@ -71,14 +75,14 @@ export const MachineListHeader = ({
     <MachinesHeader
       buttons={[
         <AddHardwareMenu
-          disabled={selectedMachines.length > 0}
+          disabled={hasSelection}
           key="add-hardware"
           setHeaderContent={setHeaderContent}
         />,
         <NodeActionMenu
           alwaysShowLifecycle
           getTitle={getTitle}
-          hasSelection={selectedMachines.length > 0}
+          hasSelection={hasSelection}
           key="machine-list-action-menu"
           nodeDisplay="machine"
           onActionClick={(action) => {

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -8,6 +8,7 @@ import type { MockStoreEnhanced } from "redux-mock-store";
 
 import type { UseFetchMachinesOptions } from "./hooks";
 import {
+  useHasSelection,
   useCanAddVLAN,
   useCanEditStorage,
   useFormattedOS,
@@ -737,6 +738,55 @@ describe("machine hook utils", () => {
         wrapper: generateWrapper(store),
       });
       expect(result.current).toBe(false);
+    });
+  });
+
+  describe("useHasSelection", () => {
+    it("can have no selected machines", () => {
+      state.machine.selectedMachines = null;
+      const store = mockStore(state);
+      const { result } = renderHook(() => useHasSelection(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(false);
+    });
+
+    it("is selected if there are filters", () => {
+      state.machine.selectedMachines = {
+        filter: { hostname: "wistful-wallaby" },
+      };
+      const store = mockStore(state);
+      const { result } = renderHook(() => useHasSelection(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("is selected if there are empty filters", () => {
+      state.machine.selectedMachines = { filter: {} };
+      const store = mockStore(state);
+      const { result } = renderHook(() => useHasSelection(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("is selected if there are groups", () => {
+      state.machine.selectedMachines = { groups: ["Admin 2"] };
+      const store = mockStore(state);
+      const { result } = renderHook(() => useHasSelection(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
+    });
+
+    it("is selected if there are items", () => {
+      state.machine.selectedMachines = { items: ["abc123"] };
+      const store = mockStore(state);
+      const { result } = renderHook(() => useHasSelection(), {
+        wrapper: generateWrapper(store),
+      });
+      expect(result.current).toBe(true);
     });
   });
 });

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -340,3 +340,22 @@ export const useCanAddVLAN = (
   // Check that there are unused VLANS available.
   return unusedVLANs.length > 0;
 };
+
+/**
+ * Whether any machines are selected.
+ */
+export const useHasSelection = (): boolean => {
+  const selectedMachines = useSelector(machineSelectors.selectedMachines);
+  if (!selectedMachines) {
+    return false;
+  }
+  // Check if the filter param is set. The just checks for a truthy value (instead
+  // of checking if there are any keys) as an empty object is equivalent to
+  // "select all".
+  const hasFilters = "filter" in selectedMachines && !!selectedMachines.filter;
+  const hasGroups =
+    "groups" in selectedMachines && (selectedMachines.groups ?? [])?.length > 0;
+  const hasItems =
+    "items" in selectedMachines && (selectedMachines.items ?? [])?.length > 0;
+  return hasFilters || hasGroups || hasItems;
+};


### PR DESCRIPTION
## Done

- Use the new selected state to check VMs in the KVM tables.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- The take action menu should be disabled and the add hardware button should be enabled.
- Tick some machines and the take action menu should get enabled and the add hardware button should get disabled.
- Go to KVM -> cluster -> Virtual machines tab (or the VMs tab on a single host).
- The take action menu should be disabled and the delete VM button should be enabled.
- Tick some machines and the take action menu should get enabled and the delete VM button should get disabled.

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1305.