### PR TITLE
feat: update error boundary notification

### DIFF
--- a/src/app/base/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/app/base/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component } from "react";
 import type { ReactNode, ErrorInfo } from "react";
 
+import { Notification } from "@canonical/react-components";
 import * as Sentry from "@sentry/browser";
 import { connect } from "react-redux";
 
@@ -49,12 +50,9 @@ class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className="p-notification--negative">
-          <p className="p-notification__response u-no-max-width">
-            <span className="p-notification__status">Error:</span>
-            {Labels.ErrorMessage}
-          </p>
-        </div>
+        <Notification severity="negative" title="Error:">
+          {Labels.ErrorMessage}
+        </Notification>
       );
     }
     return this.props.children;


### PR DESCRIPTION
## Done

- Itemised list of what was changed by this PR.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Login as a non-admin user (credentials on lastpass for `user1`)
- Go to `/MAAS/r/kvm/lxd`
- Verify the updated notification style is used

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1399

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
#### NotificationBoundary Notification style
##### Before
<img width="988" alt="image" src="https://user-images.githubusercontent.com/7452681/194539524-2180c6a7-3b01-44ba-98a2-ce8b997c6e7c.png">

##### new NotificationBoundary Notification style
<img width="991" alt="image" src="https://user-images.githubusercontent.com/7452681/194539454-91e428c2-5171-476d-bf00-164c4b24d9ce.png">
