### PR TITLE
fix(machines): warning message for deployed machines

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
@@ -1,3 +1,4 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -6,8 +7,19 @@ import configureStore from "redux-mock-store";
 import AddTagForm from "./AddTagForm";
 import type { Props } from "./AddTagForm";
 
+import { actions as machineActions } from "app/store/machine";
+import type { FetchFilters } from "app/store/machine/types";
+import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
-import { rootState as rootStateFactory } from "testing/factories";
+import { FetchNodeStatus } from "app/store/types/node";
+import {
+  rootState as rootStateFactory,
+  machineState as machineStateFactory,
+  machineStateCount as machineStateCountFactory,
+  machineStateCounts as machineStateCountsFactory,
+  tag as tagFactory,
+  tagState as tagStateFactory,
+} from "testing/factories";
 
 const mockBaseAddTagForm = jest.fn();
 jest.mock("app/tags/components/AddTagForm", () => (props: Props) => {
@@ -20,7 +32,33 @@ const mockStore = configureStore();
 let state: RootState;
 
 beforeEach(() => {
-  state = rootStateFactory();
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+  state = rootStateFactory({
+    machine: machineStateFactory({
+      counts: machineStateCountsFactory({
+        "mocked-nanoid": machineStateCountFactory({
+          count: 1,
+          loaded: true,
+        }),
+        "mocked-nanoid-1": machineStateCountFactory({
+          count: 1,
+          loaded: true,
+        }),
+        "mocked-nanoid-2": machineStateCountFactory({
+          count: 1,
+          loaded: true,
+        }),
+      }),
+    }),
+    tag: tagStateFactory({
+      items: [
+        tagFactory({
+          id: 1,
+          name: "rad",
+        }),
+      ],
+    }),
+  });
 });
 
 afterEach(() => {
@@ -128,3 +166,68 @@ it("generates a deployed message for multiple machines", async () => {
       .startsWith("2 selected machines are deployed")
   ).toBe(true);
 });
+
+it("fetches deployed machine count for selected machines", async () => {
+  const store = mockStore(state);
+  const selectedMachines = { items: ["abc", "def"] };
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+        <AddTagForm
+          name="new-tag"
+          onTagCreated={jest.fn()}
+          selectedMachines={selectedMachines}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const expected = machineActions.count("mocked-nanoid", {
+    status: FetchNodeStatus.DEPLOYED,
+    id: selectedMachines.items,
+  } as FetchFilters);
+  const actual = store
+    .getActions()
+    .find((action) => action.type === expected.type);
+  expect(actual).toStrictEqual(expected);
+});
+
+it("fetches deployed machine count separately for deployed group when selected", async () => {
+  jest
+    .spyOn(reduxToolkit, "nanoid")
+    .mockReturnValueOnce("mocked-nanoid-1")
+    .mockReturnValueOnce("mocked-nanoid-2");
+  const store = mockStore(state);
+  const selectedMachines = {
+    items: ["abc", "def"],
+    groups: [FetchNodeStatus.DEPLOYED],
+    grouping: FetchGroupKey.Status,
+  };
+  render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
+        <AddTagForm
+          name="new-tag"
+          onTagCreated={jest.fn()}
+          selectedMachines={selectedMachines}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+  const expected = [
+    machineActions.count("mocked-nanoid-1", {
+      status: FetchNodeStatus.DEPLOYED,
+      id: selectedMachines.items,
+    }),
+    machineActions.count("mocked-nanoid-2", {
+      status: FetchNodeStatus.DEPLOYED,
+    }),
+  ];
+  const actual = store
+    .getActions()
+    .filter((action) => action.type === expected[0].type);
+  expect(actual).toHaveLength(2);
+  expected.forEach((action, index) => {
+    expect(action).toStrictEqual(actual[index]);
+  });
+});
+// Assume count as 0 if grouping by status and group other than deployed is selected

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
@@ -1,7 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render } from "@testing-library/react";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddTagForm from "./AddTagForm";
@@ -20,6 +17,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
 
 const mockBaseAddTagForm = jest.fn();
 jest.mock("app/tags/components/AddTagForm", () => (props: Props) => {
@@ -27,7 +25,7 @@ jest.mock("app/tags/components/AddTagForm", () => (props: Props) => {
   return null;
 });
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState, {}>();
 
 let state: RootState;
 
@@ -67,12 +65,9 @@ afterEach(() => {
 
 it("set the analytics category for the machine list", async () => {
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />,
+    { route: "/tags", wrapperProps: { store } }
   );
   expect(mockBaseAddTagForm).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -87,17 +82,14 @@ it("set the analytics category for the machine list", async () => {
 
 it("set the analytics category for the machine details", async () => {
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm
-          machines={[]}
-          name="new-tag"
-          onTagCreated={jest.fn()}
-          viewingDetails
-        />
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <AddTagForm
+      machines={[]}
+      name="new-tag"
+      onTagCreated={jest.fn()}
+      viewingDetails
+    />,
+    { route: "/tags", wrapperProps: { store } }
   );
   expect(mockBaseAddTagForm).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -112,17 +104,14 @@ it("set the analytics category for the machine details", async () => {
 
 it("set the analytics category for the machine config", async () => {
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm
-          machines={[]}
-          name="new-tag"
-          onTagCreated={jest.fn()}
-          viewingMachineConfig
-        />
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <AddTagForm
+      machines={[]}
+      name="new-tag"
+      onTagCreated={jest.fn()}
+      viewingMachineConfig
+    />,
+    { route: "/tags", wrapperProps: { store } }
   );
   expect(mockBaseAddTagForm).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -137,12 +126,9 @@ it("set the analytics category for the machine config", async () => {
 
 it("generates a deployed message for a single machine", async () => {
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />,
+    { route: "/tags", wrapperProps: { store } }
   );
   expect(
     mockBaseAddTagForm.mock.calls[0][0]
@@ -153,12 +139,9 @@ it("generates a deployed message for a single machine", async () => {
 
 it("generates a deployed message for multiple machines", async () => {
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />,
+    { route: "/tags", wrapperProps: { store } }
   );
   expect(
     mockBaseAddTagForm.mock.calls[0][0]
@@ -170,16 +153,13 @@ it("generates a deployed message for multiple machines", async () => {
 it("fetches deployed machine count for selected machines", async () => {
   const store = mockStore(state);
   const selectedMachines = { items: ["abc", "def"] };
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm
-          name="new-tag"
-          onTagCreated={jest.fn()}
-          selectedMachines={selectedMachines}
-        />
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <AddTagForm
+      name="new-tag"
+      onTagCreated={jest.fn()}
+      selectedMachines={selectedMachines}
+    />,
+    { route: "/tags", wrapperProps: { store } }
   );
   const expected = machineActions.count("mocked-nanoid", {
     status: FetchNodeStatus.DEPLOYED,
@@ -202,16 +182,13 @@ it("fetches deployed machine count separately for deployed group when selected",
     groups: [FetchNodeStatus.DEPLOYED],
     grouping: FetchGroupKey.Status,
   };
-  render(
-    <Provider store={store}>
-      <MemoryRouter initialEntries={[{ pathname: "/tags", key: "testKey" }]}>
-        <AddTagForm
-          name="new-tag"
-          onTagCreated={jest.fn()}
-          selectedMachines={selectedMachines}
-        />
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <AddTagForm
+      name="new-tag"
+      onTagCreated={jest.fn()}
+      selectedMachines={selectedMachines}
+    />,
+    { route: "/tags", wrapperProps: { store } }
   );
   const expected = [
     machineActions.count("mocked-nanoid-1", {
@@ -230,4 +207,58 @@ it("fetches deployed machine count separately for deployed group when selected",
     expect(action).toStrictEqual(actual[index]);
   });
 });
-// Assume count as 0 if grouping by status and group other than deployed is selected
+
+it("fetches deployed machine count when all machines are selected", async () => {
+  jest
+    .spyOn(reduxToolkit, "nanoid")
+    .mockReturnValueOnce("mocked-nanoid-1")
+    .mockReturnValueOnce("mocked-nanoid-2");
+  const store = mockStore(state);
+  const selectedMachines = {
+    filter: {},
+  };
+  renderWithBrowserRouter(
+    <AddTagForm
+      name="new-tag"
+      onTagCreated={jest.fn()}
+      selectedMachines={selectedMachines}
+    />,
+    { route: "/tags", wrapperProps: { store } }
+  );
+  const expected = machineActions.count("mocked-nanoid-1", {
+    status: FetchNodeStatus.DEPLOYED,
+  });
+  const countActions = store
+    .getActions()
+    .filter((action) => action.type === expected.type);
+  expect(countActions).toHaveLength(1);
+  expect(countActions[0]).toStrictEqual(expected);
+});
+
+it(`fetches deployed machine count only for selected items
+    when grouping by status and group other than deployed is selected`, async () => {
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid-1");
+  const store = mockStore(state);
+  const selectedMachines = {
+    items: ["abc", "def"],
+    groups: [FetchNodeStatus.COMMISSIONING],
+    grouping: FetchGroupKey.Status,
+  };
+  renderWithBrowserRouter(
+    <AddTagForm
+      name="new-tag"
+      onTagCreated={jest.fn()}
+      selectedMachines={selectedMachines}
+    />,
+    { route: "/tags", wrapperProps: { store } }
+  );
+  const expected = machineActions.count("mocked-nanoid-1", {
+    status: FetchNodeStatus.DEPLOYED,
+    id: selectedMachines.items,
+  });
+  const countActions = store
+    .getActions()
+    .filter((action) => action.type === expected.type);
+  expect(countActions).toHaveLength(1);
+  expect(countActions[0]).toStrictEqual(expected);
+});

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
@@ -1,18 +1,19 @@
-import type { Machine } from "app/store/machine/types";
+import type { MachineActionFormProps } from "app/machines/types";
+import { selectedToSeparateFilters } from "app/store/machine/utils/common";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import type { Tag } from "app/store/tag/types";
-import { NodeStatus } from "app/store/types/node";
+import { FetchNodeStatus } from "app/store/types/node";
 import BaseAddTagForm from "app/tags/components/AddTagForm";
 
 export type Props = {
-  machines: Machine[];
   name: string | null;
   onTagCreated: (tag: Tag) => void;
   viewingDetails?: boolean;
   viewingMachineConfig?: boolean;
-};
+} & Partial<MachineActionFormProps>;
 
 export const AddTagForm = ({
-  machines,
+  selectedMachines,
   name,
   onTagCreated,
   viewingDetails,
@@ -24,12 +25,39 @@ export const AddTagForm = ({
   } else if (viewingDetails) {
     location = "details";
   }
+
+  const { groupFilters, itemFilters } = selectedMachines
+    ? selectedToSeparateFilters(selectedMachines)
+    : { groupFilters: null, itemFilters: null };
+
+  const { machineCount: deployedSelectedItemsMachineCount } =
+    useFetchMachineCount(
+      {
+        ...itemFilters,
+        status: FetchNodeStatus.DEPLOYED,
+      },
+      { isEnabled: !!itemFilters }
+    );
+  const { machineCount: deployedSelectedGroupsMachineCount } =
+    useFetchMachineCount(
+      {
+        ...groupFilters,
+        status: FetchNodeStatus.DEPLOYED,
+      },
+      // Assume count as 0 if grouping by status and group other than deployed is selected
+      {
+        isEnabled:
+          selectedMachines && "groups" in selectedMachines
+            ? selectedMachines?.groups?.includes(FetchNodeStatus.DEPLOYED)
+            : false,
+      }
+    );
+  const deployedSelectedMachineCount =
+    deployedSelectedGroupsMachineCount + deployedSelectedItemsMachineCount;
+
   return (
     <BaseAddTagForm
-      deployedMachines={machines.filter(
-        ({ status }) => status === NodeStatus.DEPLOYED
-      )}
-      // TODO: refactor to use selectedMachines https://github.com/canonical/app-tribe/issues/1417
+      deployedMachinesCount={deployedSelectedMachineCount}
       generateDeployedMessage={(count: number) =>
         count === 1
           ? `${count} selected machine is deployed. The new kernel options will not be applied to this machine until it is redeployed.`

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
@@ -1,3 +1,5 @@
+import fastDeepEqual from "fast-deep-equal";
+
 import type { MachineActionFormProps } from "app/machines/types";
 import { selectedToSeparateFilters } from "app/store/machine/utils/common";
 import { useFetchMachineCount } from "app/store/machine/utils/hooks";
@@ -49,7 +51,8 @@ export const AddTagForm = ({
         isEnabled:
           selectedMachines && "groups" in selectedMachines
             ? selectedMachines?.groups?.includes(FetchNodeStatus.DEPLOYED)
-            : false,
+            : // if all machines are selected, fetch deployed machine count for all machines
+              fastDeepEqual(groupFilters, {}),
       }
     );
   const deployedSelectedMachineCount =

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.tsx
@@ -134,6 +134,7 @@ export const TagFormFields = ({
                 setNewTags([...newTags, tag.id]);
                 closePortal(NULL_EVENT);
               }}
+              selectedMachines={selectedMachines}
               viewingDetails={viewingDetails}
               viewingMachineConfig={viewingMachineConfig}
             />

--- a/src/app/store/machine/utils/common.ts
+++ b/src/app/store/machine/utils/common.ts
@@ -137,3 +137,39 @@ export const selectedToFilters = (
   }
   return Object.values(filter).length > 0 ? filter : null;
 };
+
+/**
+ * Convert selected machines state to separate filters to the API
+ * which allows to get a match for items OR groups
+ */
+export const selectedToSeparateFilters = (
+  selectedMachines: SelectedMachines | null
+): { groupFilters: FetchFilters | null; itemFilters: FetchFilters | null } => {
+  const getIsSingleFilter = (
+    selectedMachines: SelectedMachines | null
+  ): selectedMachines is { filter: FetchFilters } => {
+    if (selectedMachines && "filter" in selectedMachines) {
+      return true;
+    }
+    return false;
+  };
+  const isSingleFilter = getIsSingleFilter(selectedMachines);
+  // Fetch items and groups separately
+  // - otherwise the back-end will return machines
+  // matching both groups and items
+  const groupFilters = selectedToFilters(
+    isSingleFilter
+      ? { filter: selectedMachines?.filter }
+      : {
+          groups: selectedMachines?.groups,
+          grouping: selectedMachines?.grouping,
+        }
+  );
+  const itemFilters = selectedToFilters(
+    !isSingleFilter ? { items: selectedMachines?.items } : null
+  );
+  return {
+    groupFilters,
+    itemFilters,
+  };
+};

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -129,6 +129,26 @@ describe("machine hook utils", () => {
       ).toStrictEqual(expected);
     });
 
+    it("does not fetch if isEnabled is false", async () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        (queryOptions: UseFetchQueryOptions) =>
+          useFetchMachineCount({ hostname: "spotted-quoll" }, queryOptions),
+        {
+          initialProps: { isEnabled: false },
+          wrapper: generateWrapper(store),
+        }
+      );
+      const expectedActionType = machineActions.count("mocked-nanoid-1").type;
+      const getDispatches = () =>
+        store
+          .getActions()
+          .filter((action) => action.type === expectedActionType);
+      expect(getDispatches()).toHaveLength(0);
+      rerender({ isEnabled: true });
+      expect(getDispatches()).toHaveLength(1);
+    });
+
     it("returns the machine count", async () => {
       jest.restoreAllMocks();
       jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid");

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -352,12 +352,15 @@ export const useFetchSelectedMachines = (
 };
 
 export const useFetchMachineCount = (
-  filters?: FetchFilters | null
+  filters?: FetchFilters | null,
+  queryOptions?: UseFetchQueryOptions
 ): {
   machineCount: number;
   machineCountLoading: boolean;
   machineCountLoaded: boolean;
 } => {
+  const { isEnabled } = queryOptions || { isEnabled: true };
+  const previousIsEnabled = usePrevious(isEnabled);
   const [callId, setCallId] = useState<string | null>(null);
   const previousCallId = usePrevious(callId);
   const previousFilters = usePrevious(filters);
@@ -375,10 +378,13 @@ export const useFetchMachineCount = (
   useEffect(() => {
     // undefined, null and {} are all equivalent i.e. no filters so compare the
     // current and previous filters using an empty object if the filters are falsy.
-    if (!fastDeepEqual(filters || {}, previousFilters || {}) || !callId) {
+    if (
+      (isEnabled && !fastDeepEqual(filters || {}, previousFilters || {})) ||
+      (isEnabled && !callId)
+    ) {
       setCallId(nanoid());
     }
-  }, [callId, dispatch, filters, previousFilters]);
+  }, [callId, dispatch, filters, previousFilters, isEnabled]);
 
   useEffect(() => {
     return () => {
@@ -389,10 +395,10 @@ export const useFetchMachineCount = (
   }, [callId, dispatch]);
 
   useEffect(() => {
-    if (callId && callId !== previousCallId) {
+    if (isEnabled && callId && callId !== previousCallId) {
       dispatch(machineActions.count(callId, filters));
     }
-  }, [dispatch, filters, callId, previousCallId]);
+  }, [dispatch, filters, callId, previousCallId, isEnabled, previousIsEnabled]);
 
   return {
     machineCount: machineCount || 0,

--- a/src/app/tags/components/AddTagForm/AddTagForm.tsx
+++ b/src/app/tags/components/AddTagForm/AddTagForm.tsx
@@ -17,7 +17,7 @@ import type { Props as KernelOptionsFieldProps } from "app/tags/components/Kerne
 
 type Props = PropsWithSpread<
   {
-    deployedMachines?: KernelOptionsFieldProps["deployedMachines"];
+    deployedMachinesCount?: number;
     generateDeployedMessage?: KernelOptionsFieldProps["generateDeployedMessage"];
     name: string | null;
     onTagCreated: (tag: Tag) => void;
@@ -39,7 +39,7 @@ const AddTagFormSchema = Yup.object().shape({
 });
 
 export const AddTagForm = ({
-  deployedMachines,
+  deployedMachinesCount,
   generateDeployedMessage,
   name,
   onTagCreated,
@@ -105,7 +105,7 @@ export const AddTagForm = ({
             type="text"
           />
           <KernelOptionsField
-            deployedMachines={deployedMachines}
+            deployedMachinesCount={deployedMachinesCount}
             generateDeployedMessage={generateDeployedMessage}
           />
         </Col>

--- a/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
+++ b/src/app/tags/components/KernelOptionsField/KernelOptionsField.tsx
@@ -4,7 +4,6 @@ import { useSelector } from "react-redux";
 
 import FormikField from "app/base/components/FormikField";
 import docsUrls from "app/base/docsUrls";
-import type { Machine } from "app/store/machine/types";
 import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
@@ -22,7 +21,7 @@ export enum Label {
 }
 
 export type Props = {
-  deployedMachines?: Machine[];
+  deployedMachinesCount?: number;
   generateDeployedMessage?: (count: number) => string;
   id?: Tag[TagMeta.PK];
 };
@@ -33,18 +32,21 @@ const generateDeployedMessageForExisting = (count: number) =>
     : `There are ${count} deployed machines with this tag. The new kernel options will not be applied to these machines until they are redeployed.`;
 
 export const KernelOptionsField = ({
-  deployedMachines: suppliedDeployedMachines,
+  deployedMachinesCount: suppliedDeployedMachinesCount,
   generateDeployedMessage = generateDeployedMessageForExisting,
   id,
 }: Props): JSX.Element => {
   const tag = useSelector((state: RootState) =>
     tagSelectors.getById(state, id)
   );
-  const { machineCount } = useFetchMachineCount({
-    status: FetchNodeStatus.DEPLOYED,
-    ...(tag?.id ? { tags: [tag.name] } : {}),
-  });
-  const deployedCount = suppliedDeployedMachines?.length ?? machineCount;
+  const { machineCount } = useFetchMachineCount(
+    {
+      status: FetchNodeStatus.DEPLOYED,
+      ...(tag?.id ? { tags: [tag.name] } : {}),
+    },
+    { isEnabled: !!tag?.id }
+  );
+  const deployedCount = suppliedDeployedMachinesCount ?? machineCount;
   const { values } = useFormikContext<CreateParams | UpdateParams>();
   const changedExistingOptions =
     isId(id) && values.kernel_opts !== tag?.kernel_opts;


### PR DESCRIPTION
## Done

- fix warning message deployed machines count

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
#### Tags
- Go to machine list -> tags (`/MAAS/r/tags`)
- Select create a new tag
- Type in some kernel options
- Verify there is no warning message about the count of deployed machines
- Select a tag that has kernel options and some deployed machines from the list
- Click edit
- Edit the kernel options field
- Verify the warning message is displayed with a correct count of deployed machines

#### Machine listing
- Go to machine list
- Select a few groups, and a few individual machines
- Go to take action -> Tag
- Type in a new name in the input field to create a new tag
- Verify machine.count has been called with "tags: deployed" for both selected groups and items and the resulting count displayed in the warning is correct
- Change grouping to status
- Select a group of machines with a "deployed" status
- Select a few groups, and a few individual machines
- Go to take action -> Tag
- Type in a new name in the input field to create a new tag
- Verify the warning message displays the correct count
- Clear the selection
- Select a few machines and a group with a status other than "deployed"
- verify the deployed machine count in the warning message is correct

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1417

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
