### PR TITLE
fix: renaming dns record #4556

### DIFF
--- a/src/app/base/sagas/actions.ts
+++ b/src/app/base/sagas/actions.ts
@@ -121,7 +121,8 @@ export function* updateDomainRecord(
   { payload }: PayloadAction<{ params: UpdateRecordParams }>
 ): SagaGenerator<void> {
   const { domain, name, rrdata, rrset, ttl } = payload.params;
-  const initialAction = isAddressRecord(rrset.rrtype)
+  const shouldUpdateAddressRecord = rrset.rrdata !== rrdata;
+  const addressRecordAction = shouldUpdateAddressRecord
     ? domainActions.updateAddressRecord({
         address_ttl: ttl,
         domain,
@@ -130,6 +131,13 @@ export function* updateDomainRecord(
         previous_name: rrset.name,
         previous_rrdata: rrset.rrdata,
       })
+    : domainActions.updateDNSResource({
+        dnsresource_id: rrset.dnsresource_id,
+        domain,
+        name,
+      });
+  const initialAction = isAddressRecord(rrset.rrtype)
+    ? addressRecordAction
     : domainActions.updateDNSData({
         dnsdata_id: rrset.dnsdata_id,
         dnsresource_id: rrset.dnsresource_id,

--- a/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
@@ -79,12 +79,12 @@ describe("EditRecordForm", () => {
       </Provider>
     );
 
-    const data_box = screen.getByRole("textbox", {
+    const dataInputField = screen.getByRole("textbox", {
       name: RecordFieldsLabels.Data,
     });
 
-    await userEvent.clear(data_box);
-    await userEvent.type(data_box, "testing");
+    await userEvent.clear(dataInputField);
+    await userEvent.type(dataInputField, "testing");
 
     await userEvent.type(
       screen.getByRole("spinbutton", { name: RecordFieldsLabels.Ttl }),

--- a/src/app/store/domain/slice.ts
+++ b/src/app/store/domain/slice.ts
@@ -412,14 +412,21 @@ const domainSlice = createSlice({
         // No state changes need to be handled for this action.
       },
     },
+    updateDNSResourceStart: (state: DomainState) => {
+      state.saving = true;
+      state.saved = false;
+    },
+    updateDNSResourceSuccess: (state: DomainState) => {
+      state.saving = false;
+      state.saved = true;
+      state.errors = null;
+    },
     updateDNSResourceError: (
       state: DomainState,
       action: PayloadAction<APIError>
     ) => {
+      state.saving = false;
       state.errors = action.payload;
-    },
-    updateDNSResourceSuccess: (state: DomainState) => {
-      state.errors = null;
     },
     updateRecord: {
       prepare: (params: UpdateRecordParams) => ({


### PR DESCRIPTION
## Done

- fix: renaming dns record #4556

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
- go to the DNS page
- create an A record in a domain with name "test"
- edit the entry and rename to "test-new"
- edit the entry and rename to "test" again
- entry should be renamed successfully

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4556

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
