### PR TITLE
enable GA in prod

### DIFF
--- a/src/app/base/hooks/analytics.ts
+++ b/src/app/base/hooks/analytics.ts
@@ -88,7 +88,7 @@ export const useGoogleAnalytics = (): boolean => {
     authUser &&
     uuid &&
     version &&
-    debug
+    !debug
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Done

- enable Google Analytics in production before release

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Verify that google analytics script (`https://www.googletagmanager.com/gtm.js?id=GTM-P4TGJR9`) has been loaded by checking the Network tab in developer tools

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
