### PR TITLE
Add machine actions analytics events

### DIFF
--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
@@ -8,6 +8,7 @@ import ControllerName from "./ControllerName";
 
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
+import { useSendAnalytics } from "app/base/hooks";
 import urls from "app/base/urls";
 import ControllerHeaderForms from "app/controllers/components/ControllerHeaderForms";
 import {
@@ -22,6 +23,7 @@ import controllerSelectors from "app/store/controller/selectors";
 import type { Controller } from "app/store/controller/types";
 import { isControllerDetails } from "app/store/controller/utils";
 import type { RootState } from "app/store/root/types";
+import { getNodeActionTitle } from "app/store/utils";
 
 type Props = {
   systemId: Controller["system_id"];
@@ -39,6 +41,7 @@ const ControllerDetailsHeader = ({
   );
   const { pathname } = useLocation();
   const [isEditing, setIsEditing] = useState(false);
+  const sendAnalytics = useSendAnalytics();
 
   if (!controller) {
     return <SectionHeader loading />;
@@ -54,6 +57,11 @@ const ControllerDetailsHeader = ({
           nodeDisplay="controller"
           nodes={[controller]}
           onActionClick={(action) => {
+            sendAnalytics(
+              "Controller details action form",
+              getNodeActionTitle(action),
+              "Open"
+            );
             const view = Object.values(ControllerHeaderViews).find(
               ([, actionName]) => actionName === action
             );

--- a/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux";
 import ModelListSubtitle from "app/base/components/ModelListSubtitle";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import SectionHeader from "app/base/components/SectionHeader";
+import { useSendAnalytics } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
 import ControllerHeaderForms from "app/controllers/components/ControllerHeaderForms";
 import { ControllerHeaderViews } from "app/controllers/constants";
@@ -13,6 +14,7 @@ import type {
 } from "app/controllers/types";
 import { getHeaderTitle } from "app/controllers/utils";
 import controllerSelectors from "app/store/controller/selectors";
+import { getNodeActionTitle } from "app/store/utils";
 
 type Props = {
   headerContent: ControllerHeaderContent | null;
@@ -28,6 +30,7 @@ const ControllerListHeader = ({
   const controllers = useSelector(controllerSelectors.all);
   const controllersLoaded = useSelector(controllerSelectors.loaded);
   const selectedControllers = useSelector(controllerSelectors.selected);
+  const sendAnalytics = useSendAnalytics();
 
   return (
     <SectionHeader
@@ -47,6 +50,11 @@ const ControllerListHeader = ({
           nodeDisplay="controller"
           nodes={selectedControllers}
           onActionClick={(action) => {
+            sendAnalytics(
+              "Controller list action form",
+              getNodeActionTitle(action),
+              "Open"
+            );
             const view = Object.values(ControllerHeaderViews).find(
               ([, actionName]) => actionName === action
             );

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -2,12 +2,14 @@ import { Button, Icon, Tooltip } from "@canonical/react-components";
 
 import ActionBar from "app/base/components/ActionBar";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
+import { useSendAnalytics } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
 import { VMS_PER_PAGE } from "app/kvm/components/LXDVMsTable";
 import type { KVMSetHeaderContent } from "app/kvm/types";
 import { MachineHeaderViews } from "app/machines/constants";
 import { useHasSelection } from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
+import { getNodeActionTitle } from "app/store/utils";
 
 type Props = {
   currentPage: number;
@@ -30,6 +32,7 @@ const VMsActionBar = ({
   setHeaderContent,
   vmCount,
 }: Props): JSX.Element | null => {
+  const sendAnalytics = useSendAnalytics();
   const hasSelection = useHasSelection();
   const vmActionsDisabled = !hasSelection;
 
@@ -52,6 +55,11 @@ const VMsActionBar = ({
               if (view) {
                 setHeaderContent({ view });
               }
+              sendAnalytics(
+                "LXD VMs list action form",
+                getNodeActionTitle(action),
+                "Open"
+              );
             }}
             toggleClassName="u-no-margin--bottom"
           />

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.tsx
@@ -69,9 +69,9 @@ export const ReleaseForm = ({
       modelName="machine"
       onCancel={clearHeaderContent}
       onSaveAnalytics={{
-        action: "Release machine",
+        action: "Submit",
         category: `Machine ${viewingDetails ? "details" : "list"} action form`,
-        label: "Release",
+        label: "Release machine",
       }}
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -12,7 +12,7 @@ import ScriptStatus from "app/base/components/ScriptStatus";
 import SectionHeader from "app/base/components/SectionHeader";
 import TableMenu from "app/base/components/TableMenu";
 import TooltipButton from "app/base/components/TooltipButton";
-import { useMachineActions } from "app/base/hooks";
+import { useMachineActions, useSendAnalytics } from "app/base/hooks";
 import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
 import { MachineHeaderViews } from "app/machines/constants";
 import type {
@@ -28,6 +28,7 @@ import { useFetchMachine } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { ScriptResultStatus } from "app/store/scriptresult/types";
 import { NodeActions } from "app/store/types/node";
+import { getNodeActionTitle } from "app/store/utils";
 
 type Props = {
   headerContent: MachineHeaderContent | null;
@@ -43,6 +44,7 @@ const MachineHeader = ({
   const [editingName, setEditingName] = useState(false);
   const dispatch = useDispatch();
   const { pathname } = useLocation();
+  const sendAnalytics = useSendAnalytics();
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
@@ -76,6 +78,11 @@ const MachineHeader = ({
           nodeDisplay="machine"
           nodes={[machine]}
           onActionClick={(action) => {
+            sendAnalytics(
+              "Machine details action form",
+              getNodeActionTitle(action),
+              "Open"
+            );
             const view = Object.values(MachineHeaderViews).find(
               ([, actionName]) => actionName === action
             );

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from "react";
 
 import { useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
+import { useMatch } from "react-router-dom-v5-compat";
 import { useStorageState } from "react-storage-hooks";
 
 import AddHardwareMenu from "./AddHardwareMenu";
@@ -42,7 +42,7 @@ export const MachineListHeader = ({
   setSearchFilter,
   setHeaderContent,
 }: Props): JSX.Element => {
-  const location = useLocation();
+  const machinesPathMatch = useMatch(urls.machines.index);
   const hasSelection = useHasSelection();
   const [tagsSeen, setTagsSeen] = useStorageState(
     localStorage,
@@ -64,13 +64,10 @@ export const MachineListHeader = ({
 
   // Clear the header when there are no selected machines
   useEffect(() => {
-    if (
-      location.pathname !== urls.machines.index ||
-      selectedToFilters(selectedMachines) === null
-    ) {
+    if (!machinesPathMatch || selectedToFilters(selectedMachines) === null) {
       setHeaderContent(null);
     }
-  }, [location.pathname, selectedMachines, setHeaderContent]);
+  }, [machinesPathMatch, selectedMachines, setHeaderContent]);
 
   const getTitle = useCallback(
     (action: NodeActions) => {

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -9,6 +9,7 @@ import AddHardwareMenu from "./AddHardwareMenu";
 import ModelListSubtitle from "app/base/components/ModelListSubtitle";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import MachinesHeader from "app/base/components/node/MachinesHeader";
+import { useSendAnalytics } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
 import urls from "app/base/urls";
 import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
@@ -59,6 +60,7 @@ export const MachineListHeader = ({
   const { selectedCount, selectedCountLoading } =
     useMachineSelectedCount(filter);
   const selectedMachines = useSelector(machineSelectors.selectedMachines);
+  const sendAnalytics = useSendAnalytics();
 
   // Clear the header when there are no selected machines
   useEffect(() => {
@@ -113,6 +115,11 @@ export const MachineListHeader = ({
             if (view) {
               setHeaderContent({ view });
             }
+            sendAnalytics(
+              "Machine list action form",
+              getNodeActionTitle(action),
+              "Open"
+            );
           }}
         />,
       ]}


### PR DESCRIPTION
## Done

- Add machine list action analytics events
- use `useMatch` for machines path matching

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Install the google analytics extension https://chrome.google.com/webstore/detail/jnkmfdileelhofjcijamephohjechhna and enable it by clicking on the icon in the toolbar (make sure it's "ON")
- make sure you have any adblockers disabled so that the analytics script can load
- Use the demo https://maas-ui-4548.demos.haus/ for all the steps below
- Go to https://maas-ui-4548.demos.haus/MAAS/r/machines/ (make sure there is a trailing `/` in the URL) and verify you can open the form via take action and the analytics event has been submitted.

For each of the views - machine list, machine details, controller list, controller details, LXD KVM list:
- Verify that Machine list action form event with a correct label is fired for each Machine list action on open (via Take action menu)



## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1372

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
