### PR TITLE
feat: add last deployed images fields

### DIFF
--- a/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/src/app/base/components/StatusBar/StatusBar.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import { formatDistance, parse } from "date-fns";
 import { useSelector } from "react-redux";
 
 import configSelectors from "app/store/config/selectors";
@@ -18,17 +17,7 @@ import {
   isMachineDetails,
 } from "app/store/machine/utils";
 import { NodeStatus } from "app/store/types/node";
-
-const getTimeDistanceString = (utcTimeString: string) =>
-  formatDistance(
-    parse(
-      `${utcTimeString} +00`, // let parse fn know it's UTC
-      "E, dd LLL. yyyy HH:mm:ss x",
-      new Date()
-    ),
-    new Date(),
-    { addSuffix: true }
-  );
+import { getTimeDistanceString } from "app/utils/time";
 
 const getLastCommissionedString = (machine: MachineDetails) => {
   if (machine.status === NodeStatus.COMMISSIONING) {

--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -1,5 +1,6 @@
 import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import MockDate from "mockdate";
 
 import ImagesTable, { Labels as ImagesTableLabels } from "./ImagesTable";
 
@@ -13,6 +14,14 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import { renderWithMockStore } from "testing/utils";
+
+beforeEach(() => {
+  MockDate.set("Fri, 18 Nov. 2022 10:55:00");
+});
+
+afterEach(() => {
+  MockDate.reset();
+});
 
 describe("ImagesTable", () => {
   let state: RootState;
@@ -226,5 +235,226 @@ describe("ImagesTable", () => {
     const row = screen.getByRole("row", { name: "18.04 LTS" });
     const delete_button = within(row).getByRole("button", { name: "Delete" });
     expect(delete_button).toBeDisabled();
+  });
+
+  it("displays a correct last deployed time and machine count", () => {
+    const resources = [
+      resourceFactory({
+        arch: "amd64",
+        name: "ubuntu/focal",
+        last_deployed: "Fri, 18 Nov. 2022 09:55:21",
+        numberOfNodes: 768,
+      }),
+    ];
+    const image = {
+      arch: "amd64",
+      os: "ubuntu",
+      release: "focal",
+      title: "20.04 LTS",
+    };
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources,
+      }),
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
+            value: "focal",
+          }),
+        ],
+      }),
+    });
+
+    renderWithMockStore(
+      <ImagesTable images={[image]} resources={resources} />,
+      {
+        state,
+      }
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: /Last deployed/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /Machines/i })
+    ).toBeInTheDocument();
+    const row = screen.getByRole("row", { name: "18.04 LTS" });
+    expect(
+      within(row).getByText(/Fri, 18 Nov. 2022 09:55:21/)
+    ).toBeInTheDocument();
+    expect(
+      within(row).getByRole("gridcell", { name: /about 1 hour ago/ })
+    ).toBeInTheDocument();
+    expect(
+      within(row).getByRole("gridcell", { name: /768/ })
+    ).toBeInTheDocument();
+  });
+
+  it("can handle empty string for last deployed time", () => {
+    const resources = [
+      resourceFactory({
+        arch: "amd64",
+        name: "ubuntu/focal",
+        last_deployed: "",
+        numberOfNodes: 768,
+      }),
+    ];
+    const image = {
+      arch: "amd64",
+      os: "ubuntu",
+      release: "focal",
+      title: "20.04 LTS",
+    };
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources,
+      }),
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
+            value: "focal",
+          }),
+        ],
+      }),
+    });
+
+    renderWithMockStore(
+      <ImagesTable images={[image]} resources={resources} />,
+      {
+        state,
+      }
+    );
+
+    expect(
+      screen.getByRole("columnheader", { name: /Last deployed/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: /Machines/i })
+    ).toBeInTheDocument();
+    const row = screen.getByRole("row", { name: "18.04 LTS" });
+    expect(
+      within(row).getByRole("gridcell", { name: "—" })
+    ).toBeInTheDocument();
+  });
+
+  it("can sort by last deployed time", async () => {
+    // resources sorted by last deployed time
+    const resourcesByLastDeployed = [
+      resourceFactory({
+        name: "ubuntu/xenial",
+        arch: "amd64",
+        title: "16.04 LTS",
+        last_deployed: "Tue, 16 Nov. 2022 09:55:21",
+      }),
+      resourceFactory({
+        arch: "amd64",
+        name: "ubuntu/focal",
+        title: "20.04 LTS",
+        last_deployed: "Thu, 17 Nov. 2022 09:55:21",
+        numberOfNodes: 768,
+      }),
+      resourceFactory({
+        name: "ubuntu/bionic",
+        arch: "i386",
+        title: "18.04 LTS",
+        last_deployed: "Wed, 18 Nov. 2022 08:55:21",
+      }),
+    ];
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: resourcesByLastDeployed,
+      }),
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
+            value: "focal",
+          }),
+        ],
+      }),
+    });
+
+    renderWithMockStore(
+      <ImagesTable images={[]} resources={resourcesByLastDeployed} />,
+      {
+        state,
+      }
+    );
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /Last deployed/i })
+    );
+    const tableBody = screen.getAllByRole("rowgroup")[1];
+    const getRows = () => within(tableBody).getAllByRole("row");
+    expect(getRows()).toHaveLength(resourcesByLastDeployed.length);
+    getRows().forEach((row, i) => {
+      expect(row).toHaveTextContent(resourcesByLastDeployed[i].title);
+    });
+    await userEvent.click(
+      screen.getByRole("columnheader", { name: /Last deployed/i })
+    );
+    // expect rows in a reverse sort order
+    const resourcesByLastDeployedReverse = [
+      ...resourcesByLastDeployed,
+    ].reverse();
+    getRows().forEach((row, i) => {
+      expect(row).toHaveTextContent(resourcesByLastDeployedReverse[i].title);
+    });
+  });
+
+  it("sorts by release by default", () => {
+    // resources sorted by release
+    const resourcesByReleaseTitle = [
+      resourceFactory({
+        arch: "amd64",
+        name: "ubuntu/focal",
+        title: "20.04 LTS",
+        last_deployed: "Thu, 17 Nov. 2022 09:55:21",
+        numberOfNodes: 768,
+      }),
+      resourceFactory({
+        name: "ubuntu/bionic",
+        arch: "i386",
+        title: "18.04 LTS",
+        last_deployed: "Wed, 18 Nov. 2022 08:55:21",
+      }),
+      resourceFactory({
+        name: "ubuntu/xenial",
+        arch: "amd64",
+        title: "16.04 LTS",
+        last_deployed: "Tue, 16 Nov. 2022 09:55:21",
+      }),
+    ];
+    const state = rootStateFactory({
+      bootresource: bootResourceStateFactory({
+        resources: resourcesByReleaseTitle,
+      }),
+      config: configStateFactory({
+        items: [
+          configFactory({
+            name: ConfigNames.COMMISSIONING_DISTRO_SERIES,
+            value: "focal",
+          }),
+        ],
+      }),
+    });
+
+    renderWithMockStore(
+      <ImagesTable images={[]} resources={resourcesByReleaseTitle} />,
+      {
+        state,
+      }
+    );
+    // verify rows are sorted by release by default
+    expect(
+      screen.getByRole("columnheader", { name: /Release/i })
+    ).toHaveAttribute("aria-sort", "descending");
+    const tableBody = screen.getAllByRole("rowgroup")[1];
+    const rows = within(tableBody).getAllByRole("row");
+    expect(rows).toHaveLength(3);
+    rows.forEach((row, i) => {
+      expect(row).toHaveTextContent(resourcesByReleaseTitle[i].title);
+    });
   });
 });

