### PR TITLE
Update discovery form to use the new API and machine list box

### DIFF
--- a/cypress/e2e/with-users/settings/dhcp.spec.ts
+++ b/cypress/e2e/with-users/settings/dhcp.spec.ts
@@ -1,0 +1,31 @@
+import { generateMAASURL, generateName } from "../../utils";
+
+context("Settings - DHCP Snippets", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.addMachine();
+    cy.visit(generateMAASURL("/settings/dhcp/add"));
+  });
+
+  it("can add a DHCP snippet to a machine", () => {
+    const snippetName = generateName("dhcp-snippet");
+    cy.get("[data-testid='section-header-title']").contains("Settings");
+    cy.findByLabelText("Snippet name").type(snippetName);
+    cy.findByLabelText("Type").select("Machine");
+    cy.findByRole("button", { name: /Choose machine/ }).click();
+    // ensure the data has loaded
+    cy.findByRole("grid").should("have.attr", "aria-busy", "false");
+    cy.get("tbody").within(() => {
+      cy.findAllByRole("row").first().click();
+    });
+    cy.findByLabelText("DHCP snippet").type("ddns-update-style none;");
+    cy.findByRole("button", { name: "Save snippet" }).click();
+    // expect to be redirected to the list page
+    cy.findByLabelText("Search DHCP snippets").type(snippetName);
+    cy.findByRole("grid").within(() => {
+      cy.findByText(snippetName).should("be.visible");
+      cy.findByRole("button", { name: /Delete/ }).click();
+      cy.get("[data-testid='action-confirm']").click();
+    });
+  });
+});

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,7 @@
 import "@testing-library/cypress/add-commands";
 import type { Result } from "axe-core";
