### PR TITLE
fix(ui): lxd cluster route infinite loading

### DIFF
--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -20,7 +20,6 @@ import LXDClusterVMs from "./LXDClusterVMs";
 
 import ModelNotFound from "app/base/components/ModelNotFound";
 import Section from "app/base/components/Section";
-import { useCycled } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
 import type { SetSearchFilter } from "app/base/types";
 import urls from "app/base/urls";
@@ -46,11 +45,15 @@ const LXDClusterDetails = (): JSX.Element => {
     vmClusterSelectors.getById(state, clusterId)
   );
   const clustersLoaded = useSelector(vmClusterSelectors.loaded);
-  const getting = useSelector((state: RootState) =>
+  const gettingVmCluster = useSelector((state: RootState) =>
     vmClusterSelectors.status(state, "getting")
   );
-  const [fetched] = useCycled(getting);
-  const loaded = clustersLoaded || fetched;
+  const vmCluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const fetchedVmCluster = !gettingVmCluster && vmCluster;
+
+  const loaded = clustersLoaded || fetchedVmCluster;
   const [headerContent, setHeaderContent] = useState<KVMHeaderContent | null>(
     null
   );

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
@@ -44,7 +44,15 @@ const LXDClusterHostVMs = ({
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, hostId)
   );
-  const clustersLoaded = useSelector(vmClusterSelectors.loaded);
+  const vmClustersLoaded = useSelector(vmClusterSelectors.loaded);
+  const gettingVmCluster = useSelector((state: RootState) =>
+    vmClusterSelectors.status(state, "getting")
+  );
+  const vmCluster = useSelector((state: RootState) =>
+    vmClusterSelectors.getById(state, clusterId)
+  );
+  const fetchedVmCluster = !gettingVmCluster && vmCluster;
+  const clustersLoaded = vmClustersLoaded || fetchedVmCluster;
   const hostsLoaded = useSelector(podSelectors.loaded);
   useWindowTitle(
     `${pod?.name || "Host"} in ${cluster?.name || "cluster"} virtual machines`


### PR DESCRIPTION
## Done

- fix(ui): lxd cluster route infinite loading

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- using bolla as a back-end go to `/MAAS/r/kvm/lxd/cluster/29/vms/518` and verify the page loads in full

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1331

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
