### PR TITLE
remove sourcemaps from UI build

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           CI: false
       - name: Compress
-        run: cd build && tar -czf ../${{env.PACKAGE_NAME}} ./
+        run: cd build && tar -czf ../${{env.PACKAGE_NAME}} ./ && ls -hs ../${{env.PACKAGE_NAME}}
       - name: Install upload-assets snap
         run: sudo snap install upload-assets
       - name: Upload to assets server

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -31,7 +31,7 @@ jobs:
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: CYPRESS_INSTALL_BINARY=0 yarn install
       - name: Build
-        run: REACT_APP_GIT_SHA=${{env.REACT_APP_GIT_SHA}} yarn build
+        run: REACT_APP_GIT_SHA=${{env.REACT_APP_GIT_SHA}} GENERATE_SOURCEMAP=false yarn build
         env:
           CI: false
       - name: Compress


### PR DESCRIPTION
## Done

- remove sourcemaps from UI build
  - this reduces the `maas-ui.tar.gz` bundle size by half (from ~4MB to ~2MB)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