--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -242,7 +242,7 @@ describe("ImagesTable", () => {
       resourceFactory({
         arch: "amd64",
         name: "ubuntu/focal",
-        last_deployed: "Fri, 18 Nov. 2022 09:55:21",
+        lastDeployed: "Fri, 18 Nov. 2022 09:55:21",
         numberOfNodes: 768,
       }),
     ];
@@ -296,7 +296,7 @@ describe("ImagesTable", () => {
       resourceFactory({
         arch: "amd64",
         name: "ubuntu/focal",
-        last_deployed: "",
+        lastDeployed: "",
         numberOfNodes: 768,
       }),
     ];
@@ -346,20 +346,20 @@ describe("ImagesTable", () => {
         name: "ubuntu/xenial",
         arch: "amd64",
         title: "16.04 LTS",
-        last_deployed: "Tue, 16 Nov. 2022 09:55:21",
+        lastDeployed: "Tue, 16 Nov. 2022 09:55:21",
       }),
       resourceFactory({
         arch: "amd64",
         name: "ubuntu/focal",
         title: "20.04 LTS",
-        last_deployed: "Thu, 17 Nov. 2022 09:55:21",
+        lastDeployed: "Thu, 17 Nov. 2022 09:55:21",
         numberOfNodes: 768,
       }),
       resourceFactory({
         name: "ubuntu/bionic",
         arch: "i386",
         title: "18.04 LTS",
-        last_deployed: "Wed, 18 Nov. 2022 08:55:21",
+        lastDeployed: "Wed, 18 Nov. 2022 08:55:21",
       }),
     ];
     const state = rootStateFactory({
@@ -410,20 +410,20 @@ describe("ImagesTable", () => {
         arch: "amd64",
         name: "ubuntu/focal",
         title: "20.04 LTS",
-        last_deployed: "Thu, 17 Nov. 2022 09:55:21",
+        lastDeployed: "Thu, 17 Nov. 2022 09:55:21",
         numberOfNodes: 768,
       }),
       resourceFactory({
         name: "ubuntu/bionic",
         arch: "i386",
         title: "18.04 LTS",
-        last_deployed: "Wed, 18 Nov. 2022 08:55:21",
+        lastDeployed: "Wed, 18 Nov. 2022 08:55:21",
       }),
       resourceFactory({
         name: "ubuntu/xenial",
         arch: "amd64",
         title: "16.04 LTS",
-        last_deployed: "Tue, 16 Nov. 2022 09:55:21",
+        lastDeployed: "Tue, 16 Nov. 2022 09:55:21",
       }),
     ];
     const state = rootStateFactory({

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -12,6 +12,7 @@ import type { ImageValue } from "app/images/types";
 import type { BootResource } from "app/store/bootresource/types";
 import { splitResourceName } from "app/store/bootresource/utils";
 import configSelectors from "app/store/config/selectors";
+import { sizeStringToNumber } from "app/utils/formatBytes";
 import { getTimeDistanceString } from "app/utils/time";
 
 type Props = {
@@ -199,7 +200,7 @@ const generateResourceRow = ({
     sortData: {
       title: resource.title,
       arch: resource.arch,
-      size: resource.size,
+      size: sizeStringToNumber(resource.size),
       status: resource.status,
       lastDeployed: resource.lastDeployed
         ? new Date(resource.lastDeployed).getTime() || 0

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -83,7 +83,7 @@ const generateImageRow = (
       },
       {
         content: "—",
-        className: "machine-count-col",
+        className: "machines-col",
       },
       {
         content: onClear ? (
@@ -160,10 +160,10 @@ const generateResourceRow = ({
         className: "status-col",
       },
       {
-        content: resource?.last_deployed ? (
+        content: resource.lastDeployed ? (
           <DoubleRow
-            primary={getTimeDistanceString(resource?.last_deployed)}
-            secondary={resource?.last_deployed}
+            primary={getTimeDistanceString(resource.lastDeployed)}
+            secondary={resource.lastDeployed}
           />
         ) : (
           "—"
@@ -172,7 +172,7 @@ const generateResourceRow = ({
       },
       {
         content: `${resource.numberOfNodes || "—"}`,
-        className: "machine-count-col",
+        className: "machines-col",
       },
       {
         content: (
@@ -201,8 +201,8 @@ const generateResourceRow = ({
       arch: resource.arch,
       size: resource.size,
       status: resource.status,
-      lastDeployed: resource?.last_deployed
-        ? new Date(resource?.last_deployed).getTime() || 0
+      lastDeployed: resource.lastDeployed
+        ? new Date(resource.lastDeployed).getTime() || 0
         : 0,
       machineCount: resource.numberOfNodes,
     },
@@ -272,7 +272,7 @@ const ImagesTable = ({
         { content: "Architecture", className: "arch-col", sortKey: "arch" },
         { content: "Size", className: "size-col", sortKey: "size" },
         {
-          content: <span className="u-nudge-right--large">Status</span>,
+          content: <span className="p-double-row__header-spacer">Status</span>,
           className: "status-col",
           sortKey: "status",
         },
@@ -283,12 +283,11 @@ const ImagesTable = ({
         },
         {
           content: "Machines",
-          className: "machine-count-col",
+          className: "machines-col",
           sortKey: "machineCount",
         },
         { content: "Actions", className: "actions-col u-align--right" },
       ]}
-      responsive
       rows={rows}
       sortable
     />

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -13,7 +13,7 @@ import type { BootResource } from "app/store/bootresource/types";
 import { splitResourceName } from "app/store/bootresource/utils";
 import configSelectors from "app/store/config/selectors";
 import { sizeStringToNumber } from "app/utils/formatBytes";
-import { getTimeDistanceString } from "app/utils/time";
+import { getTimeDistanceString, parseUtcDatetime } from "app/utils/time";
 
 type Props = {
   handleClear?: (image: ImageValue) => void;
@@ -202,9 +202,7 @@ const generateResourceRow = ({
       arch: resource.arch,
       size: sizeStringToNumber(resource.size),
       status: resource.status,
-      lastDeployed: resource.lastDeployed
-        ? new Date(resource.lastDeployed).getTime() || 0
-        : 0,
+      lastDeployed: parseUtcDatetime(resource.lastDeployed),
       machineCount: resource.numberOfNodes,
     },
   };

--- a/src/app/images/components/ImagesTable/_index.scss
+++ b/src/app/images/components/ImagesTable/_index.scss
@@ -1,23 +1,4 @@
 @mixin ImagesTable {
   .images-table {
-    .release-col {
-      @include breakpoint-widths(0.25, 0.25, 0.2, 0.2, 0.2, true);
-    }
-
-    .arch-col {
-      @include breakpoint-widths(0.25, 0.2, 0.15, 0.15, 0.1, true);
-    }
-
-    .size-col {
-      @include breakpoint-widths(0, 0, 0, 0, 0.1, true);
-    }
-
-    .status-col {
-      @include breakpoint-widths(0.25, 0.45, 0.55, 0.55, 0.5, true);
-    }
-
-    .actions-col {
-      @include breakpoint-widths(0.25, 0.1, 0.1, 0.1, 0.1, true)
-    }
   }
 }

--- a/src/app/images/components/ImagesTable/_index.scss
+++ b/src/app/images/components/ImagesTable/_index.scss
@@ -1,4 +1,31 @@
 @mixin ImagesTable {
   .images-table {
+    .release-col {
+      @include breakpoint-widths(0.25, 0.25, 0.2, 0.2, 0.2, true);
+    }
+
+    .arch-col {
+      @include breakpoint-widths(0.25, 0.2, 0.15, 0.1, 0.1, true);
+    }
+
+    .size-col {
+      @include breakpoint-widths(0, 0, 0, 0, 0.1, true);
+    }
+
+    .status-col {
+      @include breakpoint-widths(0.25, 0.45, 0.3, 0.35, 0.25, true);
+    }
+
+    .actions-col {
+      @include breakpoint-widths(0.25, 0.1, 0.1, 0.1, 0.1, true);
+    }
+
+    .machines-col {
+      @include breakpoint-widths(0, 0, 0.1, 0.1, 0.1, true);
+    }
+
+    .last-deployed-col {
+      @include breakpoint-widths(0, 0, 0.15, 0.2, 0.15, true);
+    }
   }
 }

--- a/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
+++ b/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import { format, parse } from "date-fns";
+import { format } from "date-fns";
 import { useDispatch, useSelector } from "react-redux";
 import type { Dispatch } from "redux";
 
@@ -15,6 +15,7 @@ import type { RootState } from "app/store/root/types";
 import { actions as scriptActions } from "app/store/script";
 import scriptSelectors from "app/store/script/selectors";
 import type { Script } from "app/store/script/types";
+import { parseUtcDatetime } from "app/utils/time";
 
 export enum Labels {
   Actions = "Table actions",
@@ -43,14 +44,7 @@ const generateRows = (
     // history timestamps are in the format: Mon, 02 Sep 2019 02:02:39 -0000
     let uploadedOn: string;
     try {
-      uploadedOn = format(
-        parse(
-          `${script.created} +00`, // let parse fn know it's UTC
-          "E, dd LLL. yyyy HH:mm:ss x",
-          new Date()
-        ),
-        "yyyy-LL-dd H:mm"
-      );
+      uploadedOn = format(parseUtcDatetime(script.created), "yyyy-LL-dd H:mm");
     } catch (error) {
       uploadedOn = "Never";
     }

--- a/src/app/store/bootresource/types/base.ts
+++ b/src/app/store/bootresource/types/base.ts
@@ -15,7 +15,7 @@ export type BootResource = Model & {
   downloading: boolean;
   icon: "in-progress" | "queued" | "succeeded" | "waiting";
   lastUpdate: string;
-  last_deployed?: string;
+  lastDeployed: string;
   name: string;
   numberOfNodes: number;
   rtype: BootResourceType;

--- a/src/app/store/bootresource/types/base.ts
+++ b/src/app/store/bootresource/types/base.ts
@@ -15,6 +15,7 @@ export type BootResource = Model & {
   downloading: boolean;
   icon: "in-progress" | "queued" | "succeeded" | "waiting";
   lastUpdate: string;
+  last_deployed?: string;
   name: string;
   numberOfNodes: number;
   rtype: BootResourceType;

--- a/src/app/utils/formatBytes.test.ts
+++ b/src/app/utils/formatBytes.test.ts
@@ -1,4 +1,4 @@
-import { formatBytes } from "./formatBytes";
+import { formatBytes, sizeStringToNumber } from "./formatBytes";
 
 describe("formatBytes", () => {
   it("correctly formats a value above the unit threshold", () => {
@@ -114,5 +114,23 @@ describe("formatBytes", () => {
       value: 0.000001,
       unit: "TB",
     });
+  });
+});
+
+describe("sizeStringToNumber", () => {
+  it("can convert a size string to a number of bytes", () => {
+    expect(sizeStringToNumber("1 B")).toBe(1);
+    expect(sizeStringToNumber("1 KB")).toBe(1000);
+    expect(sizeStringToNumber("1 GB")).toBe(1000000000);
+  });
+
+  it("ignores extra whitespace characters", () => {
+    expect(sizeStringToNumber(" 1  B ")).toBe(1);
+  });
+
+  it("returns null for an invalid size string parameter", () => {
+    expect(sizeStringToNumber("")).toBe(null);
+    expect(sizeStringToNumber()).toBe(null);
+    expect(sizeStringToNumber("1MB")).toBe(null);
   });
 });

--- a/src/app/utils/formatBytes.ts
+++ b/src/app/utils/formatBytes.ts
@@ -62,3 +62,23 @@ export const formatBytes = (
     unit: sizes[j],
   };
 };
+
+/**
+ *  Convert a size string (e.g. 1 MB) to a number of bytets
+ *  @param sizeString - the size string with a unit, e.g. "1 KB"
+ */
+export const sizeStringToNumber = (sizeString: string = ""): number | null => {
+  try {
+    const regex = /(?<value>\d+(\.\d+)?)(?:\s+?)(?<unit>[a-zA-Z]+)/;
+    const groups = sizeString.match(regex)?.groups;
+    if (groups) {
+      return formatBytes(Number(groups.value), groups.unit, {
+        convertTo: "B",
+      }).value;
+    }
+  } catch (error) {
+    console.error(error);
+  }
+
+  return null;
+};

--- a/src/app/utils/time.test.ts
+++ b/src/app/utils/time.test.ts
@@ -1,0 +1,24 @@
+import MockDate from "mockdate";
+
+import { getTimeDistanceString } from "./time";
+
+beforeEach(() => {
+  MockDate.set("Fri, 18 Nov. 2022 01:01:00");
+});
+
+afterEach(() => {
+  MockDate.reset();
+});
+
+describe("getTimeDistanceString", () => {
+  it("returns time distance for UTC TimeString in the past", () => {
+    expect(getTimeDistanceString("Fri, 18 Nov. 2022 01:00:50")).toEqual(
+      "less than a minute ago"
+    );
+  });
+  it("returns time distance for UTC TimeString in the future", () => {
+    expect(getTimeDistanceString("Fri, 18 Nov. 2022 01:01:10")).toEqual(
+      "in less than a minute"
+    );
+  });
+});

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -1,0 +1,12 @@
+import { formatDistance, parse } from "date-fns";
+
+export const getTimeDistanceString = (utcTimeString: string): string =>
+  formatDistance(
+    parse(
+      `${utcTimeString} +00`, // let parse fn know it's UTC
+      "E, dd LLL. yyyy HH:mm:ss x",
+      new Date()
+    ),
+    new Date(),
+    { addSuffix: true }
+  );

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -1,12 +1,16 @@
 import { formatDistance, parse } from "date-fns";
 
-export const getTimeDistanceString = (utcTimeString: string): string =>
-  formatDistance(
-    parse(
-      `${utcTimeString} +00`, // let parse fn know it's UTC
-      "E, dd LLL. yyyy HH:mm:ss x",
-      new Date()
-    ),
-    new Date(),
-    { addSuffix: true }
+const DATETIME_FORMAT = "E, dd LLL. yyyy HH:mm:ss";
+const UTC_DATETIME_FORMAT = `${DATETIME_FORMAT} x`;
+
+export const parseUtcDatetime = (utcTimeString: string): Date =>
+  parse(
+    `${utcTimeString} +00`, // let parse fn know it's UTC
+    UTC_DATETIME_FORMAT,
+    new Date()
   );
+
+export const getTimeDistanceString = (utcTimeString: string): string =>
+  formatDistance(parseUtcDatetime(utcTimeString), new Date(), {
+    addSuffix: true,
+  });

--- a/src/testing/factories/bootresource.ts
+++ b/src/testing/factories/bootresource.ts
@@ -34,6 +34,7 @@ export const bootResource = extend<Model, BootResource>(model, {
   downloading: false,
   numberOfNodes: 0,
   lastUpdate: "Tue, 08 Jun. 2021 02:12:47",
+  last_deployed: "Tue, 08 Jun. 2021 02:12:47",
 });
 
 export const bootResourceUbuntu = define<BootResourceUbuntu>({

--- a/src/testing/factories/bootresource.ts
+++ b/src/testing/factories/bootresource.ts
@@ -34,7 +34,7 @@ export const bootResource = extend<Model, BootResource>(model, {
   downloading: false,
   numberOfNodes: 0,
   lastUpdate: "Tue, 08 Jun. 2021 02:12:47",
-  last_deployed: "Tue, 08 Jun. 2021 02:12:47",
+  lastDeployed: "Tue, 08 Jun. 2021 02:12:47",
 });
 
 export const bootResourceUbuntu = define<BootResourceUbuntu>({


### PR DESCRIPTION
## Done

- feat: add last deployed images fields

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check out this PR locally (polong/bolla are unavailable due to disk failures at the moment)
- Go to `/MAAS/r/images`
- Verify that all image tables are displayed correctly
- Verify that sorting by machine count works correctly
- Verify that sorting by last deployed works correctly
- Click on the size column to sort images by size multiple times to sort in asc/desc order

## Fixes
https://github.com/canonical/maas-ui/issues/4641

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

<img width="1424" alt="image" src="https://user-images.githubusercontent.com/7452681/206209890-7efb0234-b2d6-4c8c-a908-ff7c90ae14c9.png">

<img width="1301" alt="image" src="https://user-images.githubusercontent.com/7452681/206237116-6ea88148-02ed-420e-b088-74b9d6cdcca8.png">



