### PR TITLE
rename tag filter param to node_filter

### DIFF
--- a/src/app/store/tag/actions.test.ts
+++ b/src/app/store/tag/actions.test.ts
@@ -13,7 +13,7 @@ describe("tag actions", () => {
   });
 
   it("returns an action for fetching tags with a filter", () => {
-    expect(actions.fetch({ filter: { id: "abc123" } }, "123456")).toEqual({
+    expect(actions.fetch({ node_filter: { id: "abc123" } }, "123456")).toEqual({
       type: "tag/fetch",
       meta: {
         model: "tag",
@@ -21,7 +21,7 @@ describe("tag actions", () => {
         callId: "123456",
         nocache: true,
       },
-      payload: { params: { filter: { id: "abc123" } } },
+      payload: { params: { node_filter: { id: "abc123" } } },
     });
   });
 

--- a/src/app/store/tag/slice.ts
+++ b/src/app/store/tag/slice.ts
@@ -1,11 +1,11 @@
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
-import type { FetchFilters } from "./../machine/types/actions";
 import { TagMeta } from "./types";
 import type { TagState, CreateParams, UpdateParams } from "./types";
 import type { Tag, TagStateList } from "./types/base";
 
+import type { FetchFilters } from "app/store/machine/types/actions";
 import type { GenericMeta } from "app/store/utils/slice";
 import {
   generateCommonReducers,
@@ -28,7 +28,7 @@ const tagSlice = createSlice({
       TagMeta.PK
     ),
     fetch: {
-      prepare: (params?: { filter: FetchFilters }, callId?: string) => {
+      prepare: (params?: { node_filter: FetchFilters }, callId?: string) => {
         return {
           meta: {
             model: TagMeta.MODEL,


### PR DESCRIPTION
## Done

- rename tag filter param to node_filter
  - related back-end change: https://code.launchpad.net/~alexsander-souza/maas/+git/maas/+merge/431450

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list and verify tags are displayed correctly
- Go to machine details and verify tags are displayed correctly

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1414

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
