### PR TITLE
fix: disabled kvm host delete button (#4642) 3.3

### DIFF
--- a/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
@@ -1,3 +1,5 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -9,6 +11,7 @@ import DeleteForm from "./DeleteForm";
 import FormikForm from "app/base/components/FormikForm";
 import { PodType } from "app/store/pod/constants";
 import podSelectors from "app/store/pod/selectors";
+import type { RootState } from "app/store/root/types";
 import vmClusterSelectors from "app/store/vmcluster/selectors";
 import {
   pod as podFactory,
@@ -21,9 +24,12 @@ import {
   vmClusterState as vmClusterStateFactory,
   vmClusterStatuses as vmClusterStatusesFactory,
 } from "testing/factories";
-import { waitForComponentToPaint } from "testing/utils";
+import {
+  renderWithBrowserRouter,
+  waitForComponentToPaint,
+} from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("DeleteForm", () => {
   afterEach(() => {
@@ -169,18 +175,18 @@ describe("DeleteForm", () => {
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <CompatRouter>
-            <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <DeleteForm clearHeaderContent={jest.fn()} hostId={1} />,
+      { route: "/kvm", store }
     );
 
-    wrapper.find("Formik").simulate("submit");
-    await waitForComponentToPaint(wrapper);
+    expect(
+      screen.getByRole("button", { name: /Remove KVM Host/i })
+    ).toBeEnabled();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Remove KVM Host/i })
+    );
+
     expect(
       store.getActions().find((action) => action.type === "pod/delete")
     ).toStrictEqual({
@@ -209,18 +215,17 @@ describe("DeleteForm", () => {
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <CompatRouter>
-            <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <DeleteForm clearHeaderContent={jest.fn()} clusterId={1} />,
+      { route: "/kvm", store }
     );
 
-    wrapper.find("Formik").simulate("submit");
-    await waitForComponentToPaint(wrapper);
+    expect(
+      screen.getByRole("button", { name: /Remove cluster/i })
+    ).toBeEnabled();
+    await userEvent.click(
+      screen.getByRole("button", { name: /Remove cluster/i })
+    );
     expect(
       store.getActions().find((action) => action.type === "vmcluster/delete")
     ).toStrictEqual({

--- a/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.tsx
@@ -124,7 +124,6 @@ const DeleteForm = ({
         dispatch(machineActions.invalidateQueries());
       }}
       processingCount={deletingCount}
-      selectedCount={deletingCount}
       submitAppearance="negative"
       validationSchema={DeleteFormSchema}
     >


### PR DESCRIPTION
## Done

- fix: disabled kvm host delete button (3.3 backport)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4643

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
