### PR TITLE
refactor: remove unused Label enum

### DIFF
--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.tsx
@@ -19,7 +19,6 @@ import { actions as tagActions } from "app/store/tag";
 
 export enum Labels {
   AppliesTo = "Applies to",
-  Loading = "Loading...",
   ChooseMachine = "Choose machine",
 }
 


### PR DESCRIPTION
## Done

-  remove unused Label enum https://github.com/canonical/maas-ui/pull/4389#pullrequestreview-1113486350

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
