### PR TITLE
log generic websocket errors to the console

### DIFF
--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -646,6 +646,7 @@ export function* setupWebSocket({
       }
     }
   } catch (error) {
+    console.error(error);
     yield* put({
       type: "status/websocketError",
       error: true,


### PR DESCRIPTION
## Done

- log generic websocket errors to the console

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- check out this branch locally
- check out the [maas-mock-server](https://github.com/canonical/maas-mock-server) locally and use `https://assets.ubuntu.com/v1/cfc9affb-responses.json` as the `MOCK_PATH` in .env file
- start the mock server
- update MAAS_URL in your .env.local to use maas-mock-server as a back-end (http://localhost:8080/)
- login using `admin` `test1` credentials
- open machine listing
- mock server contains invalid (outdated) response data, which will trigger an error
- verify it's been logged in the console not just in the UI

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