+import { nanoid } from "nanoid";
+import { generateMAASURL, generateMac } from "../e2e/utils";
 import type { A11yPageContext } from "./e2e";
 
 Cypress.Commands.add("login", (options) => {
@@ -33,6 +35,17 @@ Cypress.Commands.add("loginNonAdmin", () => {
     username: Cypress.env("nonAdminUsername"),
     password: Cypress.env("nonAdminPassword"),
   });
+});
+
+Cypress.Commands.add("addMachine", (hostname = `cypress-${nanoid()}`) => {
+  cy.visit(generateMAASURL("/machines"));
+  cy.get("[data-testid='add-hardware-dropdown'] button").click();
+  cy.get(".p-contextual-menu__link").contains("Machine").click();
+  cy.get("input[name='hostname']").type(hostname);
+  cy.get("input[name='pxe_mac']").type(generateMac());
+  cy.get("select[name='power_type']").select("manual").blur();
+  cy.get("button[type='submit']").click();
+  cy.get(`[data-testid='message']:contains(${hostname} added successfully.)`);
 });
 
 function logViolations(violations: Result[], pageContext: A11yPageContext) {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -9,6 +9,7 @@ export type A11yPageContext = { url?: string; title?: string };
 declare global {
   namespace Cypress {
     interface Chainable {
+      addMachine(hostname?: string): void;
       login(options?: {
         username?: string;
         password?: string;

--- a/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
+++ b/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
@@ -22,6 +22,7 @@ const DebounceSearchBox = ({
   onDebounced,
   searchText,
   setSearchText,
+  autoFocus,
 }: Props): JSX.Element => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [debouncing, setDebouncing] = useState(false);
@@ -38,6 +39,7 @@ const DebounceSearchBox = ({
   return (
     <div className="debounce-search-box">
       <SearchBox
+        autoFocus={autoFocus}
         externallyControlled
         onChange={(text: string) => {
           setDebouncing(true);

--- a/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
+++ b/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
@@ -23,6 +23,7 @@ const DebounceSearchBox = ({
   searchText,
   setSearchText,
   autoFocus,
+  placeholder,
 }: Props): JSX.Element => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [debouncing, setDebouncing] = useState(false);
@@ -53,6 +54,7 @@ const DebounceSearchBox = ({
             setDebouncing(false);
           }, debounceInterval);
         }}
+        placeholder={placeholder}
         value={searchText}
       />
       {debouncing && (

--- a/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
+++ b/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
@@ -9,7 +9,7 @@ type Props = {
   onDebounced: (debouncedText: string) => void;
   searchText: string;
   setSearchText: (searchText: string) => void;
-} & Omit<SearchBoxProps, "externallyControlled" | "onChange" | "value">;
+} & Omit<SearchBoxProps, "externallyControlled" | "onChange" | "value" | "ref">;
 
 export const DEFAULT_DEBOUNCE_INTERVAL = 500;
 
@@ -22,8 +22,7 @@ const DebounceSearchBox = ({
   onDebounced,
   searchText,
   setSearchText,
-  autoFocus,
-  placeholder,
+  ...props
 }: Props): JSX.Element => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [debouncing, setDebouncing] = useState(false);
@@ -40,7 +39,7 @@ const DebounceSearchBox = ({
   return (
     <div className="debounce-search-box">
       <SearchBox
-        autoFocus={autoFocus}
+        {...props}
         externallyControlled
         onChange={(text: string) => {
           setDebouncing(true);
@@ -54,7 +53,6 @@ const DebounceSearchBox = ({
             setDebouncing(false);
           }, debounceInterval);
         }}
-        placeholder={placeholder}
         value={searchText}
       />
       {debouncing && (

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -26,30 +26,7 @@ import {
 } from "testing/factories";
 
 const mockStore = configureStore();
-const machines = [
-  machineFactory({
-    actions: [],
-    architecture: "amd64/generic",
-    cpu_count: 4,
-    distro_series: "bionic",
-    extra_macs: [],
-    fqdn: "koala.example",
-    hostname: "koala",
-    ip_addresses: [],
-    memory: 8,
-    osystem: "ubuntu",
-    owner: "admin",
-    permissions: ["edit", "delete"],
-    physical_disk_count: 1,
-    pxe_mac: "00:11:22:33:44:55",
-    spaces: [],
-    status: NodeStatus.DEPLOYED,
-    status_code: NodeStatusCode.DEPLOYED,
-    status_message: "",
-    storage: 8,
-    system_id: "abc123",
-  }),
-];
+const machines = [machineFactory()];
 describe("DhcpFormFields", () => {
   let state: RootState;
 

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -10,7 +10,6 @@ import { Labels } from "./DhcpFormFields";
 
 import DhcpForm from "app/base/components/DhcpForm";
 import type { RootState } from "app/store/root/types";
-import { NodeStatus, NodeStatusCode } from "app/store/types/node";
 import {
   controllerState as controllerStateFactory,
   deviceState as deviceStateFactory,

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -183,7 +183,7 @@ describe("DhcpFormFields", () => {
     );
     within(screen.getByRole("grid")).getByText(machine.hostname).click();
     expect(
-      screen.getByRole("button", { name: machine.hostname })
+      screen.getByRole("button", { name: new RegExp(machine.hostname, "i") })
     ).toHaveAccessibleDescription(Labels.AppliesTo);
     // Change the type. The select value should be cleared.
     await userEvent.selectOptions(typeSelect, "subnet");

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.tsx
@@ -132,16 +132,7 @@ export const DhcpFormFields = ({ editing }: Props): JSX.Element => {
         ]}
       />
       {type === "machine" ? (
-        <MachineSelect
-          onSelect={(machine) => {
-            if (machine) {
-              formikProps.setFieldValue("entity", machine.system_id);
-            } else {
-              formikProps.setFieldValue("entity", "");
-            }
-          }}
-          selected={formikProps.values.entity}
-        />
+        <FormikField component={MachineSelect} name="entity" />
       ) : (
         type &&
         (isLoading || !hasLoaded ? (

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import MachineSelect, { Labels } from "./MachineSelect";
+
+import { renderWithMockStore } from "testing/utils";
+
+it("can open select box on click", async () => {
+  renderWithMockStore(<MachineSelect onSelect={jest.fn()} />);
+
+  expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  await userEvent.click(
+    screen.getByRole("button", { name: Labels.ChooseMachine })
+  );
+  expect(screen.getByRole("listbox")).toBeInTheDocument();
+});
+
+it("sets focus on the input field on open", async () => {
+  renderWithMockStore(<MachineSelect onSelect={jest.fn()} />);
+
+  await userEvent.click(
+    screen.getByRole("button", { name: Labels.ChooseMachine })
+  );
+  expect(
+    screen.getByPlaceholderText("Search by hostname, system ID or tags")
+  ).toHaveFocus();
+});

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
@@ -15,7 +15,7 @@ it("can open select box on click", async () => {
 
   expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   await userEvent.click(
-    screen.getByRole("button", { name: Labels.ChooseMachine })
+    screen.getByRole("button", { name: new RegExp(Labels.ChooseMachine, "i") })
   );
   expect(screen.getByRole("listbox")).toBeInTheDocument();
 });
@@ -28,7 +28,7 @@ it("sets focus on the input field on open", async () => {
   );
 
   await userEvent.click(
-    screen.getByRole("button", { name: Labels.ChooseMachine })
+    screen.getByRole("button", { name: new RegExp(Labels.ChooseMachine, "i") })
   );
   expect(
     screen.getByPlaceholderText("Search by hostname, system ID or tags")

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
@@ -1,12 +1,17 @@
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { Formik } from "formik";
 
 import MachineSelect, { Labels } from "./MachineSelect";
 
 import { renderWithMockStore } from "testing/utils";
 
 it("can open select box on click", async () => {
-  renderWithMockStore(<MachineSelect onSelect={jest.fn()} />);
+  renderWithMockStore(
+    <Formik initialValues={{ machine: "" }} onSubmit={jest.fn()}>
+      <MachineSelect name="machine" />
+    </Formik>
+  );
 
   expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   await userEvent.click(
@@ -16,7 +21,11 @@ it("can open select box on click", async () => {
 });
 
 it("sets focus on the input field on open", async () => {
-  renderWithMockStore(<MachineSelect onSelect={jest.fn()} />);
+  renderWithMockStore(
+    <Formik initialValues={{ machine: "" }} onSubmit={jest.fn()}>
+      <MachineSelect name="machine" />
+    </Formik>
+  );
 
   await userEvent.click(
     screen.getByRole("button", { name: Labels.ChooseMachine })

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
@@ -9,6 +9,7 @@ import SelectButton from "../../SelectButton";
 import MachineSelectBox from "./MachineSelectBox";
 
 import OutsideClickHandler from "app/base/components/OutsideClickHandler";
+import { usePreviousPersistent } from "app/base/hooks";
 import type { Machine } from "app/store/machine/types";
 import { useFetchMachine } from "app/store/machine/utils/hooks";
 import { actions as tagActions } from "app/store/tag";
@@ -37,10 +38,9 @@ export const MachineSelect = ({
     setIsOpen(false);
     onSelect(machine);
   };
-
-  const { machine: selectedMachine } = useFetchMachine(selected, {
-    keepPreviousData: true,
-  });
+  const { machine } = useFetchMachine(selected);
+  const previousMachine = usePreviousPersistent(machine);
+  const selectedMachine = machine || previousMachine;
 
   useEffect(() => {
     dispatch(tagActions.fetch());

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
@@ -1,7 +1,8 @@
 import type { HTMLProps } from "react";
 import { useEffect, useState } from "react";
 
-import { Label, useId, useOnEscapePressed } from "@canonical/react-components";
+import { useId, useOnEscapePressed } from "@canonical/react-components";
+import Field from "@canonical/react-components/dist/components/Field";
 import className from "classnames";
 import { useFormikContext } from "formik";
 import { useDispatch } from "react-redux";
@@ -37,10 +38,12 @@ export const MachineSelect = ({
   label = Labels.AppliesTo,
   defaultOption = Labels.ChooseMachine,
   value,
+  ...props
 }: Props): JSX.Element => {
   const { setFieldValue } = useFormikContext();
   const dispatch = useDispatch();
   const [isOpen, setIsOpen] = useState(false);
+  const labelId = useId();
   const selectId = useId();
   const handleSelect = (machine: Machine | null) => {
     setIsOpen(false);
@@ -55,33 +58,41 @@ export const MachineSelect = ({
     dispatch(tagActions.fetch());
   }, [dispatch]);
 
+  const buttonLabel = selectedMachine?.hostname || defaultOption;
+
   return (
     <div className="machine-select">
-      <Label id={selectId}>{label}</Label>
-      <OutsideClickHandler onClick={() => setIsOpen(false)}>
-        <SelectButton
-          aria-describedby={selectId}
-          aria-haspopup="listbox"
-          className="u-no-margin--bottom"
-          onClick={() => {
-            setIsOpen(!isOpen);
-            if (!isOpen) {
-              setFieldValue(name, "", false);
-            }
-          }}
-        >
-          {selectedMachine?.hostname || defaultOption}
-        </SelectButton>
-        <div
-          className={className("machine-select-box-wrapper", {
-            "machine-select-box-wrapper--is-open": isOpen,
-          })}
-        >
-          {isOpen ? (
-            <MachineSelectBox filters={filters} onSelect={handleSelect} />
-          ) : null}
-        </div>
-      </OutsideClickHandler>
+      {/* TODO: update once Field allows a custom label id
+      https://github.com/canonical/react-components/issues/820 */}
+      <Field label={<span id={labelId}>{label}</span>} {...props}>
+        <OutsideClickHandler onClick={() => setIsOpen(false)}>
+          <SelectButton
+            aria-describedby={labelId}
+            aria-expanded={isOpen ? "true" : "false"}
+            aria-haspopup="listbox"
+            aria-label={`${buttonLabel} - open list`}
+            className="u-no-margin--bottom"
+            id={selectId}
+            onClick={() => {
+              setIsOpen(!isOpen);
+              if (!isOpen) {
+                setFieldValue(name, "", false);
+              }
+            }}
+          >
+            {buttonLabel}
+          </SelectButton>
+          <div
+            className={className("machine-select-box-wrapper", {
+              "machine-select-box-wrapper--is-open": isOpen,
+            })}
+          >
+            {isOpen ? (
+              <MachineSelectBox filters={filters} onSelect={handleSelect} />
+            ) : null}
+          </div>
+        </OutsideClickHandler>
+      </Field>
     </div>
   );
 };

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+
+import { Label, useId } from "@canonical/react-components";
+import className from "classnames";
+import { useDispatch } from "react-redux";
+
+import SelectButton from "../../SelectButton";
+
+import MachineSelectBox from "./MachineSelectBox";
+
+import type { Machine } from "app/store/machine/types";
+import { useFetchMachine } from "app/store/machine/utils/hooks";
+import { actions as tagActions } from "app/store/tag";
+
+export enum Labels {
+  AppliesTo = "Applies to",
+  Loading = "Loading...",
+  ChooseMachine = "Choose machine",
+}
+
+type Props = {
+  label?: string;
+  onSelect: (machine: Machine | null) => void;
+  selected?: Machine["system_id"] | null;
+};
+
+export const MachineSelect = ({
+  label = Labels.AppliesTo,
+  onSelect,
+  selected = null,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+  const [isOpen, setIsOpen] = useState(false);
+  const selectId = useId();
+  const handleSelect = (machine: Machine | null) => {
+    setIsOpen(false);
+    onSelect(machine);
+  };
+
+  const { machine: selectedMachine } = useFetchMachine(selected, {
+    keepPreviousData: true,
+  });
+
+  useEffect(() => {
+    dispatch(tagActions.fetch());
+  }, [dispatch]);
+
+  return (
+    <div className="machine-select">
+      <Label id={selectId}>{label}</Label>
+      <SelectButton
+        aria-describedby={selectId}
+        aria-haspopup="listbox"
+        className="u-no-margin--bottom"
+        onClick={() => {
+          setIsOpen(!isOpen);
+          if (!isOpen) {
+            onSelect(null);
+          }
+        }}
+      >
+        {selectedMachine?.hostname || Labels.ChooseMachine}
+      </SelectButton>
+      <div
+        className={className("machine-select-box-wrapper", {
+          "machine-select-box-wrapper--is-open": isOpen,
+        })}
+      >
+        {isOpen ? <MachineSelectBox onSelect={handleSelect} /> : null}
+      </div>
+    </div>
+  );
+};
+
+export default MachineSelect;

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from "react";
 
-import { Label, useId } from "@canonical/react-components";
+import { Label, useId, useOnEscapePressed } from "@canonical/react-components";
 import className from "classnames";
 import { useDispatch } from "react-redux";
 
 import SelectButton from "../../SelectButton";
 
-import MachineSelectBox from "./MachineSelectBox";
+import MachineSelectBox from "./MachineSelectBox/MachineSelectBox";
 
 import OutsideClickHandler from "app/base/components/OutsideClickHandler";
 import { usePreviousPersistent } from "app/base/hooks";
@@ -41,6 +41,7 @@ export const MachineSelect = ({
   const { machine } = useFetchMachine(selected);
   const previousMachine = usePreviousPersistent(machine);
   const selectedMachine = machine || previousMachine;
+  useOnEscapePressed(() => setIsOpen(false));
 
   useEffect(() => {
     dispatch(tagActions.fetch());
@@ -49,30 +50,28 @@ export const MachineSelect = ({
   return (
     <div className="machine-select">
       <Label id={selectId}>{label}</Label>
-      <SelectButton
-        aria-describedby={selectId}
-        aria-haspopup="listbox"
-        className="u-no-margin--bottom"
-        onClick={() => {
-          setIsOpen(!isOpen);
-          if (!isOpen) {
-            onSelect(null);
-          }
-        }}
-      >
-        {selectedMachine?.hostname || Labels.ChooseMachine}
-      </SelectButton>
-      <div
-        className={className("machine-select-box-wrapper", {
-          "machine-select-box-wrapper--is-open": isOpen,
-        })}
-      >
-        {isOpen ? (
-          <OutsideClickHandler onClick={() => setIsOpen(false)}>
-            <MachineSelectBox onSelect={handleSelect} />
-          </OutsideClickHandler>
-        ) : null}
-      </div>
+      <OutsideClickHandler onClick={() => setIsOpen(false)}>
+        <SelectButton
+          aria-describedby={selectId}
+          aria-haspopup="listbox"
+          className="u-no-margin--bottom"
+          onClick={() => {
+            setIsOpen(!isOpen);
+            if (!isOpen) {
+              onSelect(null);
+            }
+          }}
+        >
+          {selectedMachine?.hostname || Labels.ChooseMachine}
+        </SelectButton>
+        <div
+          className={className("machine-select-box-wrapper", {
+            "machine-select-box-wrapper--is-open": isOpen,
+          })}
+        >
+          {isOpen ? <MachineSelectBox onSelect={handleSelect} /> : null}
+        </div>
+      </OutsideClickHandler>
     </div>
   );
 };

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
@@ -8,6 +8,7 @@ import SelectButton from "../../SelectButton";
 
 import MachineSelectBox from "./MachineSelectBox";
 
+import OutsideClickHandler from "app/base/components/OutsideClickHandler";
 import type { Machine } from "app/store/machine/types";
 import { useFetchMachine } from "app/store/machine/utils/hooks";
 import { actions as tagActions } from "app/store/tag";
@@ -66,7 +67,11 @@ export const MachineSelect = ({
           "machine-select-box-wrapper--is-open": isOpen,
         })}
       >
-        {isOpen ? <MachineSelectBox onSelect={handleSelect} /> : null}
+        {isOpen ? (
+          <OutsideClickHandler onClick={() => setIsOpen(false)}>
+            <MachineSelectBox onSelect={handleSelect} />
+          </OutsideClickHandler>
+        ) : null}
       </div>
     </div>
   );

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+
+import { SearchBox, Pagination } from "@canonical/react-components";
+
+import { MachineSelectTable } from "app/base/components/MachineSelectTable/MachineSelectTable";
+import type { Machine } from "app/store/machine/types";
+import { FilterGroupKey } from "app/store/machine/types";
+import { useFetchMachines } from "app/store/machine/utils/hooks";
+
+const MachineSelectBox = ({
+  onSelect,
+}: {
+  onSelect: (machine: Machine | null) => void;
+}): JSX.Element => {
+  const pageSize = 15;
+  const [searchText, setSearchText] = useState("");
+  const [currentPage, setPage] = useState(1);
+  const { machines, machineCount, loading } = useFetchMachines({
+    currentPage,
+    pageSize,
+    filters: { [FilterGroupKey.FreeText]: searchText },
+  });
+  return (
+    <div className="machine-select-box" role="listbox">
+      <SearchBox
+        autoComplete="off"
+        autoFocus
+        externallyControlled
+        onChange={(searchText: string) => {
+          setSearchText(searchText);
+        }}
+        placeholder="Search by hostname, system ID or tags"
+        value={searchText}
+      />
+      <MachineSelectTable
+        machines={machines}
+        machinesLoading={loading}
+        onMachineClick={(machine) => {
+          onSelect(machine);
+        }}
+        searchText={searchText}
+        setSearchText={setSearchText}
+      />
+      <Pagination
+        currentPage={currentPage}
+        itemsPerPage={pageSize}
+        paginate={setPage}
+        totalItems={machineCount || 0}
+      />
+    </div>
+  );
+};
+export default MachineSelectBox;

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox.tsx
@@ -1,18 +1,20 @@
 import { useState } from "react";
 
-import { SearchBox, Pagination } from "@canonical/react-components";
+import { SearchBox } from "@canonical/react-components";
 
 import { MachineSelectTable } from "app/base/components/MachineSelectTable/MachineSelectTable";
+import MachineListPagination from "app/machines/views/MachineList/MachineListTable/MachineListPagination";
 import type { Machine } from "app/store/machine/types";
 import { FilterGroupKey } from "app/store/machine/types";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 
 const MachineSelectBox = ({
   onSelect,
+  pageSize = 15,
 }: {
+  pageSize?: number;
   onSelect: (machine: Machine | null) => void;
 }): JSX.Element => {
-  const pageSize = 15;
   const [searchText, setSearchText] = useState("");
   const [currentPage, setPage] = useState(1);
   const { machines, machineCount, loading } = useFetchMachines({
@@ -41,11 +43,12 @@ const MachineSelectBox = ({
         searchText={searchText}
         setSearchText={setSearchText}
       />
-      <Pagination
+      <MachineListPagination
         currentPage={currentPage}
         itemsPerPage={pageSize}
+        machineCount={machineCount}
+        machinesLoading={loading}
         paginate={setPage}
-        totalItems={machineCount || 0}
       />
     </div>
   );

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
@@ -1,0 +1,98 @@
+import reduxToolkit from "@reduxjs/toolkit";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import configureStore from "redux-mock-store";
+
+import MachineSelectBox from "./MachineSelectBox";
+
+import { DEFAULT_DEBOUNCE_INTERVAL } from "app/base/components/DebounceSearchBox/DebounceSearchBox";
+import { actions as machineActions } from "app/store/machine";
+import type { RootState } from "app/store/root/types";
+import { rootState as rootStateFactory } from "testing/factories";
+import { renderWithMockStore } from "testing/utils";
+
+const mockStore = configureStore<RootState>();
+
+beforeEach(() => {
+  jest
+    .spyOn(reduxToolkit, "nanoid")
+    .mockReturnValueOnce("mocked-nanoid-1")
+    .mockReturnValueOnce("mocked-nanoid-2");
+  jest.useFakeTimers();
+});
+afterEach(() => {
+  jest.restoreAllMocks();
+  jest.useRealTimers();
+});
+
+it("displays a listbox and a search input field", async () => {
+  renderWithMockStore(<MachineSelectBox onSelect={jest.fn()} />);
+
+  expect(screen.getByRole("listbox")).toBeInTheDocument();
+});
+
+it("fetches machines on mount", async () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  renderWithMockStore(<MachineSelectBox onSelect={jest.fn()} />, {
+    store,
+  });
+
+  expect(screen.getByRole("listbox")).toBeInTheDocument();
+  expect(screen.getByRole("listbox")).toBeInTheDocument();
+  const expectedAction = machineActions.fetch("mocked-nanoid-1", {
+    filter: { free_text: "" },
+    group_collapsed: undefined,
+    group_key: null,
+    page_number: 1,
+    page_size: 15,
+    sort_direction: null,
+    sort_key: null,
+  });
+  expect(
+    store.getActions().find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
+});
+
+it("requests machines filtered by the free text input value", async () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  renderWithMockStore(<MachineSelectBox onSelect={jest.fn()} />, {
+    store,
+  });
+
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  await user.type(screen.getByRole("searchbox"), "test-machine");
+  const expectedInitialAction = machineActions.fetch("mocked-nanoid-1", {
+    filter: { free_text: "" },
+    group_collapsed: undefined,
+    group_key: null,
+    page_number: 1,
+    page_size: 15,
+    sort_direction: null,
+    sort_key: null,
+  });
+  const expectedAction = machineActions.fetch("mocked-nanoid-2", {
+    filter: { free_text: "test-machine" },
+    group_collapsed: undefined,
+    group_key: null,
+    page_number: 1,
+    page_size: 15,
+    sort_direction: null,
+    sort_key: null,
+  });
+  await waitFor(() => {
+    jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL);
+  });
+  await waitFor(() =>
+    expect(
+      store.getActions().filter((action) => action.type === expectedAction.type)
+        .length
+    ).toEqual(2)
+  );
+  const machineFetchActions = store
+    .getActions()
+    .filter((action) => action.type === expectedAction.type);
+  expect(machineFetchActions[0]).toStrictEqual(expectedInitialAction);
+  expect(machineFetchActions[1]).toStrictEqual(expectedAction);
+});

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
@@ -62,7 +62,7 @@ it("requests machines filtered by the free text input value", async () => {
   });
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
-  await user.type(screen.getByRole("searchbox"), "test-machine");
+  await user.type(screen.getByRole("combobox"), "test-machine");
   const expectedInitialAction = machineActions.fetch("mocked-nanoid-1", {
     filter: { free_text: "" },
     group_collapsed: undefined,

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 
-import { SearchBox } from "@canonical/react-components";
-
+import DebounceSearchBox from "app/base/components/DebounceSearchBox";
 import { MachineSelectTable } from "app/base/components/MachineSelectTable/MachineSelectTable";
 import MachineListPagination from "app/machines/views/MachineList/MachineListTable/MachineListPagination";
 import type { Machine } from "app/store/machine/types";
@@ -16,23 +15,22 @@ const MachineSelectBox = ({
   onSelect: (machine: Machine | null) => void;
 }): JSX.Element => {
   const [searchText, setSearchText] = useState("");
+  const [deboucedText, setDebouncedText] = useState("");
   const [currentPage, setPage] = useState(1);
   const { machines, machineCount, loading } = useFetchMachines({
     currentPage,
     pageSize,
-    filters: { [FilterGroupKey.FreeText]: searchText },
+    filters: { [FilterGroupKey.FreeText]: deboucedText },
   });
   return (
     <div className="machine-select-box" role="listbox">
-      <SearchBox
+      <DebounceSearchBox
         autoComplete="off"
         autoFocus
-        externallyControlled
-        onChange={(searchText: string) => {
-          setSearchText(searchText);
-        }}
+        onDebounced={setDebouncedText}
         placeholder="Search by hostname, system ID or tags"
-        value={searchText}
+        searchText={searchText}
+        setSearchText={setSearchText}
       />
       <MachineSelectTable
         machines={machines}
@@ -53,4 +51,5 @@ const MachineSelectBox = ({
     </div>
   );
 };
+
 export default MachineSelectBox;

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
@@ -15,12 +15,12 @@ const MachineSelectBox = ({
   onSelect: (machine: Machine | null) => void;
 }): JSX.Element => {
   const [searchText, setSearchText] = useState("");
-  const [deboucedText, setDebouncedText] = useState("");
+  const [debouncedText, setDebouncedText] = useState("");
   const [currentPage, setPage] = useState(1);
   const { machines, machineCount, loading } = useFetchMachines({
     currentPage,
     pageSize,
-    filters: { [FilterGroupKey.FreeText]: deboucedText },
+    filters: { [FilterGroupKey.FreeText]: debouncedText },
   });
   return (
     <div className="machine-select-box" role="listbox">

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
@@ -28,31 +28,35 @@ const MachineSelectBox = ({
     },
   });
   return (
-    <div className="machine-select-box" role="listbox">
+    <div className="machine-select-box">
       <DebounceSearchBox
+        aria-label="Search by hostname, system ID or tags"
         autoComplete="off"
         autoFocus
         onDebounced={setDebouncedText}
         placeholder="Search by hostname, system ID or tags"
+        role="combobox"
         searchText={searchText}
         setSearchText={setSearchText}
       />
-      <MachineSelectTable
-        machines={machines}
-        machinesLoading={loading}
-        onMachineClick={(machine) => {
-          onSelect(machine);
-        }}
-        searchText={searchText}
-        setSearchText={setSearchText}
-      />
-      <MachineListPagination
-        currentPage={currentPage}
-        itemsPerPage={pageSize}
-        machineCount={machineCount}
-        machinesLoading={loading}
-        paginate={setPage}
-      />
+      <div role="listbox">
+        <MachineSelectTable
+          machines={machines}
+          machinesLoading={loading}
+          onMachineClick={(machine) => {
+            onSelect(machine);
+          }}
+          searchText={searchText}
+          setSearchText={setSearchText}
+        />
+        <MachineListPagination
+          currentPage={currentPage}
+          itemsPerPage={pageSize}
+          machineCount={machineCount}
+          machinesLoading={loading}
+          paginate={setPage}
+        />
+      </div>
     </div>
   );
 };

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
@@ -3,16 +3,18 @@ import { useState } from "react";
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
 import { MachineSelectTable } from "app/base/components/MachineSelectTable/MachineSelectTable";
 import MachineListPagination from "app/machines/views/MachineList/MachineListTable/MachineListPagination";
-import type { Machine } from "app/store/machine/types";
+import type { FetchFilters, Machine } from "app/store/machine/types";
 import { FilterGroupKey } from "app/store/machine/types";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 
 const MachineSelectBox = ({
   onSelect,
   pageSize = 15,
+  filters,
 }: {
   pageSize?: number;
   onSelect: (machine: Machine | null) => void;
+  filters?: FetchFilters;
 }): JSX.Element => {
   const [searchText, setSearchText] = useState("");
   const [debouncedText, setDebouncedText] = useState("");
@@ -20,7 +22,10 @@ const MachineSelectBox = ({
   const { machines, machineCount, loading } = useFetchMachines({
     currentPage,
     pageSize,
-    filters: { [FilterGroupKey.FreeText]: debouncedText },
+    filters: {
+      [FilterGroupKey.FreeText]: debouncedText,
+      ...(filters ? filters : {}),
+    },
   });
   return (
     <div className="machine-select-box" role="listbox">

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/index.ts
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineSelectBox";

--- a/src/app/base/components/DhcpFormFields/MachineSelect/_index.scss
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/_index.scss
@@ -1,0 +1,19 @@
+@mixin MachineSelect() {
+  .machine-select {
+    margin-bottom: $spv--large;
+  }
+  .machine-select-box-wrapper {
+    transform: translate3d(0, -0.5rem, 0);
+    @include vf-animation(#{transform, opacity});
+    opacity: 0;
+    &--is-open {
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+    }
+  }
+  .machine-select-box {
+    @extend %vf-has-box-shadow;
+    @extend %vf-is-bordered;
+    padding: $spv--medium $sph--large 0 $sph--large;
+  }
+}

--- a/src/app/base/components/DhcpFormFields/MachineSelect/index.ts
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineSelect";

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -46,7 +46,7 @@ describe("MachineSelectTable", () => {
     });
   });
 
-  it("shows a spinner while data is loading", () => {
+  it("shows a loading skeleton while data is loading", () => {
     state.machine.loading = true;
     renderWithMockStore(
       <MachineSelectTable
@@ -57,7 +57,7 @@ describe("MachineSelectTable", () => {
       />,
       { state }
     );
-    expect(screen.getByText(Label.Loading)).toBeInTheDocument();
+    expect(screen.getByRole("grid")).toHaveAttribute("aria-busy", "true");
   });
 
   it("highlights the substring that matches the search text", async () => {

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -110,4 +110,25 @@ describe("MachineSelectTable", () => {
     });
     expect(within(ownerCols[0]).getByText("tagA")).toBeInTheDocument();
   });
+
+  it("can select machine by pressing Enter key", async () => {
+    const onMachineClick = jest.fn();
+    const machine = machines[0];
+    renderWithMockStore(
+      <MachineSelectTable
+        machines={machines}
+        onMachineClick={onMachineClick}
+        searchText=""
+        setSearchText={jest.fn()}
+      />,
+      { state }
+    );
+    screen
+      .getByRole("row", {
+        name: machine.hostname,
+      })
+      .focus();
+    await userEvent.keyboard("{enter}");
+    expect(onMachineClick).toHaveBeenCalledWith(machine);
+  });
 });

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
@@ -73,6 +73,12 @@ const generateRows = (
     ],
     "data-testid": "machine-select-row",
     onClick: () => onRowClick(machine),
+    onKeyPress: (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        onRowClick(machine);
+      }
+    },
     tabIndex: 0,
   }));
 };

--- a/src/app/base/components/OutsideClickHandler/OutsideClickHandler.test.tsx
+++ b/src/app/base/components/OutsideClickHandler/OutsideClickHandler.test.tsx
@@ -1,0 +1,20 @@
+import { screen, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import OutsideClickHandler from "./OutsideClickHandler";
+
+it("calls the onClick handler when clicking outside of the component", async () => {
+  const onClick = jest.fn();
+  render(
+    <div>
+      <div>Outside</div>
+      <OutsideClickHandler onClick={onClick}>
+        <div>Inside</div>
+      </OutsideClickHandler>
+    </div>
+  );
+  await userEvent.click(screen.getByText("Inside"));
+  expect(onClick).not.toHaveBeenCalled();
+  await userEvent.click(screen.getByText("Outside"));
+  expect(onClick).toHaveBeenCalled();
+});

--- a/src/app/base/components/OutsideClickHandler/OutsideClickHandler.tsx
+++ b/src/app/base/components/OutsideClickHandler/OutsideClickHandler.tsx
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from "react";
+
+const OutsideClickHandler = ({
+  children,
+  onClick,
+}: React.PropsWithChildren<{
+  onClick: () => void;
+}>): JSX.Element => {
+  const ref = useRef<HTMLDivElement>(null);
+  const handleClickOutside = ({ target }: MouseEvent) => {
+    if (ref.current && !ref.current?.contains(target as HTMLElement)) {
+      onClick();
+    }
+  };
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  });
+  return <div ref={ref}>{children}</div>;
+};
+
+export default OutsideClickHandler;

--- a/src/app/base/components/OutsideClickHandler/OutsideClickHandler.tsx
+++ b/src/app/base/components/OutsideClickHandler/OutsideClickHandler.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useClickOutside } from "@canonical/react-components";
 
 const OutsideClickHandler = ({
   children,
@@ -6,18 +6,8 @@ const OutsideClickHandler = ({
 }: React.PropsWithChildren<{
   onClick: () => void;
 }>): JSX.Element => {
-  const ref = useRef<HTMLDivElement>(null);
-  const handleClickOutside = ({ target }: MouseEvent) => {
-    if (ref.current && !ref.current?.contains(target as HTMLElement)) {
-      onClick();
-    }
-  };
-  useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  });
+  const [ref] = useClickOutside<HTMLDivElement>(onClick);
+
   return <div ref={ref}>{children}</div>;
 };
 

--- a/src/app/base/components/OutsideClickHandler/index.ts
+++ b/src/app/base/components/OutsideClickHandler/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./OutsideClickHandler";

--- a/src/app/base/components/SelectButton/SelectButton.test.tsx
+++ b/src/app/base/components/SelectButton/SelectButton.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from "@testing-library/react";
+
+import SelectButton from "./SelectButton";
+
+it("displays a button", () => {
+  render(<SelectButton>Test</SelectButton>);
+
+  expect(screen.getByRole("button", { name: "Test" })).toBeInTheDocument();
+});

--- a/src/app/base/components/SelectButton/SelectButton.tsx
+++ b/src/app/base/components/SelectButton/SelectButton.tsx
@@ -1,0 +1,20 @@
+import type { ButtonProps } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-components";
+import classNames from "classnames";
+
+const SelectButton = ({
+  children,
+  className,
+  ...props
+}: ButtonProps): JSX.Element => (
+  <Button
+    {...props}
+    className={classNames("p-button--select", className)}
+    hasIcon
+    type="button"
+  >
+    {children} <Icon name="chevron-down" />
+  </Button>
+);
+
+export default SelectButton;

--- a/src/app/base/components/SelectButton/_index.scss
+++ b/src/app/base/components/SelectButton/_index.scss
@@ -1,0 +1,11 @@
+@mixin SelectButton {
+  .p-button--select {
+    display: flex;
+    width: 100%;
+    text-align: left;
+    justify-content: space-between;
+    align-items: center;
+    border-radius: 0;
+    padding-left: 0.5rem;
+  }
+}

--- a/src/app/base/components/SelectButton/_index.scss
+++ b/src/app/base/components/SelectButton/_index.scss
@@ -6,7 +6,7 @@
     justify-content: space-between;
     align-items: center;
     border-radius: 0;
-    padding-left: 0.5rem;
+    padding-left: $sph--small;
   }
   .p-button--select:hover {
     background-color: inherit;

--- a/src/app/base/components/SelectButton/_index.scss
+++ b/src/app/base/components/SelectButton/_index.scss
@@ -8,4 +8,7 @@
     border-radius: 0;
     padding-left: 0.5rem;
   }
+  .p-button--select:hover {
+    background-color: inherit;
+  }
 }

--- a/src/app/base/components/SelectButton/index.ts
+++ b/src/app/base/components/SelectButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SelectButton";

--- a/src/app/base/hooks/base.test.tsx
+++ b/src/app/base/hooks/base.test.tsx
@@ -3,6 +3,7 @@ import { act, renderHook } from "@testing-library/react-hooks";
 import {
   useCycled,
   useId,
+  usePreviousPersistent,
   useProcessing,
   useScrollOnRender,
   useScrollToTop,
@@ -270,6 +271,28 @@ describe("hooks", () => {
       rerender();
 
       expect(scrollToSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("usePreviousPersistent", () => {
+    it("should return null on initial render", () => {
+      const { result } = renderHook(() => usePreviousPersistent({ a: "b" }));
+
+      expect(result.current).toBeNull();
+    });
+
+    it("persists previous values on re-render", () => {
+      const { rerender, result } = renderHook(
+        (state) => usePreviousPersistent(state),
+        {
+          initialProps: 1,
+        }
+      );
+
+      rerender(2);
+      expect(result.current).toEqual(1);
+      rerender(3);
+      expect(result.current).toEqual(2);
     });
   });
 });

--- a/src/app/base/hooks/base.ts
+++ b/src/app/base/hooks/base.ts
@@ -176,9 +176,11 @@ export const useScrollToTop = (): void => {
   }, [pathname]);
 };
 
+/**
+ * Returns the previous value persisted across the render cycles.
+ */
 export const usePreviousPersistent = <T extends unknown>(
-  value: T,
-  isEqualFn?: (prev: T, next: T) => boolean
+  value: T
 ): T | null => {
   const ref = useRef<{ value: T; prev: T | null }>({
     value: value,
@@ -187,7 +189,7 @@ export const usePreviousPersistent = <T extends unknown>(
 
   const current = ref.current.value;
 
-  if (isEqualFn ? !isEqualFn(current, value) : value !== current) {
+  if (value !== current) {
     ref.current = {
       value: value,
       prev: current,

--- a/src/app/base/hooks/base.ts
+++ b/src/app/base/hooks/base.ts
@@ -177,7 +177,9 @@ export const useScrollToTop = (): void => {
 };
 
 /**
- * Returns the previous value persisted across the render cycles.
+ * Returns the previous value reference persisted across the render cycles
+ * @param value - value to persist across the render cycles
+ * @returns previous value
  */
 export const usePreviousPersistent = <T extends unknown>(
   value: T

--- a/src/app/base/hooks/base.ts
+++ b/src/app/base/hooks/base.ts
@@ -175,3 +175,24 @@ export const useScrollToTop = (): void => {
     window.scrollTo(0, 0);
   }, [pathname]);
 };
+
+export const usePreviousPersistent = <T extends unknown>(
+  value: T,
+  isEqualFn?: (prev: T, next: T) => boolean
+): T | null => {
+  const ref = useRef<{ value: T; prev: T | null }>({
+    value: value,
+    prev: null,
+  });
+
+  const current = ref.current.value;
+
+  if (isEqualFn ? !isEqualFn(current, value) : value !== current) {
+    ref.current = {
+      value: value,
+      prev: current,
+    };
+  }
+
+  return ref.current.prev;
+};

--- a/src/app/base/hooks/index.ts
+++ b/src/app/base/hooks/index.ts
@@ -11,6 +11,7 @@ export {
   useScrollOnRender,
   useScrollToTop,
   useWindowTitle,
+  usePreviousPersistent,
 } from "./base";
 export { useFormikFormDisabled, useFormikErrors } from "./forms";
 export { useCompletedIntro, useCompletedUserIntro } from "./intro";

--- a/src/app/dashboard/views/DiscoveriesList/_index.scss
+++ b/src/app/dashboard/views/DiscoveriesList/_index.scss
@@ -1,5 +1,5 @@
 @mixin DiscoveriesList {
-  .p-table--network-discoveries {
+  .p-table--network-discoveries > tbody > {
     th,
     td {
       &:nth-child(1) {

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -29,6 +29,21 @@ type Props = {
   setDeviceType: (deviceType: DeviceType) => void;
 };
 
+export enum Label {
+  ChooseType = "Choose type",
+  ChooseDomain = "Choose domain",
+  Type = "Type",
+  Device = "Device",
+  DeviceName = "Device Name",
+  Interface = "Interface",
+  Parent = "Parent",
+  Hostname = "Hostname (optional)",
+  InterfaceName = "Interface name (optional)",
+  Domain = "Domain",
+  SelectDeviceName = "Select device name",
+  SelectParent = "Select parent (optional)",
+}
+
 const DiscoveryAddFormFields = ({
   discovery,
   setDevice,
@@ -60,7 +75,7 @@ const DiscoveryAddFormFields = ({
         <Col size={6}>
           <FormikField
             component={Select}
-            label="Type"
+            label={Label.Type}
             name="type"
             onChange={(evt: React.ChangeEvent<HTMLSelectElement>) => {
               setFieldValue("type", evt.target.value);
@@ -69,24 +84,24 @@ const DiscoveryAddFormFields = ({
               setDevice(null);
             }}
             options={[
-              { label: "Choose type", value: "", disabled: true },
-              { label: "Device", value: DeviceType.DEVICE },
-              { label: "Interface", value: DeviceType.INTERFACE },
+              { label: Label.ChooseType, value: "", disabled: true },
+              { label: Label.Device, value: DeviceType.DEVICE },
+              { label: Label.Interface, value: DeviceType.INTERFACE },
             ]}
             required
           />
           <FormikField
-            label={`${isDevice ? "Hostname" : "Interface name"} (optional)`}
+            label={isDevice ? Label.Hostname : Label.InterfaceName}
             name="hostname"
             type="text"
           />
           {isDevice ? (
             <FormikField
               component={Select}
-              label="Domain"
+              label={Label.Domain}
               name="domain"
               options={[
-                { label: "Choose domain", value: "", disabled: true },
+                { label: Label.ChooseDomain, value: "", disabled: true },
                 ...domains.map((domain) => ({
                   label: domain.name,
                   value: domain.name,
@@ -100,7 +115,7 @@ const DiscoveryAddFormFields = ({
               component={Select}
               label={
                 <>
-                  Device name{" "}
+                  {Label.DeviceName}{" "}
                   <TooltipButton message="Create as an interface on the selected device." />
                 </>
               }
@@ -110,7 +125,7 @@ const DiscoveryAddFormFields = ({
                 setDevice(evt.target.value as Device[DeviceMeta.PK]);
               }}
               options={[
-                { label: "Select device name", value: "", disabled: true },
+                { label: Label.SelectDeviceName, value: "", disabled: true },
                 ...devices.map((device) => ({
                   label: device.fqdn,
                   value: device[DeviceMeta.PK],
@@ -123,13 +138,13 @@ const DiscoveryAddFormFields = ({
               component={Select}
               label={
                 <>
-                  Parent{" "}
+                  {Label.Parent}{" "}
                   <TooltipButton message="Assign this device as a child of the parent machine." />
                 </>
               }
               name="parent"
               options={[
-                { label: "Select parent (optional)", value: "" },
+                { label: Label.SelectParent, value: "" },
                 ...machines.map((machine) => ({
                   label: machine.fqdn,
                   value: machine.system_id,

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom-v5-compat";
 import type { DiscoveryAddValues } from "../types";
 import { DeviceType } from "../types";
 
+import MachineSelect from "app/base/components/DhcpFormFields/MachineSelect";
 import FormikField from "app/base/components/FormikField";
 import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
 import TooltipButton from "app/base/components/TooltipButton";
@@ -15,7 +16,6 @@ import type { Device } from "app/store/device/types";
 import { DeviceMeta } from "app/store/device/types";
 import type { Discovery } from "app/store/discovery/types";
 import domainSelectors from "app/store/domain/selectors";
-import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import subnetSelectors from "app/store/subnet/selectors";
 import { getSubnetDisplay } from "app/store/subnet/utils";
@@ -51,10 +51,6 @@ const DiscoveryAddFormFields = ({
 }: Props): JSX.Element | null => {
   const devices = useSelector(deviceSelectors.all);
   const domains = useSelector(domainSelectors.all);
-  const { machines } = useFetchMachines({
-    filters: { status: FetchNodeStatus.DEPLOYED },
-  });
-
   const subnet = useSelector((state: RootState) =>
     subnetSelectors.getByCIDR(state, discovery.subnet_cidr)
   );
@@ -135,7 +131,9 @@ const DiscoveryAddFormFields = ({
             />
           ) : (
             <FormikField
-              component={Select}
+              component={MachineSelect}
+              defaultOption={Label.SelectParent}
+              filters={{ status: FetchNodeStatus.DEPLOYED }}
               label={
                 <>
                   {Label.Parent}{" "}
@@ -143,13 +141,6 @@ const DiscoveryAddFormFields = ({
                 </>
               }
               name="parent"
-              options={[
-                { label: Label.SelectParent, value: "" },
-                ...machines.map((machine) => ({
-                  label: machine.fqdn,
-                  value: machine.system_id,
-                })),
-              ]}
             />
           )}
         </Col>

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -100,11 +100,7 @@ export const DeployFormFields = (): JSX.Element => {
                   clearVmHostOptions();
                 }
               }}
-              options={
-                // This won't need to pass the empty array once this issue is fixed:
-                // https://github.com/canonical/react-components/issues/570
-                osOptions || []
-              }
+              options={osOptions}
             />
           </Col>
           <Col size={3}>

--- a/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
+++ b/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.tsx
@@ -57,11 +57,7 @@ const CommissioningFormFields = (): JSX.Element => {
           formikProps.setFieldValue("default_min_hwe_kernel", kernelValue);
           formikProps.setFieldTouched("default_min_hwe_kernel", true, true);
         }}
-        options={
-          // This won't need to pass the empty array once this issue is fixed:
-          // https://github.com/canonical/react-components/issues/570
-          distroSeriesOptions || []
-        }
+        options={distroSeriesOptions}
       />
       <FormikField
         component={Select}

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.tsx
@@ -23,11 +23,7 @@ const NetworkDiscoveryFormFields = (): JSX.Element => {
         help="When enabled, MAAS will use passive techniques (such as listening to ARP requests and mDNS advertisements) to observe networks attached to rack controllers. Active subnet mapping will also be available to be enabled on the configured subnets."
         label="Network discovery"
         name="network_discovery"
-        options={
-          // This won't need to pass the empty array once this issue is fixed:
-          // https://github.com/canonical/react-components/issues/570
-          networkDiscoveryOptions || []
-        }
+        options={networkDiscoveryOptions}
       />
       <FormikField
         component={Select}
@@ -35,11 +31,7 @@ const NetworkDiscoveryFormFields = (): JSX.Element => {
         help="When enabled, each rack will scan subnets enabled for active mapping. This helps ensure discovery information is accurate and complete."
         label="Active subnet mapping interval"
         name="active_discovery_interval"
-        options={
-          // This won't need to pass the empty array once this issue is fixed:
-          // https://github.com/canonical/react-components/issues/570
-          discoveryIntervalOptions || []
-        }
+        options={discoveryIntervalOptions}
       />
     </>
   );

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import type { FetchSortDirection, FetchParams } from "../types/actions";
 
-import { useCanEdit, usePreviousPersistent } from "app/base/hooks";
+import { useCanEdit } from "app/base/hooks";
 import type { APIError } from "app/base/types";
 import { actions as generalActions } from "app/store/general";
 import {
@@ -166,8 +166,7 @@ export const useFetchMachines = (
  * @param id - A machine's system id.
  */
 export const useFetchMachine = (
-  id?: Machine[MachineMeta.PK] | null,
-  options: { keepPreviousData?: boolean } = { keepPreviousData: false }
+  id?: Machine[MachineMeta.PK] | null
 ): { machine: Machine | null; loading?: boolean; loaded?: boolean } => {
   const [callId, setCallId] = useState<string | null>(null);
   const previousId = usePrevious(id, false);
@@ -182,7 +181,6 @@ export const useFetchMachine = (
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
-  const previousMachine = usePreviousPersistent(machine);
   useCleanup(callId);
 
   useEffect(() => {
@@ -199,7 +197,7 @@ export const useFetchMachine = (
   }, [dispatch, id, callId, previousCallId]);
 
   return {
-    machine: machine || (options.keepPreviousData ? previousMachine : null),
+    machine,
     loading,
     loaded,
   };

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -7,7 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import type { FetchSortDirection, FetchParams } from "../types/actions";
 
-import { useCanEdit } from "app/base/hooks";
+import { useCanEdit, usePreviousPersistent } from "app/base/hooks";
 import type { APIError } from "app/base/types";
 import { actions as generalActions } from "app/store/general";
 import {
@@ -166,7 +166,8 @@ export const useFetchMachines = (
  * @param id - A machine's system id.
  */
 export const useFetchMachine = (
-  id?: Machine[MachineMeta.PK] | null
+  id?: Machine[MachineMeta.PK] | null,
+  options: { keepPreviousData?: boolean } = { keepPreviousData: false }
 ): { machine: Machine | null; loading?: boolean; loaded?: boolean } => {
   const [callId, setCallId] = useState<string | null>(null);
   const previousId = usePrevious(id, false);
@@ -181,6 +182,7 @@ export const useFetchMachine = (
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, id)
   );
+  const previousMachine = usePreviousPersistent(machine);
   useCleanup(callId);
 
   useEffect(() => {
@@ -196,7 +198,11 @@ export const useFetchMachine = (
     }
   }, [dispatch, id, callId, previousCallId]);
 
-  return { machine, loading, loaded };
+  return {
+    machine: machine || (options.keepPreviousData ? previousMachine : null),
+    loading,
+    loaded,
+  };
 };
 
 /**

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -97,6 +97,7 @@
 @import "~app/base/components/Popover";
 @import "~app/base/components/Section";
 @import "~app/base/components/SectionHeader";
+@import "~app/base/components/SelectButton";
 @import "~app/base/components/SSHKeyList";
 @import "~app/base/components/Stepper";
 @import "~app/base/components/TableMenu";
@@ -129,6 +130,7 @@
 @include Popover;
 @include Section;
 @include SectionHeader;
+@include SelectButton;
 @include SSHKeyList;
 @include Stepper;
 @include TableMenu;
@@ -162,6 +164,7 @@
 @import "~app/kvm/components/CoreResources";
 @import "~app/kvm/components/CPUColumn/CPUPopover";
 @import "~app/kvm/components/KVMDetailsHeader";
+@import "~app/base/components/DhcpFormFields/MachineSelect";
 @import "~app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable";
 @import "~app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect";
 @import "~app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable";
@@ -201,6 +204,7 @@
 @include LXDHostToolbar;
 @include LxdKVMHostTable;
 @include LXDVMsSummaryCard;
+@include MachineSelect;
 @include NumaResources;
 @include NumaResourcesCard;
 @include RAMPopover;


### PR DESCRIPTION
## Done

- Update discovery form to use the new API and machine list box

Note: includes changes from: https://github.com/canonical/maas-ui/pull/4389 - that needs to be merged first.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to network discovery
- Expand the dropdown on the right hand side and select "Add discovery..."
- Select a machine from the list in the Parent field and
- Ensure the discovery has been saved correctly

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1112

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
