### PR TITLE
fix: render routes on auth loaded

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -32,6 +32,7 @@ export const App = (): JSX.Element => {
   const authenticated = useSelector(status.authenticated);
   const authenticating = useSelector(status.authenticating);
   const authLoading = useSelector(authSelectors.loading);
+  const authLoaded = useSelector(authSelectors.loaded);
   const connected = useSelector(status.connected);
   const connecting = useSelector(status.connecting);
   const connectionError = useSelector(status.error);
@@ -82,7 +83,7 @@ export const App = (): JSX.Element => {
         </Notification>
       </Section>
     );
-  } else if (connected) {
+  } else if (connected && authLoaded && authenticated) {
     content = (
       <FileContext.Provider value={fileContextStore}>
         <Routes />


### PR DESCRIPTION
## Done

- fix: render logged in routes on auth fully loaded
  - this fixes a flash of logged routes that would cause components to briefly render (and in the case of machine listing request machines more than once after refresh/login).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify that you can log in and log out
- Go to machine listing and verify that machines were requested once by looking at the websocket requests

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4506

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
