### PR TITLE
fix: clone form search regex

### DIFF
--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -131,4 +131,18 @@ describe("MachineSelectTable", () => {
     await userEvent.keyboard("{enter}");
     expect(onMachineClick).toHaveBeenCalledWith(machine);
   });
+
+  it("renders with partial search string", async () => {
+    const onMachineClick = jest.fn();
+    renderWithMockStore(
+      <MachineSelectTable
+        machines={machines}
+        onMachineClick={onMachineClick}
+        searchText="id:("
+        setSearchText={jest.fn()}
+      />,
+      { state }
+    );
+    expect(screen.getByRole("grid")).toBeInTheDocument();
+  });
 });

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
@@ -2,7 +2,7 @@ import type { KeyboardEvent } from "react";
 import { useEffect } from "react";
 
 import { MainTable } from "@canonical/react-components";
-import { highlightSubString } from "@canonical/react-components/dist/utils";
+import { highlightSubString as baseHighlightSubString } from "@canonical/react-components/dist/utils";
 import { useDispatch, useSelector } from "react-redux";
 
 import Placeholder from "../Placeholder";
@@ -29,6 +29,17 @@ type Props = {
   machinesLoading?: boolean;
   setSearchText: (searchText: string) => void;
 };
+
+const safeGetRegexString = (searchText: string): string => {
+  try {
+    new RegExp(searchText, "i");
+    return searchText;
+  } catch {
+    return "";
+  }
+};
+const highlightSubString = (text: string, highlight: string) =>
+  baseHighlightSubString(text, safeGetRegexString(highlight));
 
 const generateRows = (
   machines: Machine[],


### PR DESCRIPTION
## Done

- fix: clone form search regex

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Select a machine and press Take action -> "Clone from"
- Type in a partial filter text `id:(`
- Verify there are no errors thrown and the table is still visible
- Type in a search string that matches one of the machines displayed
- Verify the name has a highlight matching typed text

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1425

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
