### PR TITLE
refactor(machines): rename selectedMachines state

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
@@ -58,7 +58,7 @@ describe("ReleaseForm", () => {
 
   it("sets the initial disk erase behaviour from global config", () => {
     const store = mockStore(state);
-    state.machine.selected = ["abc123", "def456"];
+    state.machine.selectedMachines = { items: ["abc123", "def456"] };
     state.config.items = [
       configFactory({
         name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
@@ -97,7 +97,7 @@ describe("ReleaseForm", () => {
 
   it("correctly dispatches action to release given machines", () => {
     const store = mockStore(state);
-    state.machine.selected = ["abc123", "def456"];
+    state.machine.selectedMachines = { items: ["abc123", "def456"] };
     const wrapper = mount(
       <Provider store={store}>
         <MemoryRouter

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
@@ -114,7 +114,7 @@ describe("AddBridgeForm", () => {
   });
 
   it("can dispatch an action to add a bridge", async () => {
-    state.machine.selected = ["abc123", "def456"];
+    state.machine.selectedMachines = { items: ["abc123", "def456"] };
     const store = mockStore(state);
     renderWithBrowserRouter(
       <AddBridgeForm

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
@@ -88,7 +88,7 @@ describe("AddInterface", () => {
   });
 
   it("correctly dispatches actions to add a physical interface", async () => {
-    state.machine.selected = ["abc123", "def456"];
+    state.machine.selectedMachines = { items: ["abc123", "def456"] };
     const store = mockStore(state);
     renderWithBrowserRouter(
       <AddInterface close={jest.fn()} systemId="abc123" />,

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx
@@ -96,7 +96,7 @@ describe("EditBridgeForm", () => {
   });
 
   it("can dispatch an action to update a bridge", () => {
-    state.machine.selected = ["abc123", "def456"];
+    state.machine.selectedMachines = { items: ["abc123", "def456"] };
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -36,7 +36,6 @@ const MachineList = ({
   useWindowTitle("Machines");
   const dispatch = useDispatch();
   const errors = useSelector(machineSelectors.errors);
-  const selectedIDs = useSelector(machineSelectors.selectedIDs);
   const [currentPage, setCurrentPage] = useState(1);
   const [sortKey, setSortKey] = useState<FetchGroupKey | null>(
     DEFAULTS.sortKey
@@ -130,7 +129,6 @@ const MachineList = ({
         machines={machines}
         machinesLoading={loading}
         pageSize={PAGE_SIZE}
-        selectedIDs={selectedIDs}
         setCurrentPage={setCurrentPage}
         setHiddenGroups={setHiddenGroups}
         setSortDirection={setSortDirection}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -628,7 +628,6 @@ describe("MachineListTable", () => {
               machineCount={10}
               machines={machines}
               pageSize={20}
-              selectedIDs={[machines[0].system_id]}
               setCurrentPage={jest.fn()}
               setHiddenGroups={jest.fn()}
               setSortDirection={jest.fn()}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -65,7 +65,6 @@ type Props = {
   machines: Machine[];
   machinesLoading?: boolean | null;
   pageSize: number;
-  selectedIDs?: Machine[MachineMeta.PK][];
   setCurrentPage: (currentPage: number) => void;
   setHiddenGroups?: (hiddenGroups: (string | null)[]) => void;
   showActions?: boolean;
@@ -84,7 +83,6 @@ type GenerateRowParams = {
   hiddenColumns: NonNullable<Props["hiddenColumns"]>;
   machines: Machine[];
   onToggleMenu: (systemId: Machine[MachineMeta.PK], open: boolean) => void;
-  selectedIDs: NonNullable<Props["selectedIDs"]>;
   showActions: Props["showActions"];
   showMAC: boolean;
 };
@@ -395,7 +393,6 @@ const generateGroupRows = ({
   groups,
   hiddenGroups,
   machines,
-  selectedIDs,
   setHiddenGroups,
   showActions,
   hiddenColumns,
@@ -487,7 +484,6 @@ const generateGroupRows = ({
         callId,
         groupValue: group.value,
         machines: visibleMachines,
-        selectedIDs,
         showActions,
         hiddenColumns,
       })
@@ -507,7 +503,6 @@ export const MachineListTable = ({
   machines,
   machinesLoading,
   pageSize,
-  selectedIDs = [],
   setCurrentPage,
   setHiddenGroups,
   showActions = true,
@@ -795,7 +790,6 @@ export const MachineListTable = ({
     groups,
     hiddenGroups,
     machines,
-    selectedIDs,
     setHiddenGroups,
     hiddenColumns,
     ...rowProps,

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -99,22 +99,6 @@ describe("machine selectors", () => {
     });
   });
 
-  it("can get the unselected machines", () => {
-    const [selectedMachine, activeMachine, unselectedMachine] = [
-      machineFactory(),
-      machineFactory(),
-      machineFactory(),
-    ];
-    const state = rootStateFactory({
-      machine: machineStateFactory({
-        active: activeMachine.system_id,
-        items: [activeMachine, selectedMachine, unselectedMachine],
-        selected: [selectedMachine.system_id],
-      }),
-    });
-    expect(machine.unselected(state)).toEqual([unselectedMachine]);
-  });
-
   it("can get the errors state", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -39,14 +39,6 @@ const activeID = (state: RootState): Machine[MachineMeta.PK] | null =>
   state.machine.active;
 
 /**
- * Returns selected machine system_ids.
- * @param {RootState} state - The redux state.
- * @returns {Machine["system_id"][]} Selected machine system_ids.
- */
-const selectedIDs = (state: RootState): Machine[MachineMeta.PK][] =>
-  state.machine.selected;
-
-/**
  * Returns all machine statuses.
  * @param {RootState} state - The redux state.
  * @returns {MachineStatuses} A list of all statuses.
@@ -158,41 +150,9 @@ const active = createSelector(
  * @param {RootState} state - The redux state.
  * @returns {Machine[]} Selected machines.
  */
-const selected = createSelector(
-  [defaultSelectors.all, selectedIDs],
-  (machines: Machine[], selectedIDs: Machine[MachineMeta.PK][]) =>
-    selectedIDs.reduce<Machine[]>((selectedMachines, id) => {
-      const selectedMachine = machines.find(
-        (machine) => id === machine.system_id
-      );
-      if (selectedMachine) {
-        selectedMachines.push(selectedMachine);
-      }
-      return selectedMachines;
-    }, [])
-);
-
-/**
- * Returns selected machines.
- * @param {RootState} state - The redux state.
- * @returns {Machine[]} Selected machines.
- */
 const selectedMachines = createSelector(
   [machineState],
   ({ selectedMachines }) => selectedMachines
-);
-
-/**
- * Returns machines that are neither active nor selected.
- * @param state - The redux state.
- * @returns Unselected machines.
- */
-const unselected = createSelector(
-  [defaultSelectors.all, selectedIDs, activeID],
-  (machines, selectedIDs, activeID) =>
-    machines.filter(
-      (machine) => ![...selectedIDs, activeID].includes(machine.system_id)
-    )
 );
 
 /**
@@ -687,8 +647,6 @@ const selectors = {
   overridingFailedTesting: statusSelectors["overridingFailedTesting"],
   processing,
   releasing: statusSelectors["releasing"],
-  selected,
-  selectedIDs,
   selectedMachines,
   settingPool: statusSelectors["settingPool"],
   settingZone: statusSelectors["settingZone"],
@@ -699,7 +657,6 @@ const selectors = {
   turningOn: statusSelectors["turningOn"],
   unlocking: statusSelectors["unlocking"],
   unlinkingSubnet: statusSelectors["unlinkingSubnet"],
-  unselected,
   untagging: statusSelectors["untagging"],
   unusedIdsInCall,
   updatingTags,


### PR DESCRIPTION
## Done

- refactor(machines): rename selected state - this removes the previous selected machines implementation

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify that machine list page loads and you can select machines

## Fixes

Fixes: #1256

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
