### PR TITLE
fix: vCenter password field text is visible in settings #4427

### DIFF
--- a/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
+++ b/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
@@ -89,9 +89,9 @@ describe("VMWareForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(
-      screen.getByRole("textbox", { name: VMWareFormLabels.PasswordLabel })
-    ).toHaveValue("passwd");
+    expect(screen.getByLabelText(VMWareFormLabels.PasswordLabel)).toHaveValue(
+      "passwd"
+    );
   });
 
   it("sets vcenter_datacenter value", () => {

--- a/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
+++ b/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
@@ -89,9 +89,9 @@ describe("VMWareForm", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(screen.getByLabelText(VMWareFormLabels.PasswordLabel)).toHaveValue(
-      "passwd"
-    );
+    const passwordInput = screen.getByLabelText(VMWareFormLabels.PasswordLabel);
+    expect(passwordInput).toHaveValue("passwd");
+    expect(passwordInput).toHaveAttribute("type", "password");
   });
 
   it("sets vcenter_datacenter value", () => {

--- a/src/app/settings/views/Images/VMWareForm/VMWareForm.tsx
+++ b/src/app/settings/views/Images/VMWareForm/VMWareForm.tsx
@@ -73,7 +73,7 @@ const VMWareForm = (): JSX.Element => {
         help="VMware vCenter server password which is passed to a deployed VMware ESXi host."
         label={Labels.PasswordLabel}
         name="vcenter_password"
-        type="text"
+        type="password"
       />
       <FormikField
         help="VMware vCenter datacenter which is passed to a deployed VMware ESXi host."


### PR DESCRIPTION
## Done

- Change vCenter password field type to "password"

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to settings/images/vmware
- Type anything in the "VMware vCenter password" field
- Ensure the text you type is hidden with dots

## Fixes

Fixes #4427.

## Launchpad issue

lp#1991106

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/195546242-83f4af02-c974-40b9-bfc1-a1b9a8377735.png)

### After
![image](https://user-images.githubusercontent.com/35104482/195546308-6e2f5029-616d-4150-8b47-b03dd8d411d4.png)

