### PR TITLE
feat(vault): add backend integration

### DIFF
--- a/src/__snapshots__/root-reducer.test.ts.snap
+++ b/src/__snapshots__/root-reducer.test.ts.snap
@@ -177,6 +177,12 @@ Object {
       "loaded": false,
       "loading": false,
     },
+    "vaultEnabled": Object {
+      "data": null,
+      "errors": null,
+      "loaded": false,
+      "loading": false,
+    },
     "version": Object {
       "data": "",
       "errors": null,

--- a/src/app/store/controller/selectors.test.ts
+++ b/src/app/store/controller/selectors.test.ts
@@ -1,3 +1,5 @@
+import { NodeType } from "../types/node";
+
 import controller from "./selectors";
 import { ImageSyncStatus } from "./types/enum";
 
@@ -186,5 +188,31 @@ describe("controller selectors", () => {
       }),
     });
     expect(controller.search(state, "echidna", [])).toStrictEqual([items[0]]);
+  });
+
+  it("can get region controllers separated by vault configuration status", () => {
+    const items = [
+      controllerFactory({
+        vault_configured: false,
+        node_type: NodeType.REGION_CONTROLLER,
+      }),
+      controllerFactory({
+        vault_configured: true,
+        node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+      }),
+      controllerFactory({
+        node_type: NodeType.RACK_CONTROLLER,
+      }),
+    ];
+    const state = rootStateFactory({
+      controller: controllerStateFactory({
+        items,
+      }),
+    });
+
+    expect(controller.getVaultConfiguredControllers(state)).toStrictEqual([
+      [items[0]],
+      [items[1]],
+    ]);
   });
 });

--- a/src/app/store/controller/selectors.test.ts
+++ b/src/app/store/controller/selectors.test.ts
@@ -190,14 +190,12 @@ describe("controller selectors", () => {
     expect(controller.search(state, "echidna", [])).toStrictEqual([items[0]]);
   });
 
