### PR TITLE
feat(machines): close action form when deselected

### DIFF
--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from "react";
 
+import { usePrevious } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { useStorageState } from "react-storage-hooks";
@@ -80,11 +81,21 @@ export const MachineListHeader = ({
     selectedCount > 0 &&
     (!("groups" in selectedMachines) || !selectedMachines?.groups?.length);
 
+  const previousSelectedCount = usePrevious(selectedCount);
+
   useEffect(() => {
-    if (location.pathname !== urls.machines.index) {
+    if (
+      location.pathname !== urls.machines.index ||
+      (selectedCount !== previousSelectedCount && selectedCount === 0)
+    ) {
       setHeaderContent(null);
     }
-  }, [location.pathname, setHeaderContent]);
+  }, [
+    location.pathname,
+    setHeaderContent,
+    selectedCount,
+    previousSelectedCount,
+  ]);
 
   const getTitle = useCallback(
     (action: NodeActions) => {


### PR DESCRIPTION
## Done

- close action form when all machines are deselected

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

**Make sure you do not have Group by status selected** - it doesn't yet work with the new API. Any other grouping (e.g. by owner) should work.

- Go to machine listing
- Select a few machines
- Open the action form by clicking Take action and selecting an action from the list
- Deselect all machines
- Verify the action form has been closed

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1306

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
