### PR TITLE
fix(machines): fix the machines loading state

### DIFF
--- a/src/app/base/components/TagSelector/TagSelector.tsx
+++ b/src/app/base/components/TagSelector/TagSelector.tsx
@@ -209,7 +209,7 @@ export const TagSelector = ({
   disabledTags = [],
   ...props
 }: Props): JSX.Element => {
-  const [wrapperRef] = useClickOutside<HTMLDivElement>(() =>
+  const [wrapperRef, wrapperId] = useClickOutside<HTMLDivElement>(() =>
     setDropdownOpen(false)
   );
   const inputId = useId();
@@ -246,7 +246,7 @@ export const TagSelector = ({
   });
 
   return (
-    <div ref={wrapperRef}>
+    <div id={wrapperId} ref={wrapperRef}>
       <Field
         error={error}
         forId={inputId}

--- a/src/app/base/components/TagSelector/TagSelector.tsx
+++ b/src/app/base/components/TagSelector/TagSelector.tsx
@@ -209,7 +209,7 @@ export const TagSelector = ({
   disabledTags = [],
   ...props
 }: Props): JSX.Element => {
-  const [wrapperRef, wrapperId] = useClickOutside<HTMLDivElement>(() =>
+  const [wrapperRef] = useClickOutside<HTMLDivElement>(() =>
     setDropdownOpen(false)
   );
   const inputId = useId();
@@ -246,7 +246,7 @@ export const TagSelector = ({
   });
 
   return (
-    <div id={wrapperId} ref={wrapperRef}>
+    <div ref={wrapperRef}>
       <Field
         error={error}
         forId={inputId}

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -55,8 +55,8 @@ describe("machine reducer", () => {
     ).toEqual(
       machineStateFactory({
         items: fetchedMachines,
-        loading: true,
-        loaded: false,
+        loading: false,
+        loaded: true,
         statuses: {
           abc123: machineStatusFactory(),
           def456: machineStatusFactory(),
@@ -91,8 +91,8 @@ describe("machine reducer", () => {
     ).toEqual(
       machineStateFactory({
         items: [existingMachine, fetchedMachines[1]],
-        loading: true,
-        loaded: false,
+        loading: false,
+        loaded: true,
         statuses: {
           abc123: machineStatusFactory(),
           def456: machineStatusFactory(),

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1022,6 +1022,8 @@ const machineSlice = createSlice({
           }
         });
       });
+      state.loading = false;
+      state.loaded = true;
     },
     get: {
       prepare: (machineID: Machine[MachineMeta.PK]) => ({


### PR DESCRIPTION
## Done

- Set the loading states once machines have been fetched.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the machine list.
- Check that in the header the spinner eventually disappears and the count of machines is shown.
- Go to Settings -> DHCP snippets -> Add snippet
- Change the 'type' to "Machine".
- The spinner should appear and then get replaced with a select box containing machines.
- This should work for all other places where machines are loaded.

## Fixes

Fixes: #4401.