### PR TITLE
fix: encoded amp character

### DIFF
--- a/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.test.tsx
+++ b/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.test.tsx
@@ -8,42 +8,32 @@ import ConnectivityCard, {
   Labels as ConnectivityCardLabels,
 } from "./ConnectivityCard";
 
+const renderTestCase = () =>
+  render(
+    <Formik
+      initialValues={{
+        httpProxy: "http://www.website.com",
+        mainArchiveUrl: "http://www.mainarchive.com",
+        portsArchiveUrl: "http://www.portsarchive.com",
+        upstreamDns: "8.8.8.8",
+      }}
+      onSubmit={jest.fn()}
+      validationSchema={MaasIntroSchema}
+    >
+      <ConnectivityCard />
+    </Formik>
+  );
+
 describe("ConnectivityCard", () => {
   it("displays a tick when there are no errors", () => {
-    render(
-      <Formik
-        initialValues={{
-          httpProxy: "http://www.website.com",
-          mainArchiveUrl: "http://www.mainarchive.com",
-          portsArchiveUrl: "http://www.portsarchive.com",
-          upstreamDns: "8.8.8.8",
-        }}
-        onSubmit={jest.fn()}
-        validationSchema={MaasIntroSchema}
-      >
-        <ConnectivityCard />
-      </Formik>
-    );
+    renderTestCase();
     const icon = screen.getByLabelText("success");
     expect(icon).toBeInTheDocument();
     expect(icon).toHaveClass("p-icon--success");
   });
 
   it("displays an error icon when there are errors", async () => {
-    render(
-      <Formik
-        initialValues={{
-          httpProxy: "http://www.website.com",
-          mainArchiveUrl: "http://www.mainarchive.com",
-          portsArchiveUrl: "http://www.portsarchive.com",
-          upstreamDns: "8.8.8.8",
-        }}
-        onSubmit={jest.fn()}
-        validationSchema={MaasIntroSchema}
-      >
-        <ConnectivityCard />
-      </Formik>
-    );
+    renderTestCase();
     await userEvent.clear(
       screen.getByRole("textbox", {
         name: ConnectivityCardLabels.MainArchiveUrl,
@@ -52,5 +42,12 @@ describe("ConnectivityCard", () => {
     const icon = screen.getByLabelText("error");
     expect(icon).toBeInTheDocument();
     expect(icon).toHaveClass("p-icon--error");
+  });
+
+  it("displays HTTP proxy field", () => {
+    renderTestCase();
+    expect(
+      screen.getByLabelText("APT & HTTP/HTTPS proxy server")
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.tsx
+++ b/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.tsx
@@ -10,7 +10,7 @@ export enum Labels {
   UpstreamDns = "DNS forwarder",
   MainArchiveUrl = "Ubuntu archive",
   PortsArchiveUrl = "Ubuntu extra architectures",
-  HttpProxy = "APT &amp; HTTP/HTTPS proxy server",
+  HttpProxy = "APT \u0026 HTTP/HTTPS proxy server",
 }
 
 const ConnectivityCard = (): JSX.Element => {


### PR DESCRIPTION
## Done

- fix: encoded amp character
  - use unicode character instead of HTML entity
- refactor and add test case to `ConnectivityCard.test.tsx`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4494

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
