### PR TITLE
test: create a machine before action tests

### DIFF
--- a/cypress/e2e/with-users/machines/actions.spec.ts
+++ b/cypress/e2e/with-users/machines/actions.spec.ts
@@ -7,7 +7,7 @@ const MACHINE_ACTIONS = [
   "Release",
   "Abort",
   "Clone from",
-  "Power On",
+  "Power on",
   "Power off",
   "Test",
   "Enter rescue mode",
@@ -31,6 +31,10 @@ const selectFirstMachine = () =>
   });
 
 context("Machine listing - actions", () => {
+  before(() => {
+    cy.login();
+    cy.addMachine();
+  });
   beforeEach(() => {
     cy.login();
     cy.visit(generateMAASURL("/machines"));
@@ -50,19 +54,22 @@ context("Machine listing - actions", () => {
 
   MACHINE_ACTIONS.forEach((action) =>
     it(`loads machine ${action} form`, () => {
+      const actionLabel = new RegExp(`${action}...`, "i"); // case insensitive
       selectFirstMachine();
       cy.findByRole("button", { name: /Take action/i }).click();
       cy.findByLabelText("submenu").within(() => {
-        cy.findAllByRole("button", { name: new RegExp(action, "i") }).click();
+        cy.findAllByRole("button", { name: actionLabel }).click();
       });
-      cy.findByTestId("section-header-title").contains(action).should("exist");
+      cy.findByTestId("section-header-title")
+        .contains(actionLabel)
+        .should("exist");
       cy.get("[data-testid='section-header-content']").within(() => {
         cy.findAllByText(/Loading/).should("have.length", 0);
         cy.findByRole("button", { name: /Cancel/i }).click();
       });
       // expect the action form to be closed
       cy.findByTestId("section-header-title")
-        .contains(action)
+        .contains(actionLabel)
         .should("not.exist");
     })
   );


### PR DESCRIPTION
## Done

- test: create a machine before action tests

_Note: some of the action tests will still fail, but it's intentional - it's indicative of bugs that we need to fix in server-side filtering_

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
