### PR TITLE
chore: Upgrade GitHub actions to Ubuntu 22.04

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   cypress-axe:
     name: cypress-axe
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAAS_URL: http://localhost:5240
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -3,7 +3,7 @@ on: [push]
 jobs:
   cypress:
     name: Cypress
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAAS_URL: http://localhost:5240
     steps:
@@ -59,7 +59,7 @@ jobs:
           update_existing: true
   docs:
     name: maas.io/docs links
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@main
       - name: Get branch name

--- a/.github/workflows/lp-to-gh-issues.yml
+++ b/.github/workflows/lp-to-gh-issues.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   lp-to-gh-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -6,7 +6,7 @@ jobs:
   run-sitespeed:
     if: github.event.pull_request.merged == true
     name: Run sitespeed.io
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MAAS_DOMAIN: localhost
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.x]
@@ -32,7 +32,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.x]
@@ -55,7 +55,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         node-version: [16.x]
@@ -82,7 +82,7 @@ jobs:
 
   run-dotrun:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Install dotrun

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -6,7 +6,7 @@ jobs:
   upload-build:
     if: github.event.pull_request.merged == true
     name: Upload build artifacts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PACKAGE_NAME: maas-ui-${{ github.sha }}.tar.gz
     strategy:


### PR DESCRIPTION
## Done

Upgrade GH actions to run on Ubuntu 22.04 for:
- Accessibility
- Cypress
- Sitespeed
- CI (Lint/Build/Test/Dotrun)

Fixes #4220 