### PR TITLE
fix: cannot resolve none into field

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -244,6 +244,25 @@ describe("MachineList", () => {
     ).toStrictEqual(["Deployed"]);
   });
 
+  it("uses the default fallback value for invalid stored grouping values", () => {
+    localStorage.setItem("grouping", '"invalid_value"');
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+    const store = mockStore(state);
+    renderWithBrowserRouter(
+      <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
+      { wrapperProps: { store } }
+    );
+    expect(screen.getByLabelText(/Group by/)).toHaveValue(DEFAULTS.grouping);
+    const expected = machineActions.fetch("123456", {
+      group_key: DEFAULTS.grouping,
+    });
+    const fetches = store
+      .getActions()
+      .filter((action) => action.type === expected.type);
+    expect(fetches).toHaveLength(1);
+    expect(fetches.at(-1).payload.params.group_key).toBe(DEFAULTS.grouping);
+  });
+
   it("can change groups", () => {
     jest
       .spyOn(reduxToolkit, "nanoid")

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -41,13 +41,20 @@ const MachineList = ({
   const [sortDirection, setSortDirection] = useState<
     ValueOf<typeof SortDirection>
   >(DEFAULTS.sortDirection);
-  const [grouping, setGrouping] = useStorageState<FetchGroupKey | null>(
-    localStorage,
-    "grouping",
-    FetchGroupKey.Status
-  );
+  const [storedGrouping, setStoredGrouping] =
+    useStorageState<FetchGroupKey | null>(
+      localStorage,
+      "grouping",
+      DEFAULTS.grouping
+    );
+  // fallback to "None" if the stored grouping is not valid
+  const grouping: FetchGroupKey =
+    typeof storedGrouping === "string" &&
+    Object.values(FetchGroupKey).includes(storedGrouping)
+      ? storedGrouping
+      : DEFAULTS.grouping;
   const handleSetGrouping = (group: FetchGroupKey | null) => {
-    setGrouping(group);
+    setStoredGrouping(group);
     // clear selected machines on grouping change
     // we cannot reliably preserve the selected state for individual machines
     // as we are only fetching information about a group from the back-end

--- a/src/app/machines/views/MachineList/MachineListTable/constants.ts
+++ b/src/app/machines/views/MachineList/MachineListTable/constants.ts
@@ -6,4 +6,5 @@ export const DEFAULTS = {
   // TODO: change this to fqdn when the API supports it:
   // https://github.com/canonical/app-tribe/issues/1268
   sortKey: FetchGroupKey.Hostname,
+  grouping: FetchGroupKey.Status,
 };

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -389,6 +389,7 @@ export enum FetchGroupKey {
   Nodeuserdata = "nodeuserdata",
   NumaNodesCount = "numa_nodes_count",
   Numanode = "numanode",
+  None = "",
   Osystem = "osystem",
   Owner = "owner",
   OwnerId = "owner_id",


### PR DESCRIPTION
## Done

- fix: cannot resolve none into field

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- set the localStorage value for grouping as "none"
- refresh the page
- machine list grouping should be set to "status" both in the UI and in the machine.list websocket request
- verify you can select "None" as a value and it gets persisted when you refresh the page

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1401

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
