### PR TITLE
fix: incorrect machine count on clear filter after selection #4583

### DIFF
--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -225,6 +225,96 @@ describe("MachineListHeader", () => {
     expect(screen.getByText("3 of 10 machines selected")).toBeInTheDocument();
   });
 
+  it("displays correct count for selected machines", () => {
+    state.machine.selectedMachines = { items: ["abc123", "def456"] };
+    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
+      count: 10,
+      loaded: true,
+    });
+    renderWithBrowserRouter(
+      <MachineListHeader
+        headerContent={null}
+        searchFilter=""
+        setHeaderContent={jest.fn()}
+        setSearchFilter={jest.fn()}
+      />,
+      { state }
+    );
+    expect(screen.getByText("2 of 10 machines selected")).toBeInTheDocument();
+  });
+
+  it("displays correct machine counts when clearing an active filter", () => {
+    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
+      count: 10,
+      loaded: true,
+    });
+    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
+      count: 5,
+      loaded: true,
+    });
+    const { rerender } = renderWithBrowserRouter(
+      <MachineListHeader
+        headerContent={null}
+        searchFilter="owner:(admin)"
+        setHeaderContent={jest.fn()}
+        setSearchFilter={jest.fn()}
+      />,
+      { state }
+    );
+    expect(
+      screen.getByRole("link", { name: /10 Machines/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("section-header-subtitle")).toHaveTextContent(
+      /5 machines available/i
+    );
+    rerender(
+      <MachineListHeader
+        headerContent={null}
+        searchFilter=""
+        setHeaderContent={jest.fn()}
+        setSearchFilter={jest.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("link", { name: /10 Machines/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("section-header-subtitle")).toHaveTextContent(
+      /10 machines available/i
+    );
+  });
+
+  it("displays correct machine counts for selected groups with an active filter", () => {
+    state.machine.selectedMachines = {
+      groups: ["admin"],
+      grouping: FetchGroupKey.Owner,
+    };
+    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
+      count: 10,
+      loaded: true,
+    });
+    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
+      count: 5,
+      loaded: true,
+    });
+    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
+      count: 2,
+      loaded: true,
+    });
+    renderWithBrowserRouter(
+      <MachineListHeader
+        headerContent={null}
+        searchFilter="owner:(admin)"
+        setHeaderContent={jest.fn()}
+        setSearchFilter={jest.fn()}
+      />,
+      { state }
+    );
+    expect(
+      screen.getByRole("link", { name: /10 Machines/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("2 of 5 machines selected")).toBeInTheDocument();
+  });
+
   it("displays a message when all machines have been selected", () => {
     state.machine.selectedMachines = { filter: {} };
     state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -50,12 +50,19 @@ export const MachineListHeader = ({
     false
   );
   const filter = FilterMachines.parseFetchFilters(searchFilter);
+  const hasActiveFilter = FilterMachines.isNonEmptyFilter(searchFilter);
   // Get the count of all machines
   const { machineCount: allMachineCount } = useFetchMachineCount();
   // Get the count of all machines that match the current filter
-  const { machineCount: availableMachineCount } = useFetchMachineCount(filter, {
-    isEnabled: FilterMachines.isNonEmptyFilter(searchFilter),
-  });
+  const { machineCount: activeFilterMachineCount } = useFetchMachineCount(
+    filter,
+    {
+      isEnabled: hasActiveFilter,
+    }
+  );
+  const availableMachineCount = hasActiveFilter
+    ? activeFilterMachineCount
+    : allMachineCount;
   // Get the count of selected machines that match the current filter
   const { selectedCount, selectedCountLoading } =
     useMachineSelectedCount(filter);


### PR DESCRIPTION
## Done

- fix: incorrect machine count on clear filter 
  - fallback to using allMachineCount when there is no active filter

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

1. Go to machine list page
2. Note the total number of machines in the subheading (`x machines available`)
3. Select a filter that will have some matching machines (e.g. `status:(deployed)`)
4. Note that the total number of machines in the subheading (`x machines available`) has changed to reflect the filter 
5. Select all machines
6. Remove the filter
7. Verify that the total number of machines is displayed instead of the number of machines matching the previously used filter.

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4583

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
