### PR TITLE
feat: use single filter for machine list actions

### DIFF
--- a/src/__snapshots__/root-reducer.test.ts.snap
+++ b/src/__snapshots__/root-reducer.test.ts.snap
@@ -201,6 +201,7 @@ Object {
     "saving": false,
   },
   "machine": Object {
+    "actions": Object {},
     "active": null,
     "counts": Object {},
     "details": Object {},

--- a/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.test.tsx
+++ b/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.test.tsx
@@ -3,18 +3,17 @@ import { render, screen } from "@testing-library/react";
 import NodeActionConfirmationText from "./NodeActionConfirmationText";
 
 import { NodeActions } from "app/store/types/node";
-import { machine as machineFactory } from "testing/factories";
 
 it("displays correct confirmation text for deleting a single node", () => {
   render(
     <NodeActionConfirmationText
       action={NodeActions.DELETE}
       modelName="machine"
-      nodes={[machineFactory({ fqdn: "test" })]}
+      selectedCount={1}
     />
   );
   expect(
-    screen.getByText("Are you sure you want to delete test?")
+    screen.getByText("Are you sure you want to delete a machine?")
   ).toBeInTheDocument();
 });
 
@@ -23,10 +22,7 @@ it("displays correct confirmation text for deleting multiple nodes", () => {
     <NodeActionConfirmationText
       action={NodeActions.DELETE}
       modelName="machine"
-      nodes={[
-        machineFactory({ fqdn: "test" }),
-        machineFactory({ fqdn: "test2" }),
-      ]}
+      selectedCount={2}
     />
   );
   expect(

--- a/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.tsx
+++ b/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.tsx
@@ -1,12 +1,12 @@
-import type { Node, NodeActions } from "app/store/types/node";
+import type { NodeActions } from "app/store/types/node";
 import { getNodeActionLabel } from "app/store/utils";
 
 const NodeActionConfirmationText = ({
-  nodes,
+  selectedCount,
   action,
   modelName,
 }: {
-  nodes: Node[];
+  selectedCount: number;
   action: NodeActions;
   modelName: string;
 }): JSX.Element => (
@@ -14,7 +14,7 @@ const NodeActionConfirmationText = ({
     <p>
       Are you sure you want to{" "}
       {getNodeActionLabel(
-        nodes.length > 1 ? `${nodes.length} ${modelName}s` : nodes[0].fqdn,
+        selectedCount > 1 ? `${selectedCount} ${modelName}s` : `a ${modelName}`,
         action,
         false
       ).toLowerCase()}

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
@@ -100,7 +100,27 @@ describe("NodeActionMenu", () => {
     expect(getActionButton(NodeActions.RELEASE)).toBeDisabled();
   });
 
-  it("shows all actions that can be performed when not showing counts", async () => {
+  it(`disables the actions that cannot be performed when nodes are provided`, async () => {
+    const nodes = [machineFactory({ actions: [NodeActions.DEPLOY] })];
+    render(
+      <NodeActionMenu
+        alwaysShowLifecycle
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount={false}
+      />
+    );
+
+    await openMenu();
+
+    expect(getActionButton(NodeActions.DEPLOY)).toBeInTheDocument();
+    expect(queryActionButton(NodeActions.DEPLOY)).not.toBeDisabled();
+    expect(getActionButton(NodeActions.RELEASE)).toBeInTheDocument();
+    expect(getActionButton(NodeActions.RELEASE)).toBeDisabled();
+  });
+
+  it("shows all actions that can be performed when nodes are not provided", async () => {
     render(<NodeActionMenu hasSelection onActionClick={jest.fn()} />);
     await openMenu();
     expect(getActionButton(NodeActions.DELETE)).toBeInTheDocument();

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
@@ -131,8 +131,8 @@ const getTakeActionLinks = (
               </div>
             ),
             "data-testid": `action-link-${action}`,
-            // When not showing the counts the actions should always be enabled.
-            disabled: (showCount && count === 0) || false,
+            // When nodes are not provided actions should always be enabled.
+            disabled: nodes ? count === 0 : false,
             onClick: () => onActionClick(action),
           });
         }

--- a/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
+++ b/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
@@ -48,8 +48,10 @@ describe("DeleteForm", () => {
     );
 
     submitFormikForm(wrapper);
-
-    expect(onSubmit).toHaveBeenCalledWith();
+    expect(onSubmit).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ resetForm: expect.any(Function) })
+    );
   });
 
   it("redirects when a node is deleted from details view", () => {

--- a/src/app/base/components/node/DeleteForm/DeleteForm.tsx
+++ b/src/app/base/components/node/DeleteForm/DeleteForm.tsx
@@ -24,6 +24,7 @@ export const DeleteForm = <E,>({
   nodes,
   onSubmit,
   processingCount,
+  selectedCount,
   redirectURL,
   viewingDetails,
 }: Props<E>): JSX.Element => {
@@ -55,16 +56,16 @@ export const DeleteForm = <E,>({
         } action form`,
         label: "Delete",
       }}
-      onSubmit={() => onSubmit()}
+      onSubmit={onSubmit}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
-      selectedCount={nodes.length}
+      selectedCount={nodes ? nodes.length : selectedCount ?? 0}
       submitAppearance="negative"
     >
       <NodeActionConfirmationText
         action={NodeActions.DELETE}
         modelName={modelName}
-        nodes={nodes}
+        selectedCount={nodes ? nodes.length : selectedCount ?? 0}
       />
     </ActionForm>
   );

--- a/src/app/base/components/node/FieldlessForm/FieldlessForm.tsx
+++ b/src/app/base/components/node/FieldlessForm/FieldlessForm.tsx
@@ -22,9 +22,11 @@ export const FieldlessForm = <E,>({
   cleanup,
   clearHeaderContent,
   errors,
+  selectedFilter,
   modelName,
   nodes,
   processingCount,
+  selectedCount,
   viewingDetails,
 }: Props<E>): JSX.Element => {
   const dispatch = useDispatch();
@@ -48,18 +50,23 @@ export const FieldlessForm = <E,>({
       onSubmit={() => {
         dispatch(cleanup());
         const actionMethod = kebabToCamelCase(action);
-        nodes.forEach((node) => {
-          // Find the method for the function.
-          const [, actionFunction] =
-            Object.entries(actions).find(([key]) => key === actionMethod) || [];
-          if (actionFunction) {
-            dispatch(actionFunction({ system_id: node.system_id }));
+        // Find the method for the function.
+        const [, actionFunction] =
+          Object.entries(actions).find(([key]) => key === actionMethod) || [];
+
+        if (actionFunction) {
+          if (selectedFilter) {
+            dispatch(actionFunction({ filter: selectedFilter }));
+          } else {
+            nodes?.forEach((node) => {
+              dispatch(actionFunction({ system_id: node.system_id }));
+            });
           }
-        });
+        }
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
-      selectedCount={nodes.length}
+      selectedCount={nodes ? nodes.length : selectedCount ?? 0}
     />
   );
 };

--- a/src/app/base/components/node/SetZoneForm/SetZoneForm.tsx
+++ b/src/app/base/components/node/SetZoneForm/SetZoneForm.tsx
@@ -42,6 +42,7 @@ export const SetZoneForm = <E,>({
   onSubmit,
   processingCount,
   viewingDetails,
+  selectedCount,
 }: Props<E>): JSX.Element => {
   return (
     <ActionForm<SetZoneFormValues, E>
@@ -49,7 +50,7 @@ export const SetZoneForm = <E,>({
       cleanup={cleanup}
       errors={errors}
       initialValues={{
-        zone: getInitialZoneValue(nodes),
+        zone: nodes ? getInitialZoneValue(nodes) : "",
       }}
       modelName={modelName}
       onCancel={clearHeaderContent}
@@ -67,7 +68,7 @@ export const SetZoneForm = <E,>({
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
-      selectedCount={nodes.length}
+      selectedCount={nodes ? nodes.length : selectedCount ?? 0}
       validationSchema={SetZoneSchema}
     >
       <Row>

--- a/src/app/base/components/node/types.ts
+++ b/src/app/base/components/node/types.ts
@@ -1,10 +1,25 @@
 import type { AnyAction } from "redux";
 
-import type { CommonActionFormProps } from "app/base/types";
+import type { ActionState, CommonActionFormProps } from "app/base/types";
+import type { FetchFilters } from "app/store/machine/types";
 import type { Node } from "app/store/types/node";
 
 export type NodeActionFormProps<E = null> = CommonActionFormProps<E> & {
   cleanup?: () => AnyAction;
-  nodes: Node[];
   modelName: string;
-};
+  submitDisabled?: boolean;
+  actionStatus?: ActionState["status"];
+} & (
+    | {
+        nodes: Node[];
+        processingCount: number;
+        selectedFilter?: never;
+        selectedCount?: never;
+      }
+    | {
+        selectedFilter?: FetchFilters | null;
+        processingCount?: never;
+        selectedCount?: number;
+        nodes?: never;
+      }
+  );

--- a/src/app/base/hooks/base.ts
+++ b/src/app/base/hooks/base.ts
@@ -100,7 +100,7 @@ export const useProcessing = ({
   hasErrors?: boolean;
   onComplete?: () => void;
   onError?: () => void;
-  processingCount: number;
+  processingCount?: number;
 }): boolean => {
   const [processingStarted] = useCycled(processingCount !== 0);
   const [processingComplete, setProcessingComplete] = useState(false);

--- a/src/app/base/types.ts
+++ b/src/app/base/types.ts
@@ -68,7 +68,6 @@ export type DataTestElement<E> = E & { "data-testid"?: string };
 export type CommonActionFormProps<E = null> = {
   clearHeaderContent: ClearHeaderContent;
   errors?: APIError<E>;
-  processingCount: number;
   viewingDetails: boolean;
 };
 
@@ -81,6 +80,10 @@ type UsabillaConfig =
 export type UsabillaLive = (type: string, config?: UsabillaConfig) => void;
 
 export type ActionStatuses = ValueOf<typeof ACTION_STATUS>;
+export type ActionState = {
+  status: ActionStatuses;
+  errors: APIError;
+};
 
 export type ModelAction<PK> = {
   [ACTION_STATUS.error]: PK[];

--- a/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.tsx
@@ -118,7 +118,7 @@ export const ControllerActionFormWrapper = ({
                 controllerActions.test({
                   enable_ssh: args.enableSSH,
                   script_input: args.scriptInputs,
-                  system_id: args.systemId,
+                  system_id: args.systemId as string,
                   testing_scripts: args.scripts.map((script) => script.name),
                 })
               );

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.tsx
@@ -57,7 +57,7 @@ export const CloneForm = ({
     null
   );
   const [showResults, setShowResults] = useState(false);
-  const destinations = machines.map((machine) => machine.system_id);
+  const destinations = machines?.map((machine) => machine.system_id);
 
   // Run cleanup function here rather than in the ActionForm otherwise errors
   // get cleared before the results are shown.
@@ -70,7 +70,7 @@ export const CloneForm = ({
   return showResults ? (
     <CloneResults
       closeForm={clearHeaderContent}
-      destinations={destinations}
+      destinations={destinations || []}
       setSearchFilter={setSearchFilter}
       sourceMachine={selectedMachine}
       viewingDetails={viewingDetails}
@@ -109,7 +109,7 @@ export const CloneForm = ({
         dispatch(machineActions.cleanup());
         dispatch(
           machineActions.clone({
-            destinations,
+            destinations: destinations ?? [],
             interfaces: values.interfaces,
             storage: values.storage,
             system_id: values.source,
@@ -118,7 +118,7 @@ export const CloneForm = ({
       }}
       onSuccess={() => setShowResults(true)}
       processingCount={processingCount}
-      selectedCount={destinations.length}
+      selectedCount={destinations?.length ?? 0}
       validationSchema={CloneFormSchema}
     >
       <CloneFormFields

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -53,6 +53,7 @@ export const CommissionForm = ({
   errors,
   machines,
   processingCount,
+  selectedCount,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -142,7 +143,7 @@ export const CommissionForm = ({
         const testingScriptsParam = testingScripts.length
           ? testingScripts.map((script) => script.name)
           : [ScriptName.NONE];
-        machines.forEach((machine) => {
+        machines?.forEach((machine) => {
           dispatch(
             machineActions.commission({
               commissioning_scripts: commissioningScriptsParam,
@@ -159,7 +160,7 @@ export const CommissionForm = ({
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
-      selectedCount={machines.length}
+      selectedCount={machines ? machines.length : selectedCount ?? 0}
       validationSchema={CommissionFormSchema}
     >
       <CommissionFormFields

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/DeployForm/DeployForm.tsx
@@ -45,6 +45,8 @@ export const DeployForm = ({
   errors,
   machines,
   processingCount,
+  selectedCount,
+  selectedFilter,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -120,13 +122,13 @@ export const DeployForm = ({
             "Cloud-init user data"
           );
         }
-        machines.forEach((machine) => {
+        if (selectedFilter) {
           dispatch(
             machineActions.deploy({
               distro_series: values.release,
               hwe_kernel: values.kernel,
               osystem: values.oSystem,
-              system_id: machine.system_id,
+              filter: selectedFilter,
               ...(values.enableHwSync && { enable_hw_sync: true }),
               ...(values.vmHostType === PodType.LXD && {
                 register_vmhost: true,
@@ -137,11 +139,30 @@ export const DeployForm = ({
               ...(hasUserData && { user_data: values.userData }),
             })
           );
-        });
+        } else {
+          machines?.forEach((machine) => {
+            dispatch(
+              machineActions.deploy({
+                distro_series: values.release,
+                hwe_kernel: values.kernel,
+                osystem: values.oSystem,
+                system_id: machine.system_id,
+                ...(values.enableHwSync && { enable_hw_sync: true }),
+                ...(values.vmHostType === PodType.LXD && {
+                  register_vmhost: true,
+                }),
+                ...(values.vmHostType === PodType.VIRSH && {
+                  install_kvm: true,
+                }),
+                ...(hasUserData && { user_data: values.userData }),
+              })
+            );
+          });
+        }
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
-      selectedCount={machines.length}
+      selectedCount={machines ? machines.length : selectedCount ?? 0}
       validationSchema={DeploySchema}
     >
       <DeployFormFields />

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -26,6 +26,8 @@ export const MarkBrokenForm = ({
   errors,
   machines,
   processingCount,
+  selectedCount,
+  selectedFilter,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -55,21 +57,32 @@ export const MarkBrokenForm = ({
       }}
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
-        machines.forEach((machine) => {
+        if (selectedFilter) {
           dispatch(
             machineActions.markBroken({
               message: values.comment,
-              system_id: machine.system_id,
+              filter: selectedFilter,
             })
           );
-        });
+        } else {
+          machines?.forEach((machine) => {
+            dispatch(
+              machineActions.markBroken({
+                message: values.comment,
+                system_id: machine.system_id,
+              })
+            );
+          });
+        }
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
-      selectedCount={machines.length}
+      selectedCount={machines ? machines.length : selectedCount ?? 0}
       validationSchema={MarkBrokenSchema}
     >
-      <MarkBrokenFormFields selectedCount={machines.length} />
+      <MarkBrokenFormFields
+        selectedCount={machines ? machines.length : selectedCount ?? 0}
+      />
     </ActionForm>
   );
 };

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.tsx
@@ -33,6 +33,8 @@ export const ReleaseForm = ({
   errors,
   machines,
   processingCount,
+  selectedCount,
+  selectedFilter,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -70,24 +72,35 @@ export const ReleaseForm = ({
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
         const { enableErase, quickErase, secureErase } = values;
-        machines.forEach((machine) => {
+        if (selectedFilter) {
           dispatch(
             machineActions.release({
               erase: enableErase,
               quick_erase: enableErase && quickErase,
               secure_erase: enableErase && secureErase,
-              system_id: machine.system_id,
+              filter: selectedFilter,
             })
           );
-        });
+        } else {
+          machines?.forEach((machine) => {
+            dispatch(
+              machineActions.release({
+                erase: enableErase,
+                quick_erase: enableErase && quickErase,
+                secure_erase: enableErase && secureErase,
+                system_id: machine.system_id,
+              })
+            );
+          });
+        }
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
-      selectedCount={machines.length}
+      selectedCount={machines ? machines.length : selectedCount ?? 0}
       validationSchema={ReleaseSchema}
     >
       <Strip shallow>
-        <ReleaseFormFields machines={machines} />
+        <ReleaseFormFields machines={machines ?? []} />
       </Strip>
     </ActionForm>
   ) : (

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.tsx
@@ -27,6 +27,8 @@ export const SetPoolForm = ({
   errors,
   machines,
   processingCount,
+  selectedCount,
+  selectedFilter,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
@@ -72,21 +74,30 @@ export const SetPoolForm = ({
         if (values.poolSelection === "create") {
           dispatch(
             resourcePoolActions.createWithMachines({
-              machineIDs: machines.map(({ system_id }) => system_id),
+              machineIDs: machines?.map(({ system_id }) => system_id) || [],
               pool: values,
             })
           );
         } else {
           const pool = resourcePools.find((pool) => pool.name === values.name);
           if (pool) {
-            machines.forEach((machine) => {
+            if (selectedFilter) {
               dispatch(
                 machineActions.setPool({
                   pool_id: pool.id,
-                  system_id: machine.system_id,
+                  filter: selectedFilter,
                 })
               );
-            });
+            } else {
+              machines?.forEach((machine) => {
+                dispatch(
+                  machineActions.setPool({
+                    pool_id: pool.id,
+                    system_id: machine.system_id,
+                  })
+                );
+              });
+            }
           }
         }
         // Store the values in case there are errors and the form needs to be
@@ -95,7 +106,7 @@ export const SetPoolForm = ({
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
-      selectedCount={machines.length}
+      selectedCount={machines ? machines.length : selectedCount ?? 0}
       validationSchema={SetPoolSchema}
     >
       <SetPoolFormFields />

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.tsx
@@ -33,6 +33,8 @@ export const TagForm = ({
   errors,
   machines,
   processingCount,
+  selectedCount,
+  selectedFilter,
   viewingDetails,
   viewingMachineConfig = false,
 }: Props): JSX.Element => {
@@ -73,24 +75,42 @@ export const TagForm = ({
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
         if (values.added.length) {
-          machines.forEach((machine) => {
+          if (selectedFilter) {
             dispatch(
               machineActions.tag({
-                system_id: machine.system_id,
+                filter: selectedFilter,
                 tags: values.added.map((id) => Number(id)),
               })
             );
-          });
+          } else {
+            machines?.forEach((machine) => {
+              dispatch(
+                machineActions.tag({
+                  system_id: machine.system_id,
+                  tags: values.added.map((id) => Number(id)),
+                })
+              );
+            });
+          }
         }
         if (values.removed.length) {
-          machines.forEach((machine) => {
+          if (selectedFilter) {
             dispatch(
               machineActions.untag({
-                system_id: machine.system_id,
+                filter: selectedFilter,
                 tags: values.removed.map((id) => Number(id)),
               })
             );
-          });
+          } else {
+            machines?.forEach((machine) => {
+              dispatch(
+                machineActions.untag({
+                  system_id: machine.system_id,
+                  tags: values.removed.map((id) => Number(id)),
+                })
+              );
+            });
+          }
         }
       }}
       onSuccess={() => {
@@ -100,13 +120,13 @@ export const TagForm = ({
         );
       }}
       processingCount={processingCount}
-      selectedCount={machines.length}
+      selectedCount={machines ? machines.length : selectedCount ?? 0}
       showProcessingCount={!viewingMachineConfig}
       submitLabel="Save"
       validationSchema={TagFormSchema}
     >
       <TagFormFields
-        machines={machines}
+        machines={machines || []}
         newTags={newTags}
         setNewTags={setNewTags}
         viewingDetails={viewingDetails}

--- a/src/app/machines/components/MachineHeaderForms/MachineHeaderForms.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineHeaderForms.tsx
@@ -10,28 +10,25 @@ import type { SetSearchFilter } from "app/base/types";
 import { MachineHeaderViews } from "app/machines/constants";
 import type { MachineActionHeaderViews } from "app/machines/constants";
 import type {
+  MachineActionVariableProps,
   MachineHeaderContent,
   MachineSetHeaderContent,
 } from "app/machines/types";
-import type { Machine } from "app/store/machine/types";
 
 type Props = {
   headerContent: MachineHeaderContent;
-  machines: Machine[];
-  machinesLoading?: boolean;
-  selectedCount?: number;
-  selectedCountLoading?: boolean;
   setHeaderContent: MachineSetHeaderContent;
   setSearchFilter?: SetSearchFilter;
   viewingDetails?: boolean;
-};
+} & MachineActionVariableProps;
 
 export const MachineHeaderForms = ({
   headerContent,
   machines,
   setHeaderContent,
-  machinesLoading,
   selectedCountLoading,
+  selectedCount,
+  selectedFilter,
   setSearchFilter,
   viewingDetails = false,
 }: Props): JSX.Element | null => {
@@ -55,17 +52,18 @@ export const MachineHeaderForms = ({
         view: ValueOf<typeof MachineActionHeaderViews>;
       };
       const [, action] = view;
+      const conditionalProps = machines
+        ? { machines }
+        : { selectedCount, selectedCountLoading, selectedFilter };
       return (
         <MachineActionFormWrapper
           action={action}
           applyConfiguredNetworking={extras?.applyConfiguredNetworking}
           clearHeaderContent={clearHeaderContent}
           hardwareType={extras?.hardwareType}
-          machines={machines}
-          machinesLoading={machinesLoading}
-          selectedCountLoading={selectedCountLoading}
           setSearchFilter={setSearchFilter}
           viewingDetails={viewingDetails}
+          {...conditionalProps}
         />
       );
   }

--- a/src/app/machines/types.ts
+++ b/src/app/machines/types.ts
@@ -8,7 +8,11 @@ import type {
   HeaderContent,
   SetHeaderContent,
 } from "app/base/types";
-import type { Machine, MachineEventErrors } from "app/store/machine/types";
+import type {
+  FetchFilters,
+  Machine,
+  MachineEventErrors,
+} from "app/store/machine/types";
 import type { Script } from "app/store/script/types";
 
 export type MachineHeaderContent = HeaderContent<
@@ -21,5 +25,24 @@ export type MachineHeaderContent = HeaderContent<
 
 export type MachineSetHeaderContent = SetHeaderContent<MachineHeaderContent>;
 
-export type MachineActionFormProps =
-  CommonActionFormProps<MachineEventErrors> & { machines: Machine[] };
+export type MachineActionVariableProps =
+  | {
+      machines?: Machine[];
+      processingCount?: number;
+      selectedFilter?: never;
+      selectedCount?: never;
+      selectedCountLoading?: never;
+    }
+  | {
+      machines?: never;
+      selectedFilter?: FetchFilters | null;
+      selectedCount?: number;
+      processingCount?: never;
+      selectedCountLoading?: boolean;
+    };
+
+export type MachineActionFormProps = Omit<
+  CommonActionFormProps<MachineEventErrors>,
+  "processingCount"
+> &
+  MachineActionVariableProps;

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -73,6 +73,7 @@ const MachineHeader = ({
           hasSelection={true}
           key="action-dropdown"
           nodeDisplay="machine"
+          nodes={[machine]}
           onActionClick={(action) => {
             const view = Object.values(MachineHeaderViews).find(
               ([, actionName]) => actionName === action

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from "react";
 
 import { usePrevious } from "@canonical/react-components";
+import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { useStorageState } from "react-storage-hooks";
 
@@ -18,10 +19,10 @@ import type {
   MachineSetHeaderContent,
 } from "app/machines/types";
 import { getHeaderTitle } from "app/machines/utils";
-import { FilterMachineItems } from "app/store/machine/utils";
+import machineSelectors from "app/store/machine/selectors";
+import { FilterMachineItems, selectedToFilters } from "app/store/machine/utils";
 import {
   useFetchMachineCount,
-  useFetchSelectedMachines,
   useHasSelection,
   useMachineSelectedCount,
 } from "app/store/machine/utils/hooks";
@@ -55,12 +56,8 @@ export const MachineListHeader = ({
   const { selectedCount, selectedCountLoading } = useMachineSelectedCount();
   const previousSelectedCount = usePrevious(selectedCount);
 
-  // we need to make sure we have the data for all selected machines
-  // (including those in collapsed groups or out of bounds of the currently visible page)
-  const { machines: selectedMachines, loading: machinesLoading } =
-    useFetchSelectedMachines({
-      isEnabled: hasSelection,
-    });
+  const selectedMachines = useSelector(machineSelectors.selectedMachines);
+  const selectedFilter = selectedToFilters(selectedMachines);
 
   useEffect(() => {
     if (
@@ -108,7 +105,6 @@ export const MachineListHeader = ({
           hasSelection={hasSelection}
           key="machine-list-action-menu"
           nodeDisplay="machine"
-          nodes={selectedMachines}
           onActionClick={(action) => {
             if (action === NodeActions.TAG && !tagsSeen) {
               setTagsSeen(true);
@@ -120,16 +116,15 @@ export const MachineListHeader = ({
               setHeaderContent({ view });
             }
           }}
-          showCount
         />,
       ]}
       headerContent={
         headerContent && (
           <MachineHeaderForms
             headerContent={headerContent}
-            machines={selectedMachines}
-            machinesLoading={machinesLoading}
+            selectedCount={selectedCount}
             selectedCountLoading={selectedCountLoading}
+            selectedFilter={selectedFilter}
             setHeaderContent={setHeaderContent}
             setSearchFilter={setSearchFilter}
           />

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -18,6 +18,7 @@ import {
 describe("machine reducer", () => {
   it("should return the initial state", () => {
     expect(reducers(undefined, { type: "" })).toEqual({
+      actions: {},
       active: null,
       errors: null,
       counts: {},

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -83,6 +83,20 @@ ACTIONS.forEach(({ status }) => {
 });
 
 /**
+ * Returns a machine's action details by callId
+ */
+const getActionState = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState: MachineState, callId) =>
+    callId && callId in machineState.actions
+      ? machineState.actions[callId]
+      : null
+);
+
+/**
  * Get the machines that are either tagging or untagging.
  * @param state - The redux state.
  * @returns Machines that are either tagging or untagging.
@@ -215,7 +229,9 @@ const eventErrorsForIds = createSelector(
     const idArray = Array.isArray(ids) ? ids : [ids];
     return errors.reduce<MachineState["eventErrors"][0][]>((matches, error) => {
       let match = false;
-      const matchesId = !!error.id && idArray.includes(error.id);
+      const matchesId = !!error.id
+        ? !!error.id && idArray.includes(error.id)
+        : !!error.callId && idArray.includes(error.callId);
       // If an event has been provided as `null` then filter for errors with
       // a null event.
       if (event || event === null) {
@@ -626,6 +642,7 @@ const selectors = {
   filtersLoaded,
   filtersLoading,
   getByStatusCode,
+  getActionState,
   count,
   countLoaded,
   countLoading,

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -397,7 +397,7 @@ const statusHandlers = generateStatusHandlers<
 const generateActionParams = <P extends BaseMachineActionParams>(
   action: NodeActions
 ) => ({
-  prepare: (params: P) => {
+  prepare: (params: P, callId?: string) => {
     let actionParams: {
       action: NodeActions;
       extra: Omit<P, "filter"> | Omit<P, "system_id">;
@@ -423,6 +423,7 @@ const generateActionParams = <P extends BaseMachineActionParams>(
       meta: {
         model: MachineMeta.MODEL,
         method: "action",
+        ...(callId ? { callId } : {}),
       },
       payload: {
         params: actionParams,
@@ -438,6 +439,7 @@ const machineSlice = createSlice({
   name: MachineMeta.MODEL,
   initialState: {
     ...genericInitialState,
+    actions: {},
     active: null,
     counts: {},
     details: {},
@@ -1557,6 +1559,8 @@ const machineSlice = createSlice({
             delete state.lists[callId];
           } else if (callId in state.counts) {
             delete state.counts[callId];
+          } else if (callId in state.actions) {
+            delete state.actions[callId];
           }
         }
       },

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -55,6 +55,7 @@ export type BaseMachineActionParams =
   | BaseNodeActionParams
   | {
       filter: FetchFilters;
+      callId?: string;
     };
 
 export type CloneParams = BaseMachineActionParams & {

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -1,7 +1,7 @@
 import type { FetchFilters, FetchGroupKey } from "./actions";
 import type { MachineMeta } from "./enum";
 
-import type { APIError, Seconds } from "app/base/types";
+import type { ActionState, APIError, Seconds } from "app/base/types";
 import type { CloneError } from "app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneResults/CloneResults";
 import type { CertificateMetadata, PowerType } from "app/store/general/types";
 import type { PowerState, StorageLayout } from "app/store/types/enum";
@@ -331,7 +331,10 @@ export type SelectedMachines =
     }
   | { filter: FetchFilters };
 
+export type MachineStateActions = Record<string, ActionState>;
+
 export type MachineState = {
+  actions: MachineStateActions;
   active: Machine[MachineMeta.PK] | null;
   counts: MachineStateCounts;
   details: MachineStateDetails;

--- a/src/app/store/types/state.ts
+++ b/src/app/store/types/state.ts
@@ -1,5 +1,6 @@
 export type EventError<I, E, K extends keyof I> = {
   id: I[K] | null;
+  callId?: string;
   error: E;
   event: string | null;
 };

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -5,6 +5,8 @@ import type {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
+import { ACTION_STATUS } from "./../../base/constants";
+
 import type { KeysOfUnion } from "app/base/types";
 import type { BootResourceMeta } from "app/store/bootresource/types";
 import type { ConfigMeta } from "app/store/config/types";
@@ -425,11 +427,20 @@ export const generateStatusHandlers = <
           ) => {
             // Call the reducer handler if supplied.
             status.start && status.start(state, action);
-            const statusItem =
-              state.statuses[String(action.meta.item[indexKey])];
-            const statusKey = status.statusKey;
-            if (objectHasKey(statusKey as string, statusItem)) {
-              statusItem[statusKey] = true;
+            if (action.meta.callId && "actions" in state) {
+              state.actions[action.meta.callId] = {
+                status: ACTION_STATUS.idle,
+                errors: null,
+              };
+              const actionsItem = state.actions[action.meta.callId];
+              actionsItem.status = "loading";
+            } else {
+              const statusItem =
+                state.statuses[String(action.meta.item[indexKey])];
+              const statusKey = status.statusKey;
+              if (objectHasKey(statusKey as string, statusItem)) {
+                statusItem[statusKey] = true;
+              }
             }
           },
         },
@@ -447,14 +458,19 @@ export const generateStatusHandlers = <
           ) => {
             // Call the reducer handler if supplied.
             status.success && status.success(state, action);
-            const statusItem =
-              state.statuses[String(action.meta.item[indexKey])];
-            // Sometimes the server will respond with "machine/deleteNotify"
-            // before "machine/deleteSuccess", which removes the machine
-            // system_id from statuses so check the item exists, to be safe.
-            const statusKey = status.statusKey;
-            if (objectHasKey(statusKey as string, statusItem)) {
-              statusItem[statusKey] = false;
+            if (action.meta.callId && "actions" in state) {
+              const actionsItem = state.actions[action.meta.callId];
+              actionsItem.status = "success";
+            } else {
+              const statusItem =
+                state.statuses[String(action.meta.item[indexKey])];
+              // Sometimes the server will respond with "machine/deleteNotify"
+              // before "machine/deleteSuccess", which removes the machine
+              // system_id from statuses so check the item exists, to be safe.
+              const statusKey = status.statusKey;
+              if (objectHasKey(statusKey as string, statusItem)) {
+                statusItem[statusKey] = false;
+              }
             }
           },
         },
@@ -473,6 +489,11 @@ export const generateStatusHandlers = <
             // Call the reducer handler if supplied.
             status.error && status.error(state, action);
             state.errors = action.payload;
+            if (action.meta.callId && "actions" in state) {
+              const actionsItem = state.actions[action.meta.callId];
+              actionsItem.status = "error";
+              actionsItem.errors = action.payload;
+            }
             if (setErrors) {
               state = setErrors(state, action, status.status);
             }

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -5,8 +5,7 @@ import type {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
-import { ACTION_STATUS } from "./../../base/constants";
-
+import { ACTION_STATUS } from "app/base/constants";
 import type { KeysOfUnion } from "app/base/types";
 import type { BootResourceMeta } from "app/store/bootresource/types";
 import type { ConfigMeta } from "app/store/config/types";

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -4,7 +4,7 @@ import type { RouterState } from "redux-first-history";
 import { bondOptions } from "./general";
 
 import { ACTION_STATUS } from "app/base/constants";
-import type { APIError } from "app/base/types";
+import type { APIError, ActionState } from "app/base/types";
 import type { BootResourceState } from "app/store/bootresource/types";
 import type { ConfigState } from "app/store/config/types";
 import { DEFAULT_STATUSES as DEFAULT_CONTROLLER_STATUSES } from "app/store/controller/slice";
@@ -267,6 +267,11 @@ export const machineStateList = define<MachineStateList>({
   num_pages: null,
 });
 
+export const machineStateAction = define<ActionState>({
+  status: ACTION_STATUS.idle,
+  errors: null,
+});
+
 export const machineStateLists = define<MachineStateLists>({
   testNode: machineStateList,
 });
@@ -321,6 +326,7 @@ export const machineEventError = define<
 
 export const machineState = define<MachineState>({
   ...defaultState,
+  actions: () => ({}),
   active: null,
   counts: () => ({}),
   details: () => ({}),


### PR DESCRIPTION
## Done

- use single filter for machine list actions
- add machine action status tied to callId `machine.actions = { [callId]: status: string, errors: APIError }`
- add `useDispatchWithCallId`

Note: machine actions will either use `machines` or `selectedFilter` depending on what's passed down - but this will be updated in https://github.com/canonical/app-tribe/issues/1303 to use a single `selectedFilter` for all cases

Will be followed up by: https://github.com/canonical/app-tribe/issues/1393

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Select a group of machines
- Go to Take action -> Test
- Verify the button indicates a correct number of machines
- Start tests for machines
- Verify the action has been dispatched with a single called using a filter, e.g. ```action
: "test", filter:  {power_state: ["=unknown"]} ```

not all actions are wired with the new state with `callId` yet  - e.g. abort. It will succeed, but won't show the error message/close on it's own yet.

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1286
Fixes: https://github.com/canonical/app-tribe/issues/1392

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
