### PR TITLE
fix(machines): browser history navigation between pages

### DIFF
--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -1409,6 +1409,31 @@ describe("machine reducer", () => {
     );
   });
 
+  it("reduces unsubscribeStart for removed statuses", () => {
+    const items = [
+      machineFactory({ system_id: "abc123" }),
+      machineFactory({ system_id: "def456" }),
+    ];
+    expect(
+      reducers(
+        machineStateFactory({
+          items,
+          statuses: {
+            def456: machineStatusFactory(),
+          },
+        }),
+        actions.unsubscribeStart(["abc123"])
+      )
+    ).toEqual(
+      machineStateFactory({
+        items,
+        statuses: {
+          def456: machineStatusFactory(),
+        },
+      })
+    );
+  });
+
   it("reduces unsubscribeSuccess", () => {
     const initialState = machineStateFactory({
       items: [

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1839,7 +1839,9 @@ const machineSlice = createSlice({
         >
       ) => {
         action.meta.item.system_ids.forEach((id) => {
-          state.statuses[id].unsubscribing = true;
+          if (state.statuses[id]) {
+            state.statuses[id].unsubscribing = true;
+          }
         });
       },
     },


### PR DESCRIPTION
## Done

- fix machines listing when using browser history navigation

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Click on machine details
- Go back, go forward, go back using browser navigation
- Machine listing should load

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1421

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
