### PR TITLE
fix: info icons disappearing on toggle

### DIFF
--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
@@ -64,16 +64,12 @@ const SubnetSummary = ({ id }: Props): JSX.Element | null => {
                 description={subnet.description}
                 label="Description"
               />
-              <Definition
-                label={<ManagedAllocationLabel managed={subnet.managed} />}
-              >
+              <Definition label={<ManagedAllocationLabel />}>
                 {subnet.managed ? "Enabled" : "Disabled"}
               </Definition>
             </Col>
             <Col size={6}>
-              <Definition
-                label={<ActiveDiscoveryLabel managed={subnet.managed} />}
-              >
+              <Definition label={<ActiveDiscoveryLabel />}>
                 {subnet.active_discovery ? "Enabled" : "Disabled"}
               </Definition>
               <Definition

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.tsx
@@ -73,12 +73,12 @@ const SubnetSummaryFormFields = (): JSX.Element => {
       </Col>
       <Col size={6}>
         <FormikField
-          label={<ManagedAllocationLabel managed={values.managed} />}
+          label={<ManagedAllocationLabel />}
           name="managed"
           type="checkbox"
         />
         <FormikField
-          label={<ActiveDiscoveryLabel managed={values.managed} />}
+          label={<ActiveDiscoveryLabel />}
           name="active_discovery"
           type="checkbox"
         />

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.test.tsx
@@ -3,8 +3,8 @@ import userEvent from "@testing-library/user-event";
 
 import ActiveDiscoveryLabel from "./ActiveDiscoveryLabel";
 
-it("shows a tooltip when the subnet is managed", async () => {
-  render(<ActiveDiscoveryLabel managed />);
+it("displays a tooltip", async () => {
+  render(<ActiveDiscoveryLabel />);
 
   await userEvent.click(screen.getByRole("button"));
 
@@ -13,10 +13,4 @@ it("shows a tooltip when the subnet is managed", async () => {
       name: /When enabled, MAAS will scan this subnet/,
     })
   ).toBeInTheDocument();
-});
-
-it("does not show a tooltip when the subnet is not managed", () => {
-  render(<ActiveDiscoveryLabel managed={false} />);
-
-  expect(screen.queryByRole("button")).not.toBeInTheDocument();
 });

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.tsx
@@ -1,21 +1,14 @@
 import TooltipButton from "app/base/components/TooltipButton";
-import type { Subnet } from "app/store/subnet/types";
 
-type Props = {
-  managed: Subnet["managed"];
-};
-
-const ActiveDiscoveryLabel = ({ managed }: Props): JSX.Element => (
+const ActiveDiscoveryLabel = (): JSX.Element => (
   <>
     Active discovery{" "}
-    {managed ? (
-      <TooltipButton
-        message={`When enabled, MAAS will scan this subnet to discover hosts
+    <TooltipButton
+      message={`When enabled, MAAS will scan this subnet to discover hosts
         that have not been discovered passively.`}
-        position="btm-right"
-        positionElementClassName="u-display--inline"
-      />
-    ) : null}
+      position="btm-right"
+      positionElementClassName="u-display--inline"
+    />
   </>
 );
 

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.test.tsx
@@ -3,8 +3,8 @@ import userEvent from "@testing-library/user-event";
 
 import ManagedAllocationLabel from "./ManagedAllocationLabel";
 
-it("shows a tooltip when the subnet is not managed", async () => {
-  render(<ManagedAllocationLabel managed={false} />);
+it("shows a tooltip", async () => {
+  render(<ManagedAllocationLabel />);
 
   await userEvent.click(screen.getByRole("button"));
 
@@ -13,10 +13,4 @@ it("shows a tooltip when the subnet is not managed", async () => {
       name: /MAAS allocates IP addresses from this subnet/,
     })
   ).toBeInTheDocument();
-});
-
-it("does not show a tooltip when the subnet is managed", () => {
-  render(<ManagedAllocationLabel managed />);
-
-  expect(screen.queryByRole("button")).not.toBeInTheDocument();
 });

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.tsx
@@ -1,21 +1,14 @@
 import TooltipButton from "app/base/components/TooltipButton";
-import type { Subnet } from "app/store/subnet/types";
 
-type Props = {
-  managed: Subnet["managed"];
-};
-
-const ManagedAllocationLabel = ({ managed }: Props): JSX.Element => (
+const ManagedAllocationLabel = (): JSX.Element => (
   <>
     Managed allocation{" "}
-    {managed ? null : (
-      <TooltipButton
-        message={`MAAS allocates IP addresses from this subnet, excluding the
+    <TooltipButton
+      message={`When enabled, MAAS allocates IP addresses from this subnet, excluding the
         reserved and dynamic ranges.`}
-        position="btm-right"
-        positionElementClassName="u-display--inline"
-      />
-    )}
+      position="btm-right"
+      positionElementClassName="u-display--inline"
+    />
   </>
 );
 


### PR DESCRIPTION
## Done

- fix: info icons disappearing on toggle

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to subnet details page
- Verify that the tooltip for "Managed allocation" and "Active discovery" is displayed regardless of the checkbox checked state

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4464

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
