### PR TITLE
fix: remove colon from filters label

### DIFF
--- a/src/app/base/components/FilterAccordion/FilterAccordion.tsx
+++ b/src/app/base/components/FilterAccordion/FilterAccordion.tsx
@@ -45,7 +45,7 @@ type Section = {
 };
 
 export enum Labels {
-  Toggle = "Filters:",
+  Toggle = "Filters",
 }
 
 const getFilters = <I, PK extends keyof I>(

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
@@ -29,7 +29,7 @@ describe("DiscoveriesFilterAccordion", () => {
       <DiscoveriesFilterAccordion searchText="" setSearchText={jest.fn()} />,
       { route, wrapperProps: { state } }
     );
-    expect(screen.getByRole("button", { name: "Filters:" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Filters" })).toBeDisabled();
   });
 
   it("displays a filter accordion", () => {

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
@@ -10,7 +10,7 @@ import machineSelectors from "app/store/machine/selectors";
 import { FilterGroupKey } from "app/store/machine/types";
 
 export enum Label {
-  Toggle = "Filters:",
+  Toggle = "Filters",
   Arch = "Architecture",
   Fabrics = "Fabric",
   Owner = "Owner",


### PR DESCRIPTION
## Done

- fix: remove colon from filters label

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Verify the machine filters label label has ben updated to `Filters`

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
