### PR TITLE
fix(vault): Change icon colours to accessible grey

### DIFF
--- a/src/scss/_patterns_icons.scss
+++ b/src/scss/_patterns_icons.scss
@@ -77,12 +77,12 @@
 
   .p-icon--security-tick {
     @extend %icon;
-    @include maas-icon-security-tick($color-positive)
+    @include maas-icon-security-tick($color-mid-dark)
   }
 
   .p-icon--security-warning {
     @extend %icon;
-    @include maas-icon-security-warning($color-warning);
+    @include maas-icon-security-warning($color-mid-dark);
   }
 
   .p-icon--security-warning-grey {


### PR DESCRIPTION
## Done

- Change Vault status icon colours to accessible grey `#666`
Requested by @lyubomir-popov 

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/197187842-ae1f515c-86f1-4ee0-a546-90bb1e01d538.png)
![image](https://user-images.githubusercontent.com/35104482/197187980-fdbc7209-d66d-4bcd-abc8-cd0dda72b00f.png)
![image](https://user-images.githubusercontent.com/35104482/197189305-717edd99-f9f3-4efb-af14-fdf10ed27c21.png)
![image](https://user-images.githubusercontent.com/35104482/197189478-1e0b116d-2847-4ea7-a379-8a4f70ca02ac.png)

### After
![image](https://user-images.githubusercontent.com/35104482/197187813-db974662-3ac4-4d84-83a2-109da221bfa9.png)
![image](https://user-images.githubusercontent.com/35104482/197187921-0dcdb896-54fd-42ac-9d4b-c7723cdade6c.png)
![image](https://user-images.githubusercontent.com/35104482/197189241-118accfd-80bc-44d6-ad67-6332dc000759.png)
![image](https://user-images.githubusercontent.com/35104482/197189423-ea8150f9-f1d9-459d-81ca-36fdc3be4099.png)

