### PR TITLE
fix(machines): keep acton form open on group addition

### DIFF
--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -282,7 +282,7 @@ describe("MachineListHeader", () => {
       loaded: true,
     });
     const setHeaderContent = jest.fn();
-    const { rerender } = renderWithBrowserRouter(
+    renderWithBrowserRouter(
       <MachineListHeader
         headerContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
         searchFilter=""
@@ -294,7 +294,7 @@ describe("MachineListHeader", () => {
     expect(setHeaderContent).not.toHaveBeenCalled();
     expect(screen.getByText("Deploy")).toBeInTheDocument();
     state.machine.selectedMachines.items = [];
-    rerender(
+    renderWithBrowserRouter(
       <MachineListHeader
         headerContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
         searchFilter=""

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect } from "react";
 
-import { usePrevious } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 import { useStorageState } from "react-storage-hooks";
@@ -20,7 +19,7 @@ import type {
 } from "app/machines/types";
 import { getHeaderTitle } from "app/machines/utils";
 import machineSelectors from "app/store/machine/selectors";
-import { FilterMachineItems } from "app/store/machine/utils";
+import { FilterMachineItems, selectedToFilters } from "app/store/machine/utils";
 import {
   useFetchMachineCount,
   useHasSelection,
@@ -59,22 +58,17 @@ export const MachineListHeader = ({
   // Get the count of selected machines that match the current filter
   const { selectedCount, selectedCountLoading } =
     useMachineSelectedCount(filter);
-  const previousSelectedCount = usePrevious(selectedCount);
   const selectedMachines = useSelector(machineSelectors.selectedMachines);
 
+  // Clear the header when there are no selected machines
   useEffect(() => {
     if (
       location.pathname !== urls.machines.index ||
-      (selectedCount !== previousSelectedCount && selectedCount === 0)
+      selectedToFilters(selectedMachines) === null
     ) {
       setHeaderContent(null);
     }
-  }, [
-    location.pathname,
-    setHeaderContent,
-    selectedCount,
-    previousSelectedCount,
-  ]);
+  }, [location.pathname, selectedMachines, setHeaderContent]);
 
   const getTitle = useCallback(
     (action: NodeActions) => {


### PR DESCRIPTION
## Done

fix: keep acton form open on additional group selection

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- go to machine listing
- select group by status
- select a group of machines (e.g. "New")
- open take action form
- select additional group of machines (e.g. "Commissioning")
- ensure the action form remained open
- deselect all groups of machines
- ensure the form has been closed

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
