### PR TITLE
test: websocket requests count on machine search

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,13 +19,10 @@ jobs:
         run: yarn
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
-      - name: Install MAAS
-        run: |
-          sudo systemctl enable snapd
-          sudo snap install maas --channel=latest/edge
-          sudo snap install maas-test-db --channel=latest/edge
-      - name: Initialise MAAS
-        run: sudo maas init region+rack --maas-url=http://${{env.MAAS_URL}}/MAAS --database-uri maas-test-db:///
+      - name: Setup MAAS
+        uses: canonical/setup-maas@main
+        with:
+          maas-url: ${{env.MAAS_URL}}/MAAS
       - name: Create MAAS admin
         run: sudo maas createadmin --username=admin --password=test --email=fake@example.org
       - name: Wait for MAAS UI to be ready

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ const config: PlaywrightTestConfig = {
      * Maximum time expect() should wait for the condition to be met.
      * For example in `await expect(locator).toHaveText();`
      */
-    timeout: 5000,
+    timeout: 10000,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/tests/machines.spec.ts
+++ b/tests/machines.spec.ts
@@ -37,7 +37,17 @@ test("machines list loads", async ({ page }) => {
   await expect(page.getByTestId("subtitle-string")).toHaveText(
     /machines available/
   );
+  await expect(page.getByRole("grid", { name: /Loading/i })).not.toBeVisible();
   // expect a single machine.list and machine.count request
   await expect(machineListRequests.length).toBe(1);
   await expect(machineCountRequests.length).toBe(1);
+  // perform machine search
+  await page.getByLabel("Search").type("doesnotexist");
+  await expect(page.getByRole("grid", { name: /Loading/i })).not.toBeVisible();
+  await expect(
+    page.getByText(/No machines match the search criteria/)
+  ).toBeVisible();
+  // expect additional single machine.list and machine.count requests
+  await expect(machineListRequests.length).toBe(2);
+  await expect(machineCountRequests.length).toBe(2);
 });


### PR DESCRIPTION
## Done

- test: websocket requests count on machine search

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