-  it("can get region controllers separated by vault configuration status", () => {
+  it("can get all region/region-and-rack controllers", () => {
     const items = [
       controllerFactory({
-        vault_configured: false,
         node_type: NodeType.REGION_CONTROLLER,
       }),
       controllerFactory({
-        vault_configured: true,
         node_type: NodeType.REGION_AND_RACK_CONTROLLER,
       }),
       controllerFactory({
@@ -210,9 +208,36 @@ describe("controller selectors", () => {
       }),
     });
 
-    expect(controller.getVaultConfiguredControllers(state)).toStrictEqual([
-      [items[0]],
-      [items[1]],
+    expect(controller.getRegionControllers(state)).toStrictEqual([
+      items[0],
+      items[1],
     ]);
+  });
+
+  it("can separate region controllers by their Vault configuration status", () => {
+    const items = [
+      controllerFactory({
+        vault_configured: true,
+        node_type: NodeType.REGION_CONTROLLER,
+      }),
+      controllerFactory({
+        vault_configured: false,
+        node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+      }),
+      controllerFactory({
+        node_type: NodeType.RACK_CONTROLLER,
+      }),
+    ];
+    const state = rootStateFactory({
+      controller: controllerStateFactory({
+        items,
+      }),
+    });
+
+    const { unconfiguredControllers, configuredControllers } =
+      controller.getVaultConfiguredControllers(state);
+
+    expect(unconfiguredControllers).toStrictEqual([items[1]]);
+    expect(configuredControllers).toStrictEqual([items[0]]);
   });
 });

--- a/src/app/store/controller/selectors.ts
+++ b/src/app/store/controller/selectors.ts
@@ -375,11 +375,11 @@ const getByFabricId = createSelector(
 );
 
 /**
- * Get all region controllers and separate by their vault configuration status.
+ * Get all region/region-and-rack controllers.
  * @param state - The redux state.
- * @returns Two lists of region controllers - one where none are configured with vault, the other where all are configured with vault.
+ * @returns A list of all region/region-and-rack controllers.
  */
-const getVaultConfiguredControllers = createSelector(
+const getRegionControllers = createSelector(
   [defaultSelectors.all],
   (controllers: Controller[]) => {
     const regionControllers = controllers.filter((controller) => {
@@ -388,17 +388,30 @@ const getVaultConfiguredControllers = createSelector(
         controller.node_type === NodeType.REGION_AND_RACK_CONTROLLER
       );
     });
-    const unconfiguredControllers = regionControllers.filter((controller) => {
+
+    return regionControllers;
+  }
+);
+
+/**
+ * Get controllers separated by their vault configuration status.
+ * @param state - The redux state.
+ * @returns Two lists of region controllers - one where none are configured with vault, the other where all are configured with vault.
+ */
+const getVaultConfiguredControllers = createSelector(
+  [getRegionControllers],
+  (controllers: Controller[]) => {
+    const unconfiguredControllers = controllers.filter((controller) => {
       return (
         controller.vault_configured === false ||
         controller.vault_configured === undefined
       );
     });
-    const configuredControllers = regionControllers.filter((controller) => {
+    const configuredControllers = controllers.filter((controller) => {
       return controller.vault_configured === true;
     });
 
-    return [unconfiguredControllers, configuredControllers];
+    return { unconfiguredControllers, configuredControllers };
   }
 );
 
@@ -412,6 +425,7 @@ const selectors = {
   getStatuses,
   getStatusForController,
   getVaultConfiguredControllers,
+  getRegionControllers,
   imageSyncStatuses,
   imageSyncStatusesForController,
   processing,

--- a/src/app/store/controller/types/base.ts
+++ b/src/app/store/controller/types/base.ts
@@ -76,6 +76,7 @@ export type BaseController = BaseNode & {
     | NodeType.REGION_CONTROLLER
     | NodeType.REGION_AND_RACK_CONTROLLER;
   service_ids: number[];
+  vault_configured?: boolean;
   versions: ControllerVersions | null;
   vlans_ha?: ControllerVlansHA;
 };

--- a/src/app/store/general/actions.test.ts
+++ b/src/app/store/general/actions.test.ts
@@ -145,6 +145,18 @@ describe("general actions", () => {
     });
   });
 
+  it("should handle fetching Vault enabled status", () => {
+    expect(general.fetchVaultEnabled()).toEqual({
+      type: "general/fetchVaultEnabled",
+      meta: {
+        cache: true,
+        model: "general",
+        method: "vault_enabled",
+      },
+      payload: null,
+    });
+  });
+
   it("should handle fetching version", () => {
     expect(general.fetchVersion()).toEqual({
       type: "general/fetchVersion",

--- a/src/app/store/general/reducers.test.ts
+++ b/src/app/store/general/reducers.test.ts
@@ -91,6 +91,12 @@ describe("general reducer", () => {
         loaded: false,
         loading: false,
       },
+      vaultEnabled: {
+        data: null,
+        errors: null,
+        loaded: false,
+        loading: false,
+      },
       version: {
         data: "",
         errors: null,

--- a/src/app/store/general/selectors/index.ts
+++ b/src/app/store/general/selectors/index.ts
@@ -11,4 +11,5 @@ export { default as osInfo } from "./osInfo";
 export { default as pocketsToDisable } from "./pocketsToDisable";
 export { default as powerTypes } from "./powerTypes";
 export { default as tlsCertificate } from "./tlsCertificate";
+export { default as vaultEnabled } from "./vaultEnabled";
 export { default as version } from "./version";

--- a/src/app/store/general/selectors/vaultEnabled.test.ts
+++ b/src/app/store/general/selectors/vaultEnabled.test.ts
@@ -1,0 +1,60 @@
+import vaultEnabled from "./vaultEnabled";
+
+import {
+  generalState as generalStateFactory,
+  rootState as rootStateFactory,
+  vaultEnabledState as vaultEnabledStateFactory,
+} from "testing/factories";
+
+describe("get", () => {
+  it("returns vaultEnabled", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        vaultEnabled: vaultEnabledStateFactory({
+          data: false,
+        }),
+      }),
+    });
+    expect(vaultEnabled.get(state)).toStrictEqual(false);
+  });
+});
+
+describe("loading", () => {
+  it("returns vaultEnabled loading state", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        vaultEnabled: vaultEnabledStateFactory({
+          loading: true,
+        }),
+      }),
+    });
+    expect(vaultEnabled.loading(state)).toStrictEqual(true);
+  });
+});
+
+describe("loaded", () => {
+  it("returns vaultEnabled loaded state", () => {
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        vaultEnabled: vaultEnabledStateFactory({
+          loaded: true,
+        }),
+      }),
+    });
+    expect(vaultEnabled.loaded(state)).toStrictEqual(true);
+  });
+});
+
+describe("errors", () => {
+  it("returns vaultEnabled errors state", () => {
+    const errors = "Cannot fetch Vault status";
+    const state = rootStateFactory({
+      general: generalStateFactory({
+        vaultEnabled: vaultEnabledStateFactory({
+          errors,
+        }),
+      }),
+    });
+    expect(vaultEnabled.errors(state)).toStrictEqual(errors);
+  });
+});

--- a/src/app/store/general/selectors/vaultEnabled.ts
+++ b/src/app/store/general/selectors/vaultEnabled.ts
@@ -1,0 +1,5 @@
+import { generateGeneralSelector } from "./utils";
+
+const vaultEnabled = generateGeneralSelector<"vaultEnabled">("vaultEnabled");
+
+export default vaultEnabled;

