### PR TITLE
fix(vault): Hide additional notifications if a Vault error is displayed

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -97,7 +97,7 @@ export const App = (): JSX.Element => {
     content = (
       <Section
         header={<SectionHeader title="Failed to connect" />}
-        hideNotifications={true}
+        isNotificationListHidden={true}
       >
         <Notification severity="negative" title="Error:">
           The server connection failed with the error "{configErrors}".

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -95,7 +95,10 @@ export const App = (): JSX.Element => {
     configErrors === VaultErrors.CONNECTION_FAILED
   ) {
     content = (
-      <Section header={<SectionHeader title="Failed to connect" />}>
+      <Section
+        header={<SectionHeader title="Failed to connect" />}
+        hideNotifications={true}
+      >
         <Notification severity="negative" title="Error:">
           The server connection failed with the error "{configErrors}".
         </Notification>

--- a/src/app/base/components/Section/Section.tsx
+++ b/src/app/base/components/Section/Section.tsx
@@ -10,14 +10,14 @@ export type Props = {
   children?: ReactNode;
   header?: ReactNode;
   sidebar?: ReactNode;
-  hideNotifications?: boolean;
+  isNotificationListHidden?: boolean;
 } & HTMLProps<HTMLDivElement>;
 
 const Section = ({
   children,
   header,
   sidebar,
-  hideNotifications,
+  isNotificationListHidden = false,
   ...props
 }: Props): JSX.Element => {
   const { SIDEBAR, TOTAL } = COL_SIZES;
@@ -45,7 +45,7 @@ const Section = ({
           className="section__content"
           size={(sidebar ? TOTAL - SIDEBAR : TOTAL) as ColSize}
         >
-          {!hideNotifications && <NotificationList />}
+          {!isNotificationListHidden && <NotificationList />}
           {children}
         </Col>
       </Strip>

--- a/src/app/base/components/Section/Section.tsx
+++ b/src/app/base/components/Section/Section.tsx
@@ -10,12 +10,14 @@ export type Props = {
   children?: ReactNode;
   header?: ReactNode;
   sidebar?: ReactNode;
+  hideNotifications?: boolean;
 } & HTMLProps<HTMLDivElement>;
 
 const Section = ({
   children,
   header,
   sidebar,
+  hideNotifications,
   ...props
 }: Props): JSX.Element => {
   const { SIDEBAR, TOTAL } = COL_SIZES;
@@ -43,7 +45,7 @@ const Section = ({
           className="section__content"
           size={(sidebar ? TOTAL - SIDEBAR : TOTAL) as ColSize}
         >
-          <NotificationList />
+          {!hideNotifications && <NotificationList />}
           {children}
         </Col>
       </Strip>


### PR DESCRIPTION
## Done

- Added a `hideNotifications` prop to the `Section` component which is false by default unless specified

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)

### QA steps

- [Configure Vault fully](https://docs.google.com/document/d/1ssfthB3g1kzELDaKgKdr4Mzt5n-eLQx11mnotvNbKJM/edit?disco=AAAAktcPosI) (including migrating secrets)
- Seal vault: `vault operator seal`
- Ensure that only the "Vault request failed" notification is displayed and no others.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/203975184-442e9839-9147-44e4-a110-f33122245111.png)

### After
![image](https://user-images.githubusercontent.com/35104482/203975259-7fe4b233-003e-4e76-b6f8-80a51a5a5e54.png)

