### PR TITLE
fix: misaligned filter items

### DIFF
--- a/src/app/base/components/FilterAccordion/_index.scss
+++ b/src/app/base/components/FilterAccordion/_index.scss
@@ -45,7 +45,7 @@
   }
 
   .filter-accordion__item {
-    padding-left: $sp-unit * 5;
+    padding-left: $sp-unit * 6;
 
     &.is-active {
       background-image: url("data:image/svg+xml,%3Csvg width='22' height='16' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cpath d='M-1-1h24v24H-1z'/%3E%3Cpath fill='" + vf-url-friendly-color(


### PR DESCRIPTION
## Done

- fix misaligned filter items

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Open filters
- Verify filter items are aligned with the toggle button

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4491

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### After
<img width="355" alt="image" src="https://user-images.githubusercontent.com/7452681/196448338-ae7bacc1-19df-47bb-90c6-3d8d10e1af03.png">

