### PR TITLE
fix: display vault notification once loaded

### DIFF
--- a/src/app/base/components/VaultNotification/VaultNotification.test.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.test.tsx
@@ -1,0 +1,27 @@
+import { screen } from "@testing-library/react";
+
+import VaultNotification from "./VaultNotification";
+
+import { rootState as rootStateFactory } from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
+
+it("does not display a notification when data has not loaded", async () => {
+  const state = rootStateFactory();
+  state.controller.loaded = false;
+  renderWithBrowserRouter(<VaultNotification />, {
+    wrapperProps: { state },
+  });
+  expect(
+    screen.queryByText(/Incomplete Vault integration/)
+  ).not.toBeInTheDocument();
+});
+
+it("displays a notification when data has loaded", async () => {
+  const state = rootStateFactory();
+  state.controller.loaded = true;
+  state.general.vaultEnabled.loaded = true;
+  renderWithBrowserRouter(<VaultNotification />, {
+    wrapperProps: { state },
+  });
+  expect(screen.getByText(/Incomplete Vault integration/)).toBeInTheDocument();
+});

--- a/src/app/base/components/VaultNotification/VaultNotification.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.tsx
@@ -1,0 +1,50 @@
+import { Notification } from "@canonical/react-components";
+import { useSelector } from "react-redux";
+import { Link } from "react-router-dom-v5-compat";
+
+import controllerSelectors from "app/store/controller/selectors";
+import { vaultEnabled as vaultEnabledSelectors } from "app/store/general/selectors";
+import type { RootState } from "app/store/root/types";
+
+const VaultNotification = (): JSX.Element | null => {
+  const { unconfiguredControllers, configuredControllers } = useSelector(
+    (state: RootState) =>
+      controllerSelectors.getVaultConfiguredControllers(state)
+  );
+  const vaultEnabled = useSelector(vaultEnabledSelectors.get);
+  const vaultEnabledLoaded = useSelector(vaultEnabledSelectors.loaded);
+  const controllersLoaded = useSelector(controllerSelectors.loaded);
+
+  if (!vaultEnabledLoaded || !controllersLoaded) {
+    return null;
+  }
+
+  return configuredControllers.length >= 1 &&
+    unconfiguredControllers.length >= 1 ? (
+    <Notification
+      data-testid="vault-notification"
+      severity="caution"
+      title="Incomplete Vault integration"
+    >
+      Configure {unconfiguredControllers.length} other{" "}
+      <Link to="/controllers">
+        {unconfiguredControllers.length > 1 ? "controllers" : "controller"}
+      </Link>{" "}
+      with Vault to complete this operation. Check the{" "}
+      <Link to="/settings/configuration/security">security settings</Link> for
+      more information.
+    </Notification>
+  ) : unconfiguredControllers.length === 0 && vaultEnabled === false ? (
+    <Notification
+      data-testid="vault-notification"
+      severity="caution"
+      title="Incomplete Vault integration"
+    >
+      Migrate your secrets to Vault to complete this operation. Check the{" "}
+      <Link to="/settings/configuration/security">security settings</Link> for
+      more information.
+    </Notification>
+  ) : null;
+};
+
+export default VaultNotification;

--- a/src/app/base/components/VaultNotification/index.ts
+++ b/src/app/base/components/VaultNotification/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./VaultNotification";

