### PR TITLE
fix: clear machine list selection on delete success

### DIFF
--- a/src/app/base/components/node/DeleteForm/DeleteForm.tsx
+++ b/src/app/base/components/node/DeleteForm/DeleteForm.tsx
@@ -8,6 +8,7 @@ import { capitaliseFirst } from "app/utils";
 
 type Props<E = null> = NodeActionFormProps<E> & {
   onSubmit: () => void;
+  onAfterSuccess?: () => void;
   redirectURL: string;
 };
 
@@ -17,6 +18,7 @@ export const DeleteForm = <E,>({
   errors,
   modelName,
   nodes,
+  onAfterSuccess,
   onSubmit,
   processingCount,
   selectedCount,
@@ -42,7 +44,10 @@ export const DeleteForm = <E,>({
         label: "Delete",
       }}
       onSubmit={onSubmit}
-      onSuccess={clearHeaderContent}
+      onSuccess={() => {
+        clearHeaderContent();
+        onAfterSuccess?.();
+      }}
       processingCount={processingCount}
       savedRedirect={viewingDetails ? redirectURL : undefined}
       selectedCount={nodes ? nodes.length : selectedCount ?? 0}

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
@@ -15,6 +15,7 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 import { renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
@@ -96,4 +97,37 @@ it("can show untag errors when the tag form is open", async () => {
   );
 
   expect(screen.getByText("Untagging failed")).toBeInTheDocument();
+});
+
+it("clears selected machines on delete success", async () => {
+  mockFormikFormSaved();
+  const state = rootStateFactory();
+  const machines = [
+    machineFactory({
+      system_id: "abc123",
+    }),
+  ];
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <CompatRouter>
+          <MachineActionFormWrapper
+            action={NodeActions.DELETE}
+            clearHeaderContent={jest.fn()}
+            selectedMachines={{ items: [machines[0].system_id] }}
+            viewingDetails={false}
+          />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+
+  expect(
+    store
+      .getActions()
+      .find((action) => action.type === "machine/setSelectedMachines").payload
+  ).toEqual(null);
 });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
@@ -80,6 +80,8 @@ export const MachineActionFormWrapper = ({
     selectedCount,
     selectedCountLoading,
   };
+  const clearSelectedMachines = () =>
+    dispatch(machineActions.setSelectedMachines(null));
 
   const filter = selectedToFilters(selectedMachines || null);
 
@@ -100,6 +102,7 @@ export const MachineActionFormWrapper = ({
       case NodeActions.DELETE:
         return (
           <DeleteForm
+            onAfterSuccess={clearSelectedMachines}
             onSubmit={() => {
               dispatchForSelectedMachines(machineActions.delete);
             }}


### PR DESCRIPTION
## Done

- fix: clear machine list selection on delete success

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

Repeat the steps below on the machine list and kvm page (`/MAAS/r/kvm/lxd/[id]/vms`):

- Delete a machine
- Verify the number of selected machines is 0 after deletion


## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
