### PR TITLE
feat(machines): add hidden columns

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -67,11 +67,11 @@ context("Machine listing", () => {
     cy.findByText(/No machines match the search criteria./).should("exist");
   });
 
-  it.skip("can hide machine table columns", () => {
+  it("can hide machine table columns", () => {
     cy.findAllByRole("columnheader").should("have.length", 8);
 
-    cy.findAllByRole("button", { name: "Hidden columns" }).click();
-    cy.findByLabelText("hidden columns menu").within(() =>
+    cy.findAllByRole("button", { name: "Columns" }).click();
+    cy.findByLabelText("columns menu").within(() =>
       // eslint-disable-next-line cypress/no-force
       cy.findByRole("checkbox", { name: "Status" }).click({ force: true })
     );

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -1,3 +1,5 @@
+import type { ValueOf } from "@canonical/react-components";
+
 import { NodeActions } from "app/store/types/node";
 
 export const MachineActionHeaderViews = {
@@ -49,6 +51,14 @@ export const columns = [
   "disks",
   "storage",
 ] as const;
+export type MachineColumn = ValueOf<typeof columns>;
+export type MachineColumnToggle = Exclude<MachineColumn, "fqdn">;
+function isMachineColumnToggle(
+  column: MachineColumn
+): column is MachineColumnToggle {
+  return column !== "fqdn";
+}
+export const columnToggles = columns.filter(isMachineColumnToggle);
 
 export enum MachineColumns {
   FQDN = "fqdn",

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -55,6 +55,11 @@ const MachineList = ({
     Object.values(FetchGroupKey).includes(storedGrouping)
       ? storedGrouping
       : DEFAULTS.grouping;
+  const [hiddenColumns, setHiddenColumns] = useStorageState<string[]>(
+    localStorage,
+    "machineListHiddenColumns",
+    []
+  );
   const handleSetGrouping = (group: FetchGroupKey | null) => {
     setStoredGrouping(group);
     // clear selected machines on grouping change
@@ -115,8 +120,10 @@ const MachineList = ({
       <MachineListControls
         filter={searchFilter}
         grouping={grouping}
+        hiddenColumns={hiddenColumns}
         setFilter={handleSetSearchFilter}
         setGrouping={handleSetGrouping}
+        setHiddenColumns={setHiddenColumns}
         setHiddenGroups={setHiddenGroups}
       />
       <MachineListTable
@@ -124,6 +131,7 @@ const MachineList = ({
         currentPage={currentPage}
         filter={searchFilter}
         grouping={grouping}
+        hiddenColumns={hiddenColumns}
         hiddenGroups={hiddenGroups}
         machineCount={machineCount}
         machines={machines}

--- a/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
@@ -5,23 +5,70 @@ import configureStore from "redux-mock-store";
 
 import HiddenColumnsSelect from "./HiddenColumnsSelect";
 
+import { columnToggles } from "app/machines/constants";
 import { rootState as rootStateFactory } from "testing/factories";
 
-it("calls toggleHiddenColumn correctly on click of a checkbox", async () => {
+it("calls setHiddenColumns correctly on click of a checkbox", async () => {
   const mockStore = configureStore();
   const hiddenColumns: Array<""> = [];
   const store = mockStore(rootStateFactory());
 
-  const toggleHiddenColumn = jest.fn();
+  const setHiddenColumns = jest.fn();
   render(
     <Provider store={store}>
       <HiddenColumnsSelect
         hiddenColumns={hiddenColumns}
-        toggleHiddenColumn={toggleHiddenColumn}
+        setHiddenColumns={setHiddenColumns}
       />
     </Provider>
   );
-  await userEvent.click(screen.getByRole("button", { name: "Hidden columns" }));
+  await userEvent.click(screen.getByRole("button", { name: "Columns" }));
+  expect(
+    screen.getByRole("checkbox", { name: /10 out of 10 selected/ })
+  ).toBeInTheDocument();
   await userEvent.click(screen.getByRole("checkbox", { name: "RAM" }));
-  expect(toggleHiddenColumn).toHaveBeenCalledWith("memory");
+  expect(setHiddenColumns).toHaveBeenCalledWith(["memory"]);
+});
+
+it("displays a correct number of selected columns", async () => {
+  const mockStore = configureStore();
+  const hiddenColumns = ["memory"];
+  const store = mockStore(rootStateFactory());
+
+  const setHiddenColumns = jest.fn();
+  render(
+    <Provider store={store}>
+      <HiddenColumnsSelect
+        hiddenColumns={hiddenColumns}
+        setHiddenColumns={setHiddenColumns}
+      />
+    </Provider>
+  );
+  await userEvent.click(screen.getByRole("button", { name: "Columns" }));
+  expect(
+    screen.getByRole("checkbox", { name: /9 out of 10 selected/ })
+  ).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("checkbox", { name: "RAM" }));
+  expect(setHiddenColumns).toHaveBeenCalledWith([]);
+});
+
+it("group checkbox selects all columns on press", async () => {
+  const mockStore = configureStore();
+  const hiddenColumns: string[] = [];
+  const store = mockStore(rootStateFactory());
+
+  const setHiddenColumns = jest.fn();
+  render(
+    <Provider store={store}>
+      <HiddenColumnsSelect
+        hiddenColumns={hiddenColumns}
+        setHiddenColumns={setHiddenColumns}
+      />
+    </Provider>
+  );
+  await userEvent.click(screen.getByRole("button", { name: "Columns" }));
+  await userEvent.click(
+    screen.getByRole("checkbox", { name: /10 out of 10 selected/ })
+  );
+  expect(setHiddenColumns).toHaveBeenCalledWith([...columnToggles]);
 });

--- a/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
@@ -1,26 +1,19 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
 
 import HiddenColumnsSelect from "./HiddenColumnsSelect";
 
 import { columnToggles } from "app/machines/constants";
-import { rootState as rootStateFactory } from "testing/factories";
+import { renderWithMockStore } from "testing/utils";
 
 it("calls setHiddenColumns correctly on click of a checkbox", async () => {
-  const mockStore = configureStore();
   const hiddenColumns: Array<""> = [];
-  const store = mockStore(rootStateFactory());
-
   const setHiddenColumns = jest.fn();
-  render(
-    <Provider store={store}>
-      <HiddenColumnsSelect
-        hiddenColumns={hiddenColumns}
-        setHiddenColumns={setHiddenColumns}
-      />
-    </Provider>
+  renderWithMockStore(
+    <HiddenColumnsSelect
+      hiddenColumns={hiddenColumns}
+      setHiddenColumns={setHiddenColumns}
+    />
   );
   await userEvent.click(screen.getByRole("button", { name: "Columns" }));
   expect(
@@ -31,18 +24,13 @@ it("calls setHiddenColumns correctly on click of a checkbox", async () => {
 });
 
 it("displays a correct number of selected columns", async () => {
-  const mockStore = configureStore();
   const hiddenColumns = ["memory"];
-  const store = mockStore(rootStateFactory());
-
   const setHiddenColumns = jest.fn();
-  render(
-    <Provider store={store}>
-      <HiddenColumnsSelect
-        hiddenColumns={hiddenColumns}
-        setHiddenColumns={setHiddenColumns}
-      />
-    </Provider>
+  renderWithMockStore(
+    <HiddenColumnsSelect
+      hiddenColumns={hiddenColumns}
+      setHiddenColumns={setHiddenColumns}
+    />
   );
   await userEvent.click(screen.getByRole("button", { name: "Columns" }));
   expect(
@@ -53,18 +41,13 @@ it("displays a correct number of selected columns", async () => {
 });
 
 it("group checkbox selects all columns on press", async () => {
-  const mockStore = configureStore();
   const hiddenColumns: string[] = [];
-  const store = mockStore(rootStateFactory());
-
   const setHiddenColumns = jest.fn();
-  render(
-    <Provider store={store}>
-      <HiddenColumnsSelect
-        hiddenColumns={hiddenColumns}
-        setHiddenColumns={setHiddenColumns}
-      />
-    </Provider>
+  renderWithMockStore(
+    <HiddenColumnsSelect
+      hiddenColumns={hiddenColumns}
+      setHiddenColumns={setHiddenColumns}
+    />
   );
   await userEvent.click(screen.getByRole("button", { name: "Columns" }));
   await userEvent.click(

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
@@ -41,8 +41,8 @@ describe("MachineListControls", () => {
             hiddenColumns={[]}
             setFilter={setFilter}
             setGrouping={jest.fn()}
+            setHiddenColumns={jest.fn()}
             setHiddenGroups={jest.fn()}
-            toggleHiddenColumn={jest.fn()}
           />
         </MemoryRouter>
       </Provider>

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -3,19 +3,20 @@ import { useEffect, useState } from "react";
 import { Col, Row } from "@canonical/react-components";
 
 import GroupSelect from "./GroupSelect";
+import HiddenColumnsSelect from "./HiddenColumnsSelect";
 import MachinesFilterAccordion from "./MachinesFilterAccordion";
 
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
 import type { FetchGroupKey } from "app/store/machine/types";
 
-type Props = {
+export type MachineListControlsProps = {
   filter: string;
   grouping: FetchGroupKey | null;
   setFilter: (filter: string) => void;
   setGrouping: (group: FetchGroupKey | null) => void;
   setHiddenGroups: (groups: string[]) => void;
-  hiddenColumns?: string[];
-  toggleHiddenColumn?: (column: string) => void;
+  hiddenColumns: string[];
+  setHiddenColumns: React.Dispatch<React.SetStateAction<string[]>>;
 };
 
 const MachineListControls = ({
@@ -24,7 +25,9 @@ const MachineListControls = ({
   setFilter,
   setGrouping,
   setHiddenGroups,
-}: Props): JSX.Element => {
+  hiddenColumns,
+  setHiddenColumns,
+}: MachineListControlsProps): JSX.Element => {
   const [searchText, setSearchText] = useState(filter);
 
   useEffect(() => {
@@ -42,7 +45,7 @@ const MachineListControls = ({
           }}
         />
       </Col>
-      <Col size={6}>
+      <Col size={4}>
         <DebounceSearchBox
           onDebounced={(debouncedText) => setFilter(debouncedText)}
           searchText={searchText}
@@ -50,10 +53,20 @@ const MachineListControls = ({
         />
       </Col>
       <Col size={3}>
-        <GroupSelect
-          grouping={grouping}
-          setGrouping={setGrouping}
-          setHiddenGroups={setHiddenGroups}
+        <div className="u-flex--align-baseline">
+          <div className="u-flex--grow">
+            <GroupSelect
+              grouping={grouping}
+              setGrouping={setGrouping}
+              setHiddenGroups={setHiddenGroups}
+            />
+          </div>
+        </div>
+      </Col>
+      <Col size={2}>
+        <HiddenColumnsSelect
+          hiddenColumns={hiddenColumns}
+          setHiddenColumns={setHiddenColumns}
         />
       </Col>
     </Row>

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -134,7 +134,19 @@
     grid-gap: 0.5rem;
   }
 
-  .machines-list-hidden-columns-select {
+  .hidden-columns-select-wrapper {
     padding: $sph--small $sph--large;
+  }
+
+  .hidden-columns-toggle {
+    width: 100%;
+    padding-left: $spv--small;
+    text-align: left;
+
+    .p-contextual-menu__indicator {
+      position: absolute;
+      right: $spv--large;
+      top: calc(#{$spv--medium} - 1px);
+    }
   }
 }


### PR DESCRIPTION
## Done

- add the ability to hide columns on the machine list page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Deselect a few columns
- Make sure they're hidden in the machine list table
- Refresh the page
- Selection should be persisted

## Fixes

Fixes: MAASENG-1227

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

<img width="244" alt="image" src="https://user-images.githubusercontent.com/7452681/212047753-fac96489-b892-4c3a-8792-226deaefdb00.png">

