### PR TITLE
feat: use filter key for machine details actions

### DIFF
--- a/src/app/base/components/node/FieldlessForm/FieldlessForm.tsx
+++ b/src/app/base/components/node/FieldlessForm/FieldlessForm.tsx
@@ -6,6 +6,7 @@ import ActionForm from "app/base/components/ActionForm";
 import type { EmptyObject } from "app/base/types";
 import type { actions as controllerActions } from "app/store/controller";
 import type { actions as machineActions } from "app/store/machine";
+import { useMachineActionDispatch } from "app/store/machine/utils/hooks";
 import type { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 import { capitaliseFirst, kebabToCamelCase } from "app/utils";
@@ -30,13 +31,19 @@ export const FieldlessForm = <E,>({
   viewingDetails,
 }: Props<E>): JSX.Element => {
   const dispatch = useDispatch();
+  const {
+    dispatch: dispatchWithCallId,
+    actionStatus,
+    actionErrors,
+  } = useMachineActionDispatch();
 
   return (
     <ActionForm<EmptyObject, E>
       actionName={action}
+      actionStatus={actionStatus}
       allowUnchanged
       cleanup={cleanup}
-      errors={errors}
+      errors={errors || actionErrors}
       initialValues={{}}
       modelName={modelName}
       onCancel={clearHeaderContent}
@@ -56,7 +63,7 @@ export const FieldlessForm = <E,>({
 
         if (actionFunction) {
           if (selectedFilter) {
-            dispatch(actionFunction({ filter: selectedFilter }));
+            dispatchWithCallId(actionFunction({ filter: selectedFilter }));
           } else {
             nodes?.forEach((node) => {
               dispatch(actionFunction({ system_id: node.system_id }));

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
@@ -169,6 +169,7 @@ describe("KVMHeaderForms", () => {
   });
 
   it("renders machine action forms if a machine action is selected", () => {
+    state.machine.selectedMachines = { items: ["abc123"] };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
@@ -15,7 +15,8 @@ import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
 import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
 import type { MachineHeaderContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
-import type { Machine } from "app/store/machine/types";
+import type { FetchFilters } from "app/store/machine/types";
+import { selectedToFilters } from "app/store/machine/utils";
 
 type Props = {
   headerContent: KVMHeaderContent | null;
@@ -27,7 +28,7 @@ const getFormComponent = (
   headerContent: KVMHeaderContent,
   setHeaderContent: KVMSetHeaderContent,
   clearHeaderContent: ClearHeaderContent,
-  machines: Machine[],
+  selectedFilter: FetchFilters | null,
   setSearchFilter?: SetSearchFilter
 ) => {
   if (!headerContent) {
@@ -93,7 +94,7 @@ const getFormComponent = (
   return (
     <MachineHeaderForms
       headerContent={machineHeaderContent}
-      machines={machines}
+      selectedFilter={selectedFilter}
       setHeaderContent={setHeaderContent}
       setSearchFilter={setSearchFilter}
       viewingDetails={false}
@@ -106,7 +107,8 @@ const KVMHeaderForms = ({
   setHeaderContent,
   setSearchFilter,
 }: Props): JSX.Element | null => {
-  const selectedMachines = useSelector(machineSelectors.selected);
+  const selectedMachines = useSelector(machineSelectors.selectedMachines);
+  const selectedFilter = selectedToFilters(selectedMachines);
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
   const clearHeaderContent = useCallback(
     () => setHeaderContent(null),
@@ -122,7 +124,7 @@ const KVMHeaderForms = ({
         headerContent,
         setHeaderContent,
         clearHeaderContent,
-        selectedMachines,
+        selectedFilter,
         setSearchFilter
       )}
     </div>

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -8,7 +9,7 @@ import MachineActionFormWrapper from "./MachineActionFormWrapper";
 
 import { NodeActions } from "app/store/types/node";
 import {
-  machineEventError as machineEventErrorFactory,
+  machineActionState as machineActionStateFactory,
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
@@ -22,6 +23,7 @@ let html: HTMLHtmlElement | null;
 const originalScrollTo = global.scrollTo;
 
 beforeEach(() => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
   global.innerHeight = 500;
   // eslint-disable-next-line testing-library/no-node-access
   html = document.querySelector("html");
@@ -48,7 +50,7 @@ it("scrolls to the top of the window when opening the form", async () => {
     <MachineActionFormWrapper
       action={NodeActions.ABORT}
       clearHeaderContent={jest.fn()}
-      machines={[]}
+      selectedFilter={{}}
       viewingDetails={false}
     />
   );
@@ -58,13 +60,12 @@ it("scrolls to the top of the window when opening the form", async () => {
 it("can show untag errors when the tag form is open", async () => {
   const state = rootStateFactory({
     machine: machineStateFactory({
-      eventErrors: [
-        machineEventErrorFactory({
-          id: "abc123",
-          error: "Untagging failed",
-          event: NodeActions.UNTAG,
+      actions: {
+        "123456": machineActionStateFactory({
+          status: "error",
+          errors: "Untagging failed",
         }),
-      ],
+      },
     }),
     tag: tagStateFactory({
       loaded: true,
@@ -86,7 +87,7 @@ it("can show untag errors when the tag form is open", async () => {
           <MachineActionFormWrapper
             action={NodeActions.TAG}
             clearHeaderContent={jest.fn()}
-            machines={machines}
+            selectedFilter={{ id: machines[0].system_id }}
             viewingDetails={false}
           />
         </CompatRouter>

--- a/src/app/machines/types.ts
+++ b/src/app/machines/types.ts
@@ -25,21 +25,13 @@ export type MachineHeaderContent = HeaderContent<
 
 export type MachineSetHeaderContent = SetHeaderContent<MachineHeaderContent>;
 
-export type MachineActionVariableProps =
-  | {
-      machines?: Machine[];
-      processingCount?: number;
-      selectedFilter?: never;
-      selectedCount?: never;
-      selectedCountLoading?: never;
-    }
-  | {
-      machines?: never;
-      selectedFilter?: FetchFilters | null;
-      selectedCount?: number;
-      processingCount?: never;
-      selectedCountLoading?: boolean;
-    };
+export type MachineActionVariableProps = {
+  machines?: Machine[];
+  selectedFilter?: FetchFilters | null;
+  selectedCount?: number;
+  processingCount?: number;
+  selectedCountLoading?: boolean;
+};
 
 export type MachineActionFormProps = Omit<
   CommonActionFormProps<MachineEventErrors>,

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -88,7 +88,8 @@ const MachineHeader = ({
         headerContent ? (
           <MachineHeaderForms
             headerContent={headerContent}
-            machines={[machine]}
+            selectedCount={1}
+            selectedFilter={{ id: machine.system_id }}
             setHeaderContent={setHeaderContent}
             viewingDetails
           />

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -28,6 +28,7 @@ export {
   ipRangeState,
   licenseKeysState,
   locationState,
+  machineActionState,
   machineActionsState,
   machineEventError,
   machineFilterGroup,

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -267,7 +267,7 @@ export const machineStateList = define<MachineStateList>({
   num_pages: null,
 });
 
-export const machineStateAction = define<ActionState>({
+export const machineActionState = define<ActionState>({
   status: ACTION_STATUS.idle,
   errors: null,
   count: 0,


### PR DESCRIPTION
## Done

- pass selected state to machine details
- add `useMachineActionDispatch` for handling machine actions and their status in a single hook

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine details page
- Select an action from the "Take action" menu (e.g. test, abort)
- Verify that the action has been dispatched using a "filter", e.g. { filter: { id: ["machine_id"]}}`
- Verify that action errors are displayed correctly.
  - You can do that by running "test" action on `http://bolla.internal:5240/MAAS/r/machine/mm3tc8/summary` - it will fail

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1303

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
