### PR TITLE
feat: DHCP Snippets IP Ranges inputs

### DIFF
--- a/src/app/base/components/DHCPTable/DHCPTable.tsx
+++ b/src/app/base/components/DHCPTable/DHCPTable.tsx
@@ -15,6 +15,8 @@ import settingsURLs from "app/settings/urls";
 import { actions as dhcpsnippetActions } from "app/store/dhcpsnippet";
 import dhcpsnippetSelectors from "app/store/dhcpsnippet/selectors";
 import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
+import type { IPRange } from "app/store/iprange/types";
+import { getIpRangeDisplayName } from "app/store/iprange/utils";
 import type { RootState } from "app/store/root/types";
 import type { Subnet } from "app/store/subnet/types";
 import type { Node } from "app/store/types/node";
@@ -25,6 +27,7 @@ type BaseProps = {
   modelName: string;
   node?: Node;
   subnets?: Subnet[];
+  ipRanges?: IPRange[];
 };
 
 type NodeProps = BaseProps & {
@@ -51,7 +54,8 @@ const generateRows = (
   expanded: DHCPSnippet["id"] | null,
   setExpanded: (id: DHCPSnippet["id"] | null) => void,
   node?: Node,
-  subnets?: Subnet[]
+  subnets?: Subnet[],
+  ipranges?: IPRange[]
 ) =>
   dhcpsnippets.map((dhcpsnippet: DHCPSnippet) => {
     const isExpanded = expanded === dhcpsnippet.id;
@@ -61,6 +65,10 @@ const generateRows = (
     if (isId(dhcpsnippet.node) && node) {
       typeLabel = "Node";
       appliesTo = node.fqdn;
+    } else if (isId(dhcpsnippet.iprange) && ipranges?.length) {
+      typeLabel = "IP Range";
+      const ipRange = ipranges.find(({ id }) => id === dhcpsnippet.iprange);
+      appliesTo = getIpRangeDisplayName(ipRange);
     } else if (isId(dhcpsnippet.subnet) && subnets?.length) {
       typeLabel = "Subnet";
       appliesTo =
@@ -76,6 +84,7 @@ const generateRows = (
         {
           content: (
             <DhcpSnippetType
+              ipRangeId={dhcpsnippet.iprange}
               nodeId={dhcpsnippet.node}
               subnetId={dhcpsnippet.subnet}
             />
@@ -124,6 +133,7 @@ const DHCPTable = ({
   className,
   node,
   subnets,
+  ipRanges,
   modelName,
 }: Props): JSX.Element | null => {
   const dispatch = useDispatch();
@@ -189,7 +199,8 @@ const DHCPTable = ({
               expanded,
               setExpanded,
               node,
-              subnets
+              subnets,
+              ipRanges
             )}
             sortable
           />

--- a/src/app/base/components/DhcpForm/types.ts
+++ b/src/app/base/components/DhcpForm/types.ts
@@ -6,5 +6,5 @@ export type DHCPFormValues = {
   entity: string;
   name: DHCPSnippet["name"];
   value: DHCPSnippet["value"];
-  type: string;
+  type: "" | "controller" | "device" | "machine" | "subnet" | "iprange";
 };

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -9,8 +9,11 @@ import configureStore from "redux-mock-store";
 import { Labels } from "./DhcpFormFields";
 
 import DhcpForm from "app/base/components/DhcpForm";
+import { getIpRangeDisplayName } from "app/store/iprange/utils";
 import type { RootState } from "app/store/root/types";
 import {
+  ipRange as ipRangeFactory,
+  ipRangeState as ipRangeStateFactory,
   controllerState as controllerStateFactory,
   deviceState as deviceStateFactory,
   dhcpSnippet as dhcpSnippetFactory,
@@ -26,6 +29,7 @@ import {
 
 const mockStore = configureStore();
 const machines = [machineFactory()];
+const ipRange = ipRangeFactory();
 describe("DhcpFormFields", () => {
   let state: RootState;
 
@@ -75,6 +79,10 @@ describe("DhcpFormFields", () => {
             name: "test.local",
           }),
         ],
+        loaded: true,
+      }),
+      iprange: ipRangeStateFactory({
+        items: [ipRange],
         loaded: true,
       }),
     });
@@ -150,6 +158,32 @@ describe("DhcpFormFields", () => {
     expect(
       screen.getByRole("combobox", { name: Labels.AppliesTo })
     ).toBeInTheDocument();
+  });
+
+  it("allows to select an IP Range", async () => {
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <CompatRouter>
+            <DhcpForm analyticsCategory="settings" />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+    const select = screen.getByRole("combobox", { name: Labels.Type });
+
+    await userEvent.selectOptions(select, "iprange");
+
+    expect(
+      screen.queryByRole("alert", { name: Labels.LoadingData })
+    ).not.toBeInTheDocument();
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", {
+        name: Labels.AppliesTo,
+      }),
+      getIpRangeDisplayName(ipRange)
+    );
   });
 
   it("resets the entity if the type changes", async () => {

--- a/src/app/base/components/DhcpSnippetType/DhcpSnippetType.tsx
+++ b/src/app/base/components/DhcpSnippetType/DhcpSnippetType.tsx
@@ -6,6 +6,7 @@ import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
 type Props = {
   nodeId?: DHCPSnippet["node"];
   subnetId?: DHCPSnippet["subnet"];
+  ipRangeId?: DHCPSnippet["iprange"];
 };
 
 const dhcpTypeLabels = {
@@ -14,10 +15,19 @@ const dhcpTypeLabels = {
   global: "Global",
   machine: "Machine",
   subnet: "Subnet",
+  iprange: "IP Range",
 };
 
-const DhcpSnippetType = ({ nodeId, subnetId }: Props): JSX.Element | null => {
-  const { loading, loaded, type } = useDhcpTarget(nodeId || null, subnetId);
+const DhcpSnippetType = ({
+  nodeId,
+  subnetId,
+  ipRangeId,
+}: Props): JSX.Element | null => {
+  const { loading, loaded, type } = useDhcpTarget(
+    nodeId || null,
+    subnetId,
+    ipRangeId
+  );
 
   if (!nodeId && !subnetId) return <>{dhcpTypeLabels.global}</>;
 

--- a/src/app/settings/hooks.ts
+++ b/src/app/settings/hooks.ts
@@ -9,6 +9,8 @@ import { actions as deviceActions } from "app/store/device";
 import deviceSelectors from "app/store/device/selectors";
 import type { Device } from "app/store/device/types";
 import type { DHCPSnippet } from "app/store/dhcpsnippet/types";
+import { actions as ipRangeActions } from "app/store/iprange";
+import ipRangeSelectors from "app/store/iprange/selectors";
 import type { Machine } from "app/store/machine/types";
 import { useFetchMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
@@ -18,15 +20,19 @@ import type { Subnet } from "app/store/subnet/types";
 
 export const useDhcpTarget = (
   nodeId?: DHCPSnippet["node"],
-  subnetId?: DHCPSnippet["subnet"]
+  subnetId?: DHCPSnippet["subnet"],
+  ipRangeId?: DHCPSnippet["iprange"]
 ): {
   loading: boolean;
   loaded: boolean;
   target: Subnet | Machine | Device | Controller | null;
-  type: "subnet" | "controller" | "device" | "machine" | null;
+  type: "iprange" | "subnet" | "controller" | "device" | "machine" | null;
 } => {
   const dispatch = useDispatch();
 
+  const iprange = useSelector((state: RootState) =>
+    ipRangeSelectors.getById(state, ipRangeId)
+  );
   const subnetLoading = useSelector(subnetSelectors.loading);
   const subnetLoaded = useSelector(subnetSelectors.loaded);
   const subnet = useSelector((state: RootState) =>
@@ -58,6 +64,7 @@ export const useDhcpTarget = (
 
   useEffect(() => {
     dispatch(subnetActions.fetch());
+    dispatch(ipRangeActions.fetch());
     dispatch(controllerActions.fetch());
     dispatch(deviceActions.fetch());
   }, [dispatch]);
@@ -67,6 +74,7 @@ export const useDhcpTarget = (
     loaded: hasLoaded,
     target: subnet || machine || device || controller,
     type:
+      (iprange && "iprange") ||
       (subnet && "subnet") ||
       (controller && "controller") ||
       (device && "device") ||

--- a/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
+++ b/src/app/settings/views/Dhcp/DhcpList/DhcpList.tsx
@@ -89,6 +89,7 @@ const generateRows = (
     const type =
       (dhcpsnippet.node && "Node") ||
       (dhcpsnippet.subnet && "Subnet") ||
+      (dhcpsnippet.iprange && "IP Range") ||
       "Global";
     return {
       className: expanded ? "p-table__row is-active" : null,
@@ -110,6 +111,7 @@ const generateRows = (
         {
           content: (
             <DhcpSnippetType
+              ipRangeId={dhcpsnippet.iprange}
               nodeId={dhcpsnippet.node}
               subnetId={dhcpsnippet.subnet}
             />

--- a/src/app/store/dhcpsnippet/types/actions.ts
+++ b/src/app/store/dhcpsnippet/types/actions.ts
@@ -1,13 +1,11 @@
 import type { DHCPSnippet } from "./base";
 import type { DHCPSnippetMeta } from "./enum";
 
-import type { Model } from "app/store/types/model";
-
 export type CreateParams = {
   description?: DHCPSnippet["description"];
   enabled?: DHCPSnippet["enabled"];
   global_snippet?: boolean;
-  iprange?: Model["id"];
+  iprange?: DHCPSnippet["iprange"];
   name?: DHCPSnippet["name"];
   node?: DHCPSnippet["node"];
   subnet?: DHCPSnippet["subnet"];

--- a/src/app/store/dhcpsnippet/types/base.ts
+++ b/src/app/store/dhcpsnippet/types/base.ts
@@ -1,5 +1,6 @@
 import type { APIError } from "app/base/types";
 import type { Device } from "app/store/device/types";
+import type { IPRange } from "app/store/iprange/types";
 import type { Subnet } from "app/store/subnet/types";
 import type { Host } from "app/store/types/host";
 import type { TimestampedModel } from "app/store/types/model";
@@ -16,6 +17,7 @@ export type DHCPSnippet = TimestampedModel & {
   name: string;
   node: Host["system_id"] | Device["system_id"] | null;
   subnet: Subnet["id"] | null;
+  iprange: IPRange["id"] | null;
   value: string;
 };
 

--- a/src/app/store/iprange/utils.ts
+++ b/src/app/store/iprange/utils.ts
@@ -32,3 +32,11 @@ export const getOwnerDisplay = (ipRange: IPRange): string =>
  */
 export const getTypeDisplay = (ipRange: IPRange): string =>
   isDynamic(ipRange) ? "Dynamic" : "Reserved";
+
+/**
+ * Get display name for an IP range.
+ * @param ipRange - The IP range to check.
+ * @returns Display name text for an IP range.
+ */
+export const getIpRangeDisplayName = (ipRange?: IPRange): string =>
+  ipRange ? `${ipRange?.start_ip} - ${ipRange?.end_ip}` : "";

--- a/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
+++ b/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
@@ -3,6 +3,8 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import DHCPTable from "app/base/components/DHCPTable";
+import { actions as ipRangeActions } from "app/store/iprange";
+import ipRangeSelectors from "app/store/iprange/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import subnetSelectors from "app/store/subnet/selectors";
@@ -18,12 +20,16 @@ const DHCPSnippets = ({ modelName, subnetIds }: Props): JSX.Element => {
   const subnets = useSelector((state: RootState) =>
     subnetSelectors.getByIds(state, subnetIds)
   );
+  const ipranges = useSelector(ipRangeSelectors.all);
 
   useEffect(() => {
     dispatch(subnetActions.fetch());
+    dispatch(ipRangeActions.fetch());
   }, [dispatch]);
 
-  return <DHCPTable modelName={modelName} subnets={subnets} />;
+  return (
+    <DHCPTable ipRanges={ipranges} modelName={modelName} subnets={subnets} />
+  );
 };
 
 export default DHCPSnippets;

--- a/src/testing/factories/dhcpsnippet.ts
+++ b/src/testing/factories/dhcpsnippet.ts
@@ -22,6 +22,7 @@ export const dhcpSnippet = extend<TimestampedModel, DHCPSnippet>(
     name: "test snippet",
     node: null,
     subnet: null,
+    iprange: null,
     value: "test value",
   }
 );


### PR DESCRIPTION
## Done

- feat: allow setting IP Ranges DHCP Snippets type

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Set bolla as MAAS_URL
- Go to DHCP Settings page - MAAS/r/settings/dhcp
- Add a DHCP snippet of type "IP Range"
- Save the snippet
- Click on the subnet link for the snippet you just created
- Verify the IP Range is displayed on the Subnet details page in the IP Ranges section
- Go back to DHCP Settings page and edit the snippet you previously created
- Ensure the correct values are displayed in the edit form and get updated upon submission


## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/2629

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

### DHCP Settings page
![image](https://user-images.githubusercontent.com/7452681/194913383-65f0a0b3-7d8b-40aa-9788-dc3c232d0a20.png)
### Subnet details page
![image](https://user-images.githubusercontent.com/7452681/194913399-d579c54e-5a21-4b8f-a954-68e7bd27e2a2.png)

