### PR TITLE
fix: cancel does not reset general settings

### DIFF
--- a/cypress/e2e/with-users/settings/configuration/general.spec.ts
+++ b/cypress/e2e/with-users/settings/configuration/general.spec.ts
@@ -1,6 +1,6 @@
 import { generateMAASURL } from "../../../utils";
 
-context("Settings - General", () => {
+context("Settings - General - Theme", () => {
   beforeEach(() => {
     cy.login();
     cy.visit(generateMAASURL("/settings/configuration/general"));
@@ -63,5 +63,24 @@ context("Settings - General", () => {
     cy.findByRole("link", { name: "Deploy" }).click();
 
     cy.findByRole("banner").should("have.class", "p-navigation--default");
+  });
+});
+
+context("Settings - General", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit(generateMAASURL("/settings/configuration/general"));
+  });
+
+  it("resets to initial values on cancel", () => {
+    const getNotificationsCheckbox = () =>
+      cy.findByLabelText(/Enable new release notifications/);
+
+    getNotificationsCheckbox().should("be.checked");
+    getNotificationsCheckbox().click({ force: true });
+    getNotificationsCheckbox().should("not.be.checked");
+
+    cy.findByRole("button", { name: "Cancel" }).click();
+    getNotificationsCheckbox().should("be.checked");
   });
 });

--- a/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -77,7 +77,8 @@ const GeneralForm = (): JSX.Element => {
         enable_analytics: analyticsEnabled || false,
         release_notifications: releaseNotifications || false,
       }}
-      onCancel={(values) => {
+      onCancel={(values, { resetForm }) => {
+        resetForm();
         setTheme(maasTheme ? maasTheme : "default");
         values.theme = maasTheme ? maasTheme : "default";
       }}


### PR DESCRIPTION
## Done

- fix: cancel does not reset general settings
- add e2e test for general settings cancel action

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `MAAS/r/settings/configuration/general`
- Change any input value on the page (e.g. MAAS name)
- Click cancel
- Verify the input has been reverted to the original value

## Fixes

Fixes: #4411  .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
