### PR TITLE
feat(machines): remove filtering by selected when opening action forms

### DIFF
--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -6,10 +6,8 @@ import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import MachineList from "./MachineList";
-import MachineListHeader from "./MachineList/MachineListHeader";
 import Machines from "./Machines";
 
-import { MachineHeaderViews } from "app/machines/constants";
 import type { RootState } from "app/store/root/types";
 import {
   generalState as generalStateFactory,
@@ -110,60 +108,5 @@ describe("Machines", () => {
       wrapper.find(MachineList).props().setSearchFilter("status:new");
     });
     expect(search).toBe("?status=new");
-  });
-
-  it("adds the selected filter when an action is selected", () => {
-    state.machine.selected = ["abc123"];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <Machines />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    act(() =>
-      wrapper
-        .find(MachineListHeader)
-        .props()
-        .setHeaderContent({ view: MachineHeaderViews.SET_POOL_MACHINE })
-    );
-    wrapper.update();
-    expect(wrapper.find("MachineList").prop("searchFilter")).toBe(
-      "in:(selected)"
-    );
-  });
-
-  it("removes the selected filter when the selected action is cleared", () => {
-    state.machine.selected = ["abc123"];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <Machines />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    act(() =>
-      wrapper
-        .find(MachineListHeader)
-        .props()
-        .setHeaderContent({ view: MachineHeaderViews.SET_POOL_MACHINE })
-    );
-    wrapper.update();
-    expect(wrapper.find("MachineList").prop("searchFilter")).toBe(
-      "in:(selected)"
-    );
-    act(() => wrapper.find(MachineListHeader).props().setHeaderContent(null));
-    wrapper.update();
-    expect(wrapper.find("MachineList").prop("searchFilter")).toBe("");
   });
 });

--- a/src/app/machines/views/Machines.tsx
+++ b/src/app/machines/views/Machines.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 
-import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { useLocation, useNavigate } from "react-router-dom-v5-compat";
 
 import MachineListHeader from "./MachineList/MachineListHeader";
@@ -20,8 +19,6 @@ const Machines = (): JSX.Element => {
   );
   const [headerContent, setHeaderContent] =
     useState<MachineHeaderContent | null>(null);
-  const actionSelected = headerContent?.view[0] === "machineActionForm";
-  const previousActionSelected = usePrevious(actionSelected);
 
   const setSearchFilter = useCallback(
     (searchText) => {
@@ -31,20 +28,6 @@ const Machines = (): JSX.Element => {
     },
     [navigate, setFilter]
   );
-
-  useEffect(() => {
-    if (actionSelected !== previousActionSelected) {
-      const filters = FilterMachines.getCurrentFilters(searchFilter);
-      const newFilters = FilterMachines.toggleFilter(
-        filters,
-        "in",
-        "selected",
-        false,
-        actionSelected
-      );
-      setSearchFilter(FilterMachines.filtersToString(newFilters));
-    }
-  }, [actionSelected, previousActionSelected, searchFilter, setSearchFilter]);
 
   return (
     <Section


### PR DESCRIPTION
## Done

- Remove the filtering of the machine list by those that are selected when the action forms open.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Tick some machines.
- Use the take action menu to open a form.
- The search box should not have "in:selected" and the machine list should not get filtered.

## Fixes

Fixes: canonical/app-tribe#1334.