### PR TITLE
refactor: simplify render test-utils

### DIFF
--- a/src/app/Routes.test.tsx
+++ b/src/app/Routes.test.tsx
@@ -179,7 +179,8 @@ describe("Routes", () => {
     it(`Displays: ${title} at: ${path}`, async () => {
       renderWithBrowserRouter(<Routes />, {
         route: path,
-        wrapperProps: { state, routePattern: "/*" },
+        state,
+        routePattern: "/*",
       });
       await waitFor(() => expect(document.title).toBe(`${title} | MAAS`));
     });
@@ -189,7 +190,7 @@ describe("Routes", () => {
     it(`Displays: ${name} at: ${path}`, async () => {
       renderWithBrowserRouter(<Routes />, {
         route: path,
-        wrapperProps: { state },
+        state,
       });
       expect(window.location.pathname).toBe(`${path}/summary`);
     });
@@ -198,7 +199,7 @@ describe("Routes", () => {
   it("redirects from index to machines", () => {
     renderWithBrowserRouter(<Routes />, {
       route: urls.index,
-      wrapperProps: { state },
+      state,
     });
     expect(window.location.pathname).toBe(urls.machines.index);
   });
@@ -206,9 +207,7 @@ describe("Routes", () => {
   it("redirects from Settings base URL to configuration", () => {
     renderWithBrowserRouter(<Routes />, {
       route: urls.settings.index,
-      wrapperProps: {
-        state,
-      },
+      state,
     });
     expect(window.location.pathname).toBe(urls.settings.configuration.index);
   });
@@ -216,9 +215,7 @@ describe("Routes", () => {
   it("redirects from Preferences base URL to Details", () => {
     renderWithBrowserRouter(<Routes />, {
       route: urls.preferences.index,
-      wrapperProps: {
-        state,
-      },
+      state,
     });
     expect(window.location.pathname).toBe(urls.preferences.details);
   });

--- a/src/app/base/components/Header/Header.test.tsx
+++ b/src/app/base/components/Header/Header.test.tsx
@@ -65,7 +65,7 @@ afterEach(() => {
 it("renders", () => {
   renderWithBrowserRouter(<Header />, {
     route: "/",
-    wrapperProps: { state },
+    state,
   });
 
   // header has a role of banner in this context
@@ -91,7 +91,7 @@ it("can handle a logged out user", () => {
   state.user.auth.user = null;
   renderWithBrowserRouter(<Header />, {
     route: "/",
-    wrapperProps: { state },
+    state,
   });
 
   expect(screen.getByRole("banner")).toBeInTheDocument();
@@ -135,7 +135,7 @@ it("hides nav links if not completed intro", () => {
   state.user.auth.user = userFactory({ completed_intro: false });
   renderWithBrowserRouter(<Header />, {
     route: "/",
-    wrapperProps: { state },
+    state,
   });
 
   const mainNav = screen.getByRole("list", { name: "main" });
@@ -150,7 +150,7 @@ it("hides nav links if not completed intro", () => {
 it("can highlight active URL", () => {
   renderWithBrowserRouter(<Header />, {
     route: "/settings",
-    wrapperProps: { state },
+    state,
   });
 
   const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
@@ -161,7 +161,7 @@ it("can highlight active URL", () => {
 it("highlights machines when active", () => {
   renderWithBrowserRouter(<Header />, {
     route: "/machines",
-    wrapperProps: { state },
+    state,
   });
 
   const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
@@ -172,7 +172,7 @@ it("highlights machines when active", () => {
 it("highlights machines viewing pools", () => {
   renderWithBrowserRouter(<Header />, {
     route: "/pools",
-    wrapperProps: { state },
+    state,
   });
 
   const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
@@ -183,7 +183,7 @@ it("highlights machines viewing pools", () => {
 it("highlights machines viewing tags", () => {
   renderWithBrowserRouter(<Header />, {
     route: "/tags",
-    wrapperProps: { state },
+    state,
   });
 
   const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
@@ -194,7 +194,7 @@ it("highlights machines viewing tags", () => {
 it("highlights machines viewing a tag", () => {
   renderWithBrowserRouter(<Header />, {
     route: "/tag/1",
-    wrapperProps: { state },
+    state,
   });
 
   const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
@@ -205,7 +205,7 @@ it("highlights machines viewing a tag", () => {
 it("can highlight a url with a query param", () => {
   renderWithBrowserRouter(<Header />, {
     route: "/networks?by=fabric",
-    wrapperProps: { state },
+    state,
   });
 
   const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
@@ -216,7 +216,7 @@ it("can highlight a url with a query param", () => {
 it("highlights sub-urls", () => {
   renderWithBrowserRouter(<Header />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
   const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
   expect(currentMenuItem).toBeInTheDocument();
@@ -228,7 +228,7 @@ it("displays a warning icon next to controllers if vault is not fully configured
     controllerFactory({ vault_configured: true }),
     controllerFactory({ vault_configured: false }),
   ];
-  renderWithBrowserRouter(<Header />, { route: "/", wrapperProps: { state } });
+  renderWithBrowserRouter(<Header />, { route: "/", state });
 
   const controllerLink = screen.getByRole("link", {
     name: "warning Controllers",
@@ -244,7 +244,7 @@ it("does not display a warning icon next to controllers if vault is fully config
     controllerFactory({ vault_configured: true }),
     controllerFactory({ vault_configured: true }),
   ];
-  renderWithBrowserRouter(<Header />, { route: "/", wrapperProps: { state } });
+  renderWithBrowserRouter(<Header />, { route: "/", state });
 
   const controllerLink = screen.getByRole("link", { name: "Controllers" });
   expect(
@@ -256,7 +256,7 @@ it("links from the logo to the dashboard for admins", () => {
   state.user.auth.user = userFactory({ is_superuser: true });
   renderWithBrowserRouter(<Header />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   expect(screen.getByRole("link", { name: "Homepage" })).toHaveAttribute(
@@ -269,7 +269,7 @@ it("links from the logo to the machine list for non admins", () => {
   state.user.auth.user = userFactory({ is_superuser: false });
   renderWithBrowserRouter(<Header />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   expect(screen.getByRole("link", { name: "Homepage" })).toHaveAttribute(
@@ -285,7 +285,7 @@ it("redirects to the intro page if intro not completed", () => {
   state.user.auth.user = userFactory({ completed_intro: true });
   renderWithBrowserRouter(<Header />, {
     route: "/machines",
-    wrapperProps: { state },
+    state,
   });
 
   expect(mockUseNavigate.mock.calls[0][0].pathname).toBe(urls.intro.index);
@@ -298,7 +298,7 @@ it("redirects to the user intro page if user intro not completed", () => {
   state.user.auth.user = userFactory({ completed_intro: false });
   renderWithBrowserRouter(<Header />, {
     route: "/machines",
-    wrapperProps: { state },
+    state,
   });
 
   expect(mockUseNavigate.mock.calls[0][0].pathname).toBe(urls.intro.user);

--- a/src/app/base/components/NetworkActionRow/NetworkActionRow.test.tsx
+++ b/src/app/base/components/NetworkActionRow/NetworkActionRow.test.tsx
@@ -45,7 +45,7 @@ describe("NetworkActionRow", () => {
         node={state.machine.items[0]}
         setExpanded={jest.fn()}
       />,
-      { route: "/machine/abc123", wrapperProps: { store } }
+      { route: "/machine/abc123", store }
     );
     expect(screen.getByRole("button", { name: "Edit" })).toBeInTheDocument();
   });
@@ -60,7 +60,7 @@ describe("NetworkActionRow", () => {
           node={state.machine.items[0]}
           setExpanded={setExpanded}
         />,
-        { route: "/machine/abc123", wrapperProps: { store } }
+        { route: "/machine/abc123", store }
       );
       await userEvent.click(
         screen.getByRole("button", { name: "Add interface" })
@@ -79,7 +79,7 @@ describe("NetworkActionRow", () => {
           node={state.machine.items[0]}
           setExpanded={jest.fn()}
         />,
-        { route: "/machine/abc123", wrapperProps: { store } }
+        { route: "/machine/abc123", store }
       );
       expect(
         screen.getByRole("button", { name: "Add interface" })
@@ -100,7 +100,7 @@ describe("NetworkActionRow", () => {
           node={state.machine.items[0]}
           setExpanded={jest.fn()}
         />,
-        { route: "/machine/abc123", wrapperProps: { store } }
+        { route: "/machine/abc123", store }
       );
       expect(
         screen.getByRole("button", { name: "Add interface" })

--- a/src/app/base/components/VaultNotification/VaultNotification.test.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.test.tsx
@@ -9,7 +9,7 @@ it("does not display a notification when data has not loaded", async () => {
   const state = rootStateFactory();
   state.controller.loaded = false;
   renderWithBrowserRouter(<VaultNotification />, {
-    wrapperProps: { state },
+    state,
   });
   expect(
     screen.queryByText(/Incomplete Vault integration/)
@@ -21,7 +21,7 @@ it("displays a notification when data has loaded", async () => {
   state.controller.loaded = true;
   state.general.vaultEnabled.loaded = true;
   renderWithBrowserRouter(<VaultNotification />, {
-    wrapperProps: { state },
+    state,
   });
   expect(screen.getByText(/Incomplete Vault integration/)).toBeInTheDocument();
 });

--- a/src/app/base/components/node/HardwareCard/HardwareCard.test.tsx
+++ b/src/app/base/components/node/HardwareCard/HardwareCard.test.tsx
@@ -16,7 +16,7 @@ it("renders with system data", () => {
   });
   renderWithBrowserRouter(<HardwareCard node={machine} />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   const system = screen.getByRole("list", { name: HardwareCardLabels.System });
@@ -71,7 +71,7 @@ it("renders when system data is not available", () => {
   });
   renderWithBrowserRouter(<HardwareCard node={machine} />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   // Machine still has a BIOS boot mode, so we're looking for 9 instead of 10

--- a/src/app/base/components/node/NodeLogs/NodeLogs.test.tsx
+++ b/src/app/base/components/node/NodeLogs/NodeLogs.test.tsx
@@ -53,7 +53,7 @@ describe("NodeLogs", () => {
         />,
         {
           route: path,
-          wrapperProps: { state },
+          state,
         }
       );
       expect(screen.getByLabelText(label)).toBeInTheDocument();

--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -48,7 +48,7 @@ it("renders a link to zone configuration with edit permissions", () => {
 
   renderWithBrowserRouter(<DetailsCard node={machine} />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   expect(
@@ -66,7 +66,7 @@ it("renders a zone label without edit permissions", () => {
 
   renderWithBrowserRouter(<DetailsCard node={machine} />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   expect(
@@ -89,7 +89,7 @@ it("renders a formatted power type", () => {
 
   renderWithBrowserRouter(<DetailsCard node={machine} />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   expect(
@@ -112,7 +112,7 @@ it("shows a spinner if tags are not loaded", () => {
 
   renderWithBrowserRouter(<DetailsCard node={machine} />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   expect(screen.getByText("Loading")).toBeInTheDocument();
@@ -137,7 +137,7 @@ it("renders a list of tags once loaded", () => {
 
   renderWithBrowserRouter(<DetailsCard node={machine} />, {
     route: "/machine/abc123",
-    wrapperProps: { state },
+    state,
   });
 
   expect(screen.getByText("lxd, test, virtual")).toBeInTheDocument();
@@ -149,7 +149,7 @@ describe("node is a controller", () => {
     state.controller.items = [controller];
 
     renderWithBrowserRouter(<DetailsCard node={controller} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.queryByText(DetailsCardLabels.Owner)).not.toBeInTheDocument();
@@ -167,7 +167,7 @@ describe("node is a machine", () => {
 
     renderWithBrowserRouter(<DetailsCard node={machine} />, {
       route: "/machine/abc123",
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText(DetailsCardLabels.Owner)).toBeInTheDocument();
@@ -190,7 +190,7 @@ describe("node is a machine", () => {
 
     renderWithBrowserRouter(<DetailsCard node={machine} />, {
       route: "/machine/abc123",
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText(DetailsCardLabels.Owner)).toBeInTheDocument();
@@ -216,7 +216,7 @@ describe("node is a machine", () => {
 
     renderWithBrowserRouter(<DetailsCard node={machine} />, {
       route: "/machine/abc123",
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText(DetailsCardLabels.Host)).toBeInTheDocument();
@@ -235,7 +235,7 @@ describe("node is a machine", () => {
 
     renderWithBrowserRouter(<DetailsCard node={machine} />, {
       route: "/machine/abc123",
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -253,7 +253,7 @@ describe("node is a machine", () => {
 
     renderWithBrowserRouter(<DetailsCard node={machine} />, {
       route: "/machine/abc123",
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
@@ -81,7 +81,7 @@ describe("NetworkTable", () => {
         setExpanded={jest.fn()}
         setSelected={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     const subnetCol = screen.getByRole("gridcell", { name: Label.Subnet });
     const subnetPrimary = within(subnetCol).getByTestId("primary");
@@ -123,7 +123,7 @@ describe("NetworkTable", () => {
         setExpanded={jest.fn()}
         setSelected={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     const subnetCol = screen.getByRole("gridcell", { name: Label.Subnet });
     expect(
@@ -174,7 +174,7 @@ describe("NetworkTable", () => {
         setExpanded={jest.fn()}
         setSelected={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     const alias = screen.getByTestId("alias:1");
     expect(alias).toBeInTheDocument();
@@ -210,7 +210,7 @@ describe("NetworkTable", () => {
         setExpanded={jest.fn()}
         setSelected={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     const alias = screen.getByTestId("alias:1");
     expect(alias.className.includes("is-active")).toBe(true);
@@ -238,7 +238,7 @@ describe("NetworkTable", () => {
         setExpanded={jest.fn()}
         setSelected={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     const alias = screen.getByTestId("eth0");
     expect(alias.className.includes("is-active")).toBe(true);
@@ -278,7 +278,7 @@ describe("NetworkTable", () => {
         setExpanded={jest.fn()}
         setSelected={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     expect(
       screen.getByRole("grid").className.includes("network-table--has-actions")
@@ -329,7 +329,7 @@ describe("NetworkTable", () => {
     });
     state.controller.items = [controller];
     renderWithBrowserRouter(<NetworkTable node={controller} />, {
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByRole("grid").className.includes("network-table--has-actions")
@@ -382,7 +382,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       // There should be one checkbox for the child interface.
       expect(
@@ -402,7 +402,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={setSelected}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       await userEvent.click(
         within(
@@ -423,7 +423,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       const row = screen.getByTestId("eth0");
       expect(
@@ -440,7 +440,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       const row = screen.getByTestId("eth0");
       expect(
@@ -459,7 +459,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       const row = screen.getByTestId("eth0");
       expect(
@@ -478,7 +478,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       const row = screen.getByTestId("eth0");
       expect(
@@ -497,7 +497,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       const row = screen.getByTestId("eth0");
       expect(
@@ -516,7 +516,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       const row = screen.getByTestId("eth0");
       expect(
@@ -581,7 +581,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
       const names = screen
         .getAllByRole("row")
@@ -612,7 +612,7 @@ describe("NetworkTable", () => {
           setExpanded={jest.fn()}
           setSelected={jest.fn()}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       await userEvent.click(

--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
@@ -32,7 +32,7 @@ describe("AddController", () => {
 
   it("includes the config in the instructions", () => {
     renderWithBrowserRouter(<AddController clearHeaderContent={jest.fn()} />, {
-      wrapperProps: { state },
+      state,
     });
     const instructions = screen.getByTestId("register-snippet");
     expect(
@@ -48,7 +48,7 @@ describe("AddController", () => {
     renderWithBrowserRouter(
       <AddController clearHeaderContent={clearHeaderContent} />,
       {
-        wrapperProps: { state },
+        state,
       }
     );
     userEvent.click(screen.getByRole("button", { name: "Close" }));
@@ -57,7 +57,7 @@ describe("AddController", () => {
 
   it("uses a fixed version in both snap and packages instructions", async () => {
     renderWithBrowserRouter(<AddController clearHeaderContent={jest.fn()} />, {
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByText(/sudo snap install maas --channel=3.2/)

--- a/src/app/controllers/views/ControllerDetails/ControllerLogs/ControllerLogs.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerLogs/ControllerLogs.test.tsx
@@ -31,7 +31,7 @@ describe("ControllerLogs", () => {
       }),
     });
     renderWithBrowserRouter(<ControllerLogs systemId="abc123" />, {
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
   });
@@ -55,7 +55,7 @@ describe("ControllerLogs", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<ControllerLogs systemId="abc123" />, {
         route: path,
-        wrapperProps: { state },
+        state,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });

--- a/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.test.tsx
@@ -16,7 +16,7 @@ it("displays a spinner if controller is loading", () => {
     }),
   });
   renderWithBrowserRouter(<ControllerNetwork systemId="abc123" />, {
-    wrapperProps: { state },
+    state,
   });
   expect(screen.getByLabelText("Loading controller")).toBeInTheDocument();
   expect(screen.queryByLabelText("Controller network")).not.toBeInTheDocument();
@@ -29,7 +29,7 @@ it("displays the network tab when loaded", () => {
     }),
   });
   renderWithBrowserRouter(<ControllerNetwork systemId="abc123" />, {
-    wrapperProps: { state },
+    state,
   });
   expect(screen.queryByLabelText("Loading controller")).not.toBeInTheDocument();
   expect(screen.getByLabelText("Controller network")).toBeInTheDocument();

--- a/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
@@ -69,7 +69,7 @@ it("displays correct text when loading", function () {
   renderWithBrowserRouter(
     <ControllerVLANsTable systemId={net.controller.system_id} />,
     {
-      wrapperProps: { state },
+      state,
       route: urls.controllers.controller.vlans({
         id: net.controller.system_id,
       }),
@@ -96,7 +96,7 @@ it("displays correct text for no VLANs", function () {
   renderWithBrowserRouter(
     <ControllerVLANsTable systemId={net.controller.system_id} />,
     {
-      wrapperProps: { state },
+      state,
       route: urls.controllers.controller.vlans({
         id: net.controller.system_id,
       }),
@@ -123,7 +123,7 @@ it("displays a VLANs table with a single row", function () {
   renderWithBrowserRouter(
     <ControllerVLANsTable systemId={net.controller.system_id} />,
     {
-      wrapperProps: { state },
+      state,
       route: urls.controllers.controller.vlans({
         id: net.controller.system_id,
       }),
@@ -166,7 +166,7 @@ it("displays no duplicate vlans", function () {
   renderWithBrowserRouter(
     <ControllerVLANsTable systemId={net.controller.system_id} />,
     {
-      wrapperProps: { state },
+      state,
       route: urls.controllers.controller.vlans({
         id: net.controller.system_id,
       }),
@@ -194,7 +194,7 @@ it("displays correct text within each cell", () => {
   renderWithBrowserRouter(
     <ControllerVLANsTable systemId={net.controller.system_id} />,
     {
-      wrapperProps: { state },
+      state,
       route: urls.controllers.controller.vlans({
         id: net.controller.system_id,
       }),

--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
@@ -38,7 +38,7 @@ describe("ControllerListTable", () => {
         onSelectedChange={jest.fn()}
         selectedIDs={[]}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
 
     expect(screen.getAllByRole("link")[0]).toHaveProperty(
@@ -62,7 +62,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={jest.fn()}
           selectedIDs={[]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       let rows = screen.getAllByRole("row");
@@ -101,7 +101,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={jest.fn()}
           selectedIDs={[]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       // Change sort to descending version
@@ -132,7 +132,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={onSelectedChange}
           selectedIDs={[]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       await userEvent.click(screen.getAllByTestId("controller-checkbox")[0]);
@@ -149,7 +149,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={onSelectedChange}
           selectedIDs={["abc123"]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       await userEvent.click(screen.getAllByTestId("controller-checkbox")[0]);
@@ -169,7 +169,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={onSelectedChange}
           selectedIDs={[]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       await userEvent.click(screen.getByTestId("all-controllers-checkbox"));
@@ -189,7 +189,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={onSelectedChange}
           selectedIDs={["abc123", "def456"]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       await userEvent.click(screen.getByTestId("all-controllers-checkbox"));
@@ -211,7 +211,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={jest.fn()}
           selectedIDs={[]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       expect(screen.queryByTestId("vault-icon")).not.toBeInTheDocument();
@@ -238,7 +238,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={jest.fn()}
           selectedIDs={[]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       const rows = screen.getAllByRole("row");
@@ -299,7 +299,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={jest.fn()}
           selectedIDs={[]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       const rows = screen.getAllByRole("row");
@@ -350,7 +350,7 @@ describe("ControllerListTable", () => {
           onSelectedChange={jest.fn()}
           selectedIDs={[]}
         />,
-        { wrapperProps: { state } }
+        { state }
       );
 
       const rows = screen.getAllByRole("row");

--- a/src/app/dashboard/views/Dashboard.test.tsx
+++ b/src/app/dashboard/views/Dashboard.test.tsx
@@ -48,10 +48,8 @@ describe("Dashboard", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<Dashboard />, {
         route: path,
-        wrapperProps: {
-          state,
-          routePattern: `${urls.dashboard.index}/*`,
-        },
+        state,
+        routePattern: `${urls.dashboard.index}/*`,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
@@ -63,9 +61,7 @@ describe("Dashboard", () => {
     });
     renderWithBrowserRouter(<Dashboard />, {
       route: urls.dashboard.index,
-      wrapperProps: {
-        state,
-      },
+      state,
     });
     expect(screen.getByText(Label.Disabled)).toBeInTheDocument();
   });
@@ -76,9 +72,7 @@ describe("Dashboard", () => {
     });
     renderWithBrowserRouter(<Dashboard />, {
       route: urls.dashboard.index,
-      wrapperProps: {
-        state,
-      },
+      state,
     });
     expect(screen.queryByText(Label.Disabled)).not.toBeInTheDocument();
   });
@@ -89,9 +83,7 @@ describe("Dashboard", () => {
     });
     renderWithBrowserRouter(<Dashboard />, {
       route: urls.dashboard.index,
-      wrapperProps: {
-        state,
-      },
+      state,
     });
     expect(screen.getByText(Label.Permissions)).toBeInTheDocument();
   });

--- a/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
+++ b/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
@@ -27,7 +27,7 @@ describe("DashboardConfigurationSubnetForm", () => {
       subnet: subnetStateFactory({ loaded: false }),
     });
     renderWithBrowserRouter(<DashboardConfigurationSubnetForm />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText(SubnetFormLabels.Loading)).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe("DashboardConfigurationSubnetForm", () => {
       fabric: fabricStateFactory({ loaded: false }),
     });
     renderWithBrowserRouter(<DashboardConfigurationSubnetForm />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText(SubnetFormLabels.Loading)).toBeInTheDocument();
@@ -50,7 +50,7 @@ describe("DashboardConfigurationSubnetForm", () => {
       subnet: subnetStateFactory({ loaded: true }),
     });
     renderWithBrowserRouter(<DashboardConfigurationSubnetForm />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -72,7 +72,7 @@ describe("DashboardConfigurationSubnetForm", () => {
       subnet: subnetStateFactory({ items: [subnetFactory()], loaded: true }),
     });
     renderWithBrowserRouter(<DashboardConfigurationSubnetForm />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
@@ -90,7 +90,7 @@ describe("DashboardConfigurationSubnetForm", () => {
       subnet: subnetStateFactory({ items: [subnet], loaded: true }),
     });
     renderWithBrowserRouter(<DashboardConfigurationSubnetForm />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByRole("link", { name: "172.16.1.0/24" })).toHaveProperty(
@@ -116,7 +116,7 @@ describe("DashboardConfigurationSubnetForm", () => {
     });
     const store = mockStore(state);
     renderWithBrowserRouter(<DashboardConfigurationSubnetForm />, {
-      wrapperProps: { store },
+      store,
     });
 
     const checkboxes = screen.getAllByRole("checkbox");

--- a/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
@@ -55,7 +55,7 @@ describe("ClearAllForm", () => {
     });
     renderWithBrowserRouter(<ClearAllForm closeForm={jest.fn()} />, {
       route: "/dashboard",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByTestId("enabled-message")).toBeInTheDocument();
   });
@@ -71,7 +71,7 @@ describe("ClearAllForm", () => {
     });
     renderWithBrowserRouter(<ClearAllForm closeForm={jest.fn()} />, {
       route: "/dashboard",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByTestId("disabled-message")).toBeInTheDocument();
   });
@@ -80,7 +80,7 @@ describe("ClearAllForm", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(<ClearAllForm closeForm={jest.fn()} />, {
       route: "/dashboard",
-      wrapperProps: { store },
+      store,
     });
     await userEvent.click(
       screen.getByRole("button", { name: ClearAllFormLabels.SubmitLabel })
@@ -96,7 +96,7 @@ describe("ClearAllForm", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(<ClearAllForm closeForm={jest.fn()} />, {
       route: "/dashboard",
-      wrapperProps: { store },
+      store,
     });
 
     await userEvent.click(

--- a/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
@@ -36,7 +36,7 @@ describe("DashboardHeader", () => {
   it("displays the discovery count in the header", () => {
     renderWithBrowserRouter(<DashboardHeader />, {
       route: "/dashboard",
-      wrapperProps: { state },
+      state,
     });
 
     const indexLink = screen.getByText("2 discoveries");
@@ -50,7 +50,7 @@ describe("DashboardHeader", () => {
   it("has a button to clear discoveries", () => {
     renderWithBrowserRouter(<DashboardHeader />, {
       route: "/dashboard",
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByRole("button", { name: DashboardHeaderLabels.ClearAll })
@@ -60,7 +60,7 @@ describe("DashboardHeader", () => {
   it("hides the clear-all button when the form is visible", async () => {
     renderWithBrowserRouter(<DashboardHeader />, {
       route: "/dashboard",
-      wrapperProps: { state },
+      state,
     });
 
     const clearAllButton = screen.getByRole("button", {

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
@@ -27,7 +27,7 @@ describe("DiscoveriesFilterAccordion", () => {
     state.discovery.loaded = false;
     renderWithBrowserRouter(
       <DiscoveriesFilterAccordion searchText="" setSearchText={jest.fn()} />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(screen.getByRole("button", { name: "Filters" })).toBeDisabled();
   });
@@ -35,7 +35,7 @@ describe("DiscoveriesFilterAccordion", () => {
   it("displays a filter accordion", () => {
     renderWithBrowserRouter(
       <DiscoveriesFilterAccordion searchText="" setSearchText={jest.fn()} />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(
       screen.getByLabelText(DiscoveriesFilterAccordionLabels.FilterDiscoveries)

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -131,7 +131,7 @@ describe("DiscoveriesList", () => {
   it("displays the discoveries", () => {
     renderWithBrowserRouter(<DiscoveriesList />, {
       route: route,
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText("my-discovery-test")).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe("DiscoveriesList", () => {
     });
     renderWithBrowserRouter(<DiscoveriesList />, {
       route: route,
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText(DiscoveriesListLabels.Loading)).toBeInTheDocument();
   });
@@ -160,7 +160,7 @@ describe("DiscoveriesList", () => {
     });
     renderWithBrowserRouter(<DiscoveriesList />, {
       route: route,
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByText(DiscoveriesListLabels.NoNewDiscoveries)
@@ -173,7 +173,7 @@ describe("DiscoveriesList", () => {
   it("can display the add form", async () => {
     renderWithBrowserRouter(<DiscoveriesList />, {
       route: route,
-      wrapperProps: { state },
+      state,
     });
     const row = screen.getByRole("row", { name: "my-discovery-test" });
     expect(
@@ -196,7 +196,7 @@ describe("DiscoveriesList", () => {
   it("can display the delete form", async () => {
     renderWithBrowserRouter(<DiscoveriesList />, {
       route: route,
-      wrapperProps: { state },
+      state,
     });
     const row = screen.getByRole("row", { name: "my-discovery-test" });
     expect(screen.queryByTestId("delete-discovery")).not.toBeInTheDocument();
@@ -222,7 +222,7 @@ describe("DiscoveriesList", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(<DiscoveriesList />, {
       route: route,
-      wrapperProps: { store },
+      store,
     });
     const row = screen.getByRole("row", { name: "my-discovery-test" });
 

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -137,7 +137,7 @@ describe("DiscoveryAddForm", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />,
-      { route: "/dashboard", wrapperProps: { store } }
+      { route: "/dashboard", store }
     );
     const expectedActions = [
       "device/fetch",
@@ -162,7 +162,7 @@ describe("DiscoveryAddForm", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />,
-      { route: "/dashboard", wrapperProps: { store } }
+      { route: "/dashboard", store }
     );
     expect(screen.getByText("Loading")).toBeInTheDocument();
   });
@@ -171,7 +171,7 @@ describe("DiscoveryAddForm", () => {
     // Render the form with default state.
     const { rerender } = renderWithBrowserRouter(
       <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />,
-      { route: "/dashboard", wrapperProps: { state } }
+      { route: "/dashboard", state }
     );
     const error = "Name is invalid";
     // Change the device state to included the errors (as if it has changed via an API response).
@@ -190,7 +190,7 @@ describe("DiscoveryAddForm", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />,
-      { route: "/dashboard", wrapperProps: { store } }
+      { route: "/dashboard", store }
     );
 
     await userEvent.selectOptions(
@@ -249,7 +249,7 @@ describe("DiscoveryAddForm", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />,
-      { route: "/dashboard", wrapperProps: { store } }
+      { route: "/dashboard", store }
     );
 
     await userEvent.selectOptions(
@@ -308,7 +308,7 @@ describe("DiscoveryAddForm", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />,
-      { route: "/dashboard", wrapperProps: { store } }
+      { route: "/dashboard", store }
     );
 
     await userEvent.click(
@@ -327,7 +327,7 @@ describe("DiscoveryAddForm", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />,
-      { route: "/dashboard", wrapperProps: { store } }
+      { route: "/dashboard", store }
     );
 
     await userEvent.clear(
@@ -351,7 +351,7 @@ describe("DiscoveryAddForm", () => {
     const store = mockStore(state);
     const { rerender } = renderWithBrowserRouter(
       <DiscoveryAddForm discovery={discovery} onClose={jest.fn()} />,
-      { route: "/dashboard", wrapperProps: { store } }
+      { route: "/dashboard", store }
     );
 
     await userEvent.selectOptions(

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
@@ -43,7 +43,7 @@ describe("DiscoveryAddFormFields", () => {
           setDeviceType={jest.fn()}
         />
       </Formik>,
-      { route: "/dashboard", wrapperProps: { state } }
+      { route: "/dashboard", state }
     );
     expect(
       screen.getByRole("combobox", {
@@ -85,7 +85,7 @@ describe("DiscoveryAddFormFields", () => {
           setDeviceType={jest.fn()}
         />
       </Formik>,
-      { route: "/dashboard", wrapperProps: { state } }
+      { route: "/dashboard", state }
     );
     expect(
       screen.queryByRole("combobox", {
@@ -125,7 +125,7 @@ describe("DiscoveryAddFormFields", () => {
           setDeviceType={jest.fn()}
         />
       </Formik>,
-      { route: "/dashboard", wrapperProps: { state } }
+      { route: "/dashboard", state }
     );
 
     const ipAssignment = screen.getByRole("combobox", {
@@ -149,7 +149,7 @@ describe("DiscoveryAddFormFields", () => {
           setDeviceType={jest.fn()}
         />
       </Formik>,
-      { route: "/dashboard", wrapperProps: { state } }
+      { route: "/dashboard", state }
     );
 
     const ipAssignment = screen.getByRole("combobox", {
@@ -183,7 +183,7 @@ describe("DiscoveryAddFormFields", () => {
           setDeviceType={setDeviceType}
         />
       </Formik>,
-      { route: "/dashboard", wrapperProps: { state } }
+      { route: "/dashboard", state }
     );
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: DiscoveryAddFormFieldsLabels.Type }),
@@ -220,7 +220,7 @@ describe("DiscoveryAddFormFields", () => {
           setDeviceType={jest.fn()}
         />
       </Formik>,
-      { route: "/dashboard", wrapperProps: { state } }
+      { route: "/dashboard", state }
     );
     await userEvent.selectOptions(
       screen.getByRole("combobox", {

--- a/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
@@ -58,10 +58,8 @@ describe("DeviceDetails", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<DeviceDetails />, {
         route: path,
-        wrapperProps: {
-          state,
-          routePattern: `${urls.devices.device.index(null)}/*`,
-        },
+        state,
+        routePattern: `${urls.devices.device.index(null)}/*`,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
@@ -70,10 +68,8 @@ describe("DeviceDetails", () => {
   it("redirects to summary", () => {
     renderWithBrowserRouter(<DeviceDetails />, {
       route: urls.devices.device.index({ id: "abc123" }),
-      wrapperProps: {
-        state,
-        routePattern: `${urls.devices.device.index(null)}/*`,
-      },
+      state,
+      routePattern: `${urls.devices.device.index(null)}/*`,
     });
     expect(window.location.pathname).toBe(
       urls.devices.device.summary({ id: "abc123" })

--- a/src/app/domains/views/DomainDetails/DomainDetails.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetails.test.tsx
@@ -18,7 +18,7 @@ describe("DomainDetails", () => {
     });
     renderWithBrowserRouter(<DomainDetails />, {
       route: "/domain/1",
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText("Domain not found")).toBeInTheDocument();

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
@@ -28,7 +28,7 @@ describe("AddRecordForm", () => {
     });
 
     renderWithBrowserRouter(<AddRecordForm closeForm={closeForm} id={1} />, {
-      wrapperProps: { state },
+      state,
     });
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(closeForm).toHaveBeenCalled();

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
@@ -27,7 +27,7 @@ describe("DeleteDomainForm", () => {
       }),
     });
     renderWithBrowserRouter(<DeleteDomainForm closeForm={closeForm} id={1} />, {
-      wrapperProps: { state },
+      state,
     });
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(closeForm).toHaveBeenCalled();
@@ -96,7 +96,7 @@ describe("DeleteDomainForm", () => {
     });
 
     renderWithBrowserRouter(<DeleteDomainForm closeForm={closeForm} id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
@@ -19,7 +19,7 @@ describe("DomainDetailsHeader", () => {
     });
 
     renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
@@ -32,7 +32,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -55,7 +55,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText("5 hosts; 9 resource records")).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText("9 resource records")).toBeInTheDocument();
@@ -97,7 +97,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -120,7 +120,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText("No resource records")).toBeInTheDocument();
@@ -138,7 +138,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(<DomainDetailsHeader id={0} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
@@ -25,7 +25,7 @@ describe("DomainSummary", () => {
   it("render nothing if domain doesn't exist", () => {
     const state = rootStateFactory();
     renderWithBrowserRouter(<DomainSummary id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -47,7 +47,7 @@ describe("DomainSummary", () => {
     });
 
     renderWithBrowserRouter(<DomainSummary id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -74,7 +74,7 @@ describe("DomainSummary", () => {
     });
 
     renderWithBrowserRouter(<DomainSummary id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -105,7 +105,7 @@ describe("DomainSummary", () => {
 
     it("renders the Edit button", () => {
       renderWithBrowserRouter(<DomainSummary id={1} />, {
-        wrapperProps: { state },
+        state,
       });
 
       expect(
@@ -117,7 +117,7 @@ describe("DomainSummary", () => {
 
     it("renders the form when Edit button is clicked", async () => {
       renderWithBrowserRouter(<DomainSummary id={1} />, {
-        wrapperProps: { state },
+        state,
       });
 
       await userEvent.click(
@@ -136,7 +136,7 @@ describe("DomainSummary", () => {
 
     it("closes the form when Cancel button is clicked", async () => {
       renderWithBrowserRouter(<DomainSummary id={1} />, {
-        wrapperProps: { state },
+        state,
       });
 
       await userEvent.click(

--- a/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
@@ -37,7 +37,7 @@ describe("DeleteRecordForm", () => {
         id={domain.id}
         resource={resource}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));

--- a/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
@@ -59,7 +59,7 @@ describe("EditRecordForm", () => {
 
     renderWithBrowserRouter(
       <EditRecordForm closeForm={closeForm} id={1} resource={resourceA} />,
-      { wrapperProps: { state } }
+      { state }
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));

--- a/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.test.tsx
@@ -20,7 +20,7 @@ describe("ResourceRecords", () => {
     });
 
     renderWithBrowserRouter(<ResourceRecords id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -36,7 +36,7 @@ describe("ResourceRecords", () => {
       }),
     });
     renderWithBrowserRouter(<ResourceRecords id={1} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();

--- a/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
@@ -37,7 +37,7 @@ describe("DomainListHeader", () => {
 
     renderWithBrowserRouter(<DomainListHeader />, {
       route: "/domains",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -47,7 +47,7 @@ describe("DomainListHeader", () => {
     state.domain.loaded = true;
     renderWithBrowserRouter(<DomainListHeader />, {
       route: "/domains",
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText("2 domains available")).toBeInTheDocument();
@@ -57,7 +57,7 @@ describe("DomainListHeader", () => {
     const state = { ...initialState };
     renderWithBrowserRouter(<DomainListHeader />, {
       route: "/domains",
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -24,7 +24,7 @@ describe("DomainListHeaderForm", () => {
   it("runs closeForm function when the cancel button is clicked", async () => {
     const closeForm = jest.fn();
     renderWithBrowserRouter(<DomainListHeaderForm closeForm={closeForm} />, {
-      wrapperProps: { state },
+      state,
     });
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));

--- a/src/app/domains/views/DomainsList/DomainsList.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsList.test.tsx
@@ -48,7 +48,7 @@ describe("DomainsList", () => {
     });
     renderWithBrowserRouter(<DomainsList />, {
       route: "/",
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -46,7 +46,7 @@ describe("DomainsTable", () => {
   it("can update the sort order", async () => {
     renderWithBrowserRouter(<DomainsTable />, {
       route: "/domains",
-      wrapperProps: { state },
+      state,
     });
 
     const sortButton = screen.getByRole("columnheader", { name: "Domain" });
@@ -75,7 +75,7 @@ describe("DomainsTable", () => {
   it("has a (defaut) next to the default domain's title", () => {
     renderWithBrowserRouter(<DomainsTable />, {
       route: "/domains",
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.test.tsx
+++ b/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.test.tsx
@@ -31,7 +31,7 @@ describe("DeleteImageConfirm", () => {
       <Formik initialValues={{ images: [] }} onSubmit={jest.fn()}>
         <DeleteImageConfirm closeForm={closeForm} resource={resource} />
       </Formik>,
-      { wrapperProps: { state } }
+      { state }
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));

--- a/src/app/images/views/ImageList/ImageList.test.tsx
+++ b/src/app/images/views/ImageList/ImageList.test.tsx
@@ -61,7 +61,7 @@ describe("ImageList", () => {
     });
     renderWithBrowserRouter(<ImageList />, {
       route: "/images",
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByText(ImageListLabels.SyncDisabled)).toBeInTheDocument();

--- a/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
+++ b/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
@@ -33,7 +33,7 @@ describe("ImageListHeader", () => {
     });
     renderWithBrowserRouter(<ImageListHeader />, {
       route: "/images",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -51,7 +51,7 @@ describe("ImageListHeader", () => {
     });
     renderWithBrowserRouter(<ImageListHeader />, {
       route: "/images",
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -109,7 +109,7 @@ describe("ImageListHeader", () => {
     });
     renderWithBrowserRouter(<ImageListHeader />, {
       route: "/images",
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -128,7 +128,7 @@ describe("ImageListHeader", () => {
     });
     renderWithBrowserRouter(<ImageListHeader />, {
       route: "/images",
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
@@ -24,7 +24,7 @@ describe("OtherImages", () => {
     const state = rootStateFactory({
       bootresource: bootResourceStateFactory({ otherImages: [] }),
     });
-    renderWithBrowserRouter(<OtherImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<OtherImages />, { state });
     expect(
       screen.queryByText(OtherImagesLabels.OtherImages)
     ).not.toBeInTheDocument();
@@ -60,7 +60,7 @@ describe("OtherImages", () => {
         resources,
       }),
     });
-    renderWithBrowserRouter(<OtherImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<OtherImages />, { state });
 
     expect(screen.getByRole("checkbox", { name: "CentOS 7" })).toBeChecked();
   });
@@ -106,7 +106,7 @@ describe("OtherImages", () => {
         ],
       }),
     });
-    renderWithBrowserRouter(<OtherImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<OtherImages />, { state });
 
     expect(
       screen.queryByRole("button", { name: OtherImagesLabels.StopImport })

--- a/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
@@ -25,7 +25,7 @@ describe("SyncedImages", () => {
       }),
     });
     renderWithBrowserRouter(<SyncedImages formInCard />, {
-      wrapperProps: { state },
+      state,
     });
 
     await userEvent.click(
@@ -40,7 +40,7 @@ describe("SyncedImages", () => {
         ubuntu: ubuntuFactory({ sources: [] }),
       }),
     });
-    renderWithBrowserRouter(<SyncedImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<SyncedImages />, { state });
     expect(screen.getByText("Choose source")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Cancel" })
@@ -57,7 +57,7 @@ describe("SyncedImages", () => {
         }),
       }),
     });
-    renderWithBrowserRouter(<SyncedImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<SyncedImages />, { state });
     const images_from = screen.getByText(SyncedImagesLabels.SyncedFrom);
     expect(within(images_from).getByText("maas.io")).toBeInTheDocument();
   });
@@ -75,7 +75,7 @@ describe("SyncedImages", () => {
         }),
       }),
     });
-    renderWithBrowserRouter(<SyncedImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<SyncedImages />, { state });
     const images_from = screen.getByText(SyncedImagesLabels.SyncedFrom);
     expect(within(images_from).getByText("www.url.com")).toBeInTheDocument();
   });
@@ -86,7 +86,7 @@ describe("SyncedImages", () => {
         ubuntu: ubuntuFactory({ sources: [sourceFactory(), sourceFactory()] }),
       }),
     });
-    renderWithBrowserRouter(<SyncedImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<SyncedImages />, { state });
     const images_from = screen.getByText(SyncedImagesLabels.SyncedFrom);
     expect(within(images_from).getByText("sources")).toBeInTheDocument();
   });
@@ -98,7 +98,7 @@ describe("SyncedImages", () => {
         ubuntu: ubuntuFactory({ sources: [sourceFactory()] }),
       }),
     });
-    renderWithBrowserRouter(<SyncedImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<SyncedImages />, { state });
     expect(
       screen.getByRole("button", { name: SyncedImagesLabels.ChangeSource })
     ).toBeDisabled();

--- a/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
@@ -27,7 +27,7 @@ describe("UbuntuCoreImages", () => {
       bootresource: bootResourceStateFactory({ ubuntuCoreImages: [] }),
     });
 
-    renderWithBrowserRouter(<UbuntuCoreImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<UbuntuCoreImages />, { state });
     expect(
       screen.queryByText(UbuntuCoreImagesLabels.CoreImages)
     ).not.toBeInTheDocument();
@@ -64,7 +64,7 @@ describe("UbuntuCoreImages", () => {
       }),
     });
 
-    renderWithBrowserRouter(<UbuntuCoreImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<UbuntuCoreImages />, { state });
 
     expect(
       screen.getByRole("checkbox", { name: "Ubuntu Core 20" })
@@ -137,7 +137,7 @@ describe("UbuntuCoreImages", () => {
       }),
     });
 
-    renderWithBrowserRouter(<UbuntuCoreImages />, { wrapperProps: { state } });
+    renderWithBrowserRouter(<UbuntuCoreImages />, { state });
 
     expect(
       screen.queryByRole("button", { name: UbuntuCoreImagesLabels.StopImport })

--- a/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
@@ -76,7 +76,7 @@ describe("UbuntuImages", () => {
     });
 
     renderWithBrowserRouter(<UbuntuImages sources={[source]} />, {
-      wrapperProps: { state },
+      state,
     });
 
     const row_18_04_LTS = screen.getByRole("row", { name: "18.04 LTS" });
@@ -185,7 +185,7 @@ describe("UbuntuImages", () => {
       }),
     });
     renderWithBrowserRouter(<UbuntuImages sources={[source]} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -236,7 +236,7 @@ describe("UbuntuImages", () => {
       }),
     });
     renderWithBrowserRouter(<UbuntuImages sources={sources} />, {
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/intro/components/IntroSection/IntroSection.test.tsx
+++ b/src/app/intro/components/IntroSection/IntroSection.test.tsx
@@ -31,7 +31,7 @@ describe("IntroSection", () => {
   it("can display a loading spinner", () => {
     renderWithBrowserRouter(
       <IntroSection loading={true}>Intro content</IntroSection>,
-      { route: "/intro/user", wrapperProps: { state } }
+      { route: "/intro/user", state }
     );
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -64,7 +64,7 @@ describe("IntroSection", () => {
     });
     renderWithBrowserRouter(
       <IntroSection shouldExitIntro={true}>Intro content</IntroSection>,
-      { route: "/intro/user", wrapperProps: { state } }
+      { route: "/intro/user", state }
     );
     expect(window.location.pathname).toBe(urls.dashboard.index);
   });
@@ -77,7 +77,7 @@ describe("IntroSection", () => {
     });
     renderWithBrowserRouter(
       <IntroSection shouldExitIntro={true}>Intro content</IntroSection>,
-      { route: "/intro/user", wrapperProps: { state } }
+      { route: "/intro/user", state }
     );
     expect(window.location.pathname).toBe(urls.machines.index);
   });
@@ -88,7 +88,7 @@ describe("IntroSection", () => {
     });
     renderWithBrowserRouter(
       <IntroSection errors="Uh oh!">Intro content</IntroSection>,
-      { route: "/intro/user", wrapperProps: { state } }
+      { route: "/intro/user", state }
     );
     const title = screen.getByText("Error:");
     const message = screen.getByText("Uh oh!");

--- a/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
+++ b/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
@@ -33,7 +33,7 @@ describe("ImagesIntro", () => {
     state.bootresource.ubuntu = null;
     renderWithBrowserRouter(<ImagesIntro />, {
       route: "/intro/images",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -65,7 +65,7 @@ describe("ImagesIntro", () => {
     state.bootresource.resources = [];
     renderWithBrowserRouter(<ImagesIntro />, {
       route: "/intro/images",
-      wrapperProps: { state },
+      state,
     });
 
     expect(
@@ -83,7 +83,7 @@ describe("ImagesIntro", () => {
     state.bootresource.resources = [bootResourceFactory()];
     renderWithBrowserRouter(<ImagesIntro />, {
       route: "/intro/images",
-      wrapperProps: { state },
+      state,
     });
 
     expect(

--- a/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
+++ b/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
@@ -17,7 +17,7 @@ describe("IncompleteCard", () => {
   it("renders", () => {
     renderWithBrowserRouter(<IncompleteCard />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText(IncompleteCardLabels.Welcome)).toBeInTheDocument();
     expect(screen.getByText(IncompleteCardLabels.Help)).toBeInTheDocument();

--- a/src/app/intro/views/Intro.test.tsx
+++ b/src/app/intro/views/Intro.test.tsx
@@ -34,7 +34,7 @@ describe("Intro", () => {
     state.user.auth.loading = true;
     renderWithBrowserRouter(<Intro />, {
       route: "/intro",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -47,7 +47,7 @@ describe("Intro", () => {
     });
     renderWithBrowserRouter(<Intro />, {
       route: "/intro",
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByText(
@@ -67,7 +67,7 @@ describe("Intro", () => {
     });
     renderWithBrowserRouter(<Intro />, {
       route: "/intro",
-      wrapperProps: { state },
+      state,
     });
     expect(window.location.pathname).toBe(urls.dashboard.index);
   });
@@ -75,7 +75,7 @@ describe("Intro", () => {
   it("returns to the start when loading the user intro and the main intro is incomplete", () => {
     renderWithBrowserRouter(<Intro />, {
       route: "/intro",
-      wrapperProps: { state },
+      state,
     });
     expect(window.location.pathname).toBe(urls.intro.index);
   });
@@ -86,7 +86,7 @@ describe("Intro", () => {
     });
     renderWithBrowserRouter(<Intro />, {
       route: "/intro",
-      wrapperProps: { state },
+      state,
     });
     expect(window.location.pathname).toBe(urls.intro.user);
   });

--- a/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -68,7 +68,7 @@ describe("MaasIntro", () => {
     state.user.auth.loading = true;
     renderWithBrowserRouter(<MaasIntro />, {
       route: "/intro",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });

--- a/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
+++ b/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
@@ -47,7 +47,7 @@ describe("MaasIntroSuccess", () => {
     });
     renderWithBrowserRouter(<MaasIntroSuccess />, {
       route: "/intro/success",
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByRole("link", { name: MaasIntroSuccessLabels.FinishSetup })
@@ -60,7 +60,7 @@ describe("MaasIntroSuccess", () => {
     });
     renderWithBrowserRouter(<MaasIntroSuccess />, {
       route: "/intro/success",
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByRole("link", { name: MaasIntroSuccessLabels.FinishSetup })
@@ -73,7 +73,7 @@ describe("MaasIntroSuccess", () => {
     });
     renderWithBrowserRouter(<MaasIntroSuccess />, {
       route: "/intro/success",
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByRole("link", { name: MaasIntroSuccessLabels.FinishSetup })

--- a/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -45,7 +45,7 @@ describe("UserIntro", () => {
   it("displays a green tick icon when there are ssh keys", () => {
     renderWithBrowserRouter(<UserIntro />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     const icon = screen.getByLabelText("success");
     expect(icon).toBeInTheDocument();
@@ -56,7 +56,7 @@ describe("UserIntro", () => {
     state.sshkey.items = [];
     renderWithBrowserRouter(<UserIntro />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     const icon = screen.getByLabelText("success-grey");
     expect(icon).toBeInTheDocument();
@@ -71,7 +71,7 @@ describe("UserIntro", () => {
     });
     renderWithBrowserRouter(<UserIntro />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     expect(window.location.pathname).toBe(urls.dashboard.index);
   });
@@ -80,7 +80,7 @@ describe("UserIntro", () => {
     state.sshkey.items = [];
     renderWithBrowserRouter(<UserIntro />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByRole("button", { name: UserIntroLabels.Continue })
@@ -91,7 +91,7 @@ describe("UserIntro", () => {
     state.sshkey.items = [];
     renderWithBrowserRouter(<UserIntro />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.queryByRole("grid", { name: "SSH keys" })
@@ -101,7 +101,7 @@ describe("UserIntro", () => {
   it("shows the SSH list if there are ssh keys", () => {
     renderWithBrowserRouter(<UserIntro />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByRole("grid", { name: "SSH keys" })).toBeInTheDocument();
   });
@@ -134,7 +134,7 @@ describe("UserIntro", () => {
     });
     renderWithBrowserRouter(<UserIntro />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText("Error:")).toBeInTheDocument();
     expect(screen.getByText("Uh oh")).toBeInTheDocument();
@@ -147,7 +147,7 @@ describe("UserIntro", () => {
     markedIntroCompleteMock.mockImplementationOnce(() => [true, () => null]);
     renderWithBrowserRouter(<UserIntro />, {
       route: "/intro/user",
-      wrapperProps: { state },
+      state,
     });
     expect(window.location.pathname).toBe(urls.dashboard.index);
   });

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
@@ -198,7 +198,7 @@ describe("KVMHeaderForms", () => {
         headerContent={{ view: MachineHeaderViews.DELETE_MACHINE }}
         setHeaderContent={jest.fn()}
       />,
-      { route: "/kvm", wrapperProps: { state } }
+      { route: "/kvm", state }
     );
 
     expect(

--- a/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
+++ b/src/app/kvm/components/LXDHostVMs/LXDHostVMs.test.tsx
@@ -252,7 +252,7 @@ describe("LXDHostVMs", () => {
         setHeaderContent={jest.fn()}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { store } }
+      { store }
     );
     const expected = machineActions.fetch("123456", {
       filter: { pod: [pod.name] },

--- a/src/app/kvm/components/VmResources/VmResources.test.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.test.tsx
@@ -82,7 +82,7 @@ describe("VmResources", () => {
 
   it("can display a list of VMs", async () => {
     renderWithBrowserRouter(<VmResources podId={1} />, {
-      wrapperProps: { state },
+      state,
     });
     await userEvent.click(
       screen.getByRole("button", { name: Label.ResourceVMs })

--- a/src/app/kvm/views/KVM.test.tsx
+++ b/src/app/kvm/views/KVM.test.tsx
@@ -67,10 +67,8 @@ describe("KVM", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<KVM />, {
         route: path,
-        wrapperProps: {
-          state,
-          routePattern: `${urls.kvm.index}/*`,
-        },
+        state,
+        routePattern: `${urls.kvm.index}/*`,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -65,10 +65,8 @@ describe("LXDClusterDetails", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<LXDClusterDetails />, {
         route: path,
-        wrapperProps: {
-          state,
-          routePattern: `${urls.kvm.lxd.cluster.index(null)}/*`,
-        },
+        state,
+        routePattern: `${urls.kvm.lxd.cluster.index(null)}/*`,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsRedirect/LXDClusterDetailsRedirect.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsRedirect/LXDClusterDetailsRedirect.test.tsx
@@ -38,7 +38,7 @@ it("displays a spinner while loading", () => {
   state.pod.loaded = false;
   renderWithBrowserRouter(<LXDClusterDetailsRedirect clusterId={1} />, {
     route: urls.kvm.lxd.cluster.host.index({ clusterId: 1, hostId: 2 }),
-    wrapperProps: { state },
+    state,
   });
   expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
 });
@@ -47,7 +47,7 @@ it("displays a message if the host is not found", () => {
   state.pod.items = [];
   renderWithBrowserRouter(<LXDClusterDetailsRedirect clusterId={1} />, {
     route: urls.kvm.lxd.cluster.host.index({ clusterId: 1, hostId: 2 }),
-    wrapperProps: { state },
+    state,
   });
   expect(screen.getByText("LXD host not found")).toBeInTheDocument();
 });

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
@@ -35,10 +35,8 @@ describe("LXDClusterHostSettings", () => {
     state.pod.loading = true;
     renderWithBrowserRouter(<LXDClusterHostSettings clusterId={2} />, {
       route: urls.kvm.lxd.cluster.host.edit({ clusterId: 1, hostId: 2 }),
-      wrapperProps: {
-        state,
-        routePattern: urls.kvm.lxd.cluster.host.edit(null),
-      },
+      state,
+      routePattern: urls.kvm.lxd.cluster.host.edit(null),
     });
     expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
   });
@@ -47,10 +45,8 @@ describe("LXDClusterHostSettings", () => {
     state.pod.items = [];
     renderWithBrowserRouter(<LXDClusterHostSettings clusterId={2} />, {
       route: urls.kvm.lxd.cluster.host.edit({ clusterId: 1, hostId: 2 }),
-      wrapperProps: {
-        state,
-        routePattern: urls.kvm.lxd.cluster.host.edit(null),
-      },
+      state,
+      routePattern: urls.kvm.lxd.cluster.host.edit(null),
     });
     expect(screen.getByText("LXD host not found")).toBeInTheDocument();
   });
@@ -58,10 +54,8 @@ describe("LXDClusterHostSettings", () => {
   it("has a disabled zone field", () => {
     renderWithBrowserRouter(<LXDClusterHostSettings clusterId={2} />, {
       route: urls.kvm.lxd.cluster.host.edit({ clusterId: 1, hostId: 2 }),
-      wrapperProps: {
-        state,
-        routePattern: urls.kvm.lxd.cluster.host.edit(null),
-      },
+      state,
+      routePattern: urls.kvm.lxd.cluster.host.edit(null),
     });
     expect(screen.getByRole("combobox", { name: "Zone" })).toBeDisabled();
   });

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
@@ -46,10 +46,8 @@ describe("LXDClusterHostVMs", () => {
       />,
       {
         route: urls.kvm.lxd.cluster.vms.host({ clusterId: 1, hostId: 2 }),
-        wrapperProps: {
-          state,
-          routePattern: urls.kvm.lxd.cluster.vms.host(null),
-        },
+        state,
+        routePattern: urls.kvm.lxd.cluster.vms.host(null),
       }
     );
     expect(screen.getByText("VMs on pod1")).toBeInTheDocument();
@@ -66,10 +64,8 @@ describe("LXDClusterHostVMs", () => {
       />,
       {
         route: urls.kvm.lxd.cluster.vms.host({ clusterId: 1, hostId: 2 }),
-        wrapperProps: {
-          state,
-          routePattern: urls.kvm.lxd.cluster.vms.host(null),
-        },
+        state,
+        routePattern: urls.kvm.lxd.cluster.vms.host(null),
       }
     );
     expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
@@ -86,10 +82,8 @@ describe("LXDClusterHostVMs", () => {
       />,
       {
         route: urls.kvm.lxd.cluster.vms.host({ clusterId: 1, hostId: 2 }),
-        wrapperProps: {
-          state,
-          routePattern: urls.kvm.lxd.cluster.vms.host(null),
-        },
+        state,
+        routePattern: urls.kvm.lxd.cluster.vms.host(null),
       }
     );
     expect(screen.getByText("LXD host not found")).toBeInTheDocument();

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
@@ -164,7 +164,7 @@ describe("LXDClusterVMs", () => {
         setHeaderContent={jest.fn()}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { store } }
+      { store }
     );
     const expected = machineActions.fetch("123456", {
       filter: { pod: ["host 1", "host 2"] },

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
@@ -57,10 +57,8 @@ describe("LXDSingleDetails", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<LXDSingleDetails />, {
         route: path,
-        wrapperProps: {
-          state,
-          routePattern: `${urls.kvm.lxd.single.index(null)}/*`,
-        },
+        state,
+        routePattern: `${urls.kvm.lxd.single.index(null)}/*`,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
@@ -69,10 +67,8 @@ describe("LXDSingleDetails", () => {
   it("redirects to vms", () => {
     renderWithBrowserRouter(<LXDSingleDetails />, {
       route: urls.kvm.lxd.single.index({ id: 1 }),
-      wrapperProps: {
-        state,
-        routePattern: `${urls.kvm.lxd.single.index(null)}/*`,
-      },
+      state,
+      routePattern: `${urls.kvm.lxd.single.index(null)}/*`,
     });
     expect(window.location.pathname).toBe(urls.kvm.lxd.single.vms({ id: 1 }));
   });

--- a/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
@@ -52,10 +52,8 @@ describe("VirshDetails", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<VirshDetails />, {
         route: path,
-        wrapperProps: {
-          state,
-          routePattern: `${urls.kvm.virsh.details.index(null)}/*`,
-        },
+        state,
+        routePattern: `${urls.kvm.virsh.details.index(null)}/*`,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
@@ -64,10 +62,8 @@ describe("VirshDetails", () => {
   it("redirects to resources", () => {
     renderWithBrowserRouter(<VirshDetails />, {
       route: urls.kvm.virsh.details.index({ id: 1 }),
-      wrapperProps: {
-        state,
-        routePattern: `${urls.kvm.virsh.details.index(null)}/*`,
-      },
+      state,
+      routePattern: `${urls.kvm.virsh.details.index(null)}/*`,
     });
     expect(window.location.pathname).toBe(
       urls.kvm.virsh.details.resources({ id: 1 })

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
@@ -99,7 +99,7 @@ describe("OverrideTestForm", () => {
         }}
         viewingDetails={true}
       />,
-      { wrapperProps: { store }, route: "/machines" }
+      { store, route: "/machines" }
     );
 
     expect(screen.getByTestId("failed-results-message")).toHaveTextContent(
@@ -123,7 +123,7 @@ describe("OverrideTestForm", () => {
         }}
         viewingDetails={true}
       />,
-      { wrapperProps: { store }, route: "/machines" }
+      { store, route: "/machines" }
     );
 
     expect(screen.getByTestId("failed-results-message")).toHaveTextContent(
@@ -145,7 +145,7 @@ describe("OverrideTestForm", () => {
         }}
         viewingDetails={false}
       />,
-      { wrapperProps: { store }, route: "/machines" }
+      { store, route: "/machines" }
     );
 
     expect(screen.getByTestId("failed-results-message")).toHaveTextContent(
@@ -195,7 +195,7 @@ describe("OverrideTestForm", () => {
         }}
         viewingDetails={false}
       />,
-      { wrapperProps: { store }, route: "/machines" }
+      { store, route: "/machines" }
     );
 
     await userEvent.click(
@@ -238,7 +238,7 @@ describe("OverrideTestForm", () => {
         }}
         viewingDetails={false}
       />,
-      { wrapperProps: { store }, route: "/machines" }
+      { store, route: "/machines" }
     );
 
     await userEvent.click(
@@ -285,7 +285,7 @@ describe("OverrideTestForm", () => {
         }}
         viewingDetails={false}
       />,
-      { wrapperProps: { store }, route: "/machines" }
+      { store, route: "/machines" }
     );
 
     await userEvent.click(
@@ -318,7 +318,7 @@ describe("OverrideTestForm", () => {
         }}
         viewingDetails={false}
       />,
-      { wrapperProps: { store }, route: "/machines" }
+      { store, route: "/machines" }
     );
 
     await userEvent.click(

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
@@ -67,7 +67,7 @@ it("set the analytics category for the machine list", async () => {
   const store = mockStore(state);
   renderWithBrowserRouter(
     <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   expect(mockBaseAddTagForm).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -89,7 +89,7 @@ it("set the analytics category for the machine details", async () => {
       onTagCreated={jest.fn()}
       viewingDetails
     />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   expect(mockBaseAddTagForm).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -111,7 +111,7 @@ it("set the analytics category for the machine config", async () => {
       onTagCreated={jest.fn()}
       viewingMachineConfig
     />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   expect(mockBaseAddTagForm).toHaveBeenCalledWith(
     expect.objectContaining({
@@ -128,7 +128,7 @@ it("generates a deployed message for a single machine", async () => {
   const store = mockStore(state);
   renderWithBrowserRouter(
     <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   expect(
     mockBaseAddTagForm.mock.calls[0][0]
@@ -141,7 +141,7 @@ it("generates a deployed message for multiple machines", async () => {
   const store = mockStore(state);
   renderWithBrowserRouter(
     <AddTagForm machines={[]} name="new-tag" onTagCreated={jest.fn()} />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   expect(
     mockBaseAddTagForm.mock.calls[0][0]
@@ -159,7 +159,7 @@ it("fetches deployed machine count for selected machines", async () => {
       onTagCreated={jest.fn()}
       selectedMachines={selectedMachines}
     />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   const expected = machineActions.count("mocked-nanoid", {
     status: FetchNodeStatus.DEPLOYED,
@@ -188,7 +188,7 @@ it("fetches deployed machine count separately for deployed group when selected",
       onTagCreated={jest.fn()}
       selectedMachines={selectedMachines}
     />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   const expected = [
     machineActions.count("mocked-nanoid-1", {
@@ -223,7 +223,7 @@ it("fetches deployed machine count when all machines are selected", async () => 
       onTagCreated={jest.fn()}
       selectedMachines={selectedMachines}
     />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   const expected = machineActions.count("mocked-nanoid-1", {
     status: FetchNodeStatus.DEPLOYED,
@@ -250,7 +250,7 @@ it(`fetches deployed machine count only for selected items
       onTagCreated={jest.fn()}
       selectedMachines={selectedMachines}
     />,
-    { route: "/tags", wrapperProps: { store } }
+    { route: "/tags", store }
   );
   const expected = machineActions.count("mocked-nanoid-1", {
     status: FetchNodeStatus.DEPLOYED,

--- a/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
@@ -31,7 +31,7 @@ describe("MachineLogs", () => {
       }),
     });
     renderWithBrowserRouter(<MachineLogs systemId="abc123" />, {
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
   });
@@ -53,7 +53,7 @@ describe("MachineLogs", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<MachineLogs systemId="abc123" />, {
         route: path,
-        wrapperProps: { state },
+        state,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
@@ -107,7 +107,7 @@ describe("AddAliasOrVlan", () => {
         interfaceType={NetworkInterfaceTypes.VLAN}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -120,7 +120,7 @@ describe("AddAliasOrVlan", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     const secondarySubmit = screen.getByRole("button", {
       name: AddAliasOrVlanLabels.SaveAndAdd,
@@ -150,7 +150,7 @@ describe("AddAliasOrVlan", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(
       screen.getByRole("button", {
@@ -168,7 +168,7 @@ describe("AddAliasOrVlan", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(
       screen.getByRole("button", {
@@ -215,7 +215,7 @@ describe("AddAliasOrVlan", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
 
     expect(screen.getByRole("combobox", { name: "Fabric" })).toHaveValue(
@@ -236,7 +236,7 @@ describe("AddAliasOrVlan", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route, wrapperProps: { store } }
+      { route, store }
     );
 
     await userEvent.click(
@@ -304,7 +304,7 @@ describe("AddAliasOrVlan", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route, wrapperProps: { store } }
+      { route, store }
     );
 
     await userEvent.click(

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.test.tsx
@@ -25,7 +25,7 @@ describe("AddAliasOrVlanFields", () => {
           systemId="abc123"
         />
       </Formik>,
-      { route: route, wrapperProps: { state } }
+      { route: route, state }
     );
     expect(screen.getByRole("textbox", { name: "Tags" })).toBeInTheDocument();
   });
@@ -38,7 +38,7 @@ describe("AddAliasOrVlanFields", () => {
           systemId="abc123"
         />
       </Formik>,
-      { route: route, wrapperProps: { state } }
+      { route: route, state }
     );
     expect(
       screen.queryByRole("textbox", { name: "Tags" })

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
@@ -87,7 +87,7 @@ describe("AddBondForm", () => {
         setSelected={jest.fn()}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(
       screen.getByRole("heading", { name: "Create bond" })
@@ -122,7 +122,7 @@ describe("AddBondForm", () => {
         setSelected={jest.fn()}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     const table = screen.getByRole("grid");
     expect(within(table).getByText("test-interface-1")).toBeInTheDocument();
@@ -186,7 +186,7 @@ describe("AddBondForm", () => {
         setSelected={jest.fn()}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     let table = screen.getByRole("grid");
     // Check that selected interfaces are shown
@@ -262,7 +262,7 @@ describe("AddBondForm", () => {
       />,
       {
         route,
-        wrapperProps: { state },
+        state,
       }
     );
     await userEvent.click(screen.getByTestId("edit-members"));
@@ -289,7 +289,7 @@ describe("AddBondForm", () => {
         setSelected={jest.fn()}
         systemId="abc123"
       />,
-      { route, wrapperProps: { store } }
+      { route, store }
     );
     expect(store.getActions().some((action) => action.type === "fabric/fetch"));
     expect(store.getActions().some((action) => action.type === "subnet/fetch"));
@@ -307,7 +307,7 @@ describe("AddBondForm", () => {
         setSelected={jest.fn()}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(screen.getByText("Loading")).toBeInTheDocument();
   });
@@ -323,7 +323,7 @@ describe("AddBondForm", () => {
         setSelected={jest.fn()}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(screen.getByTestId("data-loading")).toBeInTheDocument();
   });
@@ -354,7 +354,7 @@ describe("AddBondForm", () => {
         setSelected={jest.fn()}
         systemId="abc123"
       />,
-      { route, wrapperProps: { store } }
+      { route, store }
     );
 
     await userEvent.click(

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
@@ -77,7 +77,7 @@ describe("AddBridgeForm", () => {
     const selected = [{ nicId: nic.id }];
     renderWithBrowserRouter(
       <AddBridgeForm close={jest.fn()} selected={selected} systemId="abc123" />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     const table = screen.getByRole("grid");
     expect(within(table).getAllByRole("row")).toHaveLength(2);
@@ -92,7 +92,7 @@ describe("AddBridgeForm", () => {
         selected={[{ nicId: nic.id }]}
         systemId="abc123"
       />,
-      { route, wrapperProps: { store } }
+      { route, store }
     );
     expect(store.getActions().some((action) => action.type === "vlan/fetch"));
   });
@@ -106,7 +106,7 @@ describe("AddBridgeForm", () => {
         selected={[{ nicId: nic.id }]}
         systemId="abc123"
       />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
 
     // Multiple spinners are displayed, so we have to check that there is at least one
@@ -122,7 +122,7 @@ describe("AddBridgeForm", () => {
         selected={[{ nicId: nic.id }]}
         systemId="abc123"
       />,
-      { route, wrapperProps: { store } }
+      { route, store }
     );
 
     const macAddressField = screen.getByRole("textbox", {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
@@ -67,7 +67,7 @@ describe("AddInterface", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <AddInterface close={jest.fn()} systemId="abc123" />,
-      { route, wrapperProps: { store } }
+      { route, store }
     );
     const expectedActions = ["fabric/fetch", "vlan/fetch"];
     expectedActions.forEach((expectedAction) => {
@@ -82,7 +82,7 @@ describe("AddInterface", () => {
     state.fabric.loaded = false;
     renderWithBrowserRouter(
       <AddInterface close={jest.fn()} systemId="abc123" />,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     expect(screen.getByText("Loading")).toBeInTheDocument();
   });
@@ -92,7 +92,7 @@ describe("AddInterface", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <AddInterface close={jest.fn()} systemId="abc123" />,
-      { route, wrapperProps: { store } }
+      { route, store }
     );
     await userEvent.type(
       screen.getByRole("textbox", { name: "MAC address" }),

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
@@ -81,7 +81,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
 
     expect(
@@ -94,7 +94,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
 
     await userEvent.selectOptions(
@@ -112,7 +112,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
 
     expect(
@@ -125,7 +125,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
 
     await userEvent.selectOptions(
@@ -143,7 +143,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
 
     const monitoringFieldNames = [
@@ -164,7 +164,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
 
     await userEvent.selectOptions(
@@ -188,7 +188,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{ mac_address: "" }} onSubmit={jest.fn()}>
         <BondFormFields selected={[{ nicId: 17 }]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     await userEvent.click(
       screen.getByRole("radio", { name: "Use MAC address from bond member" })
@@ -207,7 +207,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{ mac_address: "" }} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     await userEvent.click(
       screen.getByRole("radio", { name: "Manual MAC address" })
@@ -226,7 +226,7 @@ describe("BondFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     await userEvent.click(
       screen.getByRole("radio", { name: "Use MAC address from bond member" })
@@ -246,7 +246,7 @@ describe("BondFormFields", () => {
       >
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
-      { route, wrapperProps: { state } }
+      { route, state }
     );
     // Enable the mac address field so it can be changed.
     await userEvent.click(

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
@@ -33,7 +33,7 @@ describe("ToggleMembers", () => {
         setEditingMembers={jest.fn()}
         validNics={interfaces}
       />,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
 
     expect(screen.getByTestId("edit-members")).toBeDisabled();
@@ -62,7 +62,7 @@ describe("ToggleMembers", () => {
         setEditingMembers={jest.fn()}
         validNics={interfaces}
       />,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
 
     expect(screen.getByTestId("edit-members")).not.toBeDisabled();
@@ -76,7 +76,7 @@ describe("ToggleMembers", () => {
         setEditingMembers={jest.fn()}
         validNics={interfaces}
       />,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
     expect(screen.getByTestId("edit-members")).toBeDisabled();
   });

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.test.tsx
@@ -18,7 +18,7 @@ describe("BridgeFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BridgeFormFields />
       </Formik>,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
     expect(
       screen.queryByRole("textbox", { name: "Forward delay (ms)" })
@@ -31,7 +31,7 @@ describe("BridgeFormFields", () => {
       <Formik initialValues={{}} onSubmit={jest.fn()}>
         <BridgeFormFields />
       </Formik>,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
 
     await userEvent.click(screen.getByRole("checkbox", { name: "STP" }));

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
@@ -70,7 +70,7 @@ describe("EditAliasOrVlanForm", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
     const expectedActions = ["fabric/fetch", "subnet/fetch", "vlan/fetch"];
     expectedActions.forEach((expectedAction) => {
@@ -92,7 +92,7 @@ describe("EditAliasOrVlanForm", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route: "/machines", wrapperProps: { state } }
+      { route: "/machines", state }
     );
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -106,7 +106,7 @@ describe("EditAliasOrVlanForm", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
     expect(screen.getByRole("textbox", { name: "Tags" })).toBeInTheDocument();
   });
@@ -123,7 +123,7 @@ describe("EditAliasOrVlanForm", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Save Alias" }));
@@ -162,7 +162,7 @@ describe("EditAliasOrVlanForm", () => {
         nic={nic}
         systemId="abc123"
       />,
-      { route: "/machines", wrapperProps: { store } }
+      { route: "/machines", store }
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Save Alias" }));

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -17,7 +17,7 @@ it("displays a spinner if machine is loading", () => {
   });
   renderWithBrowserRouter(
     <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />,
-    { wrapperProps: { state } }
+    { state }
   );
   expect(screen.getByLabelText("Loading machine")).toBeInTheDocument();
   expect(screen.queryByLabelText("Machine network")).not.toBeInTheDocument();
@@ -31,7 +31,7 @@ it("displays the network tab when loaded", () => {
   });
   renderWithBrowserRouter(
     <MachineNetwork id="abc123" setHeaderContent={jest.fn()} />,
-    { wrapperProps: { state } }
+    { state }
   );
   expect(screen.queryByLabelText("Loading machine")).not.toBeInTheDocument();
   expect(screen.getByLabelText("Machine network")).toBeInTheDocument();

--- a/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
@@ -36,7 +36,7 @@ describe("NumaCard", () => {
     ];
     renderWithBrowserRouter(<NumaCard id="abc123" />, {
       route: "/machine/abc123",
-      wrapperProps: { state },
+      state,
     });
 
     const numa_card = screen.getByLabelText(NumaCardLabels.NumaCard);
@@ -49,7 +49,7 @@ describe("NumaCard", () => {
   it("renders with numa nodes", () => {
     renderWithBrowserRouter(<NumaCard id="abc123" />, {
       route: "/machine/abc123",
-      wrapperProps: { state },
+      state,
     });
     expect(screen.getByText("1 NUMA node")).toBeInTheDocument();
     expect(screen.getByText("Node 2")).toBeInTheDocument();

--- a/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
@@ -35,7 +35,7 @@ describe("NumaCardDetails", () => {
   it("can display as expanded", () => {
     renderWithBrowserRouter(
       <NumaCardDetails machineId="abc123" numaNode={numaNode} showExpanded />,
-      { route: "/machine/abc123", wrapperProps: { state } }
+      { route: "/machine/abc123", state }
     );
 
     expect(
@@ -64,7 +64,7 @@ describe("NumaCardDetails", () => {
   it("can display as collapsed", () => {
     renderWithBrowserRouter(
       <NumaCardDetails machineId="abc123" numaNode={numaNode} />,
-      { route: "/machine/abc123", wrapperProps: { state } }
+      { route: "/machine/abc123", state }
     );
 
     expect(screen.getByRole("button", { name: "Node 2" })).toBeInTheDocument();
@@ -76,7 +76,7 @@ describe("NumaCardDetails", () => {
   it("can be expanded", async () => {
     renderWithBrowserRouter(
       <NumaCardDetails machineId="abc123" numaNode={numaNode} />,
-      { route: "/machine/abc123", wrapperProps: { state } }
+      { route: "/machine/abc123", state }
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Node 3" }));

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -236,7 +236,7 @@ describe("MachineList", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { store } }
+      { store }
     );
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     // Click the button to toggle the group.
@@ -263,7 +263,7 @@ describe("MachineList", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { store } }
+      { store }
     );
     expect(screen.getByLabelText(/Group by/)).toHaveValue(DEFAULTS.grouping);
     const expected = machineActions.fetch("123456", {
@@ -372,7 +372,7 @@ describe("MachineList", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { store } }
+      { store }
     );
     const expected = machineActions.fetch("123456", {
       group_collapsed: [],
@@ -395,7 +395,7 @@ describe("MachineList", () => {
     const store2 = mockStore(state);
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { store: store2 } }
+      { store: store2 }
     );
     const expected2 = machineActions.fetch("123456", {
       group_collapsed: ["Deployed"],
@@ -576,7 +576,7 @@ describe("MachineList", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { store } }
+      { store }
     );
     const user = userEvent.setup({
       advanceTimers: jest.advanceTimersByTime,
@@ -619,7 +619,7 @@ describe("MachineList", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { store } }
+      { store }
     );
     const user = userEvent.setup({
       advanceTimers: jest.advanceTimersByTime,
@@ -655,7 +655,7 @@ describe("MachineList", () => {
         searchFilter="free text workload-service:prod"
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { store } }
+      { store }
     );
     const filter = {
       free_text: ["free text"],
@@ -732,7 +732,7 @@ describe("MachineList", () => {
 
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { state } }
+      { state }
     );
 
     expect(screen.getByTestId("vault-notification")).toHaveTextContent(
@@ -757,7 +757,7 @@ describe("MachineList", () => {
 
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { state } }
+      { state }
     );
 
     expect(screen.getByTestId("vault-notification")).toHaveTextContent(
@@ -782,7 +782,7 @@ describe("MachineList", () => {
 
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { state } }
+      { state }
     );
 
     expect(screen.queryByTestId("vault-notification")).not.toBeInTheDocument();
@@ -811,7 +811,7 @@ describe("MachineList", () => {
 
     renderWithBrowserRouter(
       <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
-      { wrapperProps: { state } }
+      { state }
     );
 
     expect(screen.queryByTestId("vault-notification")).not.toBeInTheDocument();

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -134,7 +134,7 @@ describe("MachineListHeader", () => {
         setHeaderContent={jest.fn()}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -155,7 +155,7 @@ describe("MachineListHeader", () => {
         setHeaderContent={jest.fn()}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
@@ -177,7 +177,7 @@ describe("MachineListHeader", () => {
         setHeaderContent={jest.fn()}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     expect(screen.getByText("1 of 10 machines selected")).toBeInTheDocument();
   });
@@ -198,7 +198,7 @@ describe("MachineListHeader", () => {
         setHeaderContent={jest.fn()}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     expect(screen.getByText("2 of 10 machines selected")).toBeInTheDocument();
   });
@@ -220,7 +220,7 @@ describe("MachineListHeader", () => {
         setHeaderContent={jest.fn()}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     expect(screen.getByText("3 of 10 machines selected")).toBeInTheDocument();
   });
@@ -242,7 +242,7 @@ describe("MachineListHeader", () => {
         setHeaderContent={jest.fn()}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     expect(screen.getByText("All machines selected")).toBeInTheDocument();
   });
@@ -289,7 +289,7 @@ describe("MachineListHeader", () => {
         setHeaderContent={setHeaderContent}
         setSearchFilter={jest.fn()}
       />,
-      { wrapperProps: { state }, route: urls.machines.index }
+      { state, route: urls.machines.index }
     );
     expect(setHeaderContent).not.toHaveBeenCalled();
     expect(screen.getByText("Deploy")).toBeInTheDocument();

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -298,7 +298,7 @@ describe("MachineListTable", () => {
         sortDirection="none"
         sortKey={null}
       />,
-      { wrapperProps: { state } }
+      { state }
     );
     expect(screen.getByText(Label.NoResults)).toBeInTheDocument();
   });

--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -36,7 +36,7 @@ describe("PoolForm", () => {
   it("can render", () => {
     renderWithBrowserRouter(<PoolForm />, {
       route: "/",
-      wrapperProps: { state },
+      state,
     });
 
     expect(screen.getByRole("form", { name: PoolFormLabels.AddPoolTitle }));
@@ -64,10 +64,8 @@ describe("PoolForm", () => {
     state.resourcepool.saved = true;
     renderWithBrowserRouter(<PoolForm />, {
       route: urls.pools.add,
-      wrapperProps: {
-        state,
-        routePattern: `${urls.pools.index}/*`,
-      },
+      state,
+      routePattern: `${urls.pools.index}/*`,
     });
     expect(window.location.pathname).toBe(urls.pools.index);
   });

--- a/src/app/pools/views/Pools.test.tsx
+++ b/src/app/pools/views/Pools.test.tsx
@@ -47,10 +47,8 @@ describe("Pools", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<Pools />, {
         route: path,
-        wrapperProps: {
-          routePattern: `${urls.pools.index}/*`,
-          state,
-        },
+        routePattern: `${urls.pools.index}/*`,
+        state,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });

--- a/src/app/preferences/components/Routes/Routes.test.tsx
+++ b/src/app/preferences/components/Routes/Routes.test.tsx
@@ -77,10 +77,8 @@ describe("Routes", () => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<Routes />, {
         route: path,
-        wrapperProps: {
-          routePattern: `${urls.preferences.index}/*`,
-          state,
-        },
+        routePattern: `${urls.preferences.index}/*`,
+        state,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });
@@ -89,9 +87,7 @@ describe("Routes", () => {
   it("redirects to details", () => {
     renderWithBrowserRouter(<Routes />, {
       route: urls.preferences.index,
-      wrapperProps: {
-        routePattern: `${urls.preferences.index}/*`,
-      },
+      routePattern: `${urls.preferences.index}/*`,
     });
     expect(window.location.pathname).toBe(urls.preferences.details);
   });

--- a/src/app/preferences/views/APIKeys/APIKeyAdd/APIKeyAdd.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyAdd/APIKeyAdd.test.tsx
@@ -13,7 +13,7 @@ describe("APIKeyAdd", () => {
   it("can render", () => {
     renderWithBrowserRouter(<APIKeyAdd />, {
       route: "/",
-      wrapperProps: { state },
+      state,
     });
     expect(
       screen.getByRole("form", { name: APIKeyFormLabels.AddFormLabel })

--- a/src/app/settings/components/Routes/Routes.test.tsx
+++ b/src/app/settings/components/Routes/Routes.test.tsx
@@ -185,7 +185,8 @@ describe("Routes", () => {
   routes.forEach(({ title, path }) => {
     it(`Displays: ${title} at: ${path}`, () => {
       renderWithBrowserRouter(<Routes />, {
-        wrapperProps: { routePattern: `${urls.settings.index}/*`, state },
+        routePattern: `${urls.settings.index}/*`,
+        state,
         route: path,
       });
       expect(document.title).toBe(`${title} | MAAS`);
@@ -195,10 +196,8 @@ describe("Routes", () => {
   it("redirects from base URL to configuration", () => {
     renderWithBrowserRouter(<Routes />, {
       route: urls.settings.index,
-      wrapperProps: {
-        state,
-        routePattern: `${urls.settings.index}/*`,
-      },
+      state,
+      routePattern: `${urls.settings.index}/*`,
     });
     expect(window.location.pathname).toBe(urls.settings.configuration.index);
   });
@@ -206,10 +205,8 @@ describe("Routes", () => {
   it("redirects from configuration index to general", () => {
     renderWithBrowserRouter(<Routes />, {
       route: urls.settings.configuration.index,
-      wrapperProps: {
-        state,
-        routePattern: `${urls.settings.index}/*`,
-      },
+      state,
+      routePattern: `${urls.settings.index}/*`,
     });
     expect(window.location.pathname).toBe(urls.settings.configuration.general);
   });
@@ -217,10 +214,8 @@ describe("Routes", () => {
   it("redirects from network index to proxy", () => {
     renderWithBrowserRouter(<Routes />, {
       route: urls.settings.network.index,
-      wrapperProps: {
-        state,
-        routePattern: `${urls.settings.index}/*`,
-      },
+      state,
+      routePattern: `${urls.settings.index}/*`,
     });
     expect(window.location.pathname).toBe(urls.settings.network.proxy);
   });

--- a/src/app/settings/views/Configuration/Security/Security.test.tsx
+++ b/src/app/settings/views/Configuration/Security/Security.test.tsx
@@ -27,7 +27,7 @@ it("displays loading text if TLS certificate has not loaded", () => {
       }),
     }),
   });
-  renderWithBrowserRouter(<Security />, { wrapperProps: { state } });
+  renderWithBrowserRouter(<Security />, { state });
 
   expect(screen.getByText(/Loading.../)).toBeInTheDocument();
 });
@@ -46,7 +46,7 @@ it("displays loading text if Vault Status has not loaded", () => {
       }),
     }),
   });
-  renderWithBrowserRouter(<Security />, { wrapperProps: { state } });
+  renderWithBrowserRouter(<Security />, { state });
 
   expect(screen.getByText(/Loading.../)).toBeInTheDocument();
 });
@@ -64,7 +64,7 @@ it("renders TLS disabled section if no TLS certificate is present", () => {
       }),
     }),
   });
-  renderWithBrowserRouter(<Security />, { wrapperProps: { state } });
+  renderWithBrowserRouter(<Security />, { state });
 
   expect(screen.getByText(/TLS disabled/)).toBeInTheDocument();
   expect(screen.queryByText(/TLS enabled/)).not.toBeInTheDocument();
@@ -83,7 +83,7 @@ it("renders TLS enabled section if TLS certificate is present", () => {
       }),
     }),
   });
-  renderWithBrowserRouter(<Security />, { wrapperProps: { state } });
+  renderWithBrowserRouter(<Security />, { state });
 
   expect(screen.getByText(/TLS enabled/)).toBeInTheDocument();
   expect(screen.queryByText(/TLS disabled/)).not.toBeInTheDocument();
@@ -107,7 +107,7 @@ it("renders the Vault section", () => {
     }),
   });
 
-  renderWithBrowserRouter(<Security />, { wrapperProps: { state } });
+  renderWithBrowserRouter(<Security />, { state });
 
   expect(screen.getByText(/Integrate with Vault/)).toBeInTheDocument();
 });

--- a/src/app/subnets/views/SubnetsList/SubnetsList.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsList.test.tsx
@@ -28,7 +28,7 @@ it("displays loading text", async () => {
   const state = getMockState();
   state.fabric.loaded = false;
   renderWithBrowserRouter(<SubnetsList />, {
-    wrapperProps: { state },
+    state,
     route: urls.index,
   });
 
@@ -42,7 +42,7 @@ it("displays loading text", async () => {
 it("displays correct text when there are no results for the search criteria", async () => {
   const state = getMockState();
   renderWithBrowserRouter(<SubnetsList />, {
-    wrapperProps: { state },
+    state,
     route: urls.index,
   });
 
@@ -60,7 +60,7 @@ it("displays correct text when there are no results for the search criteria", as
 it("sets the options from the URL on load", async () => {
   const state = getMockState();
   renderWithBrowserRouter(<SubnetsList />, {
-    wrapperProps: { state },
+    state,
     route: urls.indexWithParams({ by: "space", q: "fabric-1" }),
   });
 
@@ -80,7 +80,7 @@ it("sets the options from the URL on load", async () => {
 it("updates the URL on search", async () => {
   const state = getMockState();
   renderWithBrowserRouter(<SubnetsList />, {
-    wrapperProps: { state },
+    state,
     route: urls.index,
   });
 
@@ -94,7 +94,7 @@ it("updates the URL on search", async () => {
 it("updates the URL 'by' param once a new group by option is selected", async () => {
   const state = getMockState();
   renderWithBrowserRouter(<SubnetsList />, {
-    wrapperProps: { state },
+    state,
     route: urls.index,
   });
 

--- a/src/app/tags/views/Tags.test.tsx
+++ b/src/app/tags/views/Tags.test.tsx
@@ -60,7 +60,8 @@ describe("Tags", () => {
   ].forEach(({ label, path, pattern = `${urls.tags.tag.index(null)}/*` }) => {
     it(`Displays: ${label} at: ${path}`, () => {
       renderWithBrowserRouter(<Tags />, {
-        wrapperProps: { routePattern: pattern, state },
+        routePattern: pattern,
+        state,
         route: path,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
@@ -69,7 +70,8 @@ describe("Tags", () => {
 
   it("shows buttons when not displaying forms", () => {
     renderWithBrowserRouter(<Tags />, {
-      wrapperProps: { routePattern: `${urls.tags.tag.index(null)}/*`, state },
+      routePattern: `${urls.tags.tag.index(null)}/*`,
+      state,
       route: urls.tags.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
@@ -89,7 +91,8 @@ describe("Tags", () => {
 
   it("hides buttons when deleting tags", async () => {
     renderWithBrowserRouter(<Tags />, {
-      wrapperProps: { routePattern: `${urls.tags.tag.index(null)}/*`, state },
+      routePattern: `${urls.tags.tag.index(null)}/*`,
+      state,
       route: urls.tags.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
@@ -116,10 +119,8 @@ describe("Tags", () => {
 
   it("hides buttons when updating tags", () => {
     renderWithBrowserRouter(<Tags />, {
-      wrapperProps: {
-        routePattern: `${urls.tags.tag.index(null)}/*`,
-        state,
-      },
+      routePattern: `${urls.tags.tag.index(null)}/*`,
+      state,
       route: urls.tags.tag.update({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);
@@ -141,10 +142,8 @@ describe("Tags", () => {
 
   it("hides buttons when creating tags", async () => {
     renderWithBrowserRouter(<Tags />, {
-      wrapperProps: {
-        routePattern: `${urls.tags.tag.index(null)}/*`,
-        state,
-      },
+      routePattern: `${urls.tags.tag.index(null)}/*`,
+      state,
       route: urls.tags.tag.index({ id: 1 }),
     });
     const header = screen.getByLabelText(TagsHeaderLabel.Header);

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -159,16 +159,17 @@ const WithMockStoreProvider = ({
 
 export const renderWithBrowserRouter = (
   ui: React.ReactElement,
-  options?: RenderOptions & {
-    wrapperProps?: WrapperProps;
-    route?: string;
-  }
+  options?: RenderOptions &
+    WrapperProps & {
+      route?: string;
+    }
 ): RenderResult => {
-  window.history.pushState({}, "", options?.route);
+  const { route, ...wrapperProps } = options || {};
+  window.history.pushState({}, "", route);
 
   return render(ui, {
     wrapper: (props) => (
-      <BrowserRouterWithProvider {...props} {...options?.wrapperProps} />
+      <BrowserRouterWithProvider {...props} {...wrapperProps} />
     ),
     ...options,
   });


### PR DESCRIPTION
## Done

- refactor: simplify render test-utils
  - merge wrapperProps with base options

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
