### PR TITLE
ci: use canonical/setup-maas GitHub action

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -10,13 +10,10 @@ jobs:
       - uses: actions/checkout@main
       - name: Get branch name
         uses: nelonoel/branch-name@v1.0.1
-      - name: Install MAAS
-        run: |
-          sudo systemctl enable snapd
-          sudo snap install maas --channel=latest/edge
-          sudo snap install maas-test-db --channel=latest/edge
-      - name: Initialise MAAS
-        run: sudo maas init region+rack --maas-url=${{env.MAAS_URL}}/MAAS --database-uri maas-test-db:///
+      - name: Setup MAAS
+        uses: canonical/setup-maas@main
+        with:
+          maas-url: ${{env.MAAS_URL}}/MAAS
       - name: Install Cypress
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -10,13 +10,10 @@ jobs:
       - uses: actions/checkout@main
       - name: Get branch name
         uses: nelonoel/branch-name@v1.0.1
-      - name: Install MAAS
-        run: |
-          sudo systemctl enable snapd
-          sudo snap install maas --channel=latest/edge
-          sudo snap install maas-test-db --channel=latest/edge
-      - name: Initialise MAAS
-        run: sudo maas init region+rack --maas-url=${{env.MAAS_URL}}/MAAS --database-uri maas-test-db:///
+      - name: Setup MAAS
+        uses: canonical/setup-maas@main
+        with:
+          maas-url: ${{env.MAAS_URL}}/MAAS
       - name: Install Cypress
         uses: cypress-io/github-action@v4
         with:


### PR DESCRIPTION
## Done

- use canonical/setup-maas GitHub action

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
