### PR TITLE
refactor(machines): move mapSortDirection into hook

### DIFF
--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -14,11 +14,7 @@ import { DEFAULTS } from "app/machines/views/MachineList/MachineListTable/consta
 import { actions as machineActions } from "app/store/machine";
 import type { FetchGroupKey } from "app/store/machine/types";
 import { FilterGroupKey } from "app/store/machine/types";
-import {
-  mapSortDirection,
-  FilterMachines,
-  useFetchedCount,
-} from "app/store/machine/utils";
+import { FilterMachines, useFetchedCount } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { Pod } from "app/store/pod/types";
 
@@ -64,7 +60,7 @@ const LXDVMsTable = ({
       // Set the filters to get results that belong to this single pod or pods in a cluster.
       [FilterGroupKey.Pod]: pods,
     },
-    sortDirection: mapSortDirection(sortDirection),
+    sortDirection,
     sortKey,
     pagination: { currentPage, setCurrentPage, pageSize: VMS_PER_PAGE },
   });

--- a/src/app/kvm/components/VmResources/VmResources.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.tsx
@@ -9,7 +9,7 @@ import MachineListTable from "app/machines/views/MachineList/MachineListTable";
 import { DEFAULTS } from "app/machines/views/MachineList/MachineListTable/constants";
 import type { FetchFilters, FetchGroupKey } from "app/store/machine/types";
 import { FilterGroupKey } from "app/store/machine/types";
-import { mapSortDirection, useFetchedCount } from "app/store/machine/utils";
+import { useFetchedCount } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
@@ -47,7 +47,7 @@ const VmResources = ({ filters, podId }: Props): JSX.Element => {
       ...filters,
       [FilterGroupKey.Pod]: pod ? [pod.name] : [],
     },
-    sortDirection: mapSortDirection(sortDirection),
+    sortDirection,
     sortKey,
     pagination: {
       currentPage,

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -17,7 +17,7 @@ import { actions as generalActions } from "app/store/general";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { FetchGroupKey } from "app/store/machine/types";
-import { mapSortDirection, FilterMachines } from "app/store/machine/utils";
+import { FilterMachines } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 
 type Props = {
@@ -81,7 +81,7 @@ const MachineList = ({
       collapsedGroups: hiddenGroups,
       filters: FilterMachines.parseFetchFilters(searchFilter),
       grouping,
-      sortDirection: mapSortDirection(sortDirection),
+      sortDirection,
       sortKey,
       pagination: { currentPage, setCurrentPage, pageSize: PAGE_SIZE },
     });

--- a/src/app/store/machine/utils/common.test.ts
+++ b/src/app/store/machine/utils/common.test.ts
@@ -140,6 +140,11 @@ describe("common machine utils", () => {
     it("maps none", () => {
       expect(mapSortDirection(SortDirection.NONE)).toBeNull();
     });
+
+    it("maps nullish values", () => {
+      expect(mapSortDirection(undefined)).toBeNull();
+      expect(mapSortDirection(null)).toBeNull();
+    });
   });
 
   describe("selectedToFilters", () => {

--- a/src/app/store/machine/utils/common.ts
+++ b/src/app/store/machine/utils/common.ts
@@ -86,7 +86,7 @@ export const getHasSyncFailed = (machine?: Machine | null): boolean => {
  * Map the table sort direction to the value to send to the fetch request.
  */
 export const mapSortDirection = (
-  sortDirection: ValueOf<typeof SortDirection>
+  sortDirection?: ValueOf<typeof SortDirection> | null
 ): FetchSortDirection | null => {
   switch (sortDirection) {
     case SortDirection.ASCENDING:

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -9,14 +9,23 @@ import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
 import { FetchGroupKey } from "../types/actions";
-import type { FetchSortDirection, FetchParams } from "../types/actions";
+import type { FetchParams } from "../types/actions";
 
-import { selectedToFilters, selectedToSeparateFilters } from "./common";
+import {
+  mapSortDirection,
+  selectedToFilters,
+  selectedToSeparateFilters,
+} from "./common";
 import { FilterMachines } from "./search";
 
 import { ACTION_STATUS } from "app/base/constants";
 import { useCanEdit } from "app/base/hooks";
-import type { ActionStatuses, ActionState, APIError } from "app/base/types";
+import type {
+  ActionStatuses,
+  ActionState,
+  APIError,
+  SortDirection,
+} from "app/base/types";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as generalActions } from "app/store/general";
 import {
@@ -500,7 +509,7 @@ export type UseFetchMachinesOptions = {
   filters?: FetchFilters | null;
   grouping?: FetchGroupKey | null;
   sortKey?: FetchGroupKey | null;
-  sortDirection?: FetchSortDirection | null;
+  sortDirection?: ValueOf<typeof SortDirection> | null;
   collapsedGroups?: FetchParams["group_collapsed"];
   pagination?: {
     pageSize: number;
@@ -613,7 +622,7 @@ export const useFetchMachines = (
                 group_key: options.grouping ?? null,
                 page_number: options?.pagination?.currentPage,
                 page_size: options?.pagination?.pageSize,
-                sort_direction: options.sortDirection ?? null,
+                sort_direction: mapSortDirection(options.sortDirection),
                 sort_key: options.sortKey ?? null,
               }
             : null

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -13,7 +13,6 @@ import ErrorsNotification from "app/machines/views/MachineList/ErrorsNotificatio
 import MachineListTable from "app/machines/views/MachineList/MachineListTable";
 import { DEFAULTS } from "app/machines/views/MachineList/MachineListTable/constants";
 import type { FetchGroupKey, FetchFilters } from "app/store/machine/types";
-import { mapSortDirection } from "app/store/machine/utils";
 import { useFetchMachines } from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
@@ -49,7 +48,7 @@ const TagMachines = (): JSX.Element => {
   const { callId, loading, machineCount, machines, machinesErrors } =
     useFetchMachines({
       filters,
-      sortDirection: mapSortDirection(sortDirection),
+      sortDirection,
       sortKey,
       pagination: {
         currentPage,


### PR DESCRIPTION
## Done

- refactor(machines): move mapSortDirection into hook

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing and ensure that sorting works as before
- Go to KVM page and ensure that sorting works as before

## Fixes

Fixes: https://github.com/canonical/app-tribe/issues/1320

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
