### PR TITLE
fix: clicking on tag link does not update machines filter

### DIFF
--- a/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
+++ b/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
@@ -1,5 +1,5 @@
 import pluralize from "pluralize";
-import { Link } from "react-router-dom-v5-compat";
+import { Link, useLocation } from "react-router-dom-v5-compat";
 
 import urls from "app/base/urls";
 import { ControllerMeta } from "app/store/controller/types";
@@ -20,6 +20,8 @@ const NodesTagsLink = ({
   nodeType,
   tags,
 }: Props): JSX.Element | null => {
+  const { pathname } = useLocation();
+
   let url: string | null = null;
   let nodeName: string | null = null;
   switch (nodeType) {
@@ -39,11 +41,22 @@ const NodesTagsLink = ({
   if (!url || !nodeName) {
     return null;
   }
+
   const filters = FilterMachines.filtersToQueryString({
     tags: [`=${tags.join(",")}`],
   });
+
   return (
-    <Link className="u-display--block" to={`${url}${filters}`}>
+    <Link
+      className="u-display--block"
+      reloadDocument={
+        // reload the document if it's a machine list link clicked from machine listing page
+        // this is a hack to get around the fact that the machine listing page doesn't update when the URL changes
+        // TODO: remove the workaround below once https://github.com/canonical/maas-ui/issues/4603 is fixed
+        pathname.startsWith(url) && pathname.startsWith(urls.machines.index)
+      }
+      to={`${url}${filters}`}
+    >
       {pluralize(nodeName, count, true)}
     </Link>
   );


### PR DESCRIPTION
## Done

- fix(machines): clicking on tag link does not update machines filter

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Complete steps as described in the linked issue and make sure you get the expected result.

## Fixes

Fixes #4602 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
