### PR TITLE
refactor(machines): add action result count to redux store

### DIFF
--- a/src/app/base/types.ts
+++ b/src/app/base/types.ts
@@ -83,6 +83,7 @@ export type ActionStatuses = ValueOf<typeof ACTION_STATUS>;
 export type ActionState = {
   status: ActionStatuses;
   errors: APIError;
+  count: number;
 };
 
 export type ModelAction<PK> = {

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -62,6 +62,7 @@ import type {
 } from "./types";
 import { MachineMeta, FilterGroupType } from "./types";
 
+import { ACTION_STATUS } from "app/base/constants";
 import type { ScriptResult } from "app/store/scriptresult/types";
 import type { UpdateInterfaceParams } from "app/store/types/node";
 import { NodeActions } from "app/store/types/node";
@@ -386,6 +387,39 @@ const statusHandlers = generateStatusHandlers<
   ACTIONS.map((action) => {
     const handler: StatusHandlers<MachineState, Machine> = {
       status: kebabToCamelCase(action.name),
+      start: (state, action) => {
+        if (action.meta.callId) {
+          if (action.meta.callId in state.actions) {
+            state.actions[action.meta.callId].status = ACTION_STATUS.loading;
+          } else {
+            state.actions[action.meta.callId] = {
+              status: ACTION_STATUS.loading,
+              errors: null,
+              count: 0,
+            };
+          }
+        }
+      },
+      success: (state, action) => {
+        if (action.meta.callId) {
+          if (action.meta.callId in state.actions) {
+            const actionsItem = state.actions[action.meta.callId];
+            actionsItem.status = ACTION_STATUS.success;
+            if (typeof action.payload === "number") {
+              actionsItem.count = action.payload;
+            }
+          }
+        }
+      },
+      error: (state, action) => {
+        if (action.meta.callId) {
+          if (action.meta.callId in state.actions) {
+            const actionsItem = state.actions[action.meta.callId];
+            actionsItem.status = "error";
+            actionsItem.errors = action.payload;
+          }
+        }
+      },
       method: "action",
       statusKey: action.status,
     };

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -5,7 +5,6 @@ import type {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
-import { ACTION_STATUS } from "app/base/constants";
 import type { KeysOfUnion } from "app/base/types";
 import type { BootResourceMeta } from "app/store/bootresource/types";
 import type { ConfigMeta } from "app/store/config/types";
@@ -426,14 +425,7 @@ export const generateStatusHandlers = <
           ) => {
             // Call the reducer handler if supplied.
             status.start && status.start(state, action);
-            if (action.meta.callId && "actions" in state) {
-              state.actions[action.meta.callId] = {
-                status: ACTION_STATUS.idle,
-                errors: null,
-              };
-              const actionsItem = state.actions[action.meta.callId];
-              actionsItem.status = "loading";
-            } else {
+            if (action.meta.item) {
               const statusItem =
                 state.statuses[String(action.meta.item[indexKey])];
               const statusKey = status.statusKey;
@@ -457,10 +449,7 @@ export const generateStatusHandlers = <
           ) => {
             // Call the reducer handler if supplied.
             status.success && status.success(state, action);
-            if (action.meta.callId && "actions" in state) {
-              const actionsItem = state.actions[action.meta.callId];
-              actionsItem.status = "success";
-            } else {
+            if (action.meta.item) {
               const statusItem =
                 state.statuses[String(action.meta.item[indexKey])];
               // Sometimes the server will respond with "machine/deleteNotify"
@@ -488,19 +477,16 @@ export const generateStatusHandlers = <
             // Call the reducer handler if supplied.
             status.error && status.error(state, action);
             state.errors = action.payload;
-            if (action.meta.callId && "actions" in state) {
-              const actionsItem = state.actions[action.meta.callId];
-              actionsItem.status = "error";
-              actionsItem.errors = action.payload;
-            }
             if (setErrors) {
               state = setErrors(state, action, status.status);
             }
-            const statusItem =
-              state.statuses[String(action.meta.item[indexKey])];
-            const statusKey = status.statusKey;
-            if (objectHasKey(statusKey as string, statusItem)) {
-              statusItem[statusKey] = false;
+            if (action.meta.item) {
+              const statusItem =
+                state.statuses[String(action.meta.item[indexKey])];
+              const statusKey = status.statusKey;
+              if (objectHasKey(statusKey as string, statusItem)) {
+                statusItem[statusKey] = false;
+              }
             }
           },
         },

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -270,6 +270,7 @@ export const machineStateList = define<MachineStateList>({
 export const machineStateAction = define<ActionState>({
   status: ACTION_STATUS.idle,
   errors: null,
+  count: 0,
 });
 
 export const machineStateLists = define<MachineStateLists>({


### PR DESCRIPTION
## Done

- add machine action result count
- move machine specific (machine.actions slice) logic to `src/app/store/machine/slice.ts`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Perform an action on a machine (e.g. test)
- Verify that the count value in the store has been updated (in `machine.actions["random-call-id"].counts`)

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1394

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
