### PR TITLE
feat(machines): display error message for no machines

### DIFF
--- a/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -120,6 +120,27 @@ describe("ActionForm", () => {
     expect(screen.getByRole("button")).toBeDisabled();
   });
 
+  it("disables the submit button when selectedCount equals 0", async () => {
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter>
+          <CompatRouter>
+            <ActionForm
+              actionName="action"
+              initialValues={{}}
+              modelName="machine"
+              onSubmit={jest.fn()}
+              selectedCount={0}
+            />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
   it("shows correct saving label if selectedCount changes after submit", async () => {
     const store = mockStore(state);
     const Proxy = ({ selectedCount }: { selectedCount: number }) => (

--- a/src/app/base/components/ActionForm/ActionForm.tsx
+++ b/src/app/base/components/ActionForm/ActionForm.tsx
@@ -114,6 +114,7 @@ const ActionForm = <V, E = null>({
             )}...`
           : null
       }
+      submitDisabled={selectedCount === 0}
       submitLabel={
         submitLabel ?? getLabel(modelName, actionName, selectedCount)
       }

--- a/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -62,6 +62,30 @@ describe("FormikFormContent", () => {
     expect(screen.getByTestId(TestIds.CancelButton)).toBeDisabled();
   });
 
+  it("can disable the submit button", async () => {
+    const store = mockStore(state);
+    const onSubmit = jest.fn();
+    render(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
+          <CompatRouter>
+            <Formik initialValues={{}} onSubmit={onSubmit}>
+              <FormikFormContent
+                aria-label="example"
+                submitDisabled
+                submitLabel="Save"
+              >
+                Content
+              </FormikFormContent>
+            </Formik>
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
   it("can override disabling cancel button while saving", () => {
     const store = mockStore(state);
     render(

--- a/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -18,8 +18,9 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom-v5-compat", () => ({
   ...jest.requireActual("react-router-dom-v5-compat"),
@@ -44,163 +45,111 @@ describe("FormikFormContent", () => {
   });
 
   it("disables cancel button while saving", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent onCancel={jest.fn()} saving>
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent onCancel={jest.fn()} saving>
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(screen.getByTestId(TestIds.CancelButton)).toBeDisabled();
   });
 
   it("can disable the submit button", async () => {
-    const store = mockStore(state);
     const onSubmit = jest.fn();
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={onSubmit}>
-              <FormikFormContent
-                aria-label="example"
-                submitDisabled
-                submitLabel="Save"
-              >
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={onSubmit}>
+        <FormikFormContent
+          aria-label="example"
+          submitDisabled
+          submitLabel="Save"
+        >
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
   });
 
   it("can override disabling cancel button while saving", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent
-                cancelDisabled={false}
-                onCancel={jest.fn()}
-                saving
-              >
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent cancelDisabled={false} onCancel={jest.fn()} saving>
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(screen.getByTestId(TestIds.CancelButton)).not.toBeDisabled();
   });
 
   it("can display non-field errors from a string", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent errors="Uh oh!">Content</FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent errors="Uh oh!">Content</FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(screen.getByText("Uh oh!")).toBeInTheDocument();
   });
 
   it("can display non-field errors from the __all__ key", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent errors={{ __all__: ["Uh oh!"] }}>
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent errors={{ __all__: ["Uh oh!"] }}>
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(screen.getByText("Uh oh!")).toBeInTheDocument();
   });
 
   it("can display non-field errors from the unknown keys with strings", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent errors={{ username: "Wrong username" }}>
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent errors={{ username: "Wrong username" }}>
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(screen.getByText("Wrong username")).toBeInTheDocument();
   });
 
   it("does not display non-field errors for fields", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{ username: "" }} onSubmit={jest.fn()}>
-              <FormikFormContent errors={{ username: "Wrong username" }}>
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{ username: "" }} onSubmit={jest.fn()}>
+        <FormikFormContent errors={{ username: "Wrong username" }}>
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(screen.queryByText("Wrong username")).not.toBeInTheDocument();
   });
 
   it("can display non-field errors from the unknown keys with arrays", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent
-                errors={{
-                  username: ["Wrong username", "Username must be provided"],
-                }}
-              >
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent
+          errors={{
+            username: ["Wrong username", "Username must be provided"],
+          }}
+        >
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
     expect(
       screen.getByText("Wrong username, Username must be provided")
@@ -208,77 +157,54 @@ describe("FormikFormContent", () => {
   });
 
   it("can be inline", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent aria-label="Fake form" inline>
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent aria-label="Fake form" inline>
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
-
     expect(screen.getByRole("form", { name: "Fake form" })).toHaveClass(
       "p-form--inline"
     );
   });
 
   it("does not render buttons if editable is set to false", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent editable={false}>Content</FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent editable={false}>Content</FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("can redirect when saved", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent saved={true} savedRedirect="/success">
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent saved={true} savedRedirect="/success">
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(mockUseNavigate.mock.calls[0][0]).toBe("/success");
   });
 
   it("can clean up when unmounted", async () => {
+    const store = mockStore(state);
     const cleanup = jest.fn(() => ({
       type: "CLEANUP",
     }));
-    const store = mockStore(state);
-    const { unmount } = render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent cleanup={cleanup}>Content</FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+
+    const { unmount } = renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent cleanup={cleanup}>Content</FormikFormContent>
+      </Formik>,
+      { store }
     );
 
     unmount();
@@ -293,23 +219,18 @@ describe("FormikFormContent", () => {
       label: "Form",
     };
     const useSendMock = jest.spyOn(hooks, "useSendAnalyticsWhen");
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent
-                onSaveAnalytics={eventData}
-                saved={true}
-                savedRedirect="/success"
-              >
-                Content
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent
+          onSaveAnalytics={eventData}
+          saved={true}
+          savedRedirect="/success"
+        >
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(useSendMock).toHaveBeenCalled();
@@ -423,23 +344,13 @@ describe("FormikFormContent", () => {
 
   it("does not run onSuccess on first render", async () => {
     const onSuccess = jest.fn();
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/", key: "testKey" }]}>
-          <CompatRouter>
-            <Formik initialValues={{}} onSubmit={jest.fn()}>
-              <FormikFormContent
-                errors={null}
-                onSuccess={onSuccess}
-                saved={true}
-              >
-                <Field name="val1" />
-              </FormikFormContent>
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent errors={null} onSuccess={onSuccess} saved={true}>
+          <Field name="val1" />
+        </FormikFormContent>
+      </Formik>,
+      { state }
     );
 
     expect(onSuccess).not.toHaveBeenCalled();

--- a/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
+++ b/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.tsx
@@ -1,68 +1,11 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 
-import { Button } from "@canonical/react-components";
-
+import NodeActionWarning from "app/base/components/node/NodeActionWarning";
 import { useCycled, useScrollOnRender } from "app/base/hooks";
 import type { ClearHeaderContent } from "app/base/types";
-import type { Node } from "app/store/types/node";
-import { NodeActions } from "app/store/types/node";
+import type { Node, NodeActions } from "app/store/types/node";
 import { canOpenActionForm } from "app/store/utils";
-
-const getErrorSentence = (
-  action: NodeActions,
-  nodeType: string,
-  count: number
-) => {
-  const nodeString = `${count} ${nodeType}${count === 1 ? "" : "s"}`;
-
-  switch (action) {
-    case NodeActions.ABORT:
-      return `${nodeString} cannot abort action`;
-    case NodeActions.ACQUIRE:
-      return `${nodeString} cannot be allocated`;
-    case NodeActions.CLONE:
-      return `${nodeString} cannot be cloned to`;
-    case NodeActions.COMMISSION:
-      return `${nodeString} cannot be commissioned`;
-    case NodeActions.DELETE:
-      return `${nodeString} cannot be deleted`;
-    case NodeActions.DEPLOY:
-      return `${nodeString} cannot be deployed`;
-    case NodeActions.EXIT_RESCUE_MODE:
-      return `${nodeString} cannot exit rescue mode`;
-    case NodeActions.IMPORT_IMAGES:
-      return `${nodeString} cannot import images`;
-    case NodeActions.LOCK:
-      return `${nodeString} cannot be locked`;
-    case NodeActions.MARK_BROKEN:
-      return `${nodeString} cannot be marked broken`;
-    case NodeActions.MARK_FIXED:
-      return `${nodeString} cannot be marked fixed`;
-    case NodeActions.OFF:
-      return `${nodeString} cannot be powered off`;
-    case NodeActions.ON:
-      return `${nodeString} cannot be powered on`;
-    case NodeActions.OVERRIDE_FAILED_TESTING:
-      return `Cannot override failed tests on ${nodeString}`;
-    case NodeActions.RELEASE:
-      return `${nodeString} cannot be released`;
-    case NodeActions.RESCUE_MODE:
-      return `${nodeString} cannot be put in rescue mode`;
-    case NodeActions.SET_POOL:
-      return `Cannot set pool of ${nodeString}`;
-    case NodeActions.SET_ZONE:
-      return `Cannot set zone of ${nodeString}`;
-    case NodeActions.TAG:
-      return `${nodeString} cannot be tagged`;
-    case NodeActions.TEST:
-      return `${nodeString} cannot be tested`;
-    case NodeActions.UNLOCK:
-      return `${nodeString} cannot be unlocked`;
-    default:
-      return `${nodeString} cannot perform action`;
-  }
-};
 
 type Props = {
   action: NodeActions;
@@ -110,26 +53,12 @@ export const NodeActionFormWrapper = ({
   return (
     <div ref={onRenderRef}>
       {showWarning ? (
-        <p data-testid="node-action-warning">
-          <i className="p-icon--warning" />
-          <span className="u-nudge-right--small">
-            {getErrorSentence(
-              action,
-              nodeType,
-              nodes.length - actionableNodeIDs.length
-            )}
-            . To proceed,{" "}
-            <Button
-              appearance="link"
-              className="u-no-margin--bottom"
-              data-testid="on-update-selected"
-              onClick={() => onUpdateSelected(actionableNodeIDs)}
-            >
-              update your selection
-            </Button>
-            .
-          </span>
-        </p>
+        <NodeActionWarning
+          action={action}
+          nodeType={nodeType}
+          onUpdateSelected={() => onUpdateSelected(actionableNodeIDs)}
+          selectedCount={nodes.length - actionableNodeIDs.length}
+        />
       ) : (
         children
       )}

--- a/src/app/base/components/node/NodeActionWarning/NodeActionWarning.test.tsx
+++ b/src/app/base/components/node/NodeActionWarning/NodeActionWarning.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+
+import NodeActionWarning from "./NodeActionWarning";
+
+import { NodeActions } from "app/store/types/node";
+
+it("displays a warning for selectedCount of 0", () => {
+  render(
+    <NodeActionWarning
+      action={NodeActions.ABORT}
+      nodeType="machine"
+      onUpdateSelected={jest.fn()}
+      selectedCount={0}
+    />
+  );
+  expect(
+    screen.getByText(/No machines have been selected/)
+  ).toBeInTheDocument();
+});
+
+it("displays a warning for an action with a selected count", () => {
+  render(
+    <NodeActionWarning
+      action={NodeActions.COMMISSION}
+      nodeType="node"
+      onUpdateSelected={jest.fn()}
+      selectedCount={2}
+    />
+  );
+  expect(
+    screen.getByText(/2 nodes cannot be commissioned/)
+  ).toBeInTheDocument();
+});

--- a/src/app/base/components/node/NodeActionWarning/NodeActionWarning.tsx
+++ b/src/app/base/components/node/NodeActionWarning/NodeActionWarning.tsx
@@ -1,0 +1,101 @@
+import { Button } from "@canonical/react-components";
+
+import { NodeActions } from "app/store/types/node";
+
+const getErrorSentence = (
+  action: NodeActions,
+  nodeType: string,
+  count: number
+) => {
+  const nodeString = `${count} ${nodeType}${count === 1 ? "" : "s"}`;
+
+  if (count === 0) {
+    return `No ${nodeType}s have been selected`;
+  }
+
+  switch (action) {
+    case NodeActions.ABORT:
+      return `${nodeString} cannot abort action`;
+    case NodeActions.ACQUIRE:
+      return `${nodeString} cannot be allocated`;
+    case NodeActions.CLONE:
+      return `${nodeString} cannot be cloned to`;
+    case NodeActions.COMMISSION:
+      return `${nodeString} cannot be commissioned`;
+    case NodeActions.DELETE:
+      return `${nodeString} cannot be deleted`;
+    case NodeActions.DEPLOY:
+      return `${nodeString} cannot be deployed`;
+    case NodeActions.EXIT_RESCUE_MODE:
+      return `${nodeString} cannot exit rescue mode`;
+    case NodeActions.IMPORT_IMAGES:
+      return `${nodeString} cannot import images`;
+    case NodeActions.LOCK:
+      return `${nodeString} cannot be locked`;
+    case NodeActions.MARK_BROKEN:
+      return `${nodeString} cannot be marked broken`;
+    case NodeActions.MARK_FIXED:
+      return `${nodeString} cannot be marked fixed`;
+    case NodeActions.OFF:
+      return `${nodeString} cannot be powered off`;
+    case NodeActions.ON:
+      return `${nodeString} cannot be powered on`;
+    case NodeActions.OVERRIDE_FAILED_TESTING:
+      return `Cannot override failed tests on ${nodeString}`;
+    case NodeActions.RELEASE:
+      return `${nodeString} cannot be released`;
+    case NodeActions.RESCUE_MODE:
+      return `${nodeString} cannot be put in rescue mode`;
+    case NodeActions.SET_POOL:
+      return `Cannot set pool of ${nodeString}`;
+    case NodeActions.SET_ZONE:
+      return `Cannot set zone of ${nodeString}`;
+    case NodeActions.TAG:
+      return `${nodeString} cannot be tagged`;
+    case NodeActions.TEST:
+      return `${nodeString} cannot be tested`;
+    case NodeActions.UNLOCK:
+      return `${nodeString} cannot be unlocked`;
+    default:
+      return `${nodeString} cannot perform action`;
+  }
+};
+
+type Props = {
+  action: NodeActions;
+  nodeType: string;
+  selectedCount: number;
+  actionableNodeIDs?: string[];
+  onUpdateSelected?: () => void;
+};
+
+const NodeActionWarning = ({
+  action,
+  nodeType,
+  selectedCount,
+  onUpdateSelected,
+}: Props): JSX.Element => {
+  return (
+    <p data-testid="node-action-warning">
+      <i className="p-icon--warning" />
+      <span className="u-nudge-right--small">
+        {getErrorSentence(action, nodeType, selectedCount)}. To proceed,{" "}
+        {onUpdateSelected ? (
+          <Button
+            appearance="link"
+            className="u-no-margin--bottom"
+            data-testid="on-update-selected"
+            onClick={onUpdateSelected}
+          >
+            update your selection
+          </Button>
+        ) : (
+          "update your selection"
+        )}
+        .
+      </span>
+    </p>
+  );
+};
+
+export default NodeActionWarning;

--- a/src/app/base/components/node/NodeActionWarning/index.ts
+++ b/src/app/base/components/node/NodeActionWarning/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NodeActionWarning";

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
@@ -139,3 +139,31 @@ it("clears selected machines and invalidates queries on delete success", async (
       )
   ).toHaveLength(1);
 });
+
+it("displays a warning message and disabled submit button when selectedCount equals 0", () => {
+  const state = rootStateFactory();
+  const store = mockStore(state);
+  render(
+    <Provider store={store}>
+      <MemoryRouter
+        initialEntries={[{ pathname: "/machines", key: "testKey" }]}
+      >
+        <CompatRouter>
+          <MachineActionFormWrapper
+            action={NodeActions.DELETE}
+            clearHeaderContent={jest.fn()}
+            selectedCount={0}
+            selectedMachines={{ filter: {} }}
+            viewingDetails={false}
+          />
+        </CompatRouter>
+      </MemoryRouter>
+    </Provider>
+  );
+  expect(
+    screen.getByText(
+      /No machines have been selected. Update your selection to continue./
+    )
+  ).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Delete machine" })).toBeDisabled();
+});

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
@@ -161,9 +161,7 @@ it("displays a warning message and disabled submit button when selectedCount equ
     </Provider>
   );
   expect(
-    screen.getByText(
-      /No machines have been selected. Update your selection to continue./
-    )
+    screen.getByText(/No machines have been selected./)
   ).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "Delete machine" })).toBeDisabled();
 });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@canonical/react-components";
+import { Notification, Spinner } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
 
 import CloneForm from "./CloneForm";
@@ -175,7 +175,16 @@ export const MachineActionFormWrapper = ({
     return <Spinner />;
   }
 
-  return <div ref={onRenderRef}>{getFormComponent()}</div>;
+  return (
+    <div ref={onRenderRef}>
+      {selectedCount === 0 ? (
+        <Notification severity="caution">
+          No machines have been selected. Update your selection to continue.
+        </Notification>
+      ) : null}
+      {getFormComponent()}
+    </div>
+  );
 };
 
 export default MachineActionFormWrapper;

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
@@ -1,4 +1,4 @@
-import { Notification, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
 
 import CloneForm from "./CloneForm";
@@ -12,6 +12,7 @@ import TagForm from "./TagForm";
 
 import DeleteForm from "app/base/components/node/DeleteForm";
 import FieldlessForm from "app/base/components/node/FieldlessForm";
+import NodeActionWarning from "app/base/components/node/NodeActionWarning";
 import SetZoneForm from "app/base/components/node/SetZoneForm";
 import TestForm from "app/base/components/node/TestForm";
 import type { HardwareType } from "app/base/enum";
@@ -178,9 +179,11 @@ export const MachineActionFormWrapper = ({
   return (
     <div ref={onRenderRef}>
       {selectedCount === 0 ? (
-        <Notification severity="caution">
-          No machines have been selected. Update your selection to continue.
-        </Notification>
+        <NodeActionWarning
+          action={action}
+          nodeType={commonNodeFormProps.modelName}
+          selectedCount={selectedCount}
+        />
       ) : null}
       {getFormComponent()}
     </div>

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -115,6 +115,39 @@ describe("machine reducer", () => {
     );
   });
 
+  it("marks count requests as stale on delete notify", () => {
+    const initialState = machineStateFactory({
+      loading: false,
+      counts: {
+        "1234": machineStateCountFactory({
+          loaded: true,
+          stale: false,
+        }),
+      },
+    });
+    expect(reducers(initialState, actions.deleteNotify("abc123"))).toEqual(
+      machineStateFactory({
+        counts: {
+          "1234": machineStateCountFactory({
+            loaded: true,
+            stale: true,
+          }),
+        },
+      })
+    );
+  });
+
+  it("updates selected machines on delete notify", () => {
+    const initialState = machineStateFactory({
+      selectedMachines: { items: ["abc123"] },
+    });
+    expect(reducers(initialState, actions.deleteNotify("abc123"))).toEqual(
+      machineStateFactory({
+        selectedMachines: { items: [] },
+      })
+    );
+  });
+
   it("ignores calls that don't exist when reducing countSuccess", () => {
     const initialState = machineStateFactory({
       counts: {},

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -934,6 +934,20 @@ const machineSlice = createSlice({
       state.selected = state.selected.filter(
         (machineId: Machine[MachineMeta.PK]) => machineId !== action.payload
       );
+      if (
+        state.selectedMachines &&
+        "items" in state.selectedMachines &&
+        state.selectedMachines.items &&
+        state.selectedMachines.items.length > 0
+      ) {
+        state.selectedMachines.items = state.selectedMachines.items.filter(
+          (machineId: Machine[MachineMeta.PK]) => machineId !== action.payload
+        );
+      }
+      // mark all machine count queries as stale and in need of re-fetch
+      Object.keys(state.counts).forEach((callId) => {
+        state.counts[callId].stale = true;
+      });
       // Clean up the statuses for model.
       delete state.statuses[action.payload];
     },


### PR DESCRIPTION
## Done

- display error message for no machines 
- update selected machines on delete notify
- extract NodeActionWarning component

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Select all machines
- Open Delete action form via "take action" menu
- Make sure the delete count on the button is correct
- Open machine details for one of the machines in the list in a new tab
- Delete the machine
- Go back to the previous tab
- Make sure the delete count has been reduced by 1 to reflect the new value

---
- create 2 new machines
- add these machine hostnames as a filter to the search field (e.g. `hostname:(my-machine,other-machine)`)
- select all machines
- open delete action form via "take action" 
- Open machine details for machines you just created in a new tab
- Delete the machine
- Go back to the previous tab
- Make sure the selected count has been reduced by 1 (from `Delete 2 machines` to `Delete machine`).
- Select all machines by clicking the checkbox at the top of machine listing table
- Open the remaining machine details page in a new tab
- Delete that machine
- Make sure the "No machines selected" warning is displayed and the submit button is disabled
- Click cancel to close the form


## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1288

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

<img width="640" alt="image" src="https://user-images.githubusercontent.com/7452681/202694399-dda21d00-e226-4f63-a18c-0dc1076dca21.png">

