### PR TITLE
fix: kernel parameters reset after save #4417

### DIFF
--- a/cypress/e2e/with-users/settings/configuration/kernel-parameters.spec.ts
+++ b/cypress/e2e/with-users/settings/configuration/kernel-parameters.spec.ts
@@ -1,0 +1,30 @@
+import { generateMAASURL } from "../../../utils";
+
+const getSaveButton = () => cy.findByRole("button", { name: /Save/i });
+const getKernelParamsInput = () =>
+  cy.findByLabelText(/Global boot parameters always passed to the kernel/i);
+
+context("Settings Kernel parameters", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit(generateMAASURL("/settings/configuration/kernel-parameters"));
+  });
+
+  afterEach(() => {
+    getKernelParamsInput().clear();
+    getSaveButton().click();
+    getSaveButton().should("be.disabled");
+  });
+
+  it("can update kernel parameters", () => {
+    const kernelParams = "sysrq_always_enabled dyndbg='file drivers/usb/*";
+    getKernelParamsInput().clear().type(kernelParams);
+    getSaveButton().click();
+    // make sure the button is disabled after submission
+    getSaveButton().should("be.disabled");
+    getKernelParamsInput().should("have.value", kernelParams);
+    cy.reload();
+    // check that it has the same value after reload
+    getKernelParamsInput().should("have.value", kernelParams);
+  });
+});

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
@@ -43,10 +43,10 @@ const KernelParametersForm = (): JSX.Element => {
         category: "Configuration settings",
         label: "Kernel parameters form",
       }}
-      onSubmit={(values) => {
+      onSubmit={(values, { resetForm }) => {
         dispatch(updateConfig(values));
+        resetForm({ values });
       }}
-      resetOnSave
       saved={saved}
       saving={saving}
       validationSchema={KernelParametersSchema}


### PR DESCRIPTION
## Done

- fix kernel parameters resetting after save
- add e2e test for kernel parameters

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to `MAAS/r/settings/configuration/kernel-parameters`
- change the text value and save
- text should remain unchanged once it's saved
- reload the page, form should show the saved value
- remove the text, save
- reload the page, form should show the saved value

## Fixes

Fixes:  #4417

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
