### PR TITLE
fix(vault): Hide warning if Vault setup has not started

### DIFF
--- a/src/app/base/components/VaultNotification/VaultNotification.test.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.test.tsx
@@ -20,7 +20,7 @@ it("does not display a notification when data has not loaded", async () => {
   ).not.toBeInTheDocument();
 });
 
-it("displays a notification when data has loaded", async () => {
+it("displays a notification when data has loaded and not all controllers are configured", async () => {
   const state = rootStateFactory();
   state.controller.loaded = true;
   state.general.vaultEnabled.loaded = true;
@@ -39,4 +39,71 @@ it("displays a notification when data has loaded", async () => {
     state,
   });
   expect(screen.getByText(/Incomplete Vault integration/)).toBeInTheDocument();
+});
+
+it("displays a notification when data has loaded and secrets are not migrated to Vault", async () => {
+  const state = rootStateFactory();
+  state.controller.loaded = true;
+  state.general.vaultEnabled.loaded = true;
+  state.general.vaultEnabled.data = false;
+  state.controller.items = [
+    controllerFactory({
+      vault_configured: true,
+      node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+    }),
+    controllerFactory({
+      vault_configured: true,
+      node_type: NodeType.REGION_CONTROLLER,
+    }),
+  ];
+  renderWithBrowserRouter(<VaultNotification />, {
+    state,
+  });
+  expect(screen.getByText(/Incomplete Vault integration/)).toBeInTheDocument();
+});
+
+it("doesn't display a notification if vault setup is complete", async () => {
+  const state = rootStateFactory();
+  state.controller.loaded = true;
+  state.general.vaultEnabled.loaded = true;
+  state.general.vaultEnabled.data = true;
+  state.controller.items = [
+    controllerFactory({
+      vault_configured: true,
+      node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+    }),
+    controllerFactory({
+      vault_configured: true,
+      node_type: NodeType.REGION_CONTROLLER,
+    }),
+  ];
+  renderWithBrowserRouter(<VaultNotification />, {
+    state,
+  });
+  expect(
+    screen.queryByText(/Incomplete Vault integration/)
+  ).not.toBeInTheDocument();
+});
+
+it("doesn't display a notification if vault setup has not been started", async () => {
+  const state = rootStateFactory();
+  state.controller.loaded = true;
+  state.general.vaultEnabled.loaded = true;
+  state.general.vaultEnabled.data = false;
+  state.controller.items = [
+    controllerFactory({
+      vault_configured: false,
+      node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+    }),
+    controllerFactory({
+      vault_configured: false,
+      node_type: NodeType.REGION_CONTROLLER,
+    }),
+  ];
+  renderWithBrowserRouter(<VaultNotification />, {
+    state,
+  });
+  expect(
+    screen.queryByText(/Incomplete Vault integration/)
+  ).not.toBeInTheDocument();
 });

--- a/src/app/base/components/VaultNotification/VaultNotification.test.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.test.tsx
@@ -2,7 +2,11 @@ import { screen } from "@testing-library/react";
 
 import VaultNotification from "./VaultNotification";
 
-import { rootState as rootStateFactory } from "testing/factories";
+import { NodeType } from "app/store/types/node";
+import {
+  rootState as rootStateFactory,
+  controller as controllerFactory,
+} from "testing/factories";
 import { renderWithBrowserRouter } from "testing/utils";
 
 it("does not display a notification when data has not loaded", async () => {
@@ -20,6 +24,17 @@ it("displays a notification when data has loaded", async () => {
   const state = rootStateFactory();
   state.controller.loaded = true;
   state.general.vaultEnabled.loaded = true;
+  state.general.vaultEnabled.data = false;
+  state.controller.items = [
+    controllerFactory({
+      vault_configured: false,
+      node_type: NodeType.REGION_AND_RACK_CONTROLLER,
+    }),
+    controllerFactory({
+      vault_configured: true,
+      node_type: NodeType.REGION_CONTROLLER,
+    }),
+  ];
   renderWithBrowserRouter(<VaultNotification />, {
     state,
   });

--- a/src/app/base/components/VaultNotification/VaultNotification.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.tsx
@@ -19,31 +19,33 @@ const VaultNotification = (): JSX.Element | null => {
     return null;
   }
 
-  return configuredControllers.length >= 1 &&
-    unconfiguredControllers.length >= 1 ? (
-    <Notification
-      data-testid="vault-notification"
-      severity="caution"
-      title="Incomplete Vault integration"
-    >
-      Configure {unconfiguredControllers.length} other{" "}
-      <Link to="/controllers">
-        {unconfiguredControllers.length > 1 ? "controllers" : "controller"}
-      </Link>{" "}
-      with Vault to complete integration with Vault. Check the{" "}
-      <Link to="/settings/configuration/security">security settings</Link> for
-      more information.
-    </Notification>
-  ) : unconfiguredControllers.length === 0 && vaultEnabled === false ? (
-    <Notification
-      data-testid="vault-notification"
-      severity="caution"
-      title="Incomplete Vault integration"
-    >
-      Migrate your secrets to Vault to complete integration with Vault. Check
-      the <Link to="/settings/configuration/security">security settings</Link>{" "}
-      for more information.
-    </Notification>
+  return !vaultEnabled ? (
+    configuredControllers.length >= 1 && unconfiguredControllers.length >= 1 ? (
+      <Notification
+        data-testid="vault-notification"
+        severity="caution"
+        title="Incomplete Vault integration"
+      >
+        Configure {unconfiguredControllers.length} other{" "}
+        <Link to="/controllers">
+          {unconfiguredControllers.length > 1 ? "controllers" : "controller"}
+        </Link>{" "}
+        with Vault to complete integration with Vault. Check the{" "}
+        <Link to="/settings/configuration/security">security settings</Link> for
+        more information.
+      </Notification>
+    ) : unconfiguredControllers.length === 0 &&
+      configuredControllers.length >= 1 ? (
+      <Notification
+        data-testid="vault-notification"
+        severity="caution"
+        title="Incomplete Vault integration"
+      >
+        Migrate your secrets to Vault to complete integration with Vault. Check
+        the <Link to="/settings/configuration/security">security settings</Link>{" "}
+        for more information.
+      </Notification>
+    ) : null
   ) : null;
 };
 

--- a/src/app/base/components/VaultNotification/VaultNotification.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.tsx
@@ -15,37 +15,36 @@ const VaultNotification = (): JSX.Element | null => {
   const vaultEnabledLoaded = useSelector(vaultEnabledSelectors.loaded);
   const controllersLoaded = useSelector(controllerSelectors.loaded);
 
-  if (!vaultEnabledLoaded || !controllersLoaded) {
+  if (vaultEnabled || !vaultEnabledLoaded || !controllersLoaded) {
     return null;
   }
 
-  return !vaultEnabled ? (
-    configuredControllers.length >= 1 && unconfiguredControllers.length >= 1 ? (
-      <Notification
-        data-testid="vault-notification"
-        severity="caution"
-        title="Incomplete Vault integration"
-      >
-        Configure {unconfiguredControllers.length} other{" "}
-        <Link to="/controllers">
-          {unconfiguredControllers.length > 1 ? "controllers" : "controller"}
-        </Link>{" "}
-        with Vault to complete integration with Vault. Check the{" "}
-        <Link to="/settings/configuration/security">security settings</Link> for
-        more information.
-      </Notification>
-    ) : unconfiguredControllers.length === 0 &&
-      configuredControllers.length >= 1 ? (
-      <Notification
-        data-testid="vault-notification"
-        severity="caution"
-        title="Incomplete Vault integration"
-      >
-        Migrate your secrets to Vault to complete integration with Vault. Check
-        the <Link to="/settings/configuration/security">security settings</Link>{" "}
-        for more information.
-      </Notification>
-    ) : null
+  return configuredControllers.length >= 1 &&
+    unconfiguredControllers.length >= 1 ? (
+    <Notification
+      data-testid="vault-notification"
+      severity="caution"
+      title="Incomplete Vault integration"
+    >
+      Configure {unconfiguredControllers.length} other{" "}
+      <Link to="/controllers">
+        {unconfiguredControllers.length > 1 ? "controllers" : "controller"}
+      </Link>{" "}
+      with Vault to complete integration with Vault. Check the{" "}
+      <Link to="/settings/configuration/security">security settings</Link> for
+      more information.
+    </Notification>
+  ) : unconfiguredControllers.length === 0 &&
+    configuredControllers.length >= 1 ? (
+    <Notification
+      data-testid="vault-notification"
+      severity="caution"
+      title="Incomplete Vault integration"
+    >
+      Migrate your secrets to Vault to complete integration with Vault. Check
+      the <Link to="/settings/configuration/security">security settings</Link>{" "}
+      for more information.
+    </Notification>
   ) : null;
 };
 


### PR DESCRIPTION
## Done

- Vault warning message should no longer display if Vault has not yet started being set up

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Log in to polong as a non-admin user
- Go to /machines
- Verify that there is no vault-related warning message

## Fixes

Fixes: #4562 
