### PR TITLE
feat(vault): render error message instead of content if vault is sealed

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -69,7 +69,7 @@ describe("App", () => {
     );
   });
 
-  it("displays an error if vault is unreachable (sealed)", () => {
+  it("displays an error if vault is sealed", () => {
     state.config.errors = "Vault request failed";
     state.status.authenticated = true;
     state.status.error = null;
@@ -79,6 +79,20 @@ describe("App", () => {
     expect(
       screen.getByText(
         /The server connection failed with the error "Vault request failed"/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("displays an error if vault is unreachable", () => {
+    state.config.errors = "Vault connection failed";
+    state.status.authenticated = true;
+    state.status.error = null;
+    state.status.connected = true;
+    renderWithBrowserRouter(<App />, { route: "/settings", state });
+    expect(screen.getByText("Failed to connect")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /The server connection failed with the error "Vault connection failed"/
       )
     ).toBeInTheDocument();
   });

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,4 +1,5 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
+import { screen } from "@testing-library/react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -14,8 +15,9 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
   ...jest.requireActual("@canonical/react-components/dist/hooks"),
@@ -68,21 +70,14 @@ describe("App", () => {
   });
 
   it("displays an error if vault is unreachable (sealed)", () => {
-    state.config.errors = ["Error!"];
+    state.config.errors = "Error!!!!";
     state.status.authenticated = true;
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
-          <CompatRouter>
-            <App />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("SectionHeader").prop("title")).toBe(
-      "Failed to connect"
-    );
+    renderWithBrowserRouter(<App />, { route: "/settings", store });
+    expect(screen.getByText("Failed to connect")).toBeInTheDocument();
+    expect(
+      screen.getByText(/The server connection failed./)
+    ).toBeInTheDocument();
   });
 
   it("displays a loading message if connecting", () => {

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -70,13 +70,16 @@ describe("App", () => {
   });
 
   it("displays an error if vault is unreachable (sealed)", () => {
-    state.config.errors = "Error!!!!";
+    state.config.errors = "Vault request failed";
     state.status.authenticated = true;
-    const store = mockStore(state);
-    renderWithBrowserRouter(<App />, { route: "/settings", store });
+    state.status.error = null;
+    state.status.connected = true;
+    renderWithBrowserRouter(<App />, { route: "/settings", state });
     expect(screen.getByText("Failed to connect")).toBeInTheDocument();
     expect(
-      screen.getByText(/The server connection failed./)
+      screen.getByText(
+        /The server connection failed with the error "Vault request failed"/
+      )
     ).toBeInTheDocument();
   });
 

--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -67,6 +67,24 @@ describe("App", () => {
     );
   });
 
+  it("displays an error if vault is unreachable (sealed)", () => {
+    state.config.errors = ["Error!"];
+    state.status.authenticated = true;
+    const store = mockStore(state);
+    const wrapper = mount(
+      <Provider store={store}>
+        <MemoryRouter initialEntries={[{ pathname: "/settings" }]}>
+          <CompatRouter>
+            <App />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+    expect(wrapper.find("SectionHeader").prop("title")).toBe(
+      "Failed to connect"
+    );
+  });
+
   it("displays a loading message if connecting", () => {
     state.status.connecting = true;
     const store = mockStore(state);

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -26,6 +26,11 @@ import { actions as generalActions } from "app/store/general";
 import { actions as statusActions } from "app/store/status";
 import status from "app/store/status/selectors";
 
+export enum VaultErrors {
+  REQUEST_FAILED = "Vault request failed",
+  CONNECTION_FAILED = "Vault connection failed",
+}
+
 export const App = (): JSX.Element => {
   const dispatch = useDispatch();
   const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
@@ -86,8 +91,8 @@ export const App = (): JSX.Element => {
       </Section>
     );
   } else if (
-    configErrors === "Vault request failed" ||
-    configErrors === "Vault connection failed"
+    configErrors === VaultErrors.REQUEST_FAILED ||
+    configErrors === VaultErrors.CONNECTION_FAILED
   ) {
     content = (
       <Section header={<SectionHeader title="Failed to connect" />}>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -85,12 +85,11 @@ export const App = (): JSX.Element => {
         </Notification>
       </Section>
     );
-  } else if (configErrors) {
+  } else if (configErrors === "Vault request failed") {
     content = (
       <Section header={<SectionHeader title="Failed to connect" />}>
         <Notification severity="negative" title="Error:">
-          The server connection failed
-          {configErrors ? ` with the error "${configErrors}"` : ""}.
+          The server connection failed with the error "{configErrors}".
         </Notification>
       </Section>
     );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -37,6 +37,8 @@ export const App = (): JSX.Element => {
   const connecting = useSelector(status.connecting);
   const connectionError = useSelector(status.error);
   const maasTheme = useSelector(configSelectors.theme);
+  const configLoading = useSelector(configSelectors.loading);
+  const configErrors = useSelector(configSelectors.errors);
   const [theme, setTheme] = useState(maasTheme ? maasTheme : "default");
   const previousAuthenticated = usePrevious(authenticated, false);
 
@@ -70,7 +72,7 @@ export const App = (): JSX.Element => {
   }, [dispatch, connected]);
 
   let content: ReactNode = null;
-  if (authLoading || connecting || authenticating) {
+  if (authLoading || connecting || authenticating || configLoading) {
     content = <Section header={<SectionHeader loading />} />;
   } else if (!authenticated && !connectionError) {
     content = <Login />;
@@ -80,6 +82,15 @@ export const App = (): JSX.Element => {
         <Notification severity="negative" title="Error:">
           The server connection failed
           {connectionError ? ` with the error "${connectionError}"` : ""}.
+        </Notification>
+      </Section>
+    );
+  } else if (configErrors) {
+    content = (
+      <Section header={<SectionHeader title="Failed to connect" />}>
+        <Notification severity="negative" title="Error:">
+          The server connection failed
+          {configErrors ? ` with the error "${configErrors}"` : ""}.
         </Notification>
       </Section>
     );

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -85,7 +85,10 @@ export const App = (): JSX.Element => {
         </Notification>
       </Section>
     );
-  } else if (configErrors === "Vault request failed") {
+  } else if (
+    configErrors === "Vault request failed" ||
+    configErrors === "Vault connection failed"
+  ) {
     content = (
       <Section header={<SectionHeader title="Failed to connect" />}>
         <Notification severity="negative" title="Error:">


### PR DESCRIPTION
## Done

- Render an error message instead of full page content if an error message for vault is received.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- Follow the setup instructions shown [here](https://docs.google.com/document/d/1ssfthB3g1kzELDaKgKdr4Mzt5n-eLQx11mnotvNbKJM/edit?disco=AAAAktcPosI)
- Migrate all secrets to Vault (instructions at /settings/configuration/security)
- Seal Vault: `vault operator seal`
- Refresh the page
- Ensure that an error message is displayed indicating that there was a Vault request error
- Unseal vault: `vault operator unseal` 
- Refresh the page
- Ensure that MAAS can be accessed again

## Fixes

Fixes https://github.com/canonical/app-tribe/issues/1411
