### PR TITLE
ci: add git sha to build upload

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       PACKAGE_NAME: maas-ui-${{ github.sha }}.tar.gz
+      REACT_APP_GIT_SHA: ${{ github.sha }}
     strategy:
       matrix:
         node-version: [16.x]
@@ -30,7 +31,7 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: CYPRESS_INSTALL_BINARY=0 yarn install
       - name: Build
-        run: yarn build
+        run: REACT_APP_GIT_SHA=${{env.REACT_APP_GIT_SHA}} yarn build
         env:
           CI: false
       - name: Compress

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "analyze": "npx -y source-map-explorer 'build/static/js/*.js'",
     "build-all": "yarn build",
-    "build": "REACT_APP_GIT_SHA=$(git rev-parse HEAD) CYPRESS_INSTALL_BINARY=0 yarn install && react-scripts build",
+    "build": "CYPRESS_INSTALL_BINARY=0 yarn install && react-scripts build",
     "clean-all": "yarn clean",
     "clean": "rm -rf node_modules build",
     "cleanbuild": "yarn clean-all && yarn build",
@@ -24,7 +24,7 @@
     "percy": "./cypress/percy.sh",
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
     "serve-proxy": "nodemon ./scripts/proxy.js",
-    "serve-react": "BROWSER=none PORT=8401 REACT_APP_GIT_SHA=$(git rev-parse HEAD) react-scripts start",
+    "serve-react": "BROWSER=none PORT=8401 react-scripts start",
     "serve-static-demo": "STATIC_DEMO=true PROXY_PORT=80 nodemon ./scripts/proxy.js",
     "serve": "yarn start",
     "show-ready": "wait-on http-get://0.0.0.0:8401 && nodemon ./scripts/proxy-ready.js",


### PR DESCRIPTION
## Done

- ci: add git sha to build upload

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- None required

## Fixes


## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
