### PR TITLE
feat(kvm): display skeleton when loading VMs

### DIFF
--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -13,7 +13,11 @@ import { DEFAULTS } from "app/machines/views/MachineList/MachineListTable/consta
 import { actions as machineActions } from "app/store/machine";
 import type { FetchGroupKey } from "app/store/machine/types";
 import { FilterGroupKey } from "app/store/machine/types";
-import { mapSortDirection, FilterMachineItems } from "app/store/machine/utils";
+import {
+  mapSortDirection,
+  FilterMachineItems,
+  useFetchedCount,
+} from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { Pod } from "app/store/pod/types";
 
@@ -64,6 +68,7 @@ const LXDVMsTable = ({
     sortDirection: mapSortDirection(sortDirection),
     sortKey,
   });
+  const count = useFetchedCount(machineCount, loading);
 
   useEffect(
     () => () => {
@@ -77,13 +82,12 @@ const LXDVMsTable = ({
     <>
       <VMsActionBar
         currentPage={currentPage}
-        machinesLoading={loading}
         onAddVMClick={onAddVMClick}
         searchFilter={searchFilter}
         setCurrentPage={setCurrentPage}
         setHeaderContent={setHeaderContent}
         setSearchFilter={setSearchFilter}
-        vmCount={machineCount ?? 0}
+        vmCount={count}
       />
       <VMsTable
         callId={callId}

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -11,7 +11,7 @@ import { NodeActions } from "app/store/types/node";
 
 type Props = {
   currentPage: number;
-  machinesLoading: boolean;
+  machinesLoading?: boolean;
   onAddVMClick?: () => void;
   searchFilter: string;
   setCurrentPage: (page: number) => void;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect } from "react";
-
 import type {
   PaginationProps,
   PropsWithSpread,
 } from "@canonical/react-components";
 import { Pagination } from "@canonical/react-components";
+
+import { useFetchedCount } from "app/store/machine/utils";
 
 export enum Label {
   Pagination = "Table pagination",
@@ -26,19 +26,7 @@ const MachineListPagination = ({
   machinesLoading,
   ...props
 }: Props): JSX.Element | null => {
-  const [previousCount, setPreviousCount] = useState(machineCount);
-  const count = (machinesLoading ? previousCount : machineCount) ?? 0;
-
-  useEffect(() => {
-    // The pagination needs to be displayed while the new list is being fetched
-    // so this stores the previous machine count while the request is in progress.
-    if (
-      (machineCount || machineCount === 0) &&
-      previousCount !== machineCount
-    ) {
-      setPreviousCount(machineCount);
-    }
-  }, [machineCount, previousCount]);
+  const count = useFetchedCount(machineCount, machinesLoading);
 
   return count > 0 ? (
     <Pagination

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -359,3 +359,24 @@ export const useHasSelection = (): boolean => {
     "items" in selectedMachines && (selectedMachines.items ?? [])?.length > 0;
   return hasFilters || hasGroups || hasItems;
 };
+
+/**
+ * Return the previous count while a new fetch is in progress.
+ */
+export const useFetchedCount = (
+  newCount: number | null,
+  loading?: boolean | null
+): number => {
+  const [previousCount, setPreviousCount] = useState(newCount);
+  const count = (loading ? previousCount : newCount) ?? 0;
+
+  useEffect(() => {
+    // The pagination needs to be displayed while the new list is being fetched
+    // so this stores the previous machine count while the request is in progress.
+    if ((newCount || newCount === 0) && previousCount !== newCount) {
+      setPreviousCount(newCount);
+    }
+  }, [newCount, previousCount]);
+
+  return count;
+};

--- a/src/app/store/machine/utils/index.ts
+++ b/src/app/store/machine/utils/index.ts
@@ -11,6 +11,7 @@ export type { TagIdCountMap } from "./common";
 export {
   useCanAddVLAN,
   useCanEditStorage,
+  useFetchedCount,
   useFormattedOS,
   useHasInvalidArchitecture,
   useIsLimitedEditingAllowed,


### PR DESCRIPTION
## Done

- Display the skeleton rows when loading VMs in the LXD tables.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to KVM -> click on cluster or single host -> virtual machines tab.
- As the table loads you should see the skeleton.
- Change the page or sort or search and you should see the skeleton.

## Fixes

Fixes: canonical/app-tribe#1323.