--- a/src/app/store/general/slice.ts
+++ b/src/app/store/general/slice.ts
@@ -69,6 +69,7 @@ const generalSlice = createSlice({
     pocketsToDisable: generateInitialState([]),
     powerTypes: generateInitialState([]),
     tlsCertificate: generateInitialState(null),
+    vaultEnabled: generateInitialState(null),
     version: generateInitialState(""),
   } as GeneralState,
   reducers: {
@@ -142,6 +143,10 @@ const generalSlice = createSlice({
     fetchTlsCertificateStart: generateStartReducer("tlsCertificate"),
     fetchTlsCertificateError: generateErrorReducer("tlsCertificate"),
     fetchTlsCertificateSuccess: generateSuccessReducer("tlsCertificate"),
+    fetchVaultEnabled: generatePrepareReducer("vault_enabled"),
+    fetchVaultEnabledStart: generateStartReducer("vaultEnabled"),
+    fetchVaultEnabledError: generateErrorReducer("vaultEnabled"),
+    fetchVaultEnabledSuccess: generateSuccessReducer("vaultEnabled"),
     fetchVersion: generatePrepareReducer("version"),
     fetchVersionStart: generateStartReducer("version"),
     fetchVersionError: generateErrorReducer("version"),

--- a/src/app/store/general/types/base.ts
+++ b/src/app/store/general/types/base.ts
@@ -234,6 +234,13 @@ export type TLSCertificateState = {
   loading: boolean;
 };
 
+export type VaultEnabledState = {
+  errors: APIError;
+  data: boolean;
+  loaded: boolean;
+  loading: boolean;
+};
+
 export type Version = string;
 
 export type VersionState = {
@@ -257,5 +264,6 @@ export type GeneralState = {
   pocketsToDisable: PocketsToDisableState;
   powerTypes: PowerTypesState;
   tlsCertificate: TLSCertificateState;
+  vaultEnabled: VaultEnabledState;
   version: VersionState;
 };

--- a/src/app/store/general/types/index.ts
+++ b/src/app/store/general/types/index.ts
@@ -40,6 +40,7 @@ export type {
   PowerTypesState,
   TLSCertificate,
   TLSCertificateState,
+  VaultEnabledState,
   Version,
   VersionState,
 } from "./base";

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -72,6 +72,7 @@ export {
   tlsCertificateState,
   tokenState,
   userState,
+  vaultEnabledState,
   versionState,
   vlanEventError,
   vlanState,

--- a/src/testing/factories/nodes.ts
+++ b/src/testing/factories/nodes.ts
@@ -380,6 +380,7 @@ export const controller = extend<BaseNode, Controller>(node, {
   node_type_display: NodeTypeDisplay.REGION_AND_RACK_CONTROLLER,
   node_type: 4,
   service_ids,
+  vault_configured: false,
   versions: null,
 });
 
@@ -462,6 +463,7 @@ export const controllerDetails = extend<Controller, ControllerDetails>(
     testing_start_time: "Thu, 15 Oct. 2020 07:25:10",
     testing_status: testStatus,
     updated: "Fri, 23 Oct. 2020 05:24:41",
+    vault_configured: false,
     vlan: null,
     vlan_ids: () => [],
     workload_annotations: () => ({}),

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -45,6 +45,7 @@ import type {
   PocketsToDisableState,
   PowerTypesState,
   TLSCertificateState,
+  VaultEnabledState,
   VersionState,
 } from "app/store/general/types";
 import type { IPRangeState } from "app/store/iprange/types";
@@ -468,6 +469,11 @@ export const tlsCertificateState = define<TLSCertificateState>({
   data: null,
 });
 
+export const vaultEnabledState = define<VaultEnabledState>({
+  ...defaultGeneralState,
+  data: false,
+});
+
 export const versionState = define<VersionState>({
   ...defaultGeneralState,
   data: "",
@@ -487,6 +493,7 @@ export const generalState = define<GeneralState>({
   pocketsToDisable: pocketsToDisableState,
   powerTypes: powerTypesState,
   tlsCertificate: tlsCertificateState,
+  vaultEnabled: vaultEnabledState,
   version: versionState,
 });
 


### PR DESCRIPTION
## Done

- Create selector to get vaultEnabled status (true/false)
- Add vaultConfigured to base controller type
- Create selector to split region controllers by vault configuration status (true/false)
- Add vaultEnabledState to general base type
- Write appropriate tests for the above and update others where necessary
- Add vaultEnabledState and vaultConfigured to appropriate factories

## Fixes

Fixes https://github.com/canonical/app-tribe/issues/1405