### PR TITLE
fix(vault): show icon in controller listing if all controllers are configured but secrets are not migrated

### DIFF
--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { MainTable, Spinner, Icon, Tooltip } from "@canonical/react-components";
+import { MainTable, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import StatusColumn from "./StatusColumn";
@@ -12,6 +12,7 @@ import DoubleRow from "app/base/components/DoubleRow";
 import GroupCheckbox from "app/base/components/GroupCheckbox";
 import RowCheckbox from "app/base/components/RowCheckbox";
 import TableHeader from "app/base/components/TableHeader";
+import TooltipButton from "app/base/components/TooltipButton";
 import docsUrls from "app/base/docsUrls";
 import { useTableSort } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
@@ -98,16 +99,14 @@ const generateRows = ({
               {controller.node_type === NodeType.REGION_CONTROLLER ||
               controller.node_type === NodeType.REGION_AND_RACK_CONTROLLER ? (
                 vaultEnabled === true ? (
-                  <Tooltip
-                    children={
-                      <Icon
-                        aria-describedby="tooltip-description"
-                        data-testid="vault-icon"
-                        name="security-tick"
-                      />
-                    }
+                  <TooltipButton
+                    iconName="security-tick"
+                    iconProps={{
+                      "data-testid": "vault-icon",
+                      "aria-describedby": "tooltip-description-tick",
+                    }}
                     message={
-                      <p id="tooltip-description">
+                      <p id="tooltip-description-tick">
                         Vault is configured on this region controller for secret
                         storage.
                         <br />
@@ -118,14 +117,12 @@ const generateRows = ({
                     }
                   />
                 ) : controller.vault_configured === true ? (
-                  <Tooltip
-                    children={
-                      <Icon
-                        aria-describedby="tooltip-description"
-                        data-testid="vault-icon"
-                        name="security"
-                      />
-                    }
+                  <TooltipButton
+                    iconName="security"
+                    iconProps={{
+                      "data-testid": "vault-icon",
+                      "aria-describedby": "tooltip-description",
+                    }}
                     message={
                       <p id="tooltip-description">
                         Vault is configured on this controller. <br />
@@ -139,16 +136,14 @@ const generateRows = ({
                   />
                 ) : (
                   configuredControllers >= 1 && (
-                    <Tooltip
-                      children={
-                        <Icon
-                          aria-describedby="tooltip-description"
-                          data-testid="vault-icon"
-                          name="security-warning"
-                        />
-                      }
+                    <TooltipButton
+                      iconName="security-warning"
+                      iconProps={{
+                        "data-testid": "vault-icon",
+                        "aria-describedby": "tooltip-description-warning",
+                      }}
                       message={
-                        <p id="tooltip-description">
+                        <p id="tooltip-description-warning">
                           Missing Vault configuration.
                           <br />
                           <a href={docsUrls.vaultIntegration}>

--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -98,7 +98,7 @@ const generateRows = ({
             <span className="u-truncate">
               {controller.node_type === NodeType.REGION_CONTROLLER ||
               controller.node_type === NodeType.REGION_AND_RACK_CONTROLLER ? (
-                vaultEnabled === true ? (
+                vaultEnabled ? (
                   <TooltipButton
                     iconName="security-tick"
                     iconProps={{

--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -47,14 +47,12 @@ const getSortValue = (sortKey: SortKey, controller: Controller) => {
 
 const generateRows = ({
   controllers,
-  unconfiguredControllers,
   configuredControllers,
   selectedIDs,
   handleRowCheckbox,
   vaultEnabled,
 }: {
   controllers: Controller[];
-  unconfiguredControllers: number;
   configuredControllers: number;
   selectedIDs: Controller[ControllerMeta.PK][];
   handleRowCheckbox: CheckboxHandlers<
@@ -99,7 +97,7 @@ const generateRows = ({
             <span className="u-truncate">
               {controller.node_type === NodeType.REGION_CONTROLLER ||
               controller.node_type === NodeType.REGION_AND_RACK_CONTROLLER ? (
-                vaultEnabled ? (
+                vaultEnabled === true ? (
                   <Tooltip
                     children={
                       <Icon
@@ -120,27 +118,25 @@ const generateRows = ({
                     }
                   />
                 ) : controller.vault_configured === true ? (
-                  unconfiguredControllers >= 1 && (
-                    <Tooltip
-                      children={
-                        <Icon
-                          aria-describedby="tooltip-description"
-                          data-testid="vault-icon"
-                          name="security"
-                        />
-                      }
-                      message={
-                        <p id="tooltip-description">
-                          Vault is configured on this controller. <br />
-                          Once all controllers are configured, migrate the
-                          secrets. <br />
-                          <a href={docsUrls.vaultIntegration}>
-                            Read more about Vault integration
-                          </a>
-                        </p>
-                      }
-                    />
-                  )
+                  <Tooltip
+                    children={
+                      <Icon
+                        aria-describedby="tooltip-description"
+                        data-testid="vault-icon"
+                        name="security"
+                      />
+                    }
+                    message={
+                      <p id="tooltip-description">
+                        Vault is configured on this controller. <br />
+                        Once all controllers are configured, migrate the
+                        secrets. <br />
+                        <a href={docsUrls.vaultIntegration}>
+                          Read more about Vault integration
+                        </a>
+                      </p>
+                    }
+                  />
                 ) : (
                   configuredControllers >= 1 && (
                     <Tooltip
@@ -219,9 +215,8 @@ const ControllerListTable = ({
   const { handleGroupCheckbox, handleRowCheckbox } =
     generateCheckboxHandlers<Controller[ControllerMeta.PK]>(onSelectedChange);
   const controllerIDs = controllers.map((controller) => controller.system_id);
-  const { unconfiguredControllers, configuredControllers } = useSelector(
-    (state: RootState) =>
-      controllerSelectors.getVaultConfiguredControllers(state)
+  const { configuredControllers } = useSelector((state: RootState) =>
+    controllerSelectors.getVaultConfiguredControllers(state)
   );
   const dispatch = useDispatch();
   const vaultEnabled = useSelector(vaultEnabledSelectors.get);
@@ -328,7 +323,6 @@ const ControllerListTable = ({
       ]}
       rows={generateRows({
         controllers: sortedControllers,
-        unconfiguredControllers: unconfiguredControllers.length,
         configuredControllers: configuredControllers.length,
         selectedIDs,
         handleRowCheckbox,

--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-import { MainTable, Spinner } from "@canonical/react-components";
+import { MainTable, Spinner, Link } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
 import StatusColumn from "./StatusColumn";
@@ -110,9 +110,14 @@ const generateRows = ({
                         Vault is configured on this region controller for secret
                         storage.
                         <br />
-                        <a href={docsUrls.vaultIntegration}>
+                        <Link
+                          className="is-on-dark"
+                          href={docsUrls.vaultIntegration}
+                          rel="noreferrer noopener"
+                          target="_blank"
+                        >
                           Read more about Vault integration
-                        </a>
+                        </Link>
                       </p>
                     }
                   />
@@ -128,9 +133,14 @@ const generateRows = ({
                         Vault is configured on this controller. <br />
                         Once all controllers are configured, migrate the
                         secrets. <br />
-                        <a href={docsUrls.vaultIntegration}>
+                        <Link
+                          className="is-on-dark"
+                          href={docsUrls.vaultIntegration}
+                          rel="noreferrer noopener"
+                          target="_blank"
+                        >
                           Read more about Vault integration
-                        </a>
+                        </Link>
                       </p>
                     }
                   />
@@ -146,9 +156,14 @@ const generateRows = ({
                         <p id="tooltip-description-warning">
                           Missing Vault configuration.
                           <br />
-                          <a href={docsUrls.vaultIntegration}>
+                          <Link
+                            className="is-on-dark"
+                            href={docsUrls.vaultIntegration}
+                            rel="noreferrer noopener"
+                            target="_blank"
+                          >
                             Read more about Vault integration
-                          </a>
+                          </Link>
                         </p>
                       }
                     />


### PR DESCRIPTION
## Done

- Icons now show next to controllers if they are configured to use Vault but secrets have not been migrated

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- Either on your system or in a Multipass instance, ensure you've installed the latest MAAS snap with a test db:
   - `sudo snap install maas --channel=latest/edge`
   - `sudo snap install maas-test-db --channel=latest/edge`
- Initialise maas and create an admin user
- Install Vault: `sudo snap install vault` and jq: `sudo apt install jq`
- Run Vault: `vault server -dev -dev-root-token-id=root-token`
- In a separate terminal, run this script to set up vault: https://git.launchpad.net/maas/plain/utilities/configure-vault (you'll need to download it first). You can run it like this: `./configure-vault`, or like this: `sudo -E bash configure-vault setup`, `sudo -E bash configure-vault create-approle role-name`
   - This may require you to set some environment variables. The values you need will be in your terminal output where Vault is running, e.g. `export VAULT_TOKEN='root-token'`
   - `export VAR_NAME="varvalue"`
- Once the script has run successfully, run the command that it gives you. This will configure the primary controller to use Vault for secret storage.
- Ensure your MAAS-UI instance (this branch) is pointing to your local MAAS instance (you can set the MAAS_URL in a .env.local file)
- Go to the controller listing
- Ensure that the controller has a shield icon next to its type, with a tooltip.

