### PR TITLE
feat: set background to white

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -103,6 +103,7 @@ export const App = (): JSX.Element => {
       <ThemePreviewContext.Provider value={{ theme, setTheme }}>
         <Header />
         <main id="main-content">{content}</main>
+        <hr />
         <Footer />
         <StatusBar />
       </ThemePreviewContext.Provider>

--- a/src/app/base/components/Footer/Footer.tsx
+++ b/src/app/base/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ export const Footer = (): JSX.Element => {
   const allowUsabilla = useUsabilla();
 
   return (
-    <footer className="p-strip--light is-shallow p-footer">
+    <footer className="p-strip--light p-footer">
       <div className="row">
         <div className="col-10 p-footer__nav">
           <ul className="p-inline-list--middot">

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -297,7 +297,6 @@
 @include DeleteTagFormWarnings;
 
 #maas-ui {
-  background-color: $color-light;
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr auto;


### PR DESCRIPTION
## Done

- set background to white

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4543

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/7452681/199503077-23c869dd-e23a-4b23-a74b-f99d0e03f69f.png">
<img width="1508" alt="image" src="https://user-images.githubusercontent.com/7452681/199503126-c93aedf1-69ad-41f9-9cfd-f6809c846863.png">

### After
<img width="1509" alt="image" src="https://user-images.githubusercontent.com/7452681/199502905-9f1ae383-7d77-401b-876b-664ee708d479.png">
<img width="1506" alt="image" src="https://user-images.githubusercontent.com/7452681/199502956-87998b98-216a-40c0-9ca7-270b6fa253a1.png">
