### PR TITLE
feat(kvm): pass selected state to action forms

### DIFF
--- a/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -23,6 +23,7 @@ type Props = {
   headerContent: KVMHeaderContent | null;
   loading?: SectionHeaderProps["loading"];
   setHeaderContent: KVMSetHeaderContent;
+  searchFilter?: string;
   setSearchFilter?: SetSearchFilter;
   tabLinks: SectionHeaderProps["tabLinks"];
   title: ReactNode;
@@ -35,6 +36,7 @@ const KVMDetailsHeader = ({
   headerContent,
   loading,
   setHeaderContent,
+  searchFilter,
   setSearchFilter,
   tabLinks,
   title,
@@ -59,6 +61,7 @@ const KVMDetailsHeader = ({
         headerContent ? (
           <KVMHeaderForms
             headerContent={headerContent}
+            searchFilter={searchFilter}
             setHeaderContent={setHeaderContent}
             setSearchFilter={setSearchFilter}
           />

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
@@ -20,16 +20,25 @@ import type { SelectedMachines } from "app/store/machine/types";
 type Props = {
   headerContent: KVMHeaderContent | null;
   setHeaderContent: KVMSetHeaderContent;
+  searchFilter?: string;
   setSearchFilter?: SetSearchFilter;
 };
 
-const getFormComponent = (
-  headerContent: KVMHeaderContent,
-  setHeaderContent: KVMSetHeaderContent,
-  clearHeaderContent: ClearHeaderContent,
-  selectedMachines: SelectedMachines | null,
-  setSearchFilter?: SetSearchFilter
-) => {
+const getFormComponent = ({
+  headerContent,
+  setHeaderContent,
+  clearHeaderContent,
+  selectedMachines,
+  searchFilter,
+  setSearchFilter,
+}: {
+  headerContent: KVMHeaderContent;
+  setHeaderContent: KVMSetHeaderContent;
+  clearHeaderContent: ClearHeaderContent;
+  selectedMachines: SelectedMachines | null;
+  searchFilter?: string;
+  setSearchFilter?: SetSearchFilter;
+}) => {
   if (!headerContent) {
     return null;
   }
@@ -93,6 +102,7 @@ const getFormComponent = (
   return (
     <MachineHeaderForms
       headerContent={machineHeaderContent}
+      searchFilter={searchFilter}
       selectedMachines={selectedMachines}
       setHeaderContent={setHeaderContent}
       setSearchFilter={setSearchFilter}
@@ -104,6 +114,7 @@ const getFormComponent = (
 const KVMHeaderForms = ({
   headerContent,
   setHeaderContent,
+  searchFilter,
   setSearchFilter,
 }: Props): JSX.Element | null => {
   const selectedMachines = useSelector(machineSelectors.selectedMachines);
@@ -118,13 +129,14 @@ const KVMHeaderForms = ({
   }
   return (
     <div ref={onRenderRef}>
-      {getFormComponent(
+      {getFormComponent({
         headerContent,
         setHeaderContent,
         clearHeaderContent,
         selectedMachines,
-        setSearchFilter
-      )}
+        searchFilter,
+        setSearchFilter,
+      })}
     </div>
   );
 };

--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
+import { usePrevious } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
 
 import VMsActionBar from "./VMsActionBar";
@@ -68,6 +69,15 @@ const LXDVMsTable = ({
     pagination: { currentPage, setCurrentPage, pageSize: VMS_PER_PAGE },
   });
   const count = useFetchedCount(machineCount, loading);
+  const previousSearchFilter = usePrevious(searchFilter);
+
+  useEffect(() => {
+    // Clear machine selection and close the action form on filters change
+    if (searchFilter !== previousSearchFilter) {
+      setHeaderContent(null);
+      dispatch(machineActions.setSelectedMachines(null));
+    }
+  }, [searchFilter, previousSearchFilter, setHeaderContent, dispatch]);
 
   useEffect(
     () => () => {
@@ -94,6 +104,7 @@ const LXDVMsTable = ({
         getHostColumn={getHostColumn}
         getResources={getResources}
         machinesLoading={loading}
+        pods={pods}
         searchFilter={searchFilter}
         setSortDirection={setSortDirection}
         setSortKey={setSortKey}

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -11,6 +11,8 @@ import VMsTable, { Label } from "./VMsTable";
 import { SortDirection } from "app/base/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import {
+  pod as podFactory,
+  podState as podStateFactory,
   machine as machineFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
@@ -41,6 +43,7 @@ describe("VMsTable", () => {
         getHostColumn={undefined}
         getResources={getResources}
         machinesLoading={true}
+        pods={[]}
         searchFilter=""
         setSortDirection={jest.fn()}
         setSortKey={jest.fn()}
@@ -91,6 +94,7 @@ describe("VMsTable", () => {
             <VMsTable
               getResources={getResources}
               machinesLoading={false}
+              pods={[]}
               searchFilter=""
               setSortDirection={setSortDirection}
               setSortKey={setSortKey}
@@ -109,6 +113,7 @@ describe("VMsTable", () => {
   });
 
   it("can dispatch an action to select all VMs", () => {
+    const pod = podFactory({ id: 1, name: "pod-1" });
     const vms = [
       machineFactory({
         system_id: "abc123",
@@ -122,6 +127,7 @@ describe("VMsTable", () => {
         items: vms,
         selectedMachines: null,
       }),
+      pod: podStateFactory({ items: [pod], loaded: true }),
     });
     const store = mockStore(state);
     const wrapper = mount(
@@ -133,6 +139,7 @@ describe("VMsTable", () => {
             <VMsTable
               getResources={getResources}
               machinesLoading={false}
+              pods={[pod.name]}
               searchFilter=""
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}
@@ -154,11 +161,12 @@ describe("VMsTable", () => {
         .find((action) => action.type === "machine/setSelectedMachines")
     ).toStrictEqual({
       type: "machine/setSelectedMachines",
-      payload: { filter: {} },
+      payload: { filter: { pod: [pod.name] } },
     });
   });
 
   it("can dispatch an action to unselect all VMs", () => {
+    const pod = podFactory({ id: 1, name: "pod-1" });
     const vms = [
       machineFactory({
         system_id: "abc123",
@@ -172,6 +180,7 @@ describe("VMsTable", () => {
         items: vms,
         selectedMachines: { filter: {} },
       }),
+      pod: podStateFactory({ items: [pod], loaded: true }),
     });
     const store = mockStore(state);
     const wrapper = mount(
@@ -183,6 +192,7 @@ describe("VMsTable", () => {
             <VMsTable
               getResources={getResources}
               machinesLoading={false}
+              pods={[pod.name]}
               searchFilter=""
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}
@@ -224,6 +234,7 @@ describe("VMsTable", () => {
             <VMsTable
               getResources={getResources}
               machinesLoading={false}
+              pods={[]}
               searchFilter="system_id:(=ghi789)"
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}
@@ -259,6 +270,7 @@ describe("VMsTable", () => {
               displayForCluster
               getResources={getResources}
               machinesLoading={false}
+              pods={[]}
               searchFilter="system_id:(=ghi789)"
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}
@@ -290,6 +302,7 @@ describe("VMsTable", () => {
               getHostColumn={jest.fn()}
               getResources={getResources}
               machinesLoading={false}
+              pods={[]}
               searchFilter=""
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}
@@ -318,6 +331,7 @@ describe("VMsTable", () => {
               getHostColumn={undefined}
               getResources={getResources}
               machinesLoading={false}
+              pods={[]}
               searchFilter=""
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}
@@ -356,6 +370,7 @@ describe("VMsTable", () => {
             <VMsTable
               getResources={getResources}
               machinesLoading={false}
+              pods={[]}
               searchFilter=""
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}
@@ -384,6 +399,7 @@ describe("VMsTable", () => {
               getHostColumn={jest.fn()}
               getResources={getResources}
               machinesLoading={false}
+              pods={[]}
               searchFilter=""
               setSortDirection={jest.fn()}
               setSortKey={jest.fn()}

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.tsx
@@ -16,8 +16,9 @@ import TableHeader from "app/base/components/TableHeader";
 import { SortDirection } from "app/base/types";
 import AllCheckbox from "app/machines/views/MachineList/MachineListTable/AllCheckbox";
 import type { Machine } from "app/store/machine/types";
-import { FetchGroupKey } from "app/store/machine/types";
+import { FilterGroupKey, FetchGroupKey } from "app/store/machine/types";
 import { FilterMachineItems } from "app/store/machine/utils";
+import type { Pod } from "app/store/pod/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag } from "app/store/tag/types";
 import { getTagNamesForIds } from "app/store/tag/utils";
@@ -48,6 +49,7 @@ type Props = {
   getHostColumn?: GetHostColumn;
   getResources: GetResources;
   machinesLoading: boolean;
+  pods: Pod["name"][];
   searchFilter: string;
   sortDirection: ValueOf<typeof SortDirection>;
   sortKey: FetchGroupKey | null;
@@ -250,6 +252,7 @@ const VMsTable = ({
   sortDirection,
   sortKey,
   vms,
+  pods,
 }: Props): JSX.Element => {
   const tags = useSelector(tagSelectors.all);
   const currentSort = {
@@ -291,7 +294,11 @@ const VMsTable = ({
               <div className="u-flex">
                 <AllCheckbox
                   callId={callId}
-                  filter={FilterMachineItems.parseFetchFilters(searchFilter)}
+                  filter={{
+                    ...FilterMachineItems.parseFetchFilters(searchFilter),
+                    // Set the filters to get results that belong to this single pod or pods in a cluster.
+                    [FilterGroupKey.Pod]: pods,
+                  }}
                 />
                 <div>
                   <TableHeader


### PR DESCRIPTION
## Done

- feat(kvm): pass selected state to action forms

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

-  Go to virtual machines page (e.g. `/MAAS/r/kvm/lxd/2/vms`)
- Select all VMs on the list
- Dispatch an action (e.g. Abort)
- Verify the machine.action was dispatched with the right parameter (including a pod that limits the request to that particular pod) and response returned with the correct success count / failed ids count that reflects the number of machines that were selected.

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1304

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
