### PR TITLE
feat(machines): tag actions using the new API

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
@@ -29,6 +29,7 @@ export const AddTagForm = ({
       deployedMachines={machines.filter(
         ({ status }) => status === NodeStatus.DEPLOYED
       )}
+      // TODO: refactor to use selectedMachines https://github.com/canonical/app-tribe/issues/1417
       generateDeployedMessage={(count: number) =>
         count === 1
           ? `${count} selected machine is deployed. The new kernel options will not be applied to this machine until it is redeployed.`

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagChip/TagChip.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagChip/TagChip.tsx
@@ -8,7 +8,7 @@ type Props = PropsWithSpread<
   {
     machineCount: number;
     tag: Tag;
-    tagIdsAndCounts: TagIdCountMap;
+    tagIdsAndCounts: TagIdCountMap | null;
   },
   Partial<ChipProps>
 >;
@@ -19,7 +19,7 @@ export const TagChip = ({
   tagIdsAndCounts,
   ...props
 }: Props): JSX.Element => {
-  const tagCount = tagIdsAndCounts.get(tag.id);
+  const tagCount = tagIdsAndCounts?.get(tag.id);
   return (
     <Chip
       className="is-inline"

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { NotificationSeverity } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
@@ -14,7 +14,6 @@ import type { MachineEventErrors } from "app/store/machine/types";
 import { selectedToFilters } from "app/store/machine/utils";
 import { useSelectedMachinesActionsDispatch } from "app/store/machine/utils/hooks";
 import { actions as messageActions } from "app/store/message";
-import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
 import { NodeActions } from "app/store/types/node";
@@ -55,9 +54,6 @@ export const TagForm = ({
     } as Record<string, string | string[]>;
     delete formErrors.name;
   }
-  useEffect(() => {
-    dispatch(tagActions.fetch());
-  }, [dispatch]);
 
   return (
     <ActionForm<TagFormValues, MachineEventErrors>
@@ -127,6 +123,8 @@ export const TagForm = ({
       <TagFormFields
         machines={machines || []}
         newTags={newTags}
+        selectedCount={selectedCount}
+        selectedMachines={selectedMachines}
         setNewTags={setNewTags}
         viewingDetails={viewingDetails}
         viewingMachineConfig={viewingMachineConfig}

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -21,7 +21,7 @@ import { NULL_EVENT } from "app/base/constants";
 import type { Machine, SelectedMachines } from "app/store/machine/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
-import { getManual, getTagCounts } from "app/store/tag/utils";
+import { getTagCounts } from "app/store/tag/utils";
 
 const hasKernelOptions = (tags: Tag[], tag: TagSelectorTag) =>
   !!tags.find(({ id }) => tag.id === id)?.kernel_opts;
@@ -54,11 +54,9 @@ export const TagFormFields = ({
   const [newTagName, setNewTagName] = useState<string | null>(null);
   const { setFieldValue, values } = useFormikContext<TagFormValues>();
   const selectedTags = useSelectedTags("added");
-  const { tags: tagsForSelected, loading: tagsLoading } =
-    useFetchTagsForSelected({
-      selectedMachines,
-    });
-  const tags = getManual(tagsForSelected);
+  const { tags, loading: tagsLoading } = useFetchTagsForSelected({
+    selectedMachines,
+  });
   const allManualTags = useSelector(tagSelectors.getManual);
   const tagIdsAndCounts = getTagCounts(tags);
   // Tags can't be added if they already exist on all machines or already in

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/hooks.ts
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/hooks.ts
@@ -1,11 +1,23 @@
+import { useEffect, useState } from "react";
+
+import { usePrevious } from "@canonical/react-components";
+import { nanoid } from "@reduxjs/toolkit";
+import fastDeepEqual from "fast-deep-equal";
 import { useFormikContext } from "formik";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 
 import type { TagFormValues } from "./types";
 
+import type { APIError } from "app/base/types";
+import type { FetchFilters } from "app/store/machine/types";
+import type { SelectedMachines } from "app/store/machine/types/base";
+import { selectedToFilters } from "app/store/machine/utils";
+import type { UseFetchQueryOptions } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
+import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
+import type { TagStateList } from "app/store/tag/types/base";
 import { toFormikNumber } from "app/utils";
 
 /**
@@ -44,3 +56,155 @@ export const useUnchangedTags = (tags: Tag[]): Tag[] => {
       !values.removed.find((tagId) => toFormikNumber(tagId) === tag.id)
   );
 };
+
+const selectedToSeparateFilters = (
+  selectedMachines: SelectedMachines | null
+) => {
+  const getIsSingleFilter = (
+    selectedMachines: SelectedMachines | null
+  ): selectedMachines is { filter: FetchFilters } => {
+    if (selectedMachines && "filter" in selectedMachines) {
+      return true;
+    }
+    return false;
+  };
+  const isSingleFilter = getIsSingleFilter(selectedMachines);
+  // Fetch items and groups separately
+  // - otherwise the back-end will return machines
+  // matching both groups and items
+  const groupFilters = selectedToFilters(
+    isSingleFilter
+      ? { filter: selectedMachines?.filter }
+      : {
+          groups: selectedMachines?.groups,
+          grouping: selectedMachines?.grouping,
+        }
+  );
+  const itemFilters = selectedToFilters(
+    !isSingleFilter ? { items: selectedMachines?.items } : null
+  );
+  return {
+    groupFilters,
+    itemFilters,
+  };
+};
+
+export const useFetchTags = (
+  options?: {
+    filters: FetchFilters | null;
+  },
+  queryOptions?: UseFetchQueryOptions
+): {
+  callId: string | null;
+  loaded: boolean;
+  loading: boolean;
+  errors: APIError;
+  tags: TagStateList["items"];
+} => {
+  const { isEnabled } = queryOptions || { isEnabled: true };
+  const previousIsEnabled = usePrevious(isEnabled);
+  const [callId, setCallId] = useState<string | null>(null);
+  const previousCallId = usePrevious(callId);
+  const previousOptions = usePrevious(options, false);
+  const dispatch = useDispatch();
+  const tagsList = useSelector((state: RootState) =>
+    tagSelectors.list(state, callId)
+  );
+  const errors = useSelector((state: RootState) =>
+    tagSelectors.listErrors(state, callId)
+  );
+  const loaded = useSelector((state: RootState) =>
+    tagSelectors.listLoaded(state, callId)
+  );
+  const loading = useSelector((state: RootState) =>
+    tagSelectors.listLoading(state, callId)
+  );
+
+  useEffect(() => {
+    return () => {
+      if (callId) {
+        dispatch(tagActions.removeRequest(callId));
+      }
+    };
+  }, [callId, dispatch]);
+
+  useEffect(() => {
+    // undefined, null and {} are all equivalent i.e. no filters so compare the
+    // current and previous filters using an empty object if the filters are falsy.
+    if (
+      (isEnabled && !fastDeepEqual(options || {}, previousOptions || {})) ||
+      !callId
+    ) {
+      setCallId(nanoid());
+    }
+  }, [callId, options, previousOptions, isEnabled]);
+
+  useEffect(() => {
+    if (
+      (isEnabled && callId && callId !== previousCallId) ||
+      (isEnabled !== previousIsEnabled && callId)
+    ) {
+      dispatch(
+        tagActions.fetch(
+          options?.filters
+            ? {
+                node_filter: options.filters,
+              }
+            : undefined,
+          callId
+        )
+      );
+    }
+  }, [callId, dispatch, options, previousCallId, isEnabled, previousIsEnabled]);
+
+  return {
+    callId,
+    loaded,
+    loading,
+    errors,
+    tags: isEnabled ? tagsList || [] : [],
+  };
+};
+
+export const useFetchTagsForSelected = (options: {
+  selectedMachines?: SelectedMachines | null;
+}): {
+  loaded: boolean;
+  loading: boolean;
+  errors: APIError;
+  tags: Tag[];
+} => {
+  const { itemFilters, groupFilters } = selectedToSeparateFilters(
+    options.selectedMachines || null
+  );
+  const {
+    loading: loadingForItemFilters,
+    loaded: tagsForItemFiltersLoaded,
+    tags: tagsForItemFilters,
+    errors: errorsForItemFilters,
+  } = useFetchTags(
+    { filters: itemFilters },
+    {
+      isEnabled: itemFilters !== null,
+    }
+  );
+  const { loading, loaded, tags, errors } = useFetchTags(
+    { filters: groupFilters },
+    {
+      isEnabled: groupFilters !== null,
+    }
+  );
+
+  return {
+    loaded: tagsForItemFiltersLoaded && loaded,
+    loading: loadingForItemFilters || loading,
+    errors:
+      errorsForItemFilters || errors ? errorsForItemFilters || errors : null,
+    tags: [
+      ...(tags ? tags : []),
+      ...(tagsForItemFilters ? tagsForItemFilters : []),
+    ],
+  };
+};
+
+export type TagIdCountMap = Map<Tag[TagMeta.PK], number>;

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
@@ -53,8 +53,9 @@ const TagForm = ({ systemId }: Props): JSX.Element | null => {
           <TagActionForm
             clearHeaderContent={() => setEditing(false)}
             errors={errors}
-            machines={[machine]}
             processingCount={taggingMachines.length}
+            selectedCount={1}
+            selectedMachines={{ items: [machine.system_id] }}
             viewingDetails
             viewingMachineConfig
           />

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -425,7 +425,7 @@ const statusHandlers = generateStatusHandlers<
                 ...action.payload.failed_system_ids,
               ] as Machine[MachineMeta.PK][];
             }
-          } else {
+          } else if (actionsItem) {
             actionsItem.status = ACTION_STATUS.error;
           }
         }

--- a/src/app/store/tag/reducers.test.ts
+++ b/src/app/store/tag/reducers.test.ts
@@ -4,6 +4,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { tagStateListFactory } from "testing/factories/state";
 
 describe("tag reducer", () => {
   it("returns the initial state", () => {
@@ -58,6 +59,20 @@ describe("tag reducer", () => {
         saved: false,
         saving: false,
       }
+    );
+  });
+
+  it("reduces removeRequest for a list request", () => {
+    const initialState = tagStateFactory({
+      lists: { "mock-call-id": tagStateListFactory() },
+    });
+
+    expect(
+      reducers(initialState, actions.removeRequest("mock-call-id"))
+    ).toEqual(
+      tagStateFactory({
+        lists: {},
+      })
     );
   });
 

--- a/src/app/store/tag/selectors.ts
+++ b/src/app/store/tag/selectors.ts
@@ -65,7 +65,7 @@ const listLoaded = createSelector(
 );
 
 /**
- * Get the loading stateo for a tag list request with a given callId.
+ * Get the loading state for a tag list request with a given callId.
  */
 const listLoading = createSelector(
   [tagState, (_state: RootState, callId: string | null | undefined) => callId],

--- a/src/app/store/tag/slice.ts
+++ b/src/app/store/tag/slice.ts
@@ -116,6 +116,25 @@ const tagSlice = createSlice({
         }
       },
     },
+    removeRequest: {
+      prepare: (callId: string) => ({
+        meta: {
+          callId,
+        },
+        payload: null,
+      }),
+      reducer: (
+        state: TagState,
+        action: PayloadAction<null, string, GenericMeta>
+      ) => {
+        const { callId } = action.meta;
+        if (callId) {
+          if (callId in state.lists) {
+            delete state.lists[callId];
+          }
+        }
+      },
+    },
   },
 });
 

--- a/src/app/store/tag/utils.ts
+++ b/src/app/store/tag/utils.ts
@@ -1,3 +1,4 @@
+import type { TagIdCountMap } from "app/store/machine/utils";
 import type { Tag, TagMeta } from "app/store/tag/types";
 
 export const getTagsDisplay = (tags: Tag[]): string => {
@@ -21,3 +22,21 @@ export const getTagNamesForIds = (
     }
     return tagNames;
   }, []);
+
+export const getManual = (tags: Tag[]): Tag[] =>
+  tags.filter(({ definition }) => !definition);
+
+export const getTagCounts = (tags: Tag[]): TagIdCountMap | null => {
+  if (tags) {
+    const tagCounts = new Map();
+    tags.forEach((tag) => {
+      if (!tagCounts.has(tag.id)) {
+        tagCounts.set(tag.id, tag.machine_count);
+      } else {
+        tagCounts.set(tag.id, tagCounts.get(tag.id) + tag.machine_count);
+      }
+    });
+    return tagCounts;
+  }
+  return null;
+};


### PR DESCRIPTION
## Done

- handle tag actions using the new API

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

#### Machine list
- Go to machine listing
- select a few individual machines
- Go to Take action -> Tag
- Verify that tag counts displayed are correct for the current tags
- Remove a tag and add a new one to the machines selected
- Save
- Ensure the websocket message has been sent with the correct payload (filter with a list of system ids) to both tag and untag endpoints 

#### Machine details
- Go to machine details page
- Go to Take action -> Tag
- Verify that tag counts displayed are correct for the current tags
- Remove a tag and add a new one
- Save
- Ensure the websocket message has been sent with the correct payload (filter with a list of system ids) to both tag and untag endpoints


## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1299

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
