### PR TITLE
update override failed testing action

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
@@ -118,7 +118,9 @@ describe("OverrideTestForm", () => {
         payload: {
           params: {
             action: NodeActions.OVERRIDE_FAILED_TESTING,
-            extra: {},
+            extra: {
+              suppress_failed_script_results: false,
+            },
             filter: { id: ["abc123", "def456"] },
             system_id: undefined,
           },
@@ -141,9 +143,6 @@ describe("OverrideTestForm", () => {
       { store, route: "/machines" }
     );
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /Override failed tests/i })
-    );
     await userEvent.click(screen.getByLabelText(/Suppress test-failure/));
     await userEvent.click(
       screen.getByRole("button", { name: /Override failed tests/i })
@@ -151,13 +150,12 @@ describe("OverrideTestForm", () => {
     expect(
       store
         .getActions()
-        .filter(
-          (action) => action.type === "machine/suppressFailedScriptResults"
-        )
+        .filter((action) => action.type === "machine/overrideFailedTesting")
     ).toStrictEqual([
-      machineActions.suppressFailedScriptResults(
+      machineActions.overrideFailedTesting(
         {
           filter: { id: ["abc123"] },
+          suppress_failed_script_results: true,
         },
         "123456"
       ),
@@ -180,9 +178,6 @@ describe("OverrideTestForm", () => {
       { store, route: "/machines" }
     );
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /Override failed tests/i })
-    );
     await userEvent.click(screen.getByLabelText(/Suppress test-failure/));
     await userEvent.click(
       screen.getByRole("button", { name: /Override failed tests/i })
@@ -190,22 +185,24 @@ describe("OverrideTestForm", () => {
     expect(
       store
         .getActions()
-        .filter(
-          (action) => action.type === "machine/suppressFailedScriptResults"
-        )
+        .filter((action) => action.type === "machine/overrideFailedTesting")
     ).toStrictEqual([
-      machineActions.suppressFailedScriptResults(
+      machineActions.overrideFailedTesting(
         {
           filter: selectedToFilters({
             groups: ["admin"],
             grouping: FetchGroupKey.Owner,
           }) as FetchFilters,
+          suppress_failed_script_results: true,
         },
         "123456"
       ),
-      machineActions.suppressFailedScriptResults(
+      machineActions.overrideFailedTesting(
         {
-          filter: { id: ["abc123"] },
+          filter: selectedToFilters({
+            items: ["abc123"],
+          }) as FetchFilters,
+          suppress_failed_script_results: true,
         },
         "123456"
       ),

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -36,10 +36,7 @@ export const OverrideTestForm = ({
   const sendAnalytics = useSendAnalytics();
   const isSingleMachine = selectedCount === 1;
   const dispatch = useDispatch();
-  const { dispatch: dispatchOverrideForSelectedMachines, ...actionProps } =
-    useSelectedMachinesActionsDispatch({ selectedMachines, searchFilter });
-  // separate dispatch for the suppress failed script results as we are not tracking the action status
-  const { dispatch: dispatchSuppressForSelectedMachines } =
+  const { dispatch: dispatchForSelectedMachines, ...actionProps } =
     useSelectedMachinesActionsDispatch({ selectedMachines, searchFilter });
   const machineID = isSingleMachine
     ? selectedMachines &&
@@ -66,14 +63,9 @@ export const OverrideTestForm = ({
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
         const { suppressResults } = values;
-        dispatchOverrideForSelectedMachines(
-          machineActions.overrideFailedTesting
-        );
-        if (suppressResults) {
-          dispatchSuppressForSelectedMachines(
-            machineActions.suppressFailedScriptResults
-          );
-        }
+        dispatchForSelectedMachines(machineActions.overrideFailedTesting, {
+          suppress_failed_script_results: suppressResults,
+        });
       }}
       onSuccess={clearHeaderContent}
       processingCount={processingCount}

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -745,31 +745,6 @@ describe("machine actions", () => {
     });
   });
 
-  it("can suppress failed script results for a selection of machines", () => {
-    expect(
-      actions.suppressFailedScriptResults(
-        {
-          filter: { id: ["abc123"] },
-        },
-        "mock-call-id"
-      )
-    ).toStrictEqual({
-      type: "machine/suppressFailedScriptResults",
-      meta: {
-        model: "machine",
-        method: "suppress_failed_script_results",
-        callId: "mock-call-id",
-      },
-      payload: {
-        params: {
-          filter: {
-            id: ["abc123"],
-          },
-        },
-      },
-    });
-  });
-
   it("can putting a machine into rescue mode", () => {
     expect(actions.rescueMode({ system_id: "abc123" })).toEqual({
       type: "machine/rescueMode",
@@ -941,6 +916,28 @@ describe("machine actions", () => {
           action: NodeActions.OVERRIDE_FAILED_TESTING,
           extra: {},
           system_id: "abc123",
+        },
+      },
+    });
+  });
+
+  it("can handle suppressing script results for a selection of machines", () => {
+    expect(
+      actions.overrideFailedTesting({
+        filter: { hostname: ["ringtail-possum", "easter-rosella"] },
+        suppress_failed_script_results: true,
+      })
+    ).toEqual({
+      type: "machine/overrideFailedTesting",
+      meta: {
+        model: "machine",
+        method: "action",
+      },
+      payload: {
+        params: {
+          action: NodeActions.OVERRIDE_FAILED_TESTING,
+          extra: { suppress_failed_script_results: true },
+          filter: { hostname: ["ringtail-possum", "easter-rosella"] },
         },
       },
     });

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -61,6 +61,7 @@ import type {
   FilterGroupKey,
 } from "./types";
 import { MachineMeta, FilterGroupType } from "./types";
+import type { OverrideFailedTesting } from "./types/actions";
 import type { MachineActionStatus } from "./types/base";
 
 import { ACTION_STATUS } from "app/base/constants";
@@ -1607,7 +1608,7 @@ const machineSlice = createSlice({
     [`${NodeActions.ON}Error`]: statusHandlers.on.error,
     [`${NodeActions.ON}Start`]: statusHandlers.on.start,
     [`${NodeActions.ON}Success`]: statusHandlers.on.success,
-    overrideFailedTesting: generateActionParams<BaseMachineActionParams>(
+    overrideFailedTesting: generateActionParams<OverrideFailedTesting>(
       NodeActions.OVERRIDE_FAILED_TESTING
     ),
     overrideFailedTestingError: statusHandlers.overrideFailedTesting.error,
@@ -1748,21 +1749,6 @@ const machineSlice = createSlice({
           },
         },
       }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    suppressFailedScriptResults: {
-      prepare: (params: { filter: FetchFilters } | null, callId?: string) => {
-        return {
-          meta: {
-            model: MachineMeta.MODEL,
-            method: "suppress_failed_script_results",
-            callId,
-          },
-          payload: { params: { filter: params?.filter } },
-        };
-      },
       reducer: () => {
         // No state changes need to be handled for this action.
       },

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -471,6 +471,10 @@ export type MountSpecialParams = {
   systemId: Machine[MachineMeta.PK];
 };
 
+export type OverrideFailedTesting = BaseMachineActionParams & {
+  suppress_failed_script_results?: boolean;
+};
+
 export type OptionalFilesystemParams = {
   fstype?: string;
   mountOptions?: string;


### PR DESCRIPTION
## Done

- update override failed testing action to match changes in the API

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1141

### QA steps

- Verify the implementation matches the specification as described in the document below:
https://docs.google.com/document/d/1B8CQXRxzapUq8dbSILzCZdrNzU49brVS8K5KQAZeQiw/edit#heading=h.4wbel41znmu5

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