--- a/src/app/controllers/views/ControllerList/ControllerList.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerList.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { Link, Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
 import { useNavigate } from "react-router-dom-v5-compat";
@@ -10,6 +9,7 @@ import ControllerListHeader from "./ControllerListHeader";
 import ControllerListTable from "./ControllerListTable";
 
 import Section from "app/base/components/Section";
+import VaultNotification from "app/base/components/VaultNotification";
 import { useWindowTitle } from "app/base/hooks";
 import type { ControllerHeaderContent } from "app/controllers/types";
 import { actions as controllerActions } from "app/store/controller";
@@ -36,16 +36,11 @@ const ControllerList = (): JSX.Element => {
   );
   const selectedIDs = useSelector(controllerSelectors.selectedIDs);
 
-  const { unconfiguredControllers, configuredControllers } = useSelector(
-    (state: RootState) =>
-      controllerSelectors.getVaultConfiguredControllers(state)
-  );
   const filteredControllers = useSelector((state: RootState) =>
     controllerSelectors.search(state, searchFilter || null, selectedIDs)
   );
   const controllersLoading = useSelector(controllerSelectors.loading);
   const vaultEnabledLoading = useSelector(vaultEnabledSelectors.loading);
-  const vaultEnabled = useSelector(vaultEnabledSelectors.get);
   useWindowTitle("Controllers");
 
   useEffect(() => {
@@ -74,24 +69,7 @@ const ControllerList = (): JSX.Element => {
         />
       }
     >
-      {configuredControllers.length >= 1 &&
-      unconfiguredControllers.length >= 1 ? (
-        <Notification severity="caution" title="Incomplete Vault integration">
-          Configure {unconfiguredControllers.length} other{" "}
-          <Link href="/controllers">
-            {unconfiguredControllers.length > 1 ? "controllers" : "controller"}
-          </Link>{" "}
-          with Vault to complete this operation. Check the{" "}
-          <Link href="/settings/configuration/security">security settings</Link>{" "}
-          for more information.
-        </Notification>
-      ) : unconfiguredControllers.length === 0 && vaultEnabled === false ? (
-        <Notification severity="caution" title="Incomplete Vault integration">
-          Migrate your secrets to Vault to complete this operation. Check the{" "}
-          <Link href="/settings/configuration/security">security settings</Link>{" "}
-          for more information.
-        </Notification>
-      ) : null}
+      <VaultNotification />
       <ControllerListControls
         filter={searchFilter}
         setFilter={setSearchFilter}

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
-import { Link, Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
@@ -10,18 +9,16 @@ import MachineListControls from "./MachineListControls";
 import MachineListTable from "./MachineListTable";
 import { DEFAULTS } from "./MachineListTable/constants";
 
+import VaultNotification from "app/base/components/VaultNotification";
 import { useWindowTitle } from "app/base/hooks";
 import type { SetSearchFilter, SortDirection } from "app/base/types";
 import { actions as controllerActions } from "app/store/controller";
-import controllerSelectors from "app/store/controller/selectors";
 import { actions as generalActions } from "app/store/general";
-import { vaultEnabled as vaultEnabledSelectors } from "app/store/general/selectors";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { FetchGroupKey } from "app/store/machine/types";
 import { mapSortDirection, FilterMachineItems } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
-import type { RootState } from "app/store/root/types";
 
 type Props = {
   headerFormOpen?: boolean;
@@ -80,12 +77,6 @@ const MachineList = ({
     []
   );
 
-  const { unconfiguredControllers, configuredControllers } = useSelector(
-    (state: RootState) =>
-      controllerSelectors.getVaultConfiguredControllers(state)
-  );
-  const vaultEnabled = useSelector(vaultEnabledSelectors.get);
-
   const { callId, loading, machineCount, machines, machinesErrors } =
     useFetchMachines({
       collapsedGroups: hiddenGroups,
@@ -121,32 +112,7 @@ const MachineList = ({
         />
       ) : null}
       {!headerFormOpen ? <ErrorsNotification errors={machinesErrors} /> : null}
-      {configuredControllers.length >= 1 &&
-      unconfiguredControllers.length >= 1 ? (
-        <Notification
-          data-testid="vault-notification"
-          severity="caution"
-          title="Incomplete Vault integration"
-        >
-          Configure {unconfiguredControllers.length} other{" "}
-          <Link href="/controllers">
-            {unconfiguredControllers.length > 1 ? "controllers" : "controller"}
-          </Link>{" "}
-          with Vault to complete this operation. Check the{" "}
-          <Link href="/settings/configuration/security">security settings</Link>{" "}
-          for more information.
-        </Notification>
-      ) : unconfiguredControllers.length === 0 && vaultEnabled === false ? (
-        <Notification
-          data-testid="vault-notification"
-          severity="caution"
-          title="Incomplete Vault integration"
-        >
-          Migrate your secrets to Vault to complete this operation. Check the{" "}
-          <Link href="/settings/configuration/security">security settings</Link>{" "}
-          for more information.
-        </Notification>
-      ) : null}
+      <VaultNotification />
       <MachineListControls
         filter={searchFilter}
         grouping={grouping}


### PR DESCRIPTION
## Done

- display vault notification only once the data has loaded (this fixes a flash of the vault notification on load)
- move vault notification into own component
- use react-router `Link` component with `to` prop

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify that vault notification is displayed under the same conditions as before.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
