### PR TITLE
fix(machines): outdated tags on selection remove

### DIFF
--- a/src/app/store/tag/reducers.test.ts
+++ b/src/app/store/tag/reducers.test.ts
@@ -46,6 +46,76 @@ describe("tag reducer", () => {
     });
   });
 
+  it("ignores calls that don't exist when reducing fetchSuccess", () => {
+    const initialState = tagStateFactory({
+      items: [],
+      lists: {},
+    });
+    const fetchedTags = [
+      tagFactory({ name: "tag1" }),
+      tagFactory({ name: "tag2" }),
+    ];
+
+    expect(
+      reducers(initialState, actions.fetchSuccess(fetchedTags, "123456"))
+    ).toEqual(
+      tagStateFactory({
+        items: [],
+        lists: {},
+      })
+    );
+  });
+
+  it("can handle fetchSuccess with callId", () => {
+    const initialState = tagStateFactory({
+      items: [],
+      lists: { 123456: tagStateListFactory({ loading: true }) },
+    });
+    const fetchedTags = [
+      tagFactory({ name: "tag1" }),
+      tagFactory({ name: "tag2" }),
+    ];
+
+    expect(
+      reducers(initialState, actions.fetchSuccess(fetchedTags, "123456"))
+    ).toEqual(
+      tagStateFactory({
+        items: [],
+        loaded: false,
+        loading: false,
+        lists: {
+          123456: tagStateListFactory({
+            loading: false,
+            loaded: true,
+            items: fetchedTags,
+          }),
+        },
+      })
+    );
+  });
+
+  it("can handle fetchSuccess without callId", () => {
+    const initialState = tagStateFactory({
+      items: [],
+      loading: true,
+      loaded: false,
+      lists: {},
+    });
+    const fetchedTags = [
+      tagFactory({ name: "tag1" }),
+      tagFactory({ name: "tag2" }),
+    ];
+
+    expect(reducers(initialState, actions.fetchSuccess(fetchedTags))).toEqual(
+      tagStateFactory({
+        items: fetchedTags,
+        loading: false,
+        loaded: true,
+        lists: {},
+      })
+    );
+  });
+
   it("reduces fetchError", () => {
     const state = tagStateFactory();
 

--- a/src/app/store/tag/slice.ts
+++ b/src/app/store/tag/slice.ts
@@ -100,8 +100,6 @@ const tagSlice = createSlice({
         state: TagState,
         action: PayloadAction<Tag[], string, GenericMeta>
       ) => {
-        state.loaded = true;
-        state.loading = false;
         const { payload } = action;
         const { callId } = action.meta;
         if (callId && callId in state.lists) {
@@ -111,8 +109,11 @@ const tagSlice = createSlice({
           state.lists[callId].items = payload;
           state.lists[callId].loaded = true;
           state.lists[callId].loading = false;
-        } else {
+          // This is a regular fetch without a callId - update the main items state
+        } else if (!callId) {
           state.items = payload;
+          state.loaded = true;
+          state.loading = false;
         }
       },
     },


### PR DESCRIPTION
## Done

- fix: outdated tags on selection remove

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Follow steps form the bug attached and make sure you get the expected result

## Fixes

Fixes: #4600
https://warthogs.atlassian.net/browse/MAASENG-1156

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
