### PR TITLE
test: add mockFormikFormSaved util

### DIFF
--- a/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
+++ b/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
@@ -20,6 +20,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 
 const mockStore = configureStore();
 let state: RootState;
@@ -130,13 +131,8 @@ it("updates the new tags after creating a tag", async () => {
     screen.getByRole("textbox", { name: TagFieldLabel.Input }),
     "new-tag{enter}"
   );
-  // Simulate the state.tag.saved state going from `save: false` to `saved:
-  // true` which happens when the tag is successfully saved. This in turn will
-  // mean that the form `onSuccess` prop will get called so that the component
-  // knows that the tag was created.
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+
+  mockFormikFormSaved();
   const newTag = tagFactory({ id: 8, name: "new-tag" });
   state.tag.saved = true;
   state.tag.items.push(newTag);

--- a/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.test.tsx
+++ b/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.test.tsx
@@ -2,10 +2,10 @@ import { mount } from "enzyme";
 
 import NodeActionFormWrapper from "./NodeActionFormWrapper";
 
-import * as baseHooks from "app/base/hooks/base";
 import type { Node } from "app/store/types/node";
 import { NodeActions } from "app/store/types/node";
 import { machine as machineFactory } from "testing/factories";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 
 describe("NodeActionFormWrapper", () => {
   afterEach(() => {
@@ -65,9 +65,7 @@ describe("NodeActionFormWrapper", () => {
   it(`does not display a warning when action has started even if not all
       selected nodes can perform selected action`, async () => {
     // Mock that action has started.
-    jest
-      .spyOn(baseHooks, "useCycled")
-      .mockImplementation(() => [true, () => null]);
+    mockFormikFormSaved();
     const nodes = [
       machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
       machineFactory({ system_id: "def456", actions: [] }),

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagForm.test.tsx
@@ -9,7 +9,6 @@ import TagForm, { Label } from "./TagForm";
 import { Label as TagFormChangesLabel } from "./TagFormChanges";
 import { Label as TagFormFieldsLabel } from "./TagFormFields";
 
-import * as baseHooks from "app/base/hooks/base";
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import {
@@ -18,6 +17,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 
 const mockStore = configureStore();
 
@@ -32,13 +32,6 @@ beforeEach(() => {
       loaded: true,
     }),
   });
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [false, () => null]);
-});
-
-afterEach(() => {
-  jest.restoreAllMocks();
 });
 
 it("dispatches action to fetch tags on load", () => {
@@ -264,9 +257,7 @@ it("shows a notification on success", async () => {
     </Provider>
   );
   // Mock state.tag.saved transitioning from "false" to "true"
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+  mockFormikFormSaved();
   await userEvent.click(screen.getByLabelText(TagFormFieldsLabel.TagInput));
   await userEvent.click(screen.getByRole("option", { name: "tag2" }));
   await userEvent.click(

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -10,7 +10,6 @@ import { Label as TagFormChangesLabel } from "../TagFormChanges/TagFormChanges";
 
 import TagFormFields, { Label } from "./TagFormFields";
 
-import * as baseHooks from "app/base/hooks/base";
 import type { RootState } from "app/store/root/types";
 import type { Tag, TagMeta } from "app/store/tag/types";
 import { Label as AddTagFormLabel } from "app/tags/components/AddTagForm/AddTagForm";
@@ -21,6 +20,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 
 const mockStore = configureStore();
 let state: RootState;
@@ -44,13 +44,6 @@ beforeEach(() => {
       items: tags,
     }),
   });
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [false, () => null]);
-});
-
-afterEach(() => {
-  jest.restoreAllMocks();
 });
 
 it("displays available tags in the dropdown", async () => {
@@ -185,13 +178,7 @@ it("updates the new tags after creating a tag", async () => {
     screen.getByRole("textbox", { name: Label.TagInput }),
     "new-tag{enter}"
   );
-  // Simulate the state.tag.saved state going from `save: false` to `saved:
-  // true` which happens when the tag is successfully saved. This in turn will
-  // mean that the form `onSuccess` prop will get called so that the component
-  // knows that the tag was created.
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+  mockFormikFormSaved();
   const newTag = tagFactory({ id: 8, name: "new-tag" });
   state.tag.saved = true;
   state.tag.items.push(newTag);

--- a/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
@@ -7,7 +7,6 @@ import configureStore from "redux-mock-store";
 
 import AddTagForm, { Label } from "./AddTagForm";
 
-import * as baseHooks from "app/base/hooks/base";
 import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
@@ -17,6 +16,7 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 
 const mockStore = configureStore();
 
@@ -26,9 +26,6 @@ beforeEach(() => {
   state = rootStateFactory({
     tag: tagStateFactory(),
   });
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [false, () => null]);
 });
 
 afterEach(() => {
@@ -85,13 +82,8 @@ it("returns the newly created tag on save", async () => {
       </MemoryRouter>
     </Provider>
   );
-  // Simulate the state.tag.saved state going from `save: false` to `saved:
-  // true` which happens when the tag is successfully saved. This in turn will
-  // mean that the form `onSuccess` prop will get called so that the component
-  // knows that the tag was created.
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+
+  mockFormikFormSaved();
   const newTag = tagFactory({ id: 8, name: "new-tag" });
   state.tag = tagStateFactory({
     items: [newTag],

--- a/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -9,7 +9,6 @@ import configureStore from "redux-mock-store";
 import AddTagForm, { Label } from "./AddTagForm";
 
 import * as analyticsHooks from "app/base/hooks/analytics";
-import * as baseHooks from "app/base/hooks/base";
 import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
@@ -21,6 +20,7 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 
 const mockStore = configureStore();
 
@@ -30,13 +30,6 @@ beforeEach(() => {
   state = rootStateFactory({
     tag: tagStateFactory(),
   });
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [false, () => null]);
-});
-
-afterEach(() => {
-  jest.restoreAllMocks();
 });
 
 it("dispatches an action to create a tag", async () => {
@@ -105,13 +98,8 @@ it("redirects to the newly created tag on save", async () => {
     screen.getByRole("textbox", { name: Label.Name }),
     "tag1"
   );
-  // Simulate the state.tag.saved state going from `save: false` to `saved:
-  // true` which happens when the tag is successfully saved. This in turn will
-  // mean that the form `onSuccess` prop will get called so that the component
-  // knows that the tag was created.
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+
+  mockFormikFormSaved();
   state.tag = tagStateFactory({
     items: [tagFactory({ id: 8, name: "tag1" })],
     saved: true,
@@ -142,13 +130,8 @@ it("sends analytics when there is a definition", async () => {
     screen.getByRole("textbox", { name: Label.Name }),
     "tag1"
   );
-  // Simulate the state.tag.saved state going from `save: false` to `saved:
-  // true` which happens when the tag is successfully saved. This in turn will
-  // mean that the form `onSuccess` prop will get called so that the component
-  // knows that the tag was created.
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+
+  mockFormikFormSaved();
   state.tag = tagStateFactory({
     items: [tagFactory({ id: 8, name: "tag1", definition: "def1" })],
     saved: true,
@@ -185,13 +168,8 @@ it("sends analytics when there is no definition", async () => {
     screen.getByRole("textbox", { name: Label.Name }),
     "tag1"
   );
-  // Simulate the state.tag.saved state going from `save: false` to `saved:
-  // true` which happens when the tag is successfully saved. This in turn will
-  // mean that the form `onSuccess` prop will get called so that the component
-  // knows that the tag was created.
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+
+  mockFormikFormSaved();
   state.tag = tagStateFactory({
     items: [tagFactory({ id: 8, name: "tag1" })],
     saved: true,
@@ -230,9 +208,7 @@ it("shows a confirmation when an automatic tag is added", async () => {
     "definition"
   );
   // Mock state.tag.saved transitioning from "false" to "true"
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+  mockFormikFormSaved();
   await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
   await waitFor(() => {

--- a/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -8,7 +8,6 @@ import configureStore from "redux-mock-store";
 
 import TagUpdate from "./TagUpdate";
 
-import * as baseHooks from "app/base/hooks/base";
 import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
@@ -20,6 +19,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 
 const mockStore = configureStore();
 let state: RootState;
@@ -35,13 +35,6 @@ beforeEach(() => {
       ],
     }),
   });
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [false, () => null]);
-});
-
-afterEach(() => {
-  jest.restoreAllMocks();
 });
 
 it("dispatches actions to fetch necessary data", () => {
@@ -164,13 +157,7 @@ it("can return to the previous page on save", async () => {
     screen.getByRole("textbox", { name: Label.Name }),
     "tag1"
   );
-  // Simulate the state.tag.saved state going from `save: false` to `saved:
-  // true` which happens when the tag is successfully saved. This in turn will
-  // mean that the form `onSuccess` prop will get called so that the component
-  // knows that the tag was updated.
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+  mockFormikFormSaved();
   await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
   await waitFor(() => expect(history.location.pathname).toBe(urls.tags.index));
 });
@@ -202,13 +189,7 @@ it("goes to the tag details page if it can't go back", async () => {
     screen.getByRole("textbox", { name: Label.Name }),
     "tag1"
   );
-  // Simulate the state.tag.saved state going from `save: false` to `saved:
-  // true` which happens when the tag is successfully saved. This in turn will
-  // mean that the form `onSuccess` prop will get called so that the component
-  // knows that the tag was updated.
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+  mockFormikFormSaved();
   await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
   await waitFor(() =>
     expect(history.location.pathname).toBe(urls.tags.tag.index({ id: 1 }))
@@ -234,10 +215,7 @@ it("shows a confirmation when a tag's definition is updated", async () => {
   });
   await userEvent.clear(definitionInput);
   await userEvent.type(definitionInput, "def");
-  // Mock state.tag.saved transitioning from "false" to "true"
-  jest
-    .spyOn(baseHooks, "useCycled")
-    .mockImplementation(() => [true, () => null]);
+  mockFormikFormSaved();
   await userEvent.click(screen.getByRole("button", { name: "Save changes" }));
 
   await waitFor(() => {

--- a/src/testing/mockFormikFormSaved.tsx
+++ b/src/testing/mockFormikFormSaved.tsx
@@ -1,0 +1,17 @@
+import * as baseHooks from "app/base/hooks/base";
+
+beforeEach(() => {
+  jest
+    .spyOn(baseHooks, "useCycled")
+    .mockImplementation(() => [false, () => null]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+// Simulate FormikForm saved state going from false to true by mocking useCycled
+export const mockFormikFormSaved = (): jest.SpyInstance =>
+  jest
+    .spyOn(baseHooks, "useCycled")
+    .mockImplementation(() => [true, () => null]);


### PR DESCRIPTION
## Done

- add `mockFormikFormSaved` util to make simulating `FormikForm` save easier

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1337

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
