### PR TITLE
update versions to 3.3

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,5 +1,8 @@
 name: accessibility
-on: [push]
+on:
+  push:
+    branches:
+      - "3.3"
 jobs:
   cypress-axe:
     name: cypress-axe

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: Cypress
-on: [push]
+on:
+  push:
+    branches:
+      - "3.3"
 jobs:
   cypress:
     name: Cypress
@@ -14,6 +17,7 @@ jobs:
         uses: canonical/setup-maas@main
         with:
           maas-url: ${{env.MAAS_URL}}/MAAS
+          channel: 3.3/edge
       - name: Install Cypress
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,11 @@
 name: Playwright Tests
 on:
   push:
-    branches: [main, master]
+    branches:
+      - "3.3"
   pull_request:
-    branches: [main, master]
+    branches:
+      - "3.3"
 jobs:
   test:
     timeout-minutes: 15
@@ -22,8 +24,8 @@ jobs:
       - name: Install MAAS
         run: |
           sudo systemctl enable snapd
-          sudo snap install maas --channel=latest/edge
-          sudo snap install maas-test-db --channel=latest/edge
+          sudo snap install maas --channel=3.3/edge
+          sudo snap install maas-test-db --channel=3.3/edge
       - name: Initialise MAAS
         run: sudo maas init region+rack --maas-url=http://${{env.MAAS_URL}}/MAAS --database-uri maas-test-db:///
       - name: Create MAAS admin

--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Install MAAS
         run: |
           sudo systemctl enable snapd
-          sudo snap install maas-test-db --channel=latest/edge
-          sudo snap install maas --channel=latest/edge
+          sudo snap install maas-test-db --channel=3.3/edge
+          sudo snap install maas --channel=3.3/edge
       - name: Fetch database dump
         uses: wei/wget@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - "3.3"
   pull_request:
     branches:
-      - main
+      - "3.3"
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Done

- update versions to 3.3 (following the release guide in https://github.com/canonical/maas-ui/blob/main/docs/RELEASE.md)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
