### PR TITLE
fix: machine details take action list

### DIFF
--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
@@ -100,7 +100,27 @@ describe("NodeActionMenu", () => {
     expect(getActionButton(NodeActions.RELEASE)).toBeDisabled();
   });
 
-  it("shows all actions that can be performed when not showing counts", async () => {
+  it(`disables the actions that cannot be performed when nodes are provided`, async () => {
+    const nodes = [machineFactory({ actions: [NodeActions.DEPLOY] })];
+    render(
+      <NodeActionMenu
+        alwaysShowLifecycle
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount={false}
+      />
+    );
+
+    await openMenu();
+
+    expect(getActionButton(NodeActions.DEPLOY)).toBeInTheDocument();
+    expect(queryActionButton(NodeActions.DEPLOY)).not.toBeDisabled();
+    expect(getActionButton(NodeActions.RELEASE)).toBeInTheDocument();
+    expect(getActionButton(NodeActions.RELEASE)).toBeDisabled();
+  });
+
+  it("shows all actions that can be performed when nodes are not provided", async () => {
     render(<NodeActionMenu hasSelection onActionClick={jest.fn()} />);
     await openMenu();
     expect(getActionButton(NodeActions.DELETE)).toBeInTheDocument();

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
@@ -131,8 +131,8 @@ const getTakeActionLinks = (
               </div>
             ),
             "data-testid": `action-link-${action}`,
-            // When not showing the counts the actions should always be enabled.
-            disabled: (showCount && count === 0) || false,
+            // When nodes are not provided actions should always be enabled.
+            disabled: nodes ? count === 0 : false,
             onClick: () => onActionClick(action),
           });
         }

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -73,6 +73,7 @@ const MachineHeader = ({
           hasSelection={true}
           key="action-dropdown"
           nodeDisplay="machine"
+          nodes={[machine]}
           onActionClick={(action) => {
             const view = Object.values(MachineHeaderViews).find(
               ([, actionName]) => actionName === action


### PR DESCRIPTION
## Done

- fix: machine details take action list not displaying all available items for a machine

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a machine from machine listing and go to machine details page
- Verify that all actions available for the machine are displayed

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1389

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
