### PR TITLE
fix: update tag fields color to match vanilla-framework

### DIFF
--- a/src/app/base/components/TagSelector/_index.scss
+++ b/src/app/base/components/TagSelector/_index.scss
@@ -78,9 +78,7 @@
   }
 
   .tag-selector__selected-list {
-    @extend %vf-bg--x-light;
-    @extend %vf-has-round-corners;
-    border: 1px solid $color-mid;
+    background-color: $colors--light-theme--background-inputs;
     border-bottom: 0;
     margin: 0;
     padding: $spv--x-small $sph--small;


### PR DESCRIPTION
## Done

- fix: update tag fields color to match vanilla-framework

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Take action -> Commision
- Verify that Testing scripts field is displayed with  a consistent background colour

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
<img width="703" alt="image" src="https://user-images.githubusercontent.com/7452681/212357759-9ed6010a-4322-41fc-bf3f-350c1cc97fa9.png">

### After
<img width="715" alt="image" src="https://user-images.githubusercontent.com/7452681/212357296-95789af8-cd79-47f3-bc6b-9f06f876c71a.png">

