### PR TITLE
feat(machines): reset useFetchMachines page on filters change

### DIFF
--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -59,6 +59,7 @@ const LXDVMsTable = ({
     machines: vms,
   } = useFetchMachines({
     currentPage,
+    setCurrentPage,
     filters: {
       ...FilterMachineItems.parseFetchFilters(searchFilter),
       // Set the filters to get results that belong to this single pod or pods in a cluster.

--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -58,16 +58,14 @@ const LXDVMsTable = ({
     machineCount,
     machines: vms,
   } = useFetchMachines({
-    currentPage,
-    setCurrentPage,
     filters: {
       ...FilterMachineItems.parseFetchFilters(searchFilter),
       // Set the filters to get results that belong to this single pod or pods in a cluster.
       [FilterGroupKey.Pod]: pods,
     },
-    pageSize: VMS_PER_PAGE,
     sortDirection: mapSortDirection(sortDirection),
     sortKey,
+    pagination: { currentPage, setCurrentPage, pageSize: VMS_PER_PAGE },
   });
   const count = useFetchedCount(machineCount, loading);
 

--- a/src/app/kvm/components/VmResources/VmResources.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.tsx
@@ -43,15 +43,17 @@ const VmResources = ({ filters, podId }: Props): JSX.Element => {
     machineCount,
     machines: vms,
   } = useFetchMachines({
-    currentPage,
-    setCurrentPage,
     filters: {
       ...filters,
       [FilterGroupKey.Pod]: pod ? [pod.name] : [],
     },
-    pageSize: VMS_PER_PAGE,
     sortDirection: mapSortDirection(sortDirection),
     sortKey,
+    pagination: {
+      currentPage,
+      setCurrentPage,
+      pageSize: VMS_PER_PAGE,
+    },
   });
   const count = useFetchedCount(machineCount, loading);
   return (

--- a/src/app/kvm/components/VmResources/VmResources.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.tsx
@@ -44,6 +44,7 @@ const VmResources = ({ filters, podId }: Props): JSX.Element => {
     machines: vms,
   } = useFetchMachines({
     currentPage,
+    setCurrentPage,
     filters: {
       ...filters,
       [FilterGroupKey.Pod]: pod ? [pod.name] : [],

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
+import { usePrevious } from "@canonical/react-components";
+import fastDeepEqual from "fast-deep-equal";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
@@ -51,10 +53,12 @@ const MachineList = ({
     "hiddenGroups",
     []
   );
+
   const { callId, loading, machineCount, machines, machinesErrors } =
     useFetchMachines({
       collapsedGroups: hiddenGroups,
       currentPage,
+      setCurrentPage,
       filters: FilterMachineItems.parseFetchFilters(searchFilter),
       grouping,
       pageSize: PAGE_SIZE,

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
-import { usePrevious } from "@canonical/react-components";
-import fastDeepEqual from "fast-deep-equal";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
@@ -57,13 +55,11 @@ const MachineList = ({
   const { callId, loading, machineCount, machines, machinesErrors } =
     useFetchMachines({
       collapsedGroups: hiddenGroups,
-      currentPage,
-      setCurrentPage,
       filters: FilterMachineItems.parseFetchFilters(searchFilter),
       grouping,
-      pageSize: PAGE_SIZE,
       sortDirection: mapSortDirection(sortDirection),
       sortKey,
+      pagination: { currentPage, setCurrentPage, pageSize: PAGE_SIZE },
     });
 
   useEffect(

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -336,9 +336,11 @@ describe("machine hook utils", () => {
       const handleSetCurrentPage = jest.fn();
       const initialProps = {
         filters: { hostname: "spotted-quoll" },
-        currentPage: 2,
-        setCurrentPage: handleSetCurrentPage,
-        pageSize: 10,
+        pagination: {
+          currentPage: 2,
+          setCurrentPage: handleSetCurrentPage,
+          pageSize: 10,
+        },
       };
       const { rerender } = renderHook(
         (options: UseFetchMachinesOptions) => useFetchMachines(options),

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -331,6 +331,27 @@ describe("machine hook utils", () => {
       expect(getDispatches).toHaveLength(2);
     });
 
+    it("resets the page number if the options change", () => {
+      const store = mockStore(state);
+      const handleSetCurrentPage = jest.fn();
+      const initialProps = {
+        filters: { hostname: "spotted-quoll" },
+        currentPage: 2,
+        setCurrentPage: handleSetCurrentPage,
+        pageSize: 10,
+      };
+      const { rerender } = renderHook(
+        (options: UseFetchMachinesOptions) => useFetchMachines(options),
+        {
+          initialProps,
+          wrapper: generateWrapper(store),
+        }
+      );
+      expect(handleSetCurrentPage).not.toHaveBeenCalled();
+      rerender({ ...initialProps, filters: { hostname: "eastern-quoll" } });
+      expect(handleSetCurrentPage).toHaveBeenCalledWith(1);
+    });
+
     it("cleans up list request on unmount", async () => {
       jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid-1");
       const store = mockStore(state);

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -88,12 +88,14 @@ export const useFetchMachineCount = (
 export type UseFetchMachinesOptions = {
   filters?: FetchFilters | null;
   grouping?: FetchGroupKey | null;
-  pageSize?: number;
-  currentPage?: number;
-  setCurrentPage?: React.Dispatch<React.SetStateAction<number>>;
   sortKey?: FetchGroupKey | null;
   sortDirection?: FetchSortDirection | null;
   collapsedGroups?: FetchParams["group_collapsed"];
+  pagination?: {
+    pageSize: number;
+    currentPage: number;
+    setCurrentPage: React.Dispatch<React.SetStateAction<number>>;
+  };
 };
 
 /**
@@ -146,7 +148,7 @@ export const useFetchMachines = (
   const previousFilterOptions = usePrevious(filterOptions);
   useEffect(() => {
     if (!fastDeepEqual(filterOptions, previousFilterOptions)) {
-      options?.setCurrentPage?.(1);
+      options?.pagination?.setCurrentPage?.(1);
     }
   }, [options, filterOptions, previousFilterOptions]);
 
@@ -168,8 +170,8 @@ export const useFetchMachines = (
                 filter: options.filters ?? null,
                 group_collapsed: options.collapsedGroups,
                 group_key: options.grouping ?? null,
-                page_number: options.currentPage,
-                page_size: options.pageSize,
+                page_number: options?.pagination?.currentPage,
+                page_size: options?.pagination?.pageSize,
                 sort_direction: options.sortDirection ?? null,
                 sort_key: options.sortKey ?? null,
               }
@@ -177,7 +179,7 @@ export const useFetchMachines = (
         )
       );
     }
-  }, [callId, dispatch, options, previousOptions, previousCallId]);
+  }, [callId, dispatch, options, previousCallId]);
 
   return { callId, loaded, loading, machineCount, machines, machinesErrors };
 };

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -48,12 +48,14 @@ const TagMachines = (): JSX.Element => {
   }
   const { callId, loading, machineCount, machines, machinesErrors } =
     useFetchMachines({
-      currentPage,
-      setCurrentPage,
       filters,
-      pageSize: PAGE_SIZE,
       sortDirection: mapSortDirection(sortDirection),
       sortKey,
+      pagination: {
+        currentPage,
+        setCurrentPage,
+        pageSize: PAGE_SIZE,
+      },
     });
 
   useWindowTitle(tag ? `Deployed machines for: ${tag.name}` : "Tag");

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -49,6 +49,7 @@ const TagMachines = (): JSX.Element => {
   const { callId, loading, machineCount, machines, machinesErrors } =
     useFetchMachines({
       currentPage,
+      setCurrentPage,
       filters,
       pageSize: PAGE_SIZE,
       sortDirection: mapSortDirection(sortDirection),


### PR DESCRIPTION
## Done

- reset useFetchMachines page on filters change

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
You may need to modify the default page size in order to see pagination depending on how many machines there are in the MAAS you test this with.

- Check out this branch locally
- Change the `pageSize` value to `2` in `src/app/machines/views/MachineList/MachineListTable/constants.ts` file
- Go to machine listing and navigate to page other than `1`
- Change Filters
- Verify the page has been reset to `1` in the UI

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1326

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
