### PR TITLE
fix(ui): discovery add form

### DIFF
--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,14 +14,24 @@ import { DeviceIpAssignment, DeviceMeta } from "app/store/device/types";
 import type { Discovery } from "app/store/discovery/types";
 import type { RootState } from "app/store/root/types";
 import {
+  NodeStatus,
+  NodeStatusCode,
+  TestStatusStatus,
+} from "app/store/types/node";
+import {
   discovery as discoveryFactory,
   discoveryState as discoveryStateFactory,
   deviceState as deviceStateFactory,
   domainState as domainStateFactory,
+  machine as machineFactory,
+  testStatus as testStatusFactory,
   machineState as machineStateFactory,
+  modelRef as modelRefFactory,
   subnetState as subnetStateFactory,
   vlanState as vlanStateFactory,
   rootState as rootStateFactory,
+  machineStateList as machineStateListFactory,
+  machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
 import { submitFormikForm } from "testing/utils";
 
@@ -31,6 +42,51 @@ describe("DiscoveryAddForm", () => {
   let discovery: Discovery;
 
   beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+    const machines = [
+      machineFactory({
+        actions: [],
+        architecture: "amd64/generic",
+        cpu_count: 4,
+        cpu_test_status: testStatusFactory({
+          status: TestStatusStatus.RUNNING,
+        }),
+        distro_series: "bionic",
+        domain: modelRefFactory({
+          name: "example",
+        }),
+        extra_macs: [],
+        fqdn: "koala.example",
+        hostname: "koala",
+        ip_addresses: [],
+        memory: 8,
+        memory_test_status: testStatusFactory({
+          status: TestStatusStatus.PASSED,
+        }),
+        network_test_status: testStatusFactory({
+          status: TestStatusStatus.PASSED,
+        }),
+        osystem: "ubuntu",
+        owner: "admin",
+        permissions: ["edit", "delete"],
+        physical_disk_count: 1,
+        pool: modelRefFactory(),
+        pxe_mac: "00:11:22:33:44:55",
+        spaces: [],
+        status: NodeStatus.DEPLOYED,
+        status_code: NodeStatusCode.DEPLOYED,
+        status_message: "",
+        storage: 8,
+        storage_test_status: testStatusFactory({
+          status: TestStatusStatus.PASSED,
+        }),
+        testing_status: testStatusFactory({
+          status: TestStatusStatus.PASSED,
+        }),
+        system_id: "abc123",
+        zone: modelRefFactory(),
+      }),
+    ];
     discovery = discoveryFactory({
       ip: "1.2.3.4",
       mac_address: "aa:bb:cc",
@@ -44,7 +100,21 @@ describe("DiscoveryAddForm", () => {
         items: [discovery],
       }),
       domain: domainStateFactory({ loaded: true }),
-      machine: machineStateFactory({ loaded: true }),
+      machine: machineStateFactory({
+        loaded: true,
+        items: machines,
+        lists: {
+          "123456": machineStateListFactory({
+            loaded: true,
+            groups: [
+              machineStateListGroupFactory({
+                items: [machines[0].system_id],
+                name: "Deployed",
+              }),
+            ],
+          }),
+        },
+      }),
       subnet: subnetStateFactory({ loaded: true }),
       vlan: vlanStateFactory({ loaded: true }),
     });

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.tsx
@@ -21,12 +21,12 @@ import { actions as discoveryActions } from "app/store/discovery";
 import type { Discovery } from "app/store/discovery/types";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
-import machineSelectors from "app/store/machine/selectors";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import { actions as messageActions } from "app/store/message";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
+import { FetchNodeStatus } from "app/store/types/node";
 import { actions as vlanActions } from "app/store/vlan";
 import vlanSelectors from "app/store/vlan/selectors";
 import { preparePayload } from "app/utils";
@@ -129,7 +129,6 @@ const DiscoveryAddForm = ({ discovery, onClose }: Props): JSX.Element => {
   );
   const domainsLoaded = useSelector(domainSelectors.loaded);
   let errors = useSelector(deviceSelectors.errors);
-  const machinesLoaded = useSelector(machineSelectors.loaded);
   const saved = useSelector(deviceSelectors.saved);
   const saving = useSelector(deviceSelectors.saving);
   const creatingInterface = useSelector((state: RootState) =>
@@ -146,7 +145,9 @@ const DiscoveryAddForm = ({ discovery, onClose }: Props): JSX.Element => {
   const processing =
     deviceType === DeviceType.DEVICE ? saving : creatingInterface;
   const processed = deviceType === DeviceType.DEVICE ? saved : createdInterface;
-  useFetchMachines();
+  const { loaded: machinesLoaded } = useFetchMachines({
+    filters: { status: FetchNodeStatus.DEPLOYED },
+  });
 
   useEffect(() => {
     dispatch(deviceActions.fetch());

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -15,11 +15,11 @@ import type { Device } from "app/store/device/types";
 import { DeviceMeta } from "app/store/device/types";
 import type { Discovery } from "app/store/discovery/types";
 import domainSelectors from "app/store/domain/selectors";
-import machineSelectors from "app/store/machine/selectors";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import subnetSelectors from "app/store/subnet/selectors";
 import { getSubnetDisplay } from "app/store/subnet/utils";
-import { NodeStatusCode } from "app/store/types/node";
+import { FetchNodeStatus } from "app/store/types/node";
 import vlanSelectors from "app/store/vlan/selectors";
 import { getVLANDisplay } from "app/store/vlan/utils";
 
@@ -36,9 +36,10 @@ const DiscoveryAddFormFields = ({
 }: Props): JSX.Element | null => {
   const devices = useSelector(deviceSelectors.all);
   const domains = useSelector(domainSelectors.all);
-  const machines = useSelector((state: RootState) =>
-    machineSelectors.getByStatusCode(state, NodeStatusCode.DEPLOYED)
-  );
+  const { machines } = useFetchMachines({
+    filters: { status: FetchNodeStatus.DEPLOYED },
+  });
+
   const subnet = useSelector((state: RootState) =>
     subnetSelectors.getByCIDR(state, discovery.subnet_cidr)
   );


### PR DESCRIPTION
## Done

- fix(ui): discovery add form

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine discovery and open add discovery form
- Make sure the form loads

## Fixes

Fixes #4387 .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
