### PR TITLE
feat(machines): integrate suppress_failed_script_results action

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -1,82 +1,23 @@
 /* eslint-disable react/no-multi-comp */
-import { useEffect, useMemo, useState } from "react";
-
-import { Col, Row, Spinner } from "@canonical/react-components";
-import pluralize from "pluralize";
-import { useDispatch, useSelector } from "react-redux";
+import { Col, Row } from "@canonical/react-components";
+import { useDispatch } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 import * as Yup from "yup";
 
 import ActionForm from "app/base/components/ActionForm";
 import FormikField from "app/base/components/FormikField";
+import { useSendAnalytics } from "app/base/hooks";
 import urls from "app/base/urls";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
-import type {
-  Machine,
-  MachineEventErrors,
-  MachineMeta,
-} from "app/store/machine/types";
-import {
-  useFetchMachine,
-  useSelectedMachinesActionsDispatch,
-} from "app/store/machine/utils/hooks";
-import type { RootState } from "app/store/root/types";
-import { actions as scriptResultActions } from "app/store/scriptresult";
-import scriptResultsSelectors from "app/store/scriptresult/selectors";
+import type { MachineEventErrors } from "app/store/machine/types";
+import { useSelectedMachinesActionsDispatch } from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
 
 type Props = MachineActionFormProps;
 
 export type OverrideTestFormValues = {
   suppressResults: boolean;
-};
-
-const FailedTestsMessage = ({
-  numFailedTests,
-  selectedCount,
-  singleMachine,
-}: {
-  numFailedTests: number;
-  singleMachine: Machine | null;
-} & Pick<MachineActionFormProps, "selectedCount">): JSX.Element => {
-  if (numFailedTests > 0) {
-    const numFailedTestsString = `failed ${numFailedTests} ${pluralize(
-      "test",
-      numFailedTests
-    )}.`;
-    if (singleMachine) {
-      return (
-        <span>
-          Machine <strong>{singleMachine.hostname}</strong> has{" "}
-          <Link
-            to={urls.machines.machine.index({ id: singleMachine.system_id })}
-          >
-            {numFailedTestsString}
-          </Link>
-        </span>
-      );
-    }
-    return (
-      <span>
-        <strong>{selectedCount} machines</strong> have {numFailedTestsString}
-      </span>
-    );
-  }
-  return (
-    <>
-      {singleMachine ? (
-        <span>
-          Machine <strong>{singleMachine.hostname}</strong> has
-        </span>
-      ) : (
-        <span>
-          <strong>{selectedCount} machines</strong> have
-        </span>
-      )}{" "}
-      not failed any tests. This can occur if the test suite failed to start.
-    </>
-  );
 };
 
 const OverrideTestFormSchema = Yup.object().shape({
@@ -92,56 +33,16 @@ export const OverrideTestForm = ({
   selectedMachines,
   viewingDetails,
 }: Props): JSX.Element => {
+  const sendAnalytics = useSendAnalytics();
   const isSingleMachine = selectedCount === 1;
   const dispatch = useDispatch();
   const { dispatch: dispatchForSelectedMachines, ...actionProps } =
     useSelectedMachinesActionsDispatch({ selectedMachines, searchFilter });
-  const [requestedScriptResults, setRequestedScriptResults] = useState<
-    Machine[MachineMeta.PK][]
-  >([]);
-  const scriptResultsLoaded = useSelector(scriptResultsSelectors.loaded);
-  const scriptResultsLoading = useSelector(scriptResultsSelectors.loading);
-  // TODO: allow suppressing results for multiple machines via filter once the API supports it
-  // https://github.com/canonical/app-tribe/issues/1427
-  const machineIDs = useMemo(
-    () =>
-      isSingleMachine
-        ? (selectedMachines &&
-            "items" in selectedMachines &&
-            selectedMachines?.items) ||
-          []
-        : [],
-    [isSingleMachine, selectedMachines]
-  );
-  const { machine } = useFetchMachine(isSingleMachine ? machineIDs[0] : null);
-
-  const scriptResults = useSelector((state: RootState) =>
-    scriptResultsSelectors.getFailedTestingResultsByNodeIds(state, machineIDs)
-  );
-  // Get the number of results for all machines.
-  const numFailedTests =
-    Object.entries(scriptResults).reduce(
-      // Count the results for this machine.
-      (acc, [, results]) => acc + results.length,
-      0
-    ) || 0;
-
-  useEffect(() => {
-    const newRequests: Machine[MachineMeta.PK][] = [];
-    machineIDs?.forEach((id) => {
-      // Check that the results haven't already been requested.
-      // This fetches the results even if they've been loaded previously so that
-      // we make sure the data is not stale.
-      if (!requestedScriptResults.includes(id)) {
-        dispatch(scriptResultActions.getByNodeId(id));
-        newRequests.push(id);
-      }
-    });
-    if (newRequests.length > 0) {
-      // Store the requested ids so that they're not requested again.
-      setRequestedScriptResults(requestedScriptResults.concat(newRequests));
-    }
-  }, [dispatch, scriptResultsLoading, machineIDs, requestedScriptResults]);
+  const machineID = isSingleMachine
+    ? selectedMachines &&
+      "items" in selectedMachines &&
+      selectedMachines?.items?.[0]
+    : null;
 
   return (
     <ActionForm<OverrideTestFormValues, MachineEventErrors>
@@ -162,23 +63,11 @@ export const OverrideTestForm = ({
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
         const { suppressResults } = values;
-        if (selectedMachines) {
-          dispatchForSelectedMachines(machineActions.overrideFailedTesting);
-        }
+        dispatchForSelectedMachines(machineActions.overrideFailedTesting);
         if (suppressResults) {
-          machineIDs?.forEach((system_id) => {
-            if (
-              system_id in scriptResults &&
-              scriptResults[system_id].length > 0
-            ) {
-              dispatch(
-                machineActions.suppressScriptResults(
-                  system_id,
-                  scriptResults[system_id]
-                )
-              );
-            }
-          });
+          dispatchForSelectedMachines(
+            machineActions.suppressFailedScriptResults
+          );
         }
       }}
       onSuccess={clearHeaderContent}
@@ -190,56 +79,40 @@ export const OverrideTestForm = ({
       <Row>
         <Col size={6}>
           <>
-            {/* TODO: display failed tests message for multiple machines
-              once the API supports it https://github.com/canonical/app-tribe/issues/1427 */}
-            {isSingleMachine ? (
-              <p data-testid="failed-results-message">
-                <i className="p-icon--warning is-inline"></i>
-
-                <FailedTestsMessage
-                  numFailedTests={numFailedTests}
-                  selectedCount={selectedCount}
-                  singleMachine={machine}
-                />
-              </p>
-            ) : null}
             <p className="u-sv1">
               Overriding will allow the machines to be deployed, marked with a
               warning.
             </p>
-            {isSingleMachine && !scriptResultsLoaded ? (
-              <p>
-                <Spinner
-                  className="u-no-padding u-no-margin"
-                  text="Loading script results..."
-                />
-              </p>
-            ) : null}
-            {numFailedTests > 0 && (
-              <FormikField
-                label={
-                  <span>
-                    Suppress test-failure icons in the machines list. Results
-                    remain visible in
-                    <br />
-                    {machine ? (
-                      <Link
-                        to={urls.machines.machine.index({
-                          id: machine.system_id,
-                        })}
-                      >
-                        Machine &gt; Hardware tests
-                      </Link>
-                    ) : (
-                      "Machine > Hardware tests"
-                    )}
-                    .
-                  </span>
-                }
-                name="suppressResults"
-                type="checkbox"
-              />
-            )}
+            <FormikField
+              label={
+                <span>
+                  Suppress test-failure icons in the machines list. Results
+                  remain visible in
+                  <br />
+                  {machineID ? (
+                    <Link
+                      to={urls.machines.machine.index({
+                        id: machineID,
+                      })}
+                    >
+                      Machine &gt; Hardware tests
+                    </Link>
+                  ) : (
+                    "Machine > Hardware tests"
+                  )}
+                  .
+                </span>
+              }
+              name="suppressResults"
+              onChangeCapture={(e: React.ChangeEvent<HTMLInputElement>) => {
+                sendAnalytics(
+                  `Machine ${viewingDetails ? "details" : "list"} action form`,
+                  "Suppress failed tests",
+                  e.target.checked ? "Check" : "Uncheck"
+                );
+              }}
+              type="checkbox"
+            />
           </>
         </Col>
       </Row>

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1752,6 +1752,12 @@ const machineSlice = createSlice({
         // No state changes need to be handled for this action.
       },
     },
+    suppressFailedScriptResults: generateActionParams<BaseMachineActionParams>(
+      NodeActions.SUPPRESS_FAILED_SCRIPT_RESULTS
+    ),
+    suppressFailedScriptResultsError: statusHandlers.delete.error,
+    suppressFailedScriptResultsStart: statusHandlers.delete.start,
+    suppressFailedScriptResultsSuccess: statusHandlers.delete.success,
     [NodeActions.TAG]: generateActionParams<TagParams>(NodeActions.TAG),
     [`${NodeActions.TAG}Error`]: statusHandlers.tag.error,
     [`${NodeActions.TAG}Start`]: statusHandlers.tag.start,

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -28,7 +28,10 @@ import type {
 } from "app/store/types/node";
 import type { EventError, GenericState } from "app/store/types/state";
 
-export type MachineActions = Exclude<NodeActions, NodeActions.IMPORT_IMAGES>;
+export type MachineActions = Exclude<
+  NodeActions,
+  NodeActions.IMPORT_IMAGES | NodeActions.SUPPRESS_FAILED_SCRIPT_RESULTS
+>;
 
 // BaseMachine is returned from the server when using "machine.list", and is
 // used in the machine list. This type is missing some properties due to an

--- a/src/app/store/types/node.ts
+++ b/src/app/store/types/node.ts
@@ -174,6 +174,7 @@ export enum NodeActions {
   RESCUE_MODE = "rescue-mode",
   SET_POOL = "set-pool",
   SET_ZONE = "set-zone",
+  SUPPRESS_FAILED_SCRIPT_RESULTS = "suppress_failed_script_results",
   TAG = "tag",
   TEST = "test",
   UNLOCK = "unlock",


### PR DESCRIPTION
## Done

- feat(machines): integrate suppress_failed_script_results action

Note: suppress_failed_script_results will currently fail [has not been yet merged to main in MAAS core](https://code.launchpad.net/~alexsander-souza/maas/+git/maas/+merge/433484) - this is expected

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### Fixes
https://warthogs.atlassian.net/browse/WD-604

### QA steps
- Go to machine list
- Select a few machines and open Override failed testing action form
- select suppress failed scripts checkbox
- make sure the google analytics event has been sent with the correct ("check"/"uncheck") label
- submit the action
- make sure that 2 websocket messages have been sent (1 for override failed testing, 1 for suppress_failed_script_results action) with the correct system_ids and an error message is displayed as the action will fail
- Perform the same action on machine details page

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
