### PR TITLE
fix: machine suppress failed test results

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -36,7 +36,10 @@ export const OverrideTestForm = ({
   const sendAnalytics = useSendAnalytics();
   const isSingleMachine = selectedCount === 1;
   const dispatch = useDispatch();
-  const { dispatch: dispatchForSelectedMachines, ...actionProps } =
+  const { dispatch: dispatchOverrideForSelectedMachines, ...actionProps } =
+    useSelectedMachinesActionsDispatch({ selectedMachines, searchFilter });
+  // separate dispatch for the suppress failed script results as we are not tracking the action status
+  const { dispatch: dispatchSuppressForSelectedMachines } =
     useSelectedMachinesActionsDispatch({ selectedMachines, searchFilter });
   const machineID = isSingleMachine
     ? selectedMachines &&
@@ -63,9 +66,11 @@ export const OverrideTestForm = ({
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
         const { suppressResults } = values;
-        dispatchForSelectedMachines(machineActions.overrideFailedTesting);
+        dispatchOverrideForSelectedMachines(
+          machineActions.overrideFailedTesting
+        );
         if (suppressResults) {
-          dispatchForSelectedMachines(
+          dispatchSuppressForSelectedMachines(
             machineActions.suppressFailedScriptResults
           );
         }

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -745,6 +745,31 @@ describe("machine actions", () => {
     });
   });
 
+  it("can suppress failed script results for a selection of machines", () => {
+    expect(
+      actions.suppressFailedScriptResults(
+        {
+          filter: { id: ["abc123"] },
+        },
+        "mock-call-id"
+      )
+    ).toStrictEqual({
+      type: "machine/suppressFailedScriptResults",
+      meta: {
+        model: "machine",
+        method: "suppress_failed_script_results",
+        callId: "mock-call-id",
+      },
+      payload: {
+        params: {
+          filter: {
+            id: ["abc123"],
+          },
+        },
+      },
+    });
+  });
+
   it("can putting a machine into rescue mode", () => {
     expect(actions.rescueMode({ system_id: "abc123" })).toEqual({
       type: "machine/rescueMode",

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1752,12 +1752,21 @@ const machineSlice = createSlice({
         // No state changes need to be handled for this action.
       },
     },
-    suppressFailedScriptResults: generateActionParams<BaseMachineActionParams>(
-      NodeActions.SUPPRESS_FAILED_SCRIPT_RESULTS
-    ),
-    suppressFailedScriptResultsError: statusHandlers.delete.error,
-    suppressFailedScriptResultsStart: statusHandlers.delete.start,
-    suppressFailedScriptResultsSuccess: statusHandlers.delete.success,
+    suppressFailedScriptResults: {
+      prepare: (params: { filter: FetchFilters } | null, callId?: string) => {
+        return {
+          meta: {
+            model: MachineMeta.MODEL,
+            method: "suppress_failed_script_results",
+            callId,
+          },
+          payload: { params: { filter: params?.filter } },
+        };
+      },
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
     [NodeActions.TAG]: generateActionParams<TagParams>(NodeActions.TAG),
     [`${NodeActions.TAG}Error`]: statusHandlers.tag.error,
     [`${NodeActions.TAG}Start`]: statusHandlers.tag.start,

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -28,10 +28,7 @@ import type {
 } from "app/store/types/node";
 import type { EventError, GenericState } from "app/store/types/state";
 
-export type MachineActions = Exclude<
-  NodeActions,
-  NodeActions.IMPORT_IMAGES | NodeActions.SUPPRESS_FAILED_SCRIPT_RESULTS
->;
+export type MachineActions = Exclude<NodeActions, NodeActions.IMPORT_IMAGES>;
 
 // BaseMachine is returned from the server when using "machine.list", and is
 // used in the machine list. This type is missing some properties due to an

--- a/src/app/store/types/node.ts
+++ b/src/app/store/types/node.ts
@@ -174,7 +174,6 @@ export enum NodeActions {
   RESCUE_MODE = "rescue-mode",
   SET_POOL = "set-pool",
   SET_ZONE = "set-zone",
-  SUPPRESS_FAILED_SCRIPT_RESULTS = "suppress_failed_script_results",
   TAG = "tag",
   TEST = "test",
   UNLOCK = "unlock",


### PR DESCRIPTION
## Done

- fix: machine suppress failed test results
   - use `machine.suppress_failed_script_results` instead of `machine.action` method to suppress failed test results

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
- Go to machine list
- Select a machine
- Perform "Override failed tests action" having the "Suppress failed scripts" checked
- Make sure the `machine.suppress_failed_script_results` action has been sent over via websocket with a correct machine system_id along with `machine.action` with `{ method: "override-failed-testing" }`
- If you selected a machine that doesn't have failed test, the action should fail

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
