### PR TITLE
fix(settings): updating multiple fields

### DIFF
--- a/src/app/base/sagas/websockets.test.ts
+++ b/src/app/base/sagas/websockets.test.ts
@@ -287,7 +287,7 @@ describe("websocket sagas", () => {
         params: { name: "foo", value: "bar" },
       })
     );
-    expect(saga.next().value).toEqual(take("test/actionNotify"));
+    expect(saga.next().value).toEqual(take("test/actionSuccess"));
 
     expect(saga.next().value).toEqual(
       call([socketClient, socketClient.send], action, {
@@ -296,7 +296,7 @@ describe("websocket sagas", () => {
         params: { name: "baz", value: "qux" },
       })
     );
-    expect(saga.next().value).toEqual(take("test/actionNotify"));
+    expect(saga.next().value).toEqual(take("test/actionSuccess"));
   });
 
   it("can handle errors when sending a WebSocket message", () => {

--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -564,10 +564,7 @@ export function* sendMessage(
         // Ensure server has synced before sending next message,
         // important for dependant config like commissioning_distro_series
         // and default_min_hwe_kernel.
-        // There is an edge case where a different CLI or server event could
-        // dispatch a NOTIFY of the same type which is received before our expected NOTIFY,
-        // but this _probably_ does not matter in practice.
-        yield* take(`${type}Notify`);
+        yield* take(`${type}Success`);
       }
     } else {
       const id = yield* call(


### PR DESCRIPTION
## Done

- fix updating multiple settings fields
  - wait for config success messages instead of notify

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the Settings page and change the theme colour
- Click save
- Reload the page and make sure the setting have been persisted

This change can affect any page that uses `dispatchMultiple` option for the websocket API (Commissioning Form, Dns Form, Network Discovery Form, Ntp Form, Syslog Form, Storage Form).
- Verify that saving updates to multiple fields works correctly in the forms mentioned above, and in particular the commissioning page
- Go to `MAAS/r/settings/configuration/commissioning`
- Change the value for `Default Ubuntu release used for commissioning`
- Change the value for `Default minimum kernel version`
- Submit the form by clicking Save
- Reload the page
- Ensure the values have been saved correctly

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4429

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
