### PR TITLE
fix: enable jammy kvm host option

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -47,7 +47,8 @@ export const DeployFormFields = (): JSX.Element => {
     osInfoSelectors.getUbuntuKernelOptions(state, values.release)
   );
   const canBeKVMHost =
-    values.oSystem === "ubuntu" && ["bionic", "focal"].includes(values.release);
+    values.oSystem === "ubuntu" &&
+    ["bionic", "focal", "jammy"].includes(values.release);
   const noImages = osystems.length === 0 || releases.length === 0;
   const clearVmHostOptions = () => {
     setDeployVmHost(false);


### PR DESCRIPTION
## Done

- enable jammy kvm host option

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select a machine to deploy
- Make sure you can select Ubuntu 22.04 and enable "Register as MAAS KVM host."

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4463

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
