### PR TITLE
feat(machines): display the count of selected machines

### DIFF
--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -77,8 +77,7 @@ export const MachineListHeader = ({
   }
   const onlyHasItems =
     !!selectedMachines &&
-    "items" in selectedMachines &&
-    !!selectedMachines.items?.length &&
+    selectedCount > 0 &&
     (!("groups" in selectedMachines) || !selectedMachines?.groups?.length);
 
   useEffect(() => {

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -218,7 +218,10 @@ it("can dispatch an action to select the group", async () => {
     }
   );
   await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelectedMachines({ groups: ["admin-2"] });
+  const expected = machineActions.setSelectedMachines({
+    grouping: FetchGroupKey.AgentName,
+    groups: ["admin-2"],
+  });
   expect(
     store.getActions().find((action) => action.type === expected.type)
   ).toStrictEqual(expected);
@@ -287,6 +290,7 @@ it("does not overwrite selected machines in different groups", async () => {
   );
   await userEvent.click(screen.getByRole("checkbox"));
   const expected = machineActions.setSelectedMachines({
+    grouping: FetchGroupKey.AgentName,
     groups: ["admin-2"],
     items: ["def456"],
   });

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -5,6 +5,7 @@ import configureStore from "redux-mock-store";
 import GroupCheckbox from "./GroupCheckbox";
 
 import { actions as machineActions } from "app/store/machine";
+import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
   rootState as rootStateFactory,
@@ -43,9 +44,16 @@ it("is disabled if all machines are selected", () => {
       owner: "admin",
     },
   };
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    state,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      state,
+    }
+  );
   expect(screen.getByRole("checkbox")).toBeDisabled();
 });
 
@@ -57,9 +65,16 @@ it("is disabled if there are no machines in the group", () => {
       value: "admin-2",
     }),
   ];
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    state,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      state,
+    }
+  );
   expect(screen.getByRole("checkbox")).toBeDisabled();
 });
 
@@ -71,17 +86,31 @@ it("is not disabled if there are machines in the group", () => {
       value: "admin-2",
     }),
   ];
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    state,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      state,
+    }
+  );
   expect(screen.getByRole("checkbox")).not.toBeDisabled();
 });
 
 it("is unchecked if there are no filters, groups or items selected", () => {
   state.machine.selectedMachines = null;
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    state,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      state,
+    }
+  );
   expect(screen.getByRole("checkbox")).not.toBeChecked();
 });
 
@@ -91,9 +120,16 @@ it("is checked if all machines are selected", () => {
       owner: "admin",
     },
   };
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    state,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      state,
+    }
+  );
   expect(screen.getByRole("checkbox")).toBeChecked();
 });
 
@@ -101,9 +137,16 @@ it("is checked if the group is selected", () => {
   state.machine.selectedMachines = {
     groups: ["admin-2"],
   };
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    state,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      state,
+    }
+  );
   expect(screen.getByRole("checkbox")).toBeChecked();
 });
 
@@ -119,9 +162,16 @@ it("is partially checked if a machine in the group is selected", () => {
   state.machine.selectedMachines = {
     items: ["abc123"],
   };
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    state,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      state,
+    }
+  );
   expect(screen.getByRole("checkbox")).toBePartiallyChecked();
 });
 
