### PR TITLE
fix(vault): Hide warning message in controller list before Vault setup

### DIFF
--- a/src/app/controllers/views/ControllerList/ControllerList.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerList.tsx
@@ -74,7 +74,7 @@ const ControllerList = (): JSX.Element => {
         />
       }
     >
-      {configuredControllers.length >= 0 &&
+      {configuredControllers.length >= 1 &&
       unconfiguredControllers.length >= 1 ? (
         <Notification severity="caution" title="Incomplete Vault integration">
           Configure {unconfiguredControllers.length} other{" "}


### PR DESCRIPTION
## Done

- Hide the "Incomplete Vault integration" warning in controller listing if Vault setup has not begun

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure there are no Vault-related warning messages on the Controller list (bolla/polong)