### PR TITLE
chore: create issue on build upload failure

### DIFF
--- a/.github/ISSUE_TEMPLATE/upload-failure.md
+++ b/.github/ISSUE_TEMPLATE/upload-failure.md
@@ -1,0 +1,11 @@
+---
+name: Build upload failure
+about: ''
+title: '{{ env.BRANCH_NAME }} build upload failed'
+assignees: ''
+
+---
+
+Uploading the build to the assets server has failed for the {{ env.BRANCH_NAME }} branch:
+
+<https://github.com/>{{ env.REPO }}/actions/runs/{{ env.RUN_ID }}

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -14,6 +14,8 @@ jobs:
         node-version: [16.x]
     steps:
       - uses: actions/checkout@v3
+      - name: Get branch name
+        uses: nelonoel/branch-name@v1.0.1
       - name: Restore node_modules
         id: yarn-cache
         uses: actions/cache@v3
@@ -39,3 +41,13 @@ jobs:
         run: upload-assets --url-path ${{env.PACKAGE_NAME}} ${{env.PACKAGE_NAME}}
         env:
           UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}
+      - name: Create issue on failure
+        if: failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/upload-failure.md
+          update_existing: true


### PR DESCRIPTION
## Done

- Create a new issue on uploading build artifacts failure

Verified this works on another branch where I enabled upload workflow temporarily: https://github.com/canonical/maas-ui/issues/4456

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
