### PR TITLE
Fix MAAS UI team 404 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ MAAS server source and issue tracking [can be found on Launchpad](https://launch
 
 ## Team Members
 
-[MAAS UI](https://github.com/orgs/canonical/teams/maas-ui/members) and [Canonical Web & Design](https://github.com/orgs/canonical/teams/web-and-design/members)
+[MAAS Tribe](https://discourse.canonical.com/t/maas-tribe/272) and [Canonical Web & Design](https://github.com/orgs/canonical/teams/web-and-design/members)
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Done
replace non-existent MAAS UI link with discourse MAAS Tribe page

Fixes #4367

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
