### PR TITLE
fix: machine delete success

### DIFF
--- a/cypress/e2e/with-users/machines/details.spec.ts
+++ b/cypress/e2e/with-users/machines/details.spec.ts
@@ -88,5 +88,8 @@ context("Machine details", () => {
       cy.findByRole("button", { name: /Delete/i }).click();
     });
     cy.findByRole("button", { name: /Delete machine/i }).click();
+    cy.waitForPageToLoad();
+    // verify the user has been redirected to the machine list
+    cy.url().should("include", generateMAASURL("/machines"));
   });
 });

--- a/src/app/base/components/node/DeleteForm/DeleteForm.tsx
+++ b/src/app/base/components/node/DeleteForm/DeleteForm.tsx
@@ -1,12 +1,7 @@
-import { useEffect } from "react";
-
-import { useNavigate } from "react-router-dom-v5-compat";
-
 import NodeActionConfirmationText from "../../NodeActionConfirmationText";
 import type { NodeActionFormProps } from "../types";
 
 import ActionForm from "app/base/components/ActionForm";
-import { useProcessing } from "app/base/hooks";
 import type { EmptyObject } from "app/base/types";
 import { NodeActions } from "app/store/types/node";
 import { capitaliseFirst } from "app/utils";
@@ -27,22 +22,12 @@ export const DeleteForm = <E,>({
   selectedCount,
   redirectURL,
   viewingDetails,
+  actionStatus,
 }: Props<E>): JSX.Element => {
-  const navigate = useNavigate();
-  const deleteComplete = useProcessing({
-    hasErrors: !!errors,
-    processingCount,
-  });
-
-  useEffect(() => {
-    if (deleteComplete && viewingDetails) {
-      navigate(redirectURL, { replace: true });
-    }
-  }, [navigate, deleteComplete, redirectURL, viewingDetails]);
-
   return (
     <ActionForm<EmptyObject, E>
       actionName={NodeActions.DELETE}
+      actionStatus={actionStatus}
       allowUnchanged
       cleanup={cleanup}
       errors={errors}
@@ -59,6 +44,7 @@ export const DeleteForm = <E,>({
       onSubmit={onSubmit}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}
+      savedRedirect={viewingDetails ? redirectURL : undefined}
       selectedCount={nodes ? nodes.length : selectedCount ?? 0}
       submitAppearance="negative"
     >


### PR DESCRIPTION
## Done

- Itemised list of what was changed by this PR.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Select a machine to delete
- Go to take action -> delete
- Make sure the delete form has been closed
- Go to machine details page
- Go to take action -> delete
- Make sure the delete form has been closed and you have been redirected to machine listing

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4470
Fixes: https://github.com/canonical/maas-ui/issues/4469

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
