### PR TITLE
feat(machines): update focus states

### DIFF
--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -2,6 +2,7 @@
   $box-size: 1rem;
   $checkbox-offset: 0.1875rem; // Offset checkbox to prevent focus outline truncation
   $grouped-machines-indentation: $box-size + $sph--large - $checkbox-offset; // Checkbox + label - offset
+  $item-active-background: #dbedff;
 
   .machine-list {
     @include truncated-border($width: $grouped-machines-indentation);
@@ -76,9 +77,10 @@
     min-height: 1px;
   }
 
+  .machine-list__machine:focus-within,
   .machine-list__machine:hover:not(.machine-list__machine--inactive),
   .machine-list__machine--active {
-    background-color: $color-x-light;
+    background-color: $item-active-background;
 
     .p-table-menu {
       display: block;


### PR DESCRIPTION
## Done

- update machine list focus states

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Hover a machine
- Machine row should have a light blue colour background
- Tab through input fields on a page until one of the inputs within a machine row is selected
- Machine row should have a light blue colour background

## Fixes

Fixes: MAASENG-1228

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

<img width="1419" alt="image" src="https://user-images.githubusercontent.com/7452681/212060545-df189bdb-9e67-416b-b655-fdf182f5c497.png">
