### PR TITLE
add e2e tests with playwright

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,40 @@
+name: Playwright Tests
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+jobs:
+  test:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    env:
+      MAAS_URL: localhost:5240
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: yarn
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Install MAAS
+        run: |
+          sudo systemctl enable snapd
+          sudo snap install maas --channel=latest/edge
+          sudo snap install maas-test-db --channel=latest/edge
+      - name: Initialise MAAS
+        run: sudo maas init region+rack --maas-url=http://${{env.MAAS_URL}}/MAAS --database-uri maas-test-db:///
+      - name: Create MAAS admin
+        run: sudo maas createadmin --username=admin --password=test --email=fake@example.org
+      - name: Wait for MAAS UI to be ready
+        run: yarn run wait-on http-get://${{env.MAAS_URL}}/MAAS/r
+      - name: Run Playwright tests
+        run: yarn playwright test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ cypress.env.json
 *.fuse*
 
 sitespeed.io/results
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@percy/cli": "1.14.0",
     "@percy/cypress": "3.1.2",
+    "@playwright/test": "1.28.0",
     "@testing-library/cypress": "8.0.7",
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "12.1.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,108 @@
+import type { PlaywrightTestConfig } from "@playwright/test";
+import { devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: "./tests",
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+    baseURL: "http://0.0.0.0:5240/",
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+
+    {
+      name: "firefox",
+      use: {
+        ...devices["Desktop Firefox"],
+      },
+    },
+
+    {
+      name: "webkit",
+      use: {
+        ...devices["Desktop Safari"],
+      },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: {
+    //     ...devices['Pixel 5'],
+    //   },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: {
+    //     ...devices['iPhone 12'],
+    //   },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: {
+    //     channel: 'msedge',
+    //   },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: {
+    //     channel: 'chrome',
+    //   },
+    // },
+  ],
+
+  /* Folder for test artifacts such as screenshots, videos, traces, etc. */
+  // outputDir: 'test-results/',
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   port: 3000,
+  // },
+};
+
+export default config;

--- a/tests/machines.spec.ts
+++ b/tests/machines.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+
+let machineListRequests: (string | Buffer)[] = [];
+let machineCountRequests: (string | Buffer)[] = [];
+
+test.beforeEach(async ({ page, context }) => {
+  machineListRequests = [];
+  machineCountRequests = [];
+  await context.addCookies([
+    { name: "skipsetupintro", value: "true", url: "http://0.0.0.0:5240/" },
+    { name: "skipintro", value: "true", url: "http://0.0.0.0:5240/" },
+  ]);
+  await page.goto("/MAAS/r/machines");
+  await page.getByLabel("Username").click();
+  await page.getByLabel("Username").fill("admin");
+  await page.getByLabel("Username").press("Tab");
+  await page.getByLabel("Password").fill("test");
+  await page.getByLabel("Password").press("Enter");
+});
+
+test("machines list loads", async ({ page }) => {
+  page.on("websocket", async (ws) => {
+    console.log(`WebSocket opened: ${ws.url()}>`);
+    await ws.on("framesent", async (data) => {
+      console.log(data.payload);
+      if (data.payload.includes("machine.list")) {
+        machineListRequests.push(data.payload);
+      }
+      if (data.payload.includes("machine.count")) {
+        machineCountRequests.push(data.payload);
+      }
+    });
+    ws.on("close", () => console.log("WebSocket closed"));
+  });
+  await expect(page).toHaveTitle(/Machines/);
+  await expect(page.getByTestId("section-header-title")).toHaveText("Machines");
+  await expect(page.getByTestId("subtitle-string")).toHaveText(
+    /machines available/
+  );
+  // expect a single machine.list and machine.count request
+  await expect(machineListRequests.length).toBe(1);
+  await expect(machineCountRequests.length).toBe(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,6 +2615,14 @@
   resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.3.1.tgz#9bdedde35a861d8d0b43fcebcaa93508e938451f"
   integrity sha512-jJsJHMPmcDXFpZfQI+yJbpkdq38WQDzLNtbbHMCBNXVb6BqO2MJPijlqaNA8MuVOLsh8ULBQE+n62v/nqAVF/w==
 
+"@playwright/test@1.28.0":
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.28.0.tgz#8de83f9d2291bba3f37883e33431b325661720d9"
+  integrity sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==
+  dependencies:
+    "@types/node" "*"
+    playwright-core "1.28.0"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz#58f8217ba70069cc6a73f5d7e05e85b458c150e2"
@@ -9947,6 +9955,11 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.28.0:
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.0.tgz#61df5c714f45139cca07095eccb4891e520e06f2"
+  integrity sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==
 
 plur@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Done

- add e2e tests with playwright 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
