### PR TITLE
fix(machines): repeated machine.count API calls

### DIFF
--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
@@ -77,7 +77,7 @@ describe("MachinesHeader", () => {
           initialEntries={[{ pathname: "/machines", key: "testKey" }]}
         >
           <CompatRouter>
-            <MachinesHeader />
+            <MachinesHeader machineCount={2} />
           </CompatRouter>
         </MemoryRouter>
       </Provider>

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
@@ -8,20 +8,21 @@ import { matchPath, Link } from "react-router-dom-v5-compat";
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
 import SectionHeader from "app/base/components/SectionHeader";
 import urls from "app/base/urls";
-import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { actions as tagActions } from "app/store/tag";
 import tagSelectors from "app/store/tag/selectors";
 
-type Props = SectionHeaderProps;
+type Props = SectionHeaderProps & { machineCount: number };
 
-export const MachinesHeader = (props: Props): JSX.Element => {
+export const MachinesHeader = ({
+  machineCount,
+  ...props
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const location = useLocation();
   const poolCount = useSelector(resourcePoolSelectors.count);
   const tagCount = useSelector(tagSelectors.count);
-  const { machineCount } = useFetchMachineCount();
 
   useEffect(() => {
     dispatch(resourcePoolActions.fetch());

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -65,7 +65,11 @@ describe("MachineListHeader", () => {
   });
 
   it("displays a loader if machines have not loaded", () => {
-    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
+    state.machine.selectedMachines = {
+      groups: ["admin"],
+      grouping: FetchGroupKey.Owner,
+    };
+    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
       loading: true,
     });
     const store = mockStore(state);
@@ -89,7 +93,7 @@ describe("MachineListHeader", () => {
   });
 
   it("displays a machine count if machines have loaded", () => {
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
+    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
       count: 2,
       loaded: true,
     });
@@ -121,10 +125,6 @@ describe("MachineListHeader", () => {
       grouping: FetchGroupKey.Owner,
     };
     state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
       loading: true,
     });
     renderWithBrowserRouter(
@@ -188,10 +188,6 @@ describe("MachineListHeader", () => {
       grouping: FetchGroupKey.Owner,
     };
     state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
       count: 2,
       loaded: true,
     });
@@ -214,10 +210,6 @@ describe("MachineListHeader", () => {
       grouping: FetchGroupKey.Owner,
     };
     state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
       count: 2,
       loaded: true,
     });
@@ -235,11 +227,11 @@ describe("MachineListHeader", () => {
 
   it("displays a message when all machines have been selected", () => {
     state.machine.selectedMachines = { filter: {} };
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
+    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
       count: 10,
       loaded: true,
     });
-    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
+    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
       count: 10,
       loaded: true,
     });

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -49,15 +49,17 @@ export const MachineListHeader = ({
     "machineViewTagsSeen",
     false
   );
-  // Get the count of all machines that match the current filters.
-  const { machineCount } = useFetchMachineCount(
-    FilterMachineItems.parseFetchFilters(searchFilter)
-  );
-  const { selectedCount, selectedCountLoading } = useMachineSelectedCount(
-    FilterMachineItems.parseFetchFilters(searchFilter)
-  );
+  const filter = FilterMachineItems.parseFetchFilters(searchFilter);
+  // Get the count of all machines
+  const { machineCount: allMachineCount } = useFetchMachineCount();
+  // Get the count of all machines that match the current filter
+  const { machineCount: availableMachineCount } = useFetchMachineCount(filter, {
+    isEnabled: FilterMachineItems.isNonEmptyFilter(searchFilter),
+  });
+  // Get the count of selected machines that match the current filter
+  const { selectedCount, selectedCountLoading } =
+    useMachineSelectedCount(filter);
   const previousSelectedCount = usePrevious(selectedCount);
-
   const selectedMachines = useSelector(machineSelectors.selectedMachines);
 
   useEffect(() => {
@@ -133,9 +135,10 @@ export const MachineListHeader = ({
           />
         )
       }
+      machineCount={allMachineCount}
       subtitle={
         <ModelListSubtitle
-          available={machineCount}
+          available={availableMachineCount || allMachineCount}
           modelName="machine"
           selected={selectedCount}
         />

--- a/src/app/pools/views/Pools.tsx
+++ b/src/app/pools/views/Pools.tsx
@@ -9,10 +9,12 @@ import urls from "app/base/urls";
 import NotFound from "app/base/views/NotFound";
 import PoolAdd from "app/pools/views/PoolAdd";
 import PoolEdit from "app/pools/views/PoolEdit";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import { getRelativeRoute } from "app/utils";
 
 const Pools = (): JSX.Element => {
   const base = urls.pools.index;
+  const { machineCount } = useFetchMachineCount();
   return (
     <Section
       header={
@@ -22,6 +24,7 @@ const Pools = (): JSX.Element => {
               Add pool
             </Button>,
           ]}
+          machineCount={machineCount}
         />
       }
     >

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -149,6 +149,28 @@ describe("machine hook utils", () => {
       expect(getDispatches()).toHaveLength(1);
     });
 
+    it("fetches if isEnabled changes back to true", async () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        (queryOptions: UseFetchQueryOptions) =>
+          useFetchMachineCount({ hostname: "spotted-quoll" }, queryOptions),
+        {
+          initialProps: { isEnabled: true },
+          wrapper: generateWrapper(store),
+        }
+      );
+      const expectedActionType = machineActions.count("mocked-nanoid-1").type;
+      const getDispatches = () =>
+        store
+          .getActions()
+          .filter((action) => action.type === expectedActionType);
+      expect(getDispatches()).toHaveLength(1);
+      rerender({ isEnabled: false });
+      expect(getDispatches()).toHaveLength(1);
+      rerender({ isEnabled: true });
+      expect(getDispatches()).toHaveLength(2);
+    });
+
     it("returns the machine count", async () => {
       jest.restoreAllMocks();
       jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid");
@@ -343,6 +365,28 @@ describe("machine hook utils", () => {
       expect(getDispatches()).toHaveLength(0);
       rerender({ isEnabled: true });
       expect(getDispatches()).toHaveLength(1);
+    });
+
+    it("fetches again if isEnabled changes back to true", async () => {
+      const store = mockStore(state);
+      const { rerender } = renderHook(
+        (queryOptions: UseFetchQueryOptions) =>
+          useFetchMachines(undefined, queryOptions),
+        {
+          initialProps: { isEnabled: true },
+          wrapper: generateWrapper(store),
+        }
+      );
+      const expectedActionType = machineActions.fetch("mocked-nanoid-1").type;
+      const getDispatches = () =>
+        store
+          .getActions()
+          .filter((action) => action.type === expectedActionType);
+      expect(getDispatches()).toHaveLength(1);
+      rerender({ isEnabled: false });
+      expect(getDispatches()).toHaveLength(1);
+      rerender({ isEnabled: true });
+      expect(getDispatches()).toHaveLength(2);
     });
 
     it("does not fetch again if the options haven't changed including empty objects", () => {

--- a/src/app/store/machine/utils/search.test.ts
+++ b/src/app/store/machine/utils/search.test.ts
@@ -218,3 +218,11 @@ describe("client side search", () => {
     });
   });
 });
+
+it("isNonEmptyFilter returns false for empty search string", () => {
+  expect(FilterMachineItems.isNonEmptyFilter("")).toBe(false);
+});
+
+it("isNonEmptyFilter returns true for defined search string", () => {
+  expect(FilterMachineItems.isNonEmptyFilter("status:(=broken)")).toBe(true);
+});

--- a/src/app/store/machine/utils/search.ts
+++ b/src/app/store/machine/utils/search.ts
@@ -1,3 +1,5 @@
+import fastDeepEqual from "fast-deep-equal";
+
 import { MachineMeta } from "app/store/machine/types";
 import type { Machine, FetchFilters } from "app/store/machine/types";
 import type { Tag } from "app/store/tag/types";
@@ -240,6 +242,10 @@ class FilterMachineHandlers extends FilterHandlers {
       },
       {}
     );
+  };
+
+  isNonEmptyFilter = (filter: string) => {
+    return !fastDeepEqual(this.parseFetchFilters(filter), {});
   };
 
   /**

--- a/src/app/tags/components/TagsHeader/TagsHeader.tsx
+++ b/src/app/tags/components/TagsHeader/TagsHeader.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@canonical/react-components";
 
 import MachinesHeader from "app/base/components/node/MachinesHeader";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import TagHeaderForms from "app/tags/components/TagsHeader/TagHeaderForms";
 import { TagHeaderViews } from "app/tags/constants";
 import type { TagHeaderContent, TagSetHeaderContent } from "app/tags/types";
@@ -37,6 +38,7 @@ export const TagsHeader = ({
   setHeaderContent,
   tagViewState,
 }: Props): JSX.Element => {
+  const { machineCount } = useFetchMachineCount();
   return (
     <MachinesHeader
       aria-label={Label.Header}
@@ -62,6 +64,7 @@ export const TagsHeader = ({
           />
         )
       }
+      machineCount={machineCount}
       title={getHeaderTitle(headerContent)}
     />
   );


### PR DESCRIPTION
## Done

- Itemised list of what was changed by this PR.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Verify that only 2 machine.count API calls are made when there are no search filters
- Select a filter
- Verify that a single additional single call has been made for the count of machines matching the selected filter

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4488

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
