### PR TITLE
fix: refetch machines on after delete

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -58,10 +58,9 @@ context("Machine listing", () => {
     });
     cy.findByRole("button", { name: /Delete 2 machines/ }).should("exist");
     cy.findByRole("button", { name: /Delete 2 machines/ }).click();
-    // TODO: enable once https://github.com/canonical/maas-ui/issues/4487 is fixed
-    // cy.findByRole("searchbox").should("have.value", searchFilter);
-    // cy.findByText(/All machines selected/).should("not.exist");
-    // cy.findByText(/No machines match the search criteria./).should("exist");
+    cy.findByRole("searchbox").should("have.value", searchFilter);
+    cy.findByText(/All machines selected/).should("not.exist");
+    cy.findByText(/No machines match the search criteria./).should("exist");
   });
 
   it.skip("can hide machine table columns", () => {

--- a/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
@@ -14,6 +14,7 @@ import ActionForm from "app/base/components/ActionForm";
 import FormikField from "app/base/components/FormikField";
 import type { ClearHeaderContent } from "app/base/types";
 import urls from "app/base/urls";
+import { actions as machineActions } from "app/store/machine";
 import { actions as messageActions } from "app/store/message";
 import { actions as podActions } from "app/store/pod";
 import { PodType } from "app/store/pod/constants";
@@ -120,6 +121,7 @@ const DeleteForm = ({
         );
         navigate({ pathname: urls.kvm.index });
         clearHeaderContent();
+        dispatch(machineActions.invalidateQueries());
       }}
       processingCount={deletingCount}
       selectedCount={deletingCount}

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
@@ -7,6 +7,7 @@ import configureStore from "redux-mock-store";
 
 import MachineActionFormWrapper from "./MachineActionFormWrapper";
 
+import { actions as machineActions } from "app/store/machine";
 import { NodeActions } from "app/store/types/node";
 import {
   machineActionState as machineActionStateFactory,
@@ -99,7 +100,7 @@ it("can show untag errors when the tag form is open", async () => {
   expect(screen.getByText("Untagging failed")).toBeInTheDocument();
 });
 
-it("clears selected machines on delete success", async () => {
+it("clears selected machines and invalidates queries on delete success", async () => {
   mockFormikFormSaved();
   const state = rootStateFactory();
   const machines = [
@@ -130,4 +131,11 @@ it("clears selected machines on delete success", async () => {
       .getActions()
       .find((action) => action.type === "machine/setSelectedMachines").payload
   ).toEqual(null);
+  expect(
+    store
+      .getActions()
+      .filter(
+        (action) => action.type === machineActions.invalidateQueries().type
+      )
+  ).toHaveLength(1);
 });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
@@ -80,8 +80,10 @@ export const MachineActionFormWrapper = ({
     selectedCount,
     selectedCountLoading,
   };
-  const clearSelectedMachines = () =>
+  const clearSelectedMachines = () => {
     dispatch(machineActions.setSelectedMachines(null));
+    dispatch(machineActions.invalidateQueries());
+  };
 
   const filter = selectedToFilters(selectedMachines || null);
 

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -81,6 +81,40 @@ describe("machine reducer", () => {
     );
   });
 
+  it("reduces invalidateQueries", () => {
+    const initialState = machineStateFactory({
+      loading: false,
+      counts: {
+        "1234": machineStateCountFactory({
+          loaded: true,
+          stale: false,
+        }),
+      },
+      lists: {
+        "5678": machineStateListFactory({
+          loaded: true,
+          stale: false,
+        }),
+      },
+    });
+    expect(reducers(initialState, actions.invalidateQueries())).toEqual(
+      machineStateFactory({
+        counts: {
+          "1234": machineStateCountFactory({
+            loaded: true,
+            stale: true,
+          }),
+        },
+        lists: {
+          "5678": machineStateListFactory({
+            loaded: true,
+            stale: true,
+          }),
+        },
+      })
+    );
+  });
+
   it("ignores calls that don't exist when reducing countSuccess", () => {
     const initialState = machineStateFactory({
       counts: {},

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -473,6 +473,28 @@ const listCount = createSelector(
 );
 
 /**
+ * Get the stale value for a machine count request with a given callId
+ */
+const countStale = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => getCount(machineState, callId)?.stale ?? null
+);
+
+/**
+ * Get the stale value for a machine list request with a given callId
+ */
+const listStale = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => getList(machineState, callId)?.stale ?? null
+);
+
+/**
  * Get a group in a machine list request with a given callId.
  */
 const listGroup = createSelector(
@@ -646,6 +668,7 @@ const selectors = {
   count,
   countLoaded,
   countLoading,
+  countStale,
   getInterfaceById,
   getStatuses,
   getStatusForMachine,
@@ -657,6 +680,7 @@ const selectors = {
   listGroups,
   listLoaded,
   listLoading,
+  listStale,
   locking: statusSelectors["locking"],
   markingBroken: statusSelectors["markingBroken"],
   markingFixed: statusSelectors["markingFixed"],

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -348,12 +348,14 @@ const DEFAULT_LIST_STATE = {
   groups: null,
   loaded: false,
   loading: true,
+  stale: false,
   num_pages: null,
 };
 
 const DEFAULT_COUNT_STATE = {
   loading: false,
   loaded: false,
+  stale: false,
   count: null,
   errors: null,
 };
@@ -1171,6 +1173,15 @@ const machineSlice = createSlice({
           state.lists[callId].num_pages = payload.num_pages;
         }
       },
+    },
+    // marks all queries as stale which will trigger a re-fetch
+    invalidateQueries: (state) => {
+      Object.keys(state.lists).forEach((callId) => {
+        state.lists[callId].stale = true;
+      });
+      Object.keys(state.counts).forEach((callId) => {
+        state.counts[callId].stale = true;
+      });
     },
     filterGroups: {
       prepare: () => ({

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -222,6 +222,7 @@ export type MachineStateList = {
   groups: MachineStateListGroup[] | null;
   loaded: boolean;
   loading: boolean;
+  stale: boolean;
   num_pages: number | null;
 };
 
@@ -324,6 +325,7 @@ export type MachineStateCount = {
   errors: APIError;
   loaded: boolean;
   loading: boolean;
+  stale: boolean;
 };
 
 export type MachineStateCounts = Record<string, MachineStateCount>;

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -243,6 +243,25 @@ describe("machine hook utils", () => {
         .filter((action) => action.type === expected.type);
       expect(getDispatches).toHaveLength(2);
     });
+
+    it("fetches again if the query has been marked as stale", async () => {
+      state.machine.counts = {
+        "mocked-nanoid-1": machineStateCountFactory({
+          stale: true,
+        }),
+      };
+      const store = mockStore(state);
+      renderHook(() => useFetchMachineCount(), {
+        wrapper: generateWrapper(store),
+      });
+      const expected = machineActions.count("mocked-nanoid-1");
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected);
+      const getDispatches = () =>
+        store.getActions().filter((action) => action.type === expected.type);
+      expect(getDispatches()).toHaveLength(2);
+    });
   });
 
   describe("useFetchMachines", () => {
@@ -272,6 +291,25 @@ describe("machine hook utils", () => {
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
+    });
+
+    it("fetches again if the query has been marked as stale", async () => {
+      state.machine.lists = {
+        "mocked-nanoid-1": machineStateListFactory({
+          stale: true,
+        }),
+      };
+      const store = mockStore(state);
+      renderHook(() => useFetchMachines(), {
+        wrapper: generateWrapper(store),
+      });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected);
+      const getDispatches = () =>
+        store.getActions().filter((action) => action.type === expected.type);
+      expect(getDispatches()).toHaveLength(2);
     });
 
     it("returns the fetched machines", () => {

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -378,6 +378,14 @@ export const useFetchMachineCount = (
   const [callId, setCallId] = useState<string | null>(null);
   const previousCallId = usePrevious(callId);
   const previousFilters = usePrevious(filters);
+  const isStale = useSelector((state: RootState) =>
+    machineSelectors.countStale(state, callId)
+  );
+  useEffect(() => {
+    if (isStale) {
+      setCallId(nanoid());
+    }
+  }, [isStale]);
   const dispatch = useDispatch();
   const machineCount = useSelector((state: RootState) =>
     machineSelectors.count(state, callId)
@@ -527,6 +535,14 @@ export const useFetchMachines = (
   const [callId, setCallId] = useState<string | null>(null);
   const previousCallId = usePrevious(callId);
   const previousOptions = usePrevious(options, false);
+  const isStale = useSelector((state: RootState) =>
+    machineSelectors.listStale(state, callId)
+  );
+  useEffect(() => {
+    if (isStale) {
+      setCallId(nanoid());
+    }
+  }, [isStale]);
   const dispatch = useDispatch();
   const machines = useSelector((state: RootState) =>
     machineSelectors.list(state, callId)

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -266,6 +266,7 @@ export const machineStateList = define<MachineStateList>({
   groups: null,
   loaded: false,
   loading: false,
+  stale: false,
   num_pages: null,
 });
 
@@ -290,6 +291,7 @@ export const machineStateCount = define<MachineStateCount>({
   errors: null,
   loaded: false,
   loading: false,
+  stale: false,
 });
 
 export const machineFilterGroup = define<FilterGroup>({


### PR DESCRIPTION
## Done
- refetch machines on after delete
  - invalidate queries on after delete
  - add stale status to machine requests

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Delete a machine
- Ensure the list of machines and machine counts in the header have been updated

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4487

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
