### PR TITLE
refactor(machines): multiple tag lists handling

### DIFF
--- a/src/__snapshots__/root-reducer.test.ts.snap
+++ b/src/__snapshots__/root-reducer.test.ts.snap
@@ -355,6 +355,7 @@ Object {
   "tag": Object {
     "errors": null,
     "items": Array [],
+    "lists": Object {},
     "loaded": false,
     "loading": false,
     "saved": false,

--- a/src/app/store/tag/actions.test.ts
+++ b/src/app/store/tag/actions.test.ts
@@ -12,6 +12,19 @@ describe("tag actions", () => {
     });
   });
 
+  it("returns an action for fetching tags with a filter", () => {
+    expect(actions.fetch({ filter: { id: "abc123" } }, "123456")).toEqual({
+      type: "tag/fetch",
+      meta: {
+        model: "tag",
+        method: "list",
+        callId: "123456",
+        nocache: true,
+      },
+      payload: { params: { filter: { id: "abc123" } } },
+    });
+  });
+
   it("can create an action for creating a tag", () => {
     const params = {
       comment: "It's a tag",

--- a/src/app/store/tag/reducers.test.ts
+++ b/src/app/store/tag/reducers.test.ts
@@ -10,6 +10,7 @@ describe("tag reducer", () => {
     expect(reducers(undefined, { type: "" })).toEqual({
       errors: null,
       items: [],
+      lists: {},
       loaded: false,
       loading: false,
       saved: false,
@@ -21,6 +22,7 @@ describe("tag reducer", () => {
     expect(reducers(undefined, actions.fetchStart())).toEqual({
       errors: null,
       items: [],
+      lists: {},
       loaded: false,
       loading: true,
       saved: false,
@@ -35,6 +37,7 @@ describe("tag reducer", () => {
     expect(reducers(state, actions.fetchSuccess(tags))).toEqual({
       errors: null,
       items: tags,
+      lists: {},
       loading: false,
       loaded: true,
       saved: false,
@@ -49,6 +52,7 @@ describe("tag reducer", () => {
       {
         errors: "Could not fetch tags",
         items: [],
+        lists: {},
         loaded: false,
         loading: false,
         saved: false,
@@ -113,6 +117,7 @@ describe("tag reducer", () => {
       expect(reducers(tagState, actions.updateStart())).toEqual({
         errors: null,
         items: [],
+        lists: {},
         loaded: false,
         loading: false,
         saved: false,
@@ -128,6 +133,7 @@ describe("tag reducer", () => {
       expect(reducers(tagState, actions.updateSuccess())).toEqual({
         errors: null,
         items: [],
+        lists: {},
         loaded: false,
         loading: false,
         saved: true,
@@ -145,6 +151,7 @@ describe("tag reducer", () => {
       ).toEqual({
         errors: "Could not update tag",
         items: [],
+        lists: {},
         loaded: false,
         loading: false,
         saved: false,
@@ -169,6 +176,7 @@ describe("tag reducer", () => {
       expect(reducers(tagState, actions.updateNotify(updatedTag))).toEqual({
         errors: null,
         items: [updatedTag],
+        lists: {},
         loaded: false,
         loading: false,
         saved: false,

--- a/src/app/store/tag/selectors.test.ts
+++ b/src/app/store/tag/selectors.test.ts
@@ -5,6 +5,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { tagStateListFactory } from "testing/factories/state";
 
 describe("tag selectors", () => {
   it("can get all items", () => {
@@ -15,6 +16,52 @@ describe("tag selectors", () => {
       }),
     });
     expect(tag.all(state)).toEqual(items);
+  });
+
+  it("can get items in a list", () => {
+    const items = [tagFactory(), tagFactory()];
+    const state = rootStateFactory({
+      tag: tagStateFactory({
+        lists: {
+          "mock-call-id": tagStateListFactory({
+            items,
+          }),
+        },
+      }),
+    });
+    expect(tag.list(state, "mock-call-id")).toStrictEqual(items);
+  });
+
+  it("can get the loading state for a list", () => {
+    const items = [tagFactory(), tagFactory()];
+    const state = rootStateFactory({
+      tag: tagStateFactory({
+        lists: {
+          "mock-call-id": tagStateListFactory({
+            items,
+            loading: true,
+            loaded: false,
+          }),
+        },
+      }),
+    });
+    expect(tag.listLoading(state, "mock-call-id")).toBe(true);
+  });
+
+  it("can get the loaded state for a list", () => {
+    const items = [tagFactory(), tagFactory()];
+    const state = rootStateFactory({
+      tag: tagStateFactory({
+        lists: {
+          "mock-call-id": tagStateListFactory({
+            items,
+            loaded: true,
+            loading: false,
+          }),
+        },
+      }),
+    });
+    expect(tag.listLoaded(state, "mock-call-id")).toBe(true);
   });
 
   it("can get all manual tags", () => {

--- a/src/app/store/tag/selectors.ts
+++ b/src/app/store/tag/selectors.ts
@@ -13,6 +13,8 @@ const defaultSelectors = generateBaseSelectors<TagState, Tag, TagMeta.PK>(
   searchFunction
 );
 
+const tagState = (state: RootState): TagState => state[TagMeta.MODEL];
+
 const getTagsFromIds = (
   tags: Tag[],
   tagIDs: Tag[TagMeta.PK][] | null
@@ -41,6 +43,50 @@ const getByIDs = createSelector(
     (_state: RootState, tagIDs: Tag[TagMeta.PK][] | null) => tagIDs,
   ],
   (allTags, tagIDs) => getTagsFromIds(allTags, tagIDs)
+);
+
+const getList = (tagState: TagState, callId: string | null | undefined) =>
+  callId && callId in tagState.lists ? tagState.lists[callId] : null;
+
+/**
+ * Get the errors for a tag list request with a given callId
+ */
+const listErrors = createSelector(
+  [tagState, (_state: RootState, callId: string | null | undefined) => callId],
+  (tagState, callId) => getList(tagState, callId)?.errors || null
+);
+
+/**
+ * Get the loaded state for a tag list request with a given callId.
+ */
+const listLoaded = createSelector(
+  [tagState, (_state: RootState, callId: string | null | undefined) => callId],
+  (tagState, callId) => getList(tagState, callId)?.loaded ?? false
+);
+
+/**
+ * Get the loading stateo for a tag list request with a given callId.
+ */
+const listLoading = createSelector(
+  [tagState, (_state: RootState, callId: string | null | undefined) => callId],
+  (tagState, callId) => getList(tagState, callId)?.loading ?? false
+);
+
+/**
+ * Get tags in a list request.
+ * @param state - The redux state.
+ * @param callId - A list request id.
+ * @param selected - Whether to filter for selected tags.
+ * @returns A list of tags.
+ */
+const list = createSelector(
+  [
+    tagState,
+    (_state: RootState, callId: string | null | undefined) => ({
+      callId,
+    }),
+  ],
+  (tagState, { callId }) => getList(tagState, callId)?.items ?? null
 );
 
 /**
@@ -110,11 +156,11 @@ export enum TagSearchFilter {
 }
 
 /**
- * Get machines that match search terms and filters.
+ * Get tags that match search terms and filters.
  * @param state - The redux state.
  * @param terms - The terms to match against.
  * @param filter - A .
- * @returns A filtered list of machines.
+ * @returns A filtered list of tags.
  */
 const search = createSelector(
   [
@@ -149,6 +195,10 @@ const selectors = {
   getAutomaticByIDs,
   getManual,
   getManualByIDs,
+  list,
+  listErrors,
+  listLoaded,
+  listLoading,
   search,
 };
 

--- a/src/app/store/tag/slice.ts
+++ b/src/app/store/tag/slice.ts
@@ -1,22 +1,122 @@
+import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
+import type { FetchFilters } from "./../machine/types/actions";
 import { TagMeta } from "./types";
 import type { TagState, CreateParams, UpdateParams } from "./types";
+import type { Tag, TagStateList } from "./types/base";
 
+import type { GenericMeta } from "app/store/utils/slice";
 import {
   generateCommonReducers,
   genericInitialState,
 } from "app/store/utils/slice";
 
+const DEFAULT_LIST_STATE = {
+  errors: null,
+  items: null,
+  loaded: false,
+  loading: true,
+};
+
 const tagSlice = createSlice({
   name: TagMeta.MODEL,
-  initialState: genericInitialState as TagState,
-  reducers: generateCommonReducers<
-    TagState,
-    TagMeta.PK,
-    CreateParams,
-    UpdateParams
-  >(TagMeta.MODEL, TagMeta.PK),
+  initialState: { ...genericInitialState, lists: {} } as TagState,
+  reducers: {
+    ...generateCommonReducers<TagState, TagMeta.PK, CreateParams, UpdateParams>(
+      TagMeta.MODEL,
+      TagMeta.PK
+    ),
+    fetch: {
+      prepare: (params?: { filter: FetchFilters }, callId?: string) => {
+        return {
+          meta: {
+            model: TagMeta.MODEL,
+            method: "list",
+            ...(callId ? { callId, nocache: true } : {}),
+          },
+          payload: params
+            ? {
+                params,
+              }
+            : null,
+        };
+      },
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    fetchError: {
+      prepare: (errors: TagStateList["errors"], callId?: string) => ({
+        meta: {
+          ...(callId ? { callId } : {}),
+        },
+        payload: errors,
+      }),
+      reducer: (
+        state: TagState,
+        action: PayloadAction<TagStateList["errors"], string, GenericMeta>
+      ) => {
+        if (action.meta.callId) {
+          if (action.meta.callId in state.lists) {
+            state.lists[action.meta.callId].errors = action.payload;
+            state.lists[action.meta.callId].loading = false;
+          }
+        } else {
+          state.errors = action.payload;
+          state.loading = false;
+        }
+      },
+    },
+    fetchStart: {
+      prepare: (callId?: string) => ({
+        meta: {
+          ...(callId ? { callId } : {}),
+        },
+        payload: null,
+      }),
+      reducer: (
+        state: TagState,
+        action: PayloadAction<null, string, GenericMeta>
+      ) => {
+        if (action.meta.callId) {
+          state.lists[action.meta.callId] = {
+            ...DEFAULT_LIST_STATE,
+            loading: true,
+          };
+        } else {
+          state.loading = true;
+        }
+      },
+    },
+    fetchSuccess: {
+      prepare: (payload: Tag[], callId?: string) => ({
+        meta: {
+          ...(callId ? { callId } : {}),
+        },
+        payload,
+      }),
+      reducer: (
+        state: TagState,
+        action: PayloadAction<Tag[], string, GenericMeta>
+      ) => {
+        state.loaded = true;
+        state.loading = false;
+        const { payload } = action;
+        const { callId } = action.meta;
+        if (callId && callId in state.lists) {
+          // Only update state if this call exists in the store. This check is required
+          // because the call may have been cleaned up in the time the API takes
+          // to respond.
+          state.lists[callId].items = payload;
+          state.lists[callId].loaded = true;
+          state.lists[callId].loading = false;
+        } else {
+          state.items = payload;
+        }
+      },
+    },
+  },
 });
 
 export const { actions } = tagSlice;

--- a/src/app/store/tag/types/base.ts
+++ b/src/app/store/tag/types/base.ts
@@ -12,4 +12,15 @@ export type Tag = TimestampedModel & {
   name: string;
 };
 
-export type TagState = GenericState<Tag, APIError>;
+export type TagStateList = {
+  items: Tag[] | null;
+  errors: APIError;
+  loaded: boolean;
+  loading: boolean;
+};
+
+export type TagStateLists = Record<string, TagStateList>;
+
+export type TagState = {
+  lists: TagStateLists;
+} & GenericState<Tag, APIError>;

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -93,6 +93,7 @@ import type {
   SubnetStatuses,
 } from "app/store/subnet/types";
 import type { TagState } from "app/store/tag/types";
+import type { TagStateList } from "app/store/tag/types/base";
 import type { TokenState } from "app/store/token/types";
 import type { EventError } from "app/store/types/state";
 import type { AuthState, UserState } from "app/store/user/types";
@@ -552,8 +553,16 @@ export const subnetState = define<SubnetState>({
   statuses: () => ({}),
 });
 
+export const tagStateListFactory = define<TagStateList>({
+  errors: null,
+  items: null,
+  loaded: false,
+  loading: false,
+});
+
 export const tagState = define<TagState>({
   ...defaultState,
+  lists: () => ({}),
   errors: null,
 });
 


### PR DESCRIPTION
## Done

- add logic for handling multiple tag lists with different filters

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Verify that tags are displayed for each machine and in machine details page as before

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1404

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
