### PR TITLE
feat(machines): update action forms to use new API

### DIFF
--- a/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
+++ b/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
@@ -67,7 +67,7 @@ const getErrorSentence = (
 type Props = {
   action: NodeActions;
   children: ReactNode;
-  clearHeaderContent: ClearHeaderContent;
+  clearHeaderContent?: ClearHeaderContent;
   nodes: Node[];
   nodeType: string;
   processingCount: number;
@@ -103,7 +103,7 @@ export const NodeActionFormWrapper = ({
   useEffect(() => {
     if (nodes.length === 0) {
       // All the nodes were deselected so close the form.
-      clearHeaderContent();
+      clearHeaderContent?.();
     }
   }, [clearHeaderContent, nodes.length]);
 

--- a/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineHeaderForms/ActionFormWrapper/ActionFormWrapper.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import CloneForm from "./CloneForm";
@@ -11,10 +12,10 @@ import TagForm from "./TagForm";
 
 import DeleteForm from "app/base/components/node/DeleteForm";
 import FieldlessForm from "app/base/components/node/FieldlessForm";
+import NodeActionFormWrapper from "app/base/components/node/NodeActionFormWrapper";
 import SetZoneForm from "app/base/components/node/SetZoneForm";
 import TestForm from "app/base/components/node/TestForm";
 import type { HardwareType } from "app/base/enum";
-import { useScrollOnRender } from "app/base/hooks";
 import type { ClearHeaderContent, SetSearchFilter } from "app/base/types";
 import urls from "app/base/urls";
 import { actions as machineActions } from "app/store/machine";
@@ -35,6 +36,9 @@ type Props = {
   clearHeaderContent: ClearHeaderContent;
   hardwareType?: HardwareType;
   machines: Machine[];
+  machinesLoading?: boolean;
+  selectedCount?: number;
+  selectedCountLoading?: boolean;
   setSearchFilter?: SetSearchFilter;
   viewingDetails: boolean;
 };
@@ -75,11 +79,13 @@ export const ActionFormWrapper = ({
   clearHeaderContent,
   hardwareType,
   machines,
+  machinesLoading,
+  selectedCount,
+  selectedCountLoading,
   setSearchFilter,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const onRenderRef = useScrollOnRender<HTMLDivElement>();
   const processingMachines = useSelector(getProcessingSelector(action));
   // When updating tags we want to surface both "tag" and "untag" errors.
   const errorEvents = isTagUpdateAction(action)
@@ -113,6 +119,7 @@ export const ActionFormWrapper = ({
     modelName: "machine",
     nodes: machines,
     processingCount,
+    selectedCount,
     viewingDetails,
   };
 
@@ -208,7 +215,24 @@ export const ActionFormWrapper = ({
     }
   };
 
-  return <div ref={onRenderRef}>{getFormComponent()}</div>;
+  if (selectedCountLoading || machinesLoading) {
+    return <Spinner />;
+  }
+
+  return (
+    <NodeActionFormWrapper
+      action={action}
+      nodeType="machine"
+      nodes={machines}
+      onUpdateSelected={(machineIDs) =>
+        dispatch(machineActions.setSelectedMachines({ items: machineIDs }))
+      }
+      processingCount={processingCount}
+      viewingDetails={viewingDetails}
+    >
+      {getFormComponent()}
+    </NodeActionFormWrapper>
+  );
 };
 
 export default ActionFormWrapper;

--- a/src/app/machines/components/MachineHeaderForms/MachineHeaderForms.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineHeaderForms.tsx
@@ -18,6 +18,9 @@ import type { Machine } from "app/store/machine/types";
 type Props = {
   headerContent: MachineHeaderContent;
   machines: Machine[];
+  machinesLoading?: boolean;
+  selectedCount?: number;
+  selectedCountLoading?: boolean;
   setHeaderContent: MachineSetHeaderContent;
   setSearchFilter?: SetSearchFilter;
   viewingDetails?: boolean;
@@ -27,6 +30,8 @@ export const MachineHeaderForms = ({
   headerContent,
   machines,
   setHeaderContent,
+  machinesLoading,
+  selectedCountLoading,
   setSearchFilter,
   viewingDetails = false,
 }: Props): JSX.Element | null => {
@@ -57,6 +62,8 @@ export const MachineHeaderForms = ({
           clearHeaderContent={clearHeaderContent}
           hardwareType={extras?.hardwareType}
           machines={machines}
+          machinesLoading={machinesLoading}
+          selectedCountLoading={selectedCountLoading}
           setSearchFilter={setSearchFilter}
           viewingDetails={viewingDetails}
         />


### PR DESCRIPTION
## Done

- make the new API work for all machine listing actions
- pass selected state to action forms - this maintains the current functionality and displays the counts of actionable machines and dispatches actions on them individually
  - extract selected count logic to `useMachineSelectedCount` hook
  - add isEnabled option to useFetchMachines to allow skipping API calls
- add `useFetchSelectedMachines` hook to make sure we have the data for all selected machines

_Note: This will be followed by work intended to use machine filters instead of individual machines as what's passed into actions first (potentially adopting progressive enhancement approach)._ https://github.com/canonical/app-tribe/issues/1373

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

_Note: Grouping by status still doesn't work correctly on the back-end, use any other grouping type._

- Go to machine listing
- Select a few machines
- Go to the take action menu in the top right
- Select an action that has a lower number than the total number of selected machines
- Ensure you can update the selection (remove machines that this action cannot be performed on)
- Make sure that once you submit the action correct websocket messages are being sent (with the right `id` for each machine)
- Play around with selecting groups, all items, none
- Try to break it

## Fixes

Fixes: #1302 
Fixes: #1301

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/7452681/191738959-fe236d5f-1009-45bd-824d-0c3a7f73d7ff.png)

---

![image](https://user-images.githubusercontent.com/7452681/191738989-d9976cf3-cd47-4c3b-a5a0-6d1bd8f5943d.png)

### After
![image](https://user-images.githubusercontent.com/7452681/191739070-386697c1-daec-419d-bb97-992baa810696.png)

---

![image](https://user-images.githubusercontent.com/7452681/191739048-22bb42c7-2d60-47cc-be5c-3987f15135e0.png)

---

![image](https://user-images.githubusercontent.com/7452681/191739028-37db1f86-34a9-4464-afe9-cc4f72d84fe0.png)

