### PR TITLE
Revert "fix(settings): updating multiple fields (#4432)"

### DIFF
--- a/src/app/base/sagas/websockets.test.ts
+++ b/src/app/base/sagas/websockets.test.ts
@@ -287,7 +287,7 @@ describe("websocket sagas", () => {
         params: { name: "foo", value: "bar" },
       })
     );
-    expect(saga.next().value).toEqual(take("test/actionSuccess"));
+    expect(saga.next().value).toEqual(take("test/actionNotify"));
 
     expect(saga.next().value).toEqual(
       call([socketClient, socketClient.send], action, {
@@ -296,7 +296,7 @@ describe("websocket sagas", () => {
         params: { name: "baz", value: "qux" },
       })
     );
-    expect(saga.next().value).toEqual(take("test/actionSuccess"));
+    expect(saga.next().value).toEqual(take("test/actionNotify"));
   });
 
   it("can handle errors when sending a WebSocket message", () => {

--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -564,7 +564,10 @@ export function* sendMessage(
         // Ensure server has synced before sending next message,
         // important for dependant config like commissioning_distro_series
         // and default_min_hwe_kernel.
-        yield* take(`${type}Success`);
+        // There is an edge case where a different CLI or server event could
+        // dispatch a NOTIFY of the same type which is received before our expected NOTIFY,
+        // but this _probably_ does not matter in practice.
+        yield* take(`${type}Notify`);
       }
     } else {
       const id = yield* call(


### PR DESCRIPTION


## Done

- Revert "fix(settings): updating multiple fields (#4432)"
This reverts commit f414650797adba13883c9ec5a127891701f08ea7.

Related to a fix in core:
https://code.launchpad.net/~ack/maas/+git/maas/+merge/430877

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
