### PR TITLE
test: add machine action e2e tests

### DIFF
--- a/cypress/e2e/with-users/machines/actions.spec.ts
+++ b/cypress/e2e/with-users/machines/actions.spec.ts
@@ -1,0 +1,70 @@
+import { generateMAASURL } from "../../utils";
+
+const MACHINE_ACTIONS = [
+  "Commission",
+  "Allocate",
+  "Deploy",
+  "Release",
+  "Abort",
+  "Clone from",
+  "Power On",
+  "Power off",
+  "Test",
+  "Enter rescue mode",
+  "Exit rescue mode",
+  "Mark fixed",
+  "Mark broken",
+  "Override failed testing",
+  "Lock",
+  "Unlock",
+  "Tag",
+  "Set zone",
+  "Set pool",
+  "Import images",
+  "Delete",
+];
+
+const selectFirstMachine = () =>
+  cy.findByRole("grid", { name: /Machines/i }).within(() => {
+    cy.findAllByRole("gridcell", { name: /FQDN/i })
+      .first() // eslint-disable-next-line cypress/no-force
+      .within(() => cy.findByRole("checkbox").click({ force: true }));
+  });
+
+context("Machine listing - actions", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit(generateMAASURL("/machines"));
+    cy.waitForPageToLoad();
+    // cy.wait for table data to fully load
+    cy.waitForTableToLoad({ name: "Machines" });
+  });
+
+  it("displays the correct actions in the action menu", () => {
+    selectFirstMachine();
+    cy.findByRole("button", { name: /Take action/i }).click();
+    cy.findByLabelText("submenu").within(() => {
+      cy.findAllByRole("button").should("have.length", MACHINE_ACTIONS.length);
+      cy.findAllByRole("button").should("be.enabled");
+    });
+  });
+
+  MACHINE_ACTIONS.forEach((action) =>
+    it(`loads machine ${action} form`, () => {
+      selectFirstMachine();
+      cy.findByRole("button", { name: /Take action/i }).click();
+      cy.findByLabelText("submenu").within(() => {
+        cy.findAllByRole("button", { name: new RegExp(action, "i") }).click();
+      });
+      cy.findByTestId("section-header-title").contains(action).should("exist");
+      cy.get("[data-testid='section-header-content']").within(() => {
+        cy.findAllByText(/Loading/).should("have.length", 0);
+        cy.findByRole("button", { name: /Cancel/i }).click();
+      });
+      // expect the action form to be closed
+      cy.findByTestId("section-header-title")
+        .contains(action)
+        .should("not.exist");
+    })
+  );
+});

--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -19,7 +19,7 @@ context("Machine listing", () => {
   });
 
   it("can group machines by all supported keys", () => {
-    const groupByOptions = [
+    const GROUP_BY_OPTIONS = [
       "No grouping",
       "Group by owner",
       "Group by parent",
@@ -31,13 +31,11 @@ context("Machine listing", () => {
     const getGroupBySelect = () =>
       cy.findByRole("combobox", { name: "Group by" });
     getGroupBySelect().within(() => {
-      cy.findAllByRole("option").should("have.length", groupByOptions.length);
+      cy.findAllByRole("option").should("have.length", GROUP_BY_OPTIONS.length);
     });
-    groupByOptions.forEach((option) => {
+    GROUP_BY_OPTIONS.forEach((option) => {
       getGroupBySelect().select(option);
-      cy.findByRole("grid", { name: /Loading/i }).should("exist");
-      cy.findByRole("grid", { name: /Loading/i }).should("not.exist");
-      cy.findByRole("grid", { name: "Machines" }).should("exist");
+      cy.waitForTableToLoad({ name: "Machines" });
     });
   });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -95,3 +95,9 @@ Cypress.Commands.add("waitForPageToLoad", () => {
   cy.findByText("Failed to connect").should("not.exist");
   cy.get("[data-testid='section-header-title']").should("be.visible");
 });
+
+Cypress.Commands.add("waitForTableToLoad", ({ name } = { name: undefined }) => {
+  cy.findByRole("grid", { name: /Loading/i }).should("exist");
+  cy.findByRole("grid", { name: /Loading/i }).should("not.exist");
+  cy.findByRole("grid", { name }).should("exist");
+});

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -19,6 +19,7 @@ declare global {
       loginNonAdmin(): void;
       testA11y(pageContext: A11yPageContext): void;
       waitForPageToLoad(): void;
+      waitForTableToLoad(options?: { name?: string | RegExp }): void;
     }
   }
 }


### PR DESCRIPTION
## Done

- test: add machine action e2e tests

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- None required

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1426

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
