### PR TITLE
test: migrate KVMDetailsHeader to RTL

### DIFF
--- a/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -1,93 +1,63 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import configureStore from "redux-mock-store";
+import { screen } from "@testing-library/react";
 
 import KVMDetailsHeader from "./KVMDetailsHeader";
 
+import urls from "app/base/urls";
 import { KVMHeaderViews } from "app/kvm/constants";
-import type { RootState } from "app/store/root/types";
-import {
-  pod as podFactory,
-  podResources as podResourcesFactory,
-  podState as podStateFactory,
-  podStatus as podStatusFactory,
-  podStatuses as podStatusesFactory,
-  podVmCount as podVmCountFactory,
-  rootState as rootStateFactory,
-} from "testing/factories";
-
-const mockStore = configureStore();
+import { getTestState, renderWithBrowserRouter } from "testing/utils";
 
 describe("KVMDetailsHeader", () => {
-  let state: RootState;
+  let state: ReturnType<typeof getTestState>;
 
   beforeEach(() => {
-    state = rootStateFactory({
-      pod: podStateFactory({
-        errors: {},
-        loading: false,
-        loaded: true,
-        items: [
-          podFactory({
-            id: 1,
-            name: "pod-1",
-            resources: podResourcesFactory({
-              vm_count: podVmCountFactory({ tracked: 10 }),
-            }),
-          }),
-        ],
-        statuses: podStatusesFactory({
-          1: podStatusFactory(),
-        }),
-      }),
-    });
+    state = getTestState();
   });
 
   it("renders header forms and no extra title blocks if header content has been selected", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <KVMDetailsHeader
-            headerContent={{
-              view: KVMHeaderViews.COMPOSE_VM,
-              extras: { hostId: 1 },
-            }}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-            tabLinks={[]}
-            title="Title"
-            titleBlocks={[{ title: "Title", subtitle: "Subtitle" }]}
-          />
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <KVMDetailsHeader
+        headerContent={{
+          view: KVMHeaderViews.COMPOSE_VM,
+          extras: { hostId: 1 },
+        }}
+        setHeaderContent={jest.fn()}
+        setSearchFilter={jest.fn()}
+        tabLinks={[]}
+        title="Title"
+        titleBlocks={[{ title: "Title", subtitle: "Subtitle" }]}
+      />,
+      {
+        route: "/kvm/1",
+        routePattern: `${urls.kvm.index}/*`,
+        state,
+      }
     );
-    expect(wrapper.find("KVMHeaderForms").exists()).toBe(true);
-    expect(wrapper.find("[data-testid='extra-title-block']").exists()).toBe(
-      false
-    );
+    expect(
+      screen.getByRole("form", { name: /Compose VM/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("extra-title-block")).not.toBeInTheDocument();
   });
 
   it("renders extra title blocks if no header content has been selected", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <KVMDetailsHeader
-            headerContent={null}
-            setHeaderContent={jest.fn()}
-            setSearchFilter={jest.fn()}
-            tabLinks={[]}
-            title="Title"
-            titleBlocks={[{ title: "Title", subtitle: "Subtitle" }]}
-          />
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <KVMDetailsHeader
+        headerContent={null}
+        setHeaderContent={jest.fn()}
+        setSearchFilter={jest.fn()}
+        tabLinks={[]}
+        title="Title"
+        titleBlocks={[{ title: "Title", subtitle: "Subtitle" }]}
+      />,
+      {
+        route: "/kvm/1",
+        routePattern: `${urls.kvm.index}/*`,
+        state,
+      }
     );
-    expect(wrapper.find("[data-testid='extra-title-block']").exists()).toBe(
-      true
-    );
-    expect(wrapper.find("KVMHeaderForms").exists()).toBe(false);
+
+    expect(
+      screen.queryByRole("form", { name: /Compose VM/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("extra-title-block")).toBeInTheDocument();
   });
 });

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/ComposeForm.tsx
@@ -429,6 +429,7 @@ const ComposeForm = ({ clearHeaderContent, hostId }: Props): JSX.Element => {
       <ActionForm<ComposeFormValues>
         actionName="compose"
         allowUnchanged
+        aria-label="Compose VM"
         cleanup={cleanup}
         errors={errors}
         initialTouched={{

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
@@ -1,8 +1,4 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
+import { screen } from "@testing-library/react";
 
 import LXDClusterHosts from "./LXDClusterHosts";
 
@@ -17,8 +13,7 @@ import {
   vmHost as vmHostFactory,
   vmClusterState as vmClusterStateFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithBrowserRouter } from "testing/utils";
 
 describe("LXDClusterHosts", () => {
   let state: RootState;
@@ -46,20 +41,14 @@ describe("LXDClusterHosts", () => {
 
   it("displays a spinner if pods haven't loaded", () => {
     state.pod.loaded = false;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            { pathname: urls.kvm.lxd.cluster.hosts({ clusterId: 1 }) },
-          ]}
-        >
-          <CompatRouter>
-            <LXDClusterHosts clusterId={1} setHeaderContent={jest.fn()} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <LXDClusterHosts clusterId={1} setHeaderContent={jest.fn()} />,
+      {
+        route: urls.kvm.lxd.cluster.hosts({ clusterId: 1 }),
+        routePattern: `${urls.kvm.index}/*`,
+        state,
+      }
     );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 });

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -15,7 +15,26 @@ import configureStore from "redux-mock-store";
 import FormikForm from "app/base/components/FormikForm";
 import type { AnyObject } from "app/base/types";
 import type { RootState } from "app/store/root/types";
-import { rootState as rootStateFactory } from "testing/factories";
+import {
+  domainState as domainStateFactory,
+  fabric as fabricFactory,
+  fabricState as fabricStateFactory,
+  generalState as generalStateFactory,
+  podDetails as podDetailsFactory,
+  podState as podStateFactory,
+  podStatus as podStatusFactory,
+  powerType as powerTypeFactory,
+  powerTypesState as powerTypesStateFactory,
+  resourcePoolState as resourcePoolStateFactory,
+  rootState as rootStateFactory,
+  spaceState as spaceStateFactory,
+  subnet as subnetFactory,
+  subnetState as subnetStateFactory,
+  vlan as vlanFactory,
+  vlanState as vlanStateFactory,
+  zoneGenericActions as zoneGenericActionsFactory,
+  zoneState as zoneStateFactory,
+} from "testing/factories";
 
 /**
  * Assert that some JSX from Enzyme is equal to some provided JSX.
@@ -196,3 +215,54 @@ export const renderWithMockStore = (
 
 export const getUrlParam: URLSearchParams["get"] = (param: string) =>
   new URLSearchParams(window.location.search).get(param);
+
+// Complete initial test state with all data loaded and no errors
+export const getTestState = (): RootState => {
+  const fabric = fabricFactory({ name: "pxe-fabric" });
+  const nonBootVlan = vlanFactory({ fabric: fabric.id });
+  const bootVlan = vlanFactory({ fabric: fabric.id, name: "pxe-vlan" });
+  const nonBootSubnet = subnetFactory({ vlan: nonBootVlan.id });
+  const bootSubnet = subnetFactory({ name: "pxe-subnet", vlan: bootVlan.id });
+  const pod = podDetailsFactory({
+    attached_vlans: [nonBootVlan.id, bootVlan.id],
+    boot_vlans: [bootVlan.id],
+    id: 1,
+  });
+  return rootStateFactory({
+    domain: domainStateFactory({
+      loaded: true,
+    }),
+    fabric: fabricStateFactory({
+      items: [fabric],
+      loaded: true,
+    }),
+    general: generalStateFactory({
+      powerTypes: powerTypesStateFactory({
+        data: [powerTypeFactory()],
+        loaded: true,
+      }),
+    }),
+    pod: podStateFactory({
+      items: [pod],
+      loaded: true,
+      statuses: { [pod.id]: podStatusFactory() },
+    }),
+    resourcepool: resourcePoolStateFactory({
+      loaded: true,
+    }),
+    space: spaceStateFactory({
+      loaded: true,
+    }),
+    subnet: subnetStateFactory({
+      items: [nonBootSubnet, bootSubnet],
+      loaded: true,
+    }),
+    vlan: vlanStateFactory({
+      items: [nonBootVlan, bootVlan],
+      loaded: true,
+    }),
+    zone: zoneStateFactory({
+      genericActions: zoneGenericActionsFactory({ fetch: "success" }),
+    }),
+  });
+};


### PR DESCRIPTION
## Done

- test: migrate KVMDetailsHeader to RTL
- add getTestState util function

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
