### PR TITLE
add sitespeed workflow to 3.2

### DIFF
--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -1,0 +1,51 @@
+name: sitespeed.io
+on:
+  push:
+    branches:
+      - 3.2
+  pull_request:
+    branches:
+      - 3.2
+jobs:
+  run-sitespeed:
+    # if: github.event.pull_request.merged == true
+    name: Run sitespeed.io
+    runs-on: ubuntu-20.04
+    env:
+      MAAS_DOMAIN: localhost
+    steps:
+      - uses: actions/checkout@main
+      - name: Install MAAS
+        run: |
+          sudo systemctl enable snapd
+          sudo snap install maas-test-db --channel=3.2/stable
+          sudo snap install maas --channel=3.2/stable
+      - name: Fetch database dump
+        uses: wei/wget@v1
+        with:
+          args: -O maasdb.dump https://github.com/canonical/maas-ui-testing/raw/main/db/maasdb-20.04-3.2-1000.dump
+      - name: Set up MAAS with database dump
+        run: |
+          sudo sed -i "s/dynamic_shared_memory_type = posix/dynamic_shared_memory_type = sysv/" /var/snap/maas-test-db/common/postgres/data/postgresql.conf
+          sudo snap restart maas-test-db
+          sudo mv maasdb.dump /var/snap/maas-test-db/common/maasdb.dump
+          sudo snap run --shell maas-test-db.psql -c 'db-dump restore /var/snap/maas-test-db/common/maasdb.dump maassampledata'
+          sudo maas init region+rack --maas-url=http://${{env.MAAS_DOMAIN}}:5240/MAAS --database-uri maas-test-db:///
+          sudo sed -i "s/database_name: maasdb/database_name: maassampledata/" /var/snap/maas/current/regiond.conf
+          sudo snap restart maas
+      - name: Create MAAS admin
+        run: sudo maas createadmin --username=admin --password=test --email=fake@example.org
+      - name: Wait for MAAS
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: "http://${{env.MAAS_DOMAIN}}:5240/MAAS/r"
+          responseCode: 200
+          timeout: 200000
+          interval: 500
+      - name: Run sitespeed.io tests
+        run: yarn sitespeed --browsertime.domain=${{env.MAAS_DOMAIN}}
+      - name: Upload results
+        uses: actions/upload-artifact@v2
+        with:
+          name: sitespeed.io-results
+          path: sitespeed.io/results

--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -1,14 +1,10 @@
 name: sitespeed.io
 on:
-  push:
-    branches:
-      - 3.2
   pull_request:
-    branches:
-      - 3.2
+    types: [closed]
 jobs:
   run-sitespeed:
-    # if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     name: Run sitespeed.io
     runs-on: ubuntu-20.04
     env:

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lint-root": "cd root && yarn run lint",
     "lint-cypress": "cd integration && yarn run lint",
     "lint": "yarn build-shared && yarn lint-legacy && yarn lint-ui && yarn lint-shared && yarn lint-root && yarn lint-cypress",
+    "sitespeed": "docker run -v \"$(pwd)/sitespeed.io:/sitespeed.io\" --network=host sitespeedio/sitespeed.io:25.2.1 --config /sitespeed.io/config.json /sitespeed.io/scripts/machines.js --multi --spa",
     "test-cypress": "yarn --cwd integration run cypress-test",
     "test-legacy": "cd legacy && yarn run test",
     "test-ui": "cd ui && yarn run test --watchAll=false",

--- a/sitespeed.io/config.json
+++ b/sitespeed.io/config.json
@@ -1,0 +1,8 @@
+{
+  "browsertime": {
+    "domain": "localhost",
+    "port": 5240,
+    "preScript": "./login.js"
+  },
+  "outputFolder": "./results"
+}

--- a/sitespeed.io/login.js
+++ b/sitespeed.io/login.js
@@ -1,0 +1,26 @@
+const { constructURL } = require("./utils");
+
+const TIMEOUT = 5000;
+
+module.exports = async function (context, commands) {
+  await commands.cdp.send("Network.setCookie", {
+    domain: context.options.domain,
+    name: "skipsetupintro",
+    value: "true",
+  });
+  await commands.cdp.send("Network.setCookie", {
+    domain: context.options.domain,
+    name: "skipintro",
+    value: "true",
+  });
+  await commands.navigate(constructURL(context, "/dashboard"));
+  await commands.wait.bySelector("input[name='username']", TIMEOUT);
+  await commands.addText.byName("admin", "username");
+  await commands.addText.byName("test", "password");
+  await commands.click.bySelector("button.p-button--positive");
+  await commands.wait.bySelector(
+    "[data-testid='section-header-title-spinner']",
+    TIMEOUT
+  );
+  await commands.wait.byXpath("//header//a[text()='admin']");
+};

--- a/sitespeed.io/scripts/machines.js
+++ b/sitespeed.io/scripts/machines.js
@@ -1,0 +1,24 @@
+const { constructURL } = require("../utils");
+
+const TIMEOUT = 120000;
+
+const coldCache = async (context, commands) => {
+  await commands.cache.clearKeepCookies();
+  await commands.measure.start("Machine list - cold cache");
+  await commands.navigate(constructURL(context, "/machines"));
+  await commands.wait.byXpath("//*[text()='1000 Machines']", TIMEOUT);
+  return commands.measure.stop();
+};
+
+const warmCache = async (context, commands) => {
+  await commands.navigate(constructURL(context, "/machines"));
+  await commands.measure.start("Machine list - warm cache");
+  await commands.navigate(constructURL(context, "/machines"));
+  await commands.wait.byXpath("//*[text()='1000 Machines']", TIMEOUT);
+  return commands.measure.stop();
+};
+
+module.exports = async (context, commands) => {
+  await coldCache(context, commands);
+  return warmCache(context, commands);
+};

--- a/sitespeed.io/utils.js
+++ b/sitespeed.io/utils.js
@@ -1,0 +1,6 @@
+const constructURL = (context, path) =>
+  `http://${context.options.domain}:${context.options.port}/MAAS/r${path}`;
+
+module.exports = {
+  constructURL,
+};


### PR DESCRIPTION
## Done

- add sitespeed workflow to 3.2

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
