### PR TITLE
expose maas-ui version info

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "analyze": "npx -y source-map-explorer 'build/static/js/*.js'",
     "build-all": "yarn build",
-    "build": "CYPRESS_INSTALL_BINARY=0 yarn install && react-scripts build",
+    "build": "REACT_APP_GIT_SHA=$(git rev-parse HEAD) CYPRESS_INSTALL_BINARY=0 yarn install && react-scripts build",
     "clean-all": "yarn clean",
     "clean": "rm -rf node_modules build",
     "cleanbuild": "yarn clean-all && yarn build",
@@ -24,7 +24,7 @@
     "percy": "./cypress/percy.sh",
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
     "serve-proxy": "nodemon ./scripts/proxy.js",
-    "serve-react": "BROWSER=none PORT=8401 react-scripts start",
+    "serve-react": "BROWSER=none PORT=8401 REACT_APP_GIT_SHA=$(git rev-parse HEAD) react-scripts start",
     "serve-static-demo": "STATIC_DEMO=true PROXY_PORT=80 nodemon ./scripts/proxy.js",
     "serve": "yarn start",
     "show-ready": "wait-on http-get://0.0.0.0:8401 && nodemon ./scripts/proxy-ready.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,8 @@ import { Provider } from "react-redux";
 import { Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
+import packageInfo from "../package.json";
+
 import App from "./app/App";
 import * as serviceWorker from "./serviceWorker";
 
@@ -31,6 +33,13 @@ const rootNode = document.getElementById("root");
 if (rootNode) {
   ReactDOM.render(<Root />, rootNode);
 }
+
+// log the maas-ui version to the console
+console.info(
+  `${packageInfo.name} ${packageInfo.version} ${
+    process.env.REACT_APP_GIT_SHA ?? ""
+  }`
+);
 
 export default Root;
 


### PR DESCRIPTION
## Done

expose maas-ui version info
- add git sha to the metadata in the index.html
- log the git sha in the browser console

This is using the full hash as it's consistent with the package name that's generated by the upload script:
https://github.com/canonical/maas-ui/runs/8159279483?check_suite_focus=true#step:8:5
https://github.com/canonical/maas-ui/blob/main/.github/workflows/upload.yml#L11

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the demo site
- Open the browser console
- You should see the maas-ui version logged in the console (`maas-ui 3.3.0`)

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4404

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
