### PR TITLE
feat(machines): handle bulk actions results

### DIFF
--- a/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/src/app/base/components/ActionForm/ActionForm.tsx
@@ -43,6 +43,7 @@ export type Props<V, E = null> = Omit<
   showProcessingCount?: boolean;
   submitLabel?: string;
   actionStatus?: ActionState["status"];
+  actionErrors?: ActionState["errors"];
 };
 
 export enum Labels {
@@ -50,6 +51,7 @@ export enum Labels {
 }
 
 const ActionForm = <V, E = null>({
+  actionErrors,
   actionName,
   buttonsBordered = false,
   children,
@@ -83,12 +85,12 @@ const ActionForm = <V, E = null>({
     ? {
         saving: actionStatus === "loading",
         saved: actionStatus === "success",
-        errors,
+        errors: errors || actionErrors,
       }
     : {
         saved: processingComplete,
         saving: !!processingCount && processingCount > 0,
-        errors,
+        errors: errors || actionErrors,
       };
 
   return (

--- a/src/app/base/components/node/FieldlessForm/FieldlessForm.tsx
+++ b/src/app/base/components/node/FieldlessForm/FieldlessForm.tsx
@@ -6,7 +6,7 @@ import ActionForm from "app/base/components/ActionForm";
 import type { EmptyObject } from "app/base/types";
 import type { actions as controllerActions } from "app/store/controller";
 import type { actions as machineActions } from "app/store/machine";
-import { useMachineActionDispatch } from "app/store/machine/utils/hooks";
+import { useSelectedMachinesActionsDispatch } from "app/store/machine/utils/hooks";
 import type { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 import { capitaliseFirst, kebabToCamelCase } from "app/utils";
@@ -23,7 +23,7 @@ export const FieldlessForm = <E,>({
   cleanup,
   clearHeaderContent,
   errors,
-  selectedFilter,
+  selectedMachines,
   modelName,
   nodes,
   processingCount,
@@ -31,19 +31,15 @@ export const FieldlessForm = <E,>({
   viewingDetails,
 }: Props<E>): JSX.Element => {
   const dispatch = useDispatch();
-  const {
-    dispatch: dispatchWithCallId,
-    actionStatus,
-    actionErrors,
-  } = useMachineActionDispatch();
+  const { dispatch: dispatchForSelectedMachines, ...actionProps } =
+    useSelectedMachinesActionsDispatch(selectedMachines);
 
   return (
     <ActionForm<EmptyObject, E>
       actionName={action}
-      actionStatus={actionStatus}
       allowUnchanged
       cleanup={cleanup}
-      errors={errors || actionErrors}
+      errors={errors}
       initialValues={{}}
       modelName={modelName}
       onCancel={clearHeaderContent}
@@ -62,8 +58,8 @@ export const FieldlessForm = <E,>({
           Object.entries(actions).find(([key]) => key === actionMethod) || [];
 
         if (actionFunction) {
-          if (selectedFilter) {
-            dispatchWithCallId(actionFunction({ filter: selectedFilter }));
+          if (selectedMachines) {
+            dispatchForSelectedMachines(actionFunction);
           } else {
             nodes?.forEach((node) => {
               dispatch(actionFunction({ system_id: node.system_id }));
@@ -74,6 +70,7 @@ export const FieldlessForm = <E,>({
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
       selectedCount={nodes ? nodes.length : selectedCount ?? 0}
+      {...actionProps}
     />
   );
 };

--- a/src/app/base/components/node/TestForm/TestForm.tsx
+++ b/src/app/base/components/node/TestForm/TestForm.tsx
@@ -9,7 +9,6 @@ import TestFormFields from "./TestFormFields";
 
 import ActionForm from "app/base/components/ActionForm";
 import type { HardwareType } from "app/base/enum";
-import type { FetchFilters } from "app/store/machine/types";
 import { actions as scriptActions } from "app/store/script";
 import scriptSelectors from "app/store/script/selectors";
 import type { Script } from "app/store/script/types";
@@ -45,13 +44,7 @@ type Props<E = null> = NodeActionFormProps<E> & {
   applyConfiguredNetworking?: Script["apply_configured_networking"];
   cleanup: NonNullable<NodeActionFormProps<E>["cleanup"]>;
   hardwareType?: HardwareType;
-  onTest: (
-    args: FormValues &
-      (
-        | { systemId: Node["system_id"]; filter?: never }
-        | { systemId?: never; filter: FetchFilters }
-      )
-  ) => void;
+  onTest: (args: FormValues & { systemId?: Node["system_id"] }) => void;
 };
 
 export const TestForm = <E,>({
@@ -65,7 +58,7 @@ export const TestForm = <E,>({
   nodes,
   onTest,
   processingCount,
-  selectedFilter,
+  selectedMachines,
   selectedCount,
   viewingDetails,
 }: Props<E>): JSX.Element => {
@@ -149,9 +142,8 @@ export const TestForm = <E,>({
       onSubmit={(values) => {
         dispatch(cleanup());
         const { enableSSH, scripts, scriptInputs } = values;
-        if (selectedFilter) {
+        if (selectedMachines) {
           onTest({
-            filter: selectedFilter,
             scripts,
             enableSSH,
             scriptInputs,

--- a/src/app/base/components/node/types.ts
+++ b/src/app/base/components/node/types.ts
@@ -1,7 +1,7 @@
 import type { AnyAction } from "redux";
 
 import type { ActionState, CommonActionFormProps } from "app/base/types";
-import type { FetchFilters } from "app/store/machine/types";
+import type { SelectedMachines } from "app/store/machine/types";
 import type { Node } from "app/store/types/node";
 
 export type NodeActionFormProps<E = null> = CommonActionFormProps<E> & {
@@ -13,11 +13,11 @@ export type NodeActionFormProps<E = null> = CommonActionFormProps<E> & {
     | {
         nodes: Node[];
         processingCount: number;
-        selectedFilter?: never;
+        selectedMachines?: never;
         selectedCount?: never;
       }
     | {
-        selectedFilter?: FetchFilters | null;
+        selectedMachines?: SelectedMachines | null;
         processingCount?: never;
         selectedCount?: number;
         nodes?: never;

--- a/src/app/base/types.ts
+++ b/src/app/base/types.ts
@@ -3,6 +3,8 @@ import type { PayloadAction } from "@reduxjs/toolkit";
 
 import type { ACTION_STATUS } from "./constants";
 
+import type { Machine } from "app/store/machine/types";
+
 export type TSFixMe = any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
 export type Seconds = number;
@@ -83,7 +85,8 @@ export type ActionStatuses = ValueOf<typeof ACTION_STATUS>;
 export type ActionState = {
   status: ActionStatuses;
   errors: APIError;
-  count: number;
+  failedSystemIds?: Machine["system_id"][];
+  successCount: number;
 };
 
 export type ModelAction<PK> = {

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
@@ -15,8 +15,7 @@ import type { KVMHeaderContent, KVMSetHeaderContent } from "app/kvm/types";
 import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
 import type { MachineHeaderContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
-import type { FetchFilters } from "app/store/machine/types";
-import { selectedToFilters } from "app/store/machine/utils";
+import type { SelectedMachines } from "app/store/machine/types";
 
 type Props = {
   headerContent: KVMHeaderContent | null;
@@ -28,7 +27,7 @@ const getFormComponent = (
   headerContent: KVMHeaderContent,
   setHeaderContent: KVMSetHeaderContent,
   clearHeaderContent: ClearHeaderContent,
-  selectedFilter: FetchFilters | null,
+  selectedMachines: SelectedMachines | null,
   setSearchFilter?: SetSearchFilter
 ) => {
   if (!headerContent) {
@@ -94,7 +93,7 @@ const getFormComponent = (
   return (
     <MachineHeaderForms
       headerContent={machineHeaderContent}
-      selectedFilter={selectedFilter}
+      selectedMachines={selectedMachines}
       setHeaderContent={setHeaderContent}
       setSearchFilter={setSearchFilter}
       viewingDetails={false}
@@ -108,7 +107,6 @@ const KVMHeaderForms = ({
   setSearchFilter,
 }: Props): JSX.Element | null => {
   const selectedMachines = useSelector(machineSelectors.selectedMachines);
-  const selectedFilter = selectedToFilters(selectedMachines);
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
   const clearHeaderContent = useCallback(
     () => setHeaderContent(null),
@@ -124,7 +122,7 @@ const KVMHeaderForms = ({
         headerContent,
         setHeaderContent,
         clearHeaderContent,
-        selectedFilter,
+        selectedMachines,
         setSearchFilter
       )}
     </div>

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
@@ -50,7 +50,7 @@ it("scrolls to the top of the window when opening the form", async () => {
     <MachineActionFormWrapper
       action={NodeActions.ABORT}
       clearHeaderContent={jest.fn()}
-      selectedFilter={{}}
+      selectedMachines={{}}
       viewingDetails={false}
     />
   );
@@ -87,7 +87,7 @@ it("can show untag errors when the tag form is open", async () => {
           <MachineActionFormWrapper
             action={NodeActions.TAG}
             clearHeaderContent={jest.fn()}
-            selectedFilter={{ id: machines[0].system_id }}
+            selectedMachines={{ items: [machines[0].system_id] }}
             viewingDetails={false}
           />
         </CompatRouter>

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MarkBrokenForm/MarkBrokenForm.tsx
@@ -9,6 +9,7 @@ import ActionForm from "app/base/components/ActionForm";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import type { MachineEventErrors } from "app/store/machine/types";
+import { useSelectedMachinesActionsDispatch } from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
 
 const MarkBrokenSchema = Yup.object().shape({
@@ -27,10 +28,12 @@ export const MarkBrokenForm = ({
   machines,
   processingCount,
   selectedCount,
-  selectedFilter,
+  selectedMachines,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const { dispatch: dispatchForSelectedMachines, ...actionProps } =
+    useSelectedMachinesActionsDispatch(selectedMachines);
 
   useEffect(
     () => () => {
@@ -57,13 +60,10 @@ export const MarkBrokenForm = ({
       }}
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
-        if (selectedFilter) {
-          dispatch(
-            machineActions.markBroken({
-              message: values.comment,
-              filter: selectedFilter,
-            })
-          );
+        if (selectedMachines) {
+          dispatchForSelectedMachines(machineActions.markBroken, {
+            message: values.comment,
+          });
         } else {
           machines?.forEach((machine) => {
             dispatch(
@@ -79,6 +79,7 @@ export const MarkBrokenForm = ({
       processingCount={processingCount}
       selectedCount={machines ? machines.length : selectedCount ?? 0}
       validationSchema={MarkBrokenSchema}
+      {...actionProps}
     >
       <MarkBrokenFormFields
         selectedCount={machines ? machines.length : selectedCount ?? 0}

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -16,6 +16,7 @@ import type {
   MachineEventErrors,
   MachineMeta,
 } from "app/store/machine/types";
+import { useSelectedMachinesActionsDispatch } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as scriptResultActions } from "app/store/scriptresult";
 import scriptResultsSelectors from "app/store/scriptresult/selectors";
@@ -86,10 +87,12 @@ export const OverrideTestForm = ({
   machines,
   processingCount,
   selectedCount,
-  selectedFilter,
+  selectedMachines,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const { dispatch: dispatchForSelectedMachines, ...actionProps } =
+    useSelectedMachinesActionsDispatch(selectedMachines);
   const [requestedScriptResults, setRequestedScriptResults] = useState<
     Machine[MachineMeta.PK][]
   >([]);
@@ -148,12 +151,8 @@ export const OverrideTestForm = ({
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
         const { suppressResults } = values;
-        if (selectedFilter) {
-          dispatch(
-            machineActions.overrideFailedTesting({
-              filter: selectedFilter,
-            })
-          );
+        if (selectedMachines) {
+          dispatchForSelectedMachines(machineActions.overrideFailedTesting);
         } else {
           machines?.forEach((machine) => {
             dispatch(
@@ -183,6 +182,7 @@ export const OverrideTestForm = ({
       processingCount={processingCount}
       selectedCount={machines ? machines.length : selectedCount ?? 0}
       validationSchema={OverrideTestFormSchema}
+      {...actionProps}
     >
       <Row>
         <Col size={6}>

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.tsx
@@ -10,6 +10,7 @@ import ActionForm from "app/base/components/ActionForm";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import type { MachineEventErrors } from "app/store/machine/types";
+import { useSelectedMachinesActionsDispatch } from "app/store/machine/utils/hooks";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { NodeActions } from "app/store/types/node";
@@ -28,10 +29,12 @@ export const SetPoolForm = ({
   machines,
   processingCount,
   selectedCount,
-  selectedFilter,
+  selectedMachines,
   viewingDetails,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+  const { dispatch: dispatchForSelectedMachines, ...actionProps } =
+    useSelectedMachinesActionsDispatch(selectedMachines);
   const [initialValues, setInitialValues] = useState<SetPoolFormValues>({
     poolSelection: "select",
     description: "",
@@ -81,13 +84,10 @@ export const SetPoolForm = ({
         } else {
           const pool = resourcePools.find((pool) => pool.name === values.name);
           if (pool) {
-            if (selectedFilter) {
-              dispatch(
-                machineActions.setPool({
-                  pool_id: pool.id,
-                  filter: selectedFilter,
-                })
-              );
+            if (selectedMachines) {
+              dispatchForSelectedMachines(machineActions.setPool, {
+                pool_id: pool.id,
+              });
             } else {
               machines?.forEach((machine) => {
                 dispatch(
@@ -108,6 +108,7 @@ export const SetPoolForm = ({
       processingCount={processingCount}
       selectedCount={machines ? machines.length : selectedCount ?? 0}
       validationSchema={SetPoolSchema}
+      {...actionProps}
     >
       <SetPoolFormFields />
     </ActionForm>

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
@@ -13,6 +14,7 @@ import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
+  machineActionState,
   rootState as rootStateFactory,
   tag as tagFactory,
   tagState as tagStateFactory,
@@ -184,10 +186,14 @@ it("correctly dispatches actions to tag and untag a machine", async () => {
 });
 
 it("shows saving label if not viewing from machine config page", () => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
   const machines = [
     machineFactory({ system_id: "abc123", tags: [] }),
     machineFactory({ system_id: "def456", tags: [] }),
   ];
+  state.machine.actions["mocked-nanoid"] = machineActionState({
+    status: "loading",
+  });
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -208,6 +214,7 @@ it("shows saving label if not viewing from machine config page", () => {
   );
 
   expect(screen.getByTestId("saving-label")).toBeInTheDocument();
+  jest.restoreAllMocks();
 });
 
 it("does not show saving label if viewing from machine config page", () => {

--- a/src/app/machines/components/MachineHeaderForms/MachineHeaderForms.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineHeaderForms.tsx
@@ -28,7 +28,7 @@ export const MachineHeaderForms = ({
   setHeaderContent,
   selectedCountLoading,
   selectedCount,
-  selectedFilter,
+  selectedMachines,
   setSearchFilter,
   viewingDetails = false,
 }: Props): JSX.Element | null => {
@@ -54,7 +54,7 @@ export const MachineHeaderForms = ({
       const [, action] = view;
       const conditionalProps = machines
         ? { machines }
-        : { selectedCount, selectedCountLoading, selectedFilter };
+        : { selectedCount, selectedCountLoading, selectedMachines };
       return (
         <MachineActionFormWrapper
           action={action}

--- a/src/app/machines/types.ts
+++ b/src/app/machines/types.ts
@@ -9,9 +9,9 @@ import type {
   SetHeaderContent,
 } from "app/base/types";
 import type {
-  FetchFilters,
   Machine,
   MachineEventErrors,
+  SelectedMachines,
 } from "app/store/machine/types";
 import type { Script } from "app/store/script/types";
 
@@ -27,7 +27,7 @@ export type MachineSetHeaderContent = SetHeaderContent<MachineHeaderContent>;
 
 export type MachineActionVariableProps = {
   machines?: Machine[];
-  selectedFilter?: FetchFilters | null;
+  selectedMachines?: SelectedMachines | null;
   selectedCount?: number;
   processingCount?: number;
   selectedCountLoading?: boolean;

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -89,7 +89,7 @@ const MachineHeader = ({
           <MachineHeaderForms
             headerContent={headerContent}
             selectedCount={1}
-            selectedFilter={{ id: machine.system_id }}
+            selectedMachines={{ items: [machine.system_id] }}
             setHeaderContent={setHeaderContent}
             viewingDetails
           />

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -20,7 +20,7 @@ import type {
 } from "app/machines/types";
 import { getHeaderTitle } from "app/machines/utils";
 import machineSelectors from "app/store/machine/selectors";
-import { FilterMachineItems, selectedToFilters } from "app/store/machine/utils";
+import { FilterMachineItems } from "app/store/machine/utils";
 import {
   useFetchMachineCount,
   useHasSelection,
@@ -57,7 +57,6 @@ export const MachineListHeader = ({
   const previousSelectedCount = usePrevious(selectedCount);
 
   const selectedMachines = useSelector(machineSelectors.selectedMachines);
-  const selectedFilter = selectedToFilters(selectedMachines);
 
   useEffect(() => {
     if (
@@ -124,7 +123,7 @@ export const MachineListHeader = ({
             headerContent={headerContent}
             selectedCount={selectedCount}
             selectedCountLoading={selectedCountLoading}
-            selectedFilter={selectedFilter}
+            selectedMachines={selectedMachines}
             setHeaderContent={setHeaderContent}
             setSearchFilter={setSearchFilter}
           />

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -380,7 +380,7 @@ const setErrors = (
 
 const statusHandlers = generateStatusHandlers<
   MachineState,
-  Machine,
+  Machine, // { success_count: number; failed_ids: Machine[MachineMeta.PK][] }
   MachineMeta.PK
 >(
   MachineMeta.PK,
@@ -395,7 +395,8 @@ const statusHandlers = generateStatusHandlers<
             state.actions[action.meta.callId] = {
               status: ACTION_STATUS.loading,
               errors: null,
-              count: 0,
+              successCount: 0,
+              failedSystemIds: [],
             };
           }
         }
@@ -405,8 +406,14 @@ const statusHandlers = generateStatusHandlers<
           if (action.meta.callId in state.actions) {
             const actionsItem = state.actions[action.meta.callId];
             actionsItem.status = ACTION_STATUS.success;
-            if (typeof action.payload === "number") {
-              actionsItem.count = action.payload;
+            if (typeof action.payload?.success_count === "number") {
+              actionsItem.successCount = action.payload.success_count as number;
+            }
+            if (action.payload?.failed_system_ids?.length > 0) {
+              actionsItem.status = ACTION_STATUS.error;
+              actionsItem.failedSystemIds = [
+                ...action.payload.failed_system_ids,
+              ] as Machine[MachineMeta.PK][];
             }
           }
         }

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -184,6 +184,12 @@ export type MachineStatus = {
   updatingVmfsDatastore: boolean;
 };
 
+export type MachineActionStatus = {
+  errors: APIError;
+  failed_system_ids: Machine["system_id"][];
+  success_count: number;
+};
+
 export type MachineStatuses = Record<Machine[MachineMeta.PK], MachineStatus>;
 
 export type MachineStateDetailsItem = {

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -9,6 +9,8 @@ import type { MockStoreEnhanced } from "redux-mock-store";
 import { selectedToFilters } from "./common";
 import type { UseFetchMachinesOptions, UseFetchQueryOptions } from "./hooks";
 import {
+  getCombinedActionStatus,
+  useSelectedMachinesActionsDispatch,
   useMachineActionDispatch,
   useDispatchWithCallId,
   useFetchSelectedMachines,
@@ -25,9 +27,15 @@ import {
 } from "./hooks";
 
 import { actions as machineActions } from "app/store/machine";
-import type { FetchFilters, Machine } from "app/store/machine/types";
+import type {
+  FetchFilters,
+  FetchGroupKey,
+  Machine,
+  SelectedMachines,
+} from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
+import type { FetchNodeStatus, TestParams } from "app/store/types/node";
 import { NodeStatus, NodeStatusCode } from "app/store/types/node";
 import {
   architecturesState as architecturesStateFactory,
@@ -489,6 +497,138 @@ describe("machine hook utils", () => {
       });
       expect(result.current.actionStatus).toEqual("success");
       expect(result.current.actionErrors).toEqual(null);
+    });
+  });
+
+  describe("useSelectedMachinesActionsDispatch", () => {
+    const generateWrapper =
+      (store: MockStoreEnhanced<unknown>) =>
+      ({ children }: { children?: ReactNode }) =>
+        <Provider store={store}>{children}</Provider>;
+
+    it("dispatches separate calls when there are selected both groups and items", async () => {
+      jest
+        .spyOn(reduxToolkit, "nanoid")
+        .mockReturnValueOnce("mocked-nanoid")
+        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce("mocked-nanoid-2");
+      state.machine.actions["mocked-nanoid"] = machineActionState({
+        status: "success",
+      });
+      const store = mockStore(state);
+      const selectedMachines: SelectedMachines = {
+        groups: ["new", "broken"],
+        grouping: "status" as FetchGroupKey,
+        items: ["abcd123"],
+      };
+      const { result } = renderHook(
+        () => useSelectedMachinesActionsDispatch(selectedMachines),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      const { dispatch } = result.current;
+      dispatch(machineActions.test);
+      const expectedGroupsDispatch = machineActions.test({
+        filter: {
+          status: ["=new" as FetchNodeStatus, "=broken" as FetchNodeStatus],
+        },
+      });
+      const expectedItemsDispatch = machineActions.test({
+        filter: { id: ["abcd123"] },
+      });
+      const actual = store
+        .getActions()
+        .filter(
+          (action) => action.type === machineActions.test({} as TestParams).type
+        );
+      expect(actual[0].payload).toStrictEqual(expectedGroupsDispatch.payload);
+      expect(actual[1].payload).toStrictEqual(expectedItemsDispatch.payload);
+      expect(result.current.actionErrors).toEqual(null);
+    });
+
+    it("dispatches a single call when there are only items selected", async () => {
+      jest
+        .spyOn(reduxToolkit, "nanoid")
+        .mockReturnValueOnce("mocked-nanoid")
+        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce("mocked-nanoid-2");
+      state.machine.actions["mocked-nanoid"] = machineActionState({
+        status: "success",
+      });
+      const store = mockStore(state);
+      const selectedMachines: SelectedMachines = {
+        items: ["abcd123"],
+      };
+      const { result } = renderHook(
+        () => useSelectedMachinesActionsDispatch(selectedMachines),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      const { dispatch } = result.current;
+      dispatch(machineActions.test);
+      const expectedItemsDispatch = machineActions.test({
+        filter: { id: ["abcd123"] },
+      });
+      const actual = store
+        .getActions()
+        .filter(
+          (action) => action.type === machineActions.test({} as TestParams).type
+        );
+      expect(actual).toHaveLength(1);
+      expect(actual[0].payload).toStrictEqual(expectedItemsDispatch.payload);
+    });
+
+    it("dispatches a single call when there are only groups selected", async () => {
+      jest
+        .spyOn(reduxToolkit, "nanoid")
+        .mockReturnValueOnce("mocked-nanoid")
+        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce("mocked-nanoid-2");
+      state.machine.actions["mocked-nanoid"] = machineActionState({
+        status: "success",
+      });
+      const store = mockStore(state);
+      const selectedMachines: SelectedMachines = {
+        groups: ["new", "broken"],
+        grouping: "status" as FetchGroupKey,
+      };
+      const { result } = renderHook(
+        () => useSelectedMachinesActionsDispatch(selectedMachines),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      const { dispatch } = result.current;
+      dispatch(machineActions.test);
+      const expectedItemsDispatch = machineActions.test({
+        filter: {
+          status: ["=new" as FetchNodeStatus, "=broken" as FetchNodeStatus],
+        },
+      });
+      const actual = store
+        .getActions()
+        .filter(
+          (action) => action.type === machineActions.test({} as TestParams).type
+        );
+      expect(actual).toHaveLength(1);
+      expect(actual[0].payload).toStrictEqual(expectedItemsDispatch.payload);
+    });
+  });
+
+  describe("getCombinedActionStatus", () => {
+    it("returns success when all actions are successful", () => {
+      getCombinedActionStatus("success", "success", "success");
+    });
+    it("returns error when at least one action is in error", () => {
+      getCombinedActionStatus("success", "error", "success");
+    });
+    it("returns loading when at least one action is loading", () => {
+      getCombinedActionStatus("success", "error", "loading");
+    });
+    it("returns idle when there are no actions", () => {
+      getCombinedActionStatus();
     });
   });
 

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -498,6 +498,32 @@ describe("machine hook utils", () => {
       expect(result.current.actionStatus).toEqual("success");
       expect(result.current.actionErrors).toEqual(null);
     });
+
+    it("can return an error message", async () => {
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+      state.machine.actions["mocked-nanoid"] = machineActionState({
+        status: "success",
+        failedSystemIds: ["abc123"],
+      });
+      const store = mockStore(state);
+      const { result } = renderHook(() => useMachineActionDispatch(), {
+        wrapper: generateWrapper(store),
+      });
+      const { dispatch } = result.current;
+      const testAction = { type: "test" };
+      dispatch(testAction);
+      const actual = store
+        .getActions()
+        .find((action) => action.type === testAction.type);
+      expect(actual).toStrictEqual({
+        type: "test",
+        meta: { callId: "mocked-nanoid" },
+      });
+      expect(result.current.actionStatus).toEqual("success");
+      expect(result.current.actionErrors).toEqual(
+        "Action failed for 1 machine"
+      );
+    });
   });
 
   describe("useSelectedMachinesActionsDispatch", () => {

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -94,19 +94,24 @@ export const useMachineActionDispatch = <
   );
   const actionStatus = actionState?.status || ACTION_STATUS.idle;
   const failedSystemIds = actionState?.failedSystemIds || [];
-  const { machines: failedMachines, machineCount: failedMachinesCount } =
-    useFetchMachines(
-      { filters: { id: failedSystemIds } },
-      { isEnabled: failedSystemIds.length > 0 }
-    );
+  const failedMachinesCount = failedSystemIds.length;
+  const { machines: failedMachines } = useFetchMachines(
+    { filters: { id: failedSystemIds } },
+    { isEnabled: failedMachinesCount > 0 }
+  );
+
+  const failedMachinesDescription =
+    failedMachines.length > 0
+      ? `: ${failedMachines.map((machine) => machine.hostname).join(", ")}`
+      : "";
 
   const actionErrors =
-    actionState?.errors || (failedMachinesCount && failedMachinesCount > 0)
+    actionState?.errors || failedMachinesCount > 0
       ? `Action failed for ${pluralize(
           "machine",
-          failedMachinesCount as number,
+          failedMachinesCount,
           true
-        )}: ${failedMachines.map((machine) => machine.hostname).join(", ")}`
+        )}${failedMachinesDescription}`
       : null;
 
   return {

--- a/src/app/store/pod/slice.ts
+++ b/src/app/store/pod/slice.ts
@@ -44,7 +44,7 @@ const statusHandlers = generateStatusHandlers<PodState, Pod, PodMeta.PK>(
       statusKey: "refreshing",
       success: (state, action) => {
         for (const i in state.items) {
-          if (state.items[i].id === action.payload.id) {
+          if (state.items[i].id === action.payload?.id) {
             state.items[i] = action.payload;
             return;
           }

--- a/src/app/store/utils/slice.test.ts
+++ b/src/app/store/utils/slice.test.ts
@@ -402,7 +402,7 @@ describe("slice", () => {
             statusKey: "refreshing",
             success: (state, action) => {
               for (const i in state.items) {
-                if (state.items[i].id === action.payload.id) {
+                if (state.items[i].id === action.payload?.id) {
                   state.items[i] = action.payload;
                   return;
                 }

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -366,7 +366,9 @@ export const generateCommonReducers = <
  */
 export type StatusHandlers<
   S extends StatusStateTypes,
-  I extends S["items"][0]
+  I extends S["items"][0],
+  // alternative success payload type
+  A = void
 > = {
   method?: string;
   status: string;
@@ -379,7 +381,7 @@ export type StatusHandlers<
   // The handler for when the action has started.
   start?: CaseReducer<S, PayloadAction<I, string, GenericItemMeta<I>>>;
   // The handler for when the action has successfully completed.
-  success?: CaseReducer<S, PayloadAction<I, string, GenericItemMeta<I>>>;
+  success?: CaseReducer<S, PayloadAction<I | A, string, GenericItemMeta<I>>>;
 };
 
 /**
@@ -398,10 +400,12 @@ export const generateStatusHandlers = <
   S extends StatusStateTypes,
   I extends S["items"][0],
   // A model key as a reference to the supplied state item.
-  K extends keyof I
+  K extends keyof I,
+  // optional alternative success payload type
+  A = void
 >(
   indexKey: K,
-  handlers: StatusHandlers<S, I>[],
+  handlers: StatusHandlers<S, I, A>[],
   setErrors?: (
     state: Draft<S>,
     action: PayloadAction<S["errors"]>,
@@ -445,7 +449,7 @@ export const generateStatusHandlers = <
           }),
           reducer: (
             state: Draft<S>,
-            action: PayloadAction<I, string, GenericItemMeta<I>>
+            action: PayloadAction<I | A, string, GenericItemMeta<I>>
           ) => {
             // Call the reducer handler if supplied.
             status.success && status.success(state, action);

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -270,7 +270,7 @@ export const machineStateList = define<MachineStateList>({
 export const machineActionState = define<ActionState>({
   status: ACTION_STATUS.idle,
   errors: null,
-  count: 0,
+  successCount: 0,
 });
 
 export const machineStateLists = define<MachineStateLists>({


### PR DESCRIPTION
## Done

- handle bulk machine actions results (failed system id count and success count)
- add `useSelectedMachinesActionsDispatch` hook for handling of multiple action dispatches when there are groups and items selected
- stricter type checking for machine slice reducer with `MachineActionStatus`
- refactor to use `selectedMachines` instead of selectedFilter (initially I wanted to simplify this, but because we need to handle multiple dispatches in case there are selected both groups and items this was not possible)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Select a few machines and dispatch an action via "Take action" menu
- Ensure that the form is closed upon successful submission
- If you select a group of machines and an item outside of that group, there should be 2 machine.action websocket calls - 1 for the groups, 1 for the items
- If an action is not successful for all selected nodes, the form should remain open and an error message should be displayed
- if the back-end responds with a failed system ids an error message indicating the number of failed nodes should be displayed
  - you can test this by testing a machine and attempting to test it again once testing is in progress

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1397
Fixes: https://github.com/canonical/app-tribe/issues/1396

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
