### PR TITLE
test: google analytics integration

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -3,6 +3,12 @@ import { defineConfig } from "cypress";
 export default defineConfig({
   defaultCommandTimeout: 10000,
   e2e: {
+    // block analytics
+    blockHosts: [
+      "www.googletagmanager.com",
+      "www.google-analytics.com",
+      "sentry.is.canonical.com",
+    ],
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {

--- a/cypress/constants.ts
+++ b/cypress/constants.ts
@@ -13,3 +13,5 @@ export const pages: Page[] = [
   { heading: "Settings", url: "/settings/configuration/general" },
   { heading: "My preferences", url: "/account/prefs/details" },
 ];
+// longer timeout that can be useful for slow commands
+export const LONG_TIMEOUT = 30000;

--- a/cypress/e2e/with-users/analytics.ts
+++ b/cypress/e2e/with-users/analytics.ts
@@ -7,8 +7,8 @@ context("Google Analytics", () => {
     Cypress.on("window:before:load", (win) => {
       Object.defineProperty(win, "ga", {
         configurable: false,
-        get: () => ga, // always return the stub
-        set: () => {}, // don't allow actual google analytics to overwrite this property
+        get: () => ga,
+        set: () => {},
       });
     });
     cy.login();

--- a/cypress/e2e/with-users/analytics.ts
+++ b/cypress/e2e/with-users/analytics.ts
@@ -1,0 +1,28 @@
+import { generateMAASURL } from "../utils";
+
+context("Google Analytics", () => {
+  beforeEach(function () {
+    const ga = cy.stub().as("ga");
+    cy.intercept({ hostname: "www.google-analytics.com" }, { statusCode: 503 });
+    Cypress.on("window:before:load", (win) => {
+      Object.defineProperty(win, "ga", {
+        configurable: false,
+        get: () => ga, // always return the stub
+        set: () => {}, // don't allow actual google analytics to overwrite this property
+      });
+    });
+    cy.login();
+  });
+
+  it("window.ga is called correctly", function () {
+    cy.visit(generateMAASURL("/machines"));
+    cy.get("@ga")
+      // ensure GA was created with our google analytics ID
+      .should("be.calledWith", "create", "UA-1018242-63")
+      // ensure that the initial pageview is sent
+      .and("be.calledWith", "send", "pageview", "/MAAS/r/machines");
+
+    cy.visit(generateMAASURL("/devices"));
+    cy.get("@ga").and("be.calledWith", "send", "pageview", "/MAAS/r/devices");
+  });
+});

--- a/cypress/e2e/with-users/controllers/details.spec.ts
+++ b/cypress/e2e/with-users/controllers/details.spec.ts
@@ -1,3 +1,4 @@
+import { LONG_TIMEOUT } from "../../../constants";
 import { generateMAASURL, generateId } from "../../utils";
 
 context("Controller details", () => {
@@ -84,7 +85,7 @@ context("Controller details", () => {
     cy.findByRole("link", { name: "Commissioning" }).click();
     cy.findByRole("grid").within(() => {
       cy.findAllByRole("button", { name: /Take action/i })
-        .first()
+        .last({ timeout: LONG_TIMEOUT })
         .click();
     });
     cy.findByLabelText("submenu").within(() => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -1,5 +1,6 @@
 import "@testing-library/cypress/add-commands";
 import type { Result } from "axe-core";
+import { LONG_TIMEOUT } from "../constants";
 import { generateMAASURL, generateMac, generateName } from "../e2e/utils";
 import type { A11yPageContext } from "./e2e";
 
@@ -44,7 +45,9 @@ Cypress.Commands.add("addMachine", (hostname = generateName()) => {
   cy.get("input[name='pxe_mac']").type(generateMac());
   cy.get("select[name='power_type']").select("manual").blur();
   cy.get("button[type='submit']").click();
-  cy.get(`[data-testid='message']:contains(${hostname} added successfully.)`);
+  cy.get(`[data-testid='message']:contains(${hostname} added successfully.)`, {
+    timeout: LONG_TIMEOUT,
+  });
 });
 
 Cypress.Commands.add("addMachines", (hostnames: string[]) => {


### PR DESCRIPTION
## Done

- test google analytics integration
- fix failing tests
- block analytics hosts in e2e tests

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