@@ -142,17 +192,31 @@ it("is not checked if a selected machine is in another group", () => {
   state.machine.selectedMachines = {
     items: ["def456"],
   };
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    state,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      state,
+    }
+  );
   expect(screen.getByRole("checkbox")).not.toBeChecked();
 });
 
 it("can dispatch an action to select the group", async () => {
   const store = mockStore(state);
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    store,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      store,
+    }
+  );
   await userEvent.click(screen.getByRole("checkbox"));
   const expected = machineActions.setSelectedMachines({ groups: ["admin-2"] });
   expect(
@@ -173,9 +237,16 @@ it("removes selected machines that are in the group that was clicked", async () 
     items: ["abc123", "def456"],
   };
   const store = mockStore(state);
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    store,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      store,
+    }
+  );
   await userEvent.click(screen.getByRole("checkbox"));
   const expected = machineActions.setSelectedMachines({
     items: ["def456"],
@@ -204,9 +275,16 @@ it("does not overwrite selected machines in different groups", async () => {
     items: ["def456"],
   };
   const store = mockStore(state);
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    store,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      store,
+    }
+  );
   await userEvent.click(screen.getByRole("checkbox"));
   const expected = machineActions.setSelectedMachines({
     groups: ["admin-2"],
@@ -237,9 +315,16 @@ it("can dispatch an action to unselect the group", async () => {
     items: ["def456"],
   };
   const store = mockStore(state);
-  renderWithMockStore(<GroupCheckbox callId={callId} groupName="admin2" />, {
-    store,
-  });
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      store,
+    }
+  );
   await userEvent.click(screen.getByRole("checkbox"));
   const expected = machineActions.setSelectedMachines({
     groups: ["admin-1"],

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
@@ -4,15 +4,23 @@ import { useSelector } from "react-redux";
 import TableCheckbox from "app/machines/components/TableCheckbox";
 import { Checked } from "app/machines/components/TableCheckbox/TableCheckbox";
 import machineSelectors from "app/store/machine/selectors";
-import type { MachineStateListGroup } from "app/store/machine/types";
+import type {
+  MachineStateListGroup,
+  FetchGroupKey,
+} from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 
 type Props = {
   callId?: string | null;
+  grouping: FetchGroupKey | null;
   groupName: MachineStateListGroup["name"];
 };
 
-const GroupCheckbox = ({ callId, groupName }: Props): JSX.Element | null => {
+const GroupCheckbox = ({
+  callId,
+  grouping,
+  groupName,
+}: Props): JSX.Element | null => {
   const selected = useSelector(machineSelectors.selectedMachines);
   const group = useSelector((state: RootState) =>
     machineSelectors.listGroup(state, callId, groupName)
@@ -56,6 +64,7 @@ const GroupCheckbox = ({ callId, groupName }: Props): JSX.Element | null => {
           // If the checkbox has been checked and the group is not in the list
           // then add it.
           newSelected.groups.push(group.value);
+          newSelected.grouping = grouping;
         } else if (!checked && newSelected.groups?.includes(group.value)) {
           // If the checkbox has been unchecked and the group is in the list
           // then remove it.

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -33,12 +33,12 @@ import { SortDirection } from "app/base/types";
 import { columnLabels, columns, MachineColumns } from "app/machines/constants";
 import { actions as generalActions } from "app/store/general";
 import machineSelectors from "app/store/machine/selectors";
-import { FetchGroupKey } from "app/store/machine/types";
 import type {
   Machine,
   MachineMeta,
   MachineStateListGroup,
 } from "app/store/machine/types";
+import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachineItems } from "app/store/machine/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import type { RootState } from "app/store/root/types";
@@ -424,7 +424,11 @@ const generateGroupRows = ({
                   data-testid="group-cell"
                   primary={
                     showActions ? (
-                      <GroupCheckbox callId={callId} groupName={name} />
+                      <GroupCheckbox
+                        callId={callId}
+                        groupName={name}
+                        grouping={grouping}
+                      />
                     ) : (
                       <strong>{name}</strong>
                     )

--- a/src/app/machines/views/Machines.tsx
+++ b/src/app/machines/views/Machines.tsx
@@ -51,6 +51,7 @@ const Machines = (): JSX.Element => {
       header={
         <MachineListHeader
           headerContent={headerContent}
+          searchFilter={searchFilter}
           setHeaderContent={setHeaderContent}
           setSearchFilter={setSearchFilter}
         />

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -569,7 +569,7 @@ const machineSlice = createSlice({
       },
     },
     count: {
-      prepare: (callId: string, filters?: FetchFilters) => ({
+      prepare: (callId: string, filters?: FetchFilters | null) => ({
         meta: {
           model: MachineMeta.MODEL,
           method: "count",

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -268,7 +268,7 @@ type Filters = {
   [FilterGroupKey.Domain]: Domain["name"];
   [FilterGroupKey.ErrorDescription]: Machine["error_description"];
   [FilterGroupKey.FabricClasses]: Fabric["class_type"];
-  [FilterGroupKey.Fabrics]: Machine["fabrics"];
+  [FilterGroupKey.Fabrics]: Machine["fabrics"][0];
   [FilterGroupKey.FreeText]: string;
   [FilterGroupKey.Hostname]: Machine["hostname"];
   [FilterGroupKey.IpAddresses]: NodeIpAddress["ip"];
@@ -283,7 +283,7 @@ type Filters = {
   [FilterGroupKey.Spaces]: Space["name"];
   [FilterGroupKey.Status]: FetchNodeStatus;
   [FilterGroupKey.Subnets]: Subnet["name"];
-  [FilterGroupKey.SystemId]: Machine["system_id"];
+  [FilterGroupKey.Id]: Machine["system_id"];
   [FilterGroupKey.Tags]: Tag["name"];
   [FilterGroupKey.Vlans]: NodeVlan["name"];
   [FilterGroupKey.Workloads]: string;
@@ -291,25 +291,25 @@ type Filters = {
 };
 
 type ExcludeFilters = {
-  [FilterGroupKey.NotArch]: Filters["arch"];
-  [FilterGroupKey.NotCpuCount]: Machine["cpu_count"];
-  [FilterGroupKey.NotCpuSpeed]: Machine["cpu_speed"];
-  [FilterGroupKey.NotDistroSeries]: Filters["distro_series"];
-  [FilterGroupKey.NotFabricClasses]: Filters["fabric_classes"];
-  [FilterGroupKey.NotFabrics]: Filters["fabrics"];
-  [FilterGroupKey.NotInPool]: Filters["pool"];
-  [FilterGroupKey.NotInZone]: Filters["zone"];
-  [FilterGroupKey.NotIpAddresses]: Filters["ip_addresses"];
-  [FilterGroupKey.NotLinkSpeed]: Machine["link_speeds"][0];
-  [FilterGroupKey.NotMem]: Machine["memory"];
-  [FilterGroupKey.NotOsystem]: Filters["osystem"];
-  [FilterGroupKey.NotOwner]: Filters["owner"];
-  [FilterGroupKey.NotPod]: Filters["pod"];
-  [FilterGroupKey.NotPodType]: Filters["pod_type"];
-  [FilterGroupKey.NotSubnets]: Filters["subnets"];
-  [FilterGroupKey.NotSystemId]: Filters["system_id"];
-  [FilterGroupKey.NotTags]: Filters["tags"];
-  [FilterGroupKey.NotVlans]: Filters["vlans"];
+  [FilterGroupKey.NotArch]: Filters[FilterGroupKey.Arch];
+  [FilterGroupKey.NotCpuCount]: Filters[FilterGroupKey.CpuCount];
+  [FilterGroupKey.NotCpuSpeed]: Filters[FilterGroupKey.CpuSpeed];
+  [FilterGroupKey.NotDistroSeries]: Filters[FilterGroupKey.DistroSeries];
+  [FilterGroupKey.NotFabricClasses]: Filters[FilterGroupKey.FabricClasses];
+  [FilterGroupKey.NotFabrics]: Filters[FilterGroupKey.Fabrics];
+  [FilterGroupKey.NotInPool]: Filters[FilterGroupKey.Pool];
+  [FilterGroupKey.NotInZone]: Filters[FilterGroupKey.Zone];
+  [FilterGroupKey.NotIpAddresses]: Filters[FilterGroupKey.IpAddresses];
+  [FilterGroupKey.NotLinkSpeed]: Filters[FilterGroupKey.LinkSpeed];
+  [FilterGroupKey.NotMem]: Filters[FilterGroupKey.Mem];
+  [FilterGroupKey.NotOsystem]: Filters[FilterGroupKey.Osystem];
+  [FilterGroupKey.NotOwner]: Filters[FilterGroupKey.Owner];
+  [FilterGroupKey.NotPod]: Filters[FilterGroupKey.Pod];
+  [FilterGroupKey.NotPodType]: Filters[FilterGroupKey.PodType];
+  [FilterGroupKey.NotSubnets]: Filters[FilterGroupKey.Subnets];
+  [FilterGroupKey.NotId]: Filters[FilterGroupKey.Id];
+  [FilterGroupKey.NotTags]: Filters[FilterGroupKey.Tags];
+  [FilterGroupKey.NotVlans]: Filters[FilterGroupKey.Vlans];
 };
 
 export type FetchFilters = Partial<

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -1,4 +1,4 @@
-import type { FetchFilters } from "./actions";
+import type { FetchFilters, FetchGroupKey } from "./actions";
 import type { MachineMeta } from "./enum";
 
 import type { APIError, Seconds } from "app/base/types";
@@ -195,6 +195,8 @@ export type MachineStateDetailsItem = {
 
 export type MachineStateDetails = Record<string, MachineStateDetailsItem>;
 
+export type FilterGroupOptionType = boolean | number | string;
+
 export type FilterGroupOption<K = FilterGroupOptionType> = {
   key: K;
   label: string;
@@ -220,8 +222,6 @@ export type MachineStateList = {
 
 export type MachineStateLists = Record<string, MachineStateList>;
 
-export type FilterGroupOptionType = boolean | number | string;
-
 export enum FilterGroupType {
   Bool = "bool",
   Dict = "dict[str,str]",
@@ -246,6 +246,7 @@ export enum FilterGroupKey {
   Fabrics = "fabrics",
   FreeText = "free_text",
   Hostname = "hostname",
+  Id = "id",
   IpAddresses = "ip_addresses",
   LinkSpeed = "link_speed",
   MacAddress = "mac_address",
@@ -256,6 +257,7 @@ export enum FilterGroupKey {
   NotDistroSeries = "not_distro_series",
   NotFabricClasses = "not_fabric_classes",
   NotFabrics = "not_fabrics",
+  NotId = "not_id",
   NotInPool = "not_in_pool",
   NotInZone = "not_in_zone",
   NotIpAddresses = "not_ip_addresses",
@@ -266,7 +268,6 @@ export enum FilterGroupKey {
   NotPod = "not_pod",
   NotPodType = "not_pod_type",
   NotSubnets = "not_subnets",
-  NotSystemId = "not_system_id",
   NotTags = "not_tags",
   NotVlans = "not_vlans",
   Osystem = "osystem",
@@ -277,7 +278,6 @@ export enum FilterGroupKey {
   Spaces = "spaces",
   Status = "status",
   Subnets = "subnets",
-  SystemId = "system_id",
   Tags = "tags",
   Vlans = "vlans",
   Workloads = "workloads",
@@ -326,6 +326,7 @@ export type SelectedMachines =
   | {
       items?: Machine[MachineMeta.PK][];
       groups?: MachineStateListGroup["value"][];
+      grouping?: FetchGroupKey | null;
     }
   | { filter: FetchFilters };
 

--- a/src/app/store/machine/utils/common.test.ts
+++ b/src/app/store/machine/utils/common.test.ts
@@ -5,11 +5,12 @@ import {
   isMachineDetails,
   isDeployedWithHardwareSync,
   mapSortDirection,
+  selectedToFilters,
 } from "./common";
 
 import { SortDirection } from "app/base/types";
 import { PowerFieldScope } from "app/store/general/types";
-import { FetchSortDirection } from "app/store/machine/types";
+import { FetchSortDirection, FetchGroupKey } from "app/store/machine/types";
 import { NodeStatus } from "app/store/types/node";
 import {
   machine as machineFactory,
@@ -138,6 +139,33 @@ describe("common machine utils", () => {
 
     it("maps none", () => {
       expect(mapSortDirection(SortDirection.NONE)).toBeNull();
+    });
+  });
+
+  describe("selectedToFilters", () => {
+    it("converts filter", () => {
+      expect(
+        selectedToFilters({ filter: { free_text: "some filter" } })
+      ).toStrictEqual({ free_text: "some filter" });
+    });
+
+    it("converts items", () => {
+      expect(selectedToFilters({ items: ["abc123", "def456"] })).toStrictEqual({
+        id: ["abc123", "def456"],
+      });
+    });
+
+    it("converts groups", () => {
+      expect(
+        selectedToFilters({
+          groups: ["admin", "admin3"],
+          grouping: FetchGroupKey.Owner,
+        })
+      ).toStrictEqual({ owner: ["=admin", "=admin3"] });
+    });
+
+    it("handles no filters", () => {
+      expect(selectedToFilters({ items: [], groups: [] })).toBeNull();
     });
   });
 });

--- a/src/app/store/machine/utils/common.ts
+++ b/src/app/store/machine/utils/common.ts
@@ -2,8 +2,14 @@ import type { ValueOf } from "@canonical/react-components";
 
 import { SortDirection } from "app/base/types";
 import { PowerFieldScope } from "app/store/general/types";
-import type { Machine, MachineDetails } from "app/store/machine/types";
-import { FetchSortDirection } from "app/store/machine/types";
+import type {
+  FetchFilters,
+  Machine,
+  MachineDetails,
+  SelectedMachines,
+  FilterGroupOptionType,
+} from "app/store/machine/types";
+import { FetchSortDirection, FilterGroupKey } from "app/store/machine/types";
 import type { Tag, TagMeta } from "app/store/tag/types";
 import { NodeStatus } from "app/store/types/node";
 
@@ -90,4 +96,41 @@ export const mapSortDirection = (
     default:
       return null;
   }
+};
+
+/**
+ * Convert selected machines state to filters that can be sent to the API.
+ */
+export const selectedToFilters = (
+  selected: SelectedMachines | null
+): FetchFilters | null => {
+  if (!selected) {
+    return null;
+  }
+  if ("filter" in selected) {
+    return selected.filter;
+  }
+  let filter: Record<
+    string,
+    FilterGroupOptionType | null | (FilterGroupOptionType | null)[]
+  > = {};
+  if ("items" in selected && selected.items?.length) {
+    filter[FilterGroupKey.Id] = selected.items;
+  }
+  if (
+    "groups" in selected &&
+    selected.groups?.length &&
+    "grouping" in selected &&
+    selected.grouping
+  ) {
+    const grouping = selected.grouping;
+    filter[grouping] = selected.groups.map((group) => {
+      if (typeof group === "string") {
+        // String filters should be exact matches.
+        return `=${group}`;
+      }
+      return group;
+    });
+  }
+  return Object.values(filter).length > 0 ? filter : null;
 };

--- a/src/app/store/machine/utils/common.ts
+++ b/src/app/store/machine/utils/common.ts
@@ -107,6 +107,7 @@ export const selectedToFilters = (
   if (!selected) {
     return null;
   }
+  // If the selected state is a filter then there's not manipulation required.
   if ("filter" in selected) {
     return selected.filter;
   }
@@ -114,17 +115,19 @@ export const selectedToFilters = (
     string,
     FilterGroupOptionType | null | (FilterGroupOptionType | null)[]
   > = {};
+  // Map items to the id filter.
   if ("items" in selected && selected.items?.length) {
     filter[FilterGroupKey.Id] = selected.items;
   }
+  // Map groups to their filter key.
   if (
     "groups" in selected &&
     selected.groups?.length &&
     "grouping" in selected &&
     selected.grouping
   ) {
-    const grouping = selected.grouping;
-    filter[grouping] = selected.groups.map((group) => {
+    // The grouping value is the key of the filter.
+    filter[selected.grouping] = selected.groups.map((group) => {
       if (typeof group === "string") {
         // String filters should be exact matches.
         return `=${group}`;

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -5,7 +5,11 @@ import { nanoid } from "@reduxjs/toolkit";
 import fastDeepEqual from "fast-deep-equal";
 import { useDispatch, useSelector } from "react-redux";
 
-import type { FetchSortDirection, FetchParams } from "../types/actions";
+import type {
+  FetchGroupKey,
+  FetchSortDirection,
+  FetchParams,
+} from "../types/actions";
 
 import { useCanEdit } from "app/base/hooks";
 import type { APIError } from "app/base/types";
@@ -20,7 +24,6 @@ import type {
   FetchFilters,
   Machine,
   MachineMeta,
-  FetchGroupKey,
 } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
@@ -36,7 +39,7 @@ import vlanSelectors from "app/store/vlan/selectors";
 import { isId } from "app/utils";
 
 export const useFetchMachineCount = (
-  filters?: FetchFilters
+  filters?: FetchFilters | null
 ): {
   machineCount: number;
   machineCountLoading: boolean;

--- a/src/app/store/machine/utils/index.ts
+++ b/src/app/store/machine/utils/index.ts
@@ -5,6 +5,7 @@ export {
   isDeployedWithHardwareSync,
   isMachineDetails,
   mapSortDirection,
+  selectedToFilters,
 } from "./common";
 export type { TagIdCountMap } from "./common";
 


### PR DESCRIPTION
## Done

- Display the count of machines that have been selected in the machine list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Tick some machines and you should see the count update instantly in the header.
- Untick all machines and tick a group (you'll need to be grouped by something other than status e.g. owner). You should see the count get loaded and appear in the header (note that this number doesn't currently match the number of machines in the group - this is being fixed on the backend).
- Now tick some machines as well as the group. You should see the count update.
- Now tick the checkbox in the table header and "All machines selected" should appear.

## Fixes

Fixes: canonical/app-tribe#1102.

