### PR TITLE
refactor: use single testing/utils import

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -1,5 +1,4 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
-import { screen } from "@testing-library/react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -15,7 +14,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/Routes.test.tsx
+++ b/src/app/Routes.test.tsx
@@ -1,5 +1,3 @@
-import { waitFor } from "@testing-library/react";
-
 import Routes from "./Routes";
 import type { RootState } from "./store/root/types";
 
@@ -20,7 +18,7 @@ import {
   machine as machineFactory,
   machineState as machineStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { waitFor, renderWithBrowserRouter } from "testing/utils";
 
 const nodeSummaryRoutes: { path: string; name: string }[] = [
   {

--- a/src/app/base/components/ActionBar/ActionBar.test.tsx
+++ b/src/app/base/components/ActionBar/ActionBar.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import ActionBar from "./ActionBar";
 
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -10,6 +9,7 @@ import ActionForm, { Labels } from "./ActionForm";
 import { TestIds } from "app/base/components/FormikFormButtons";
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 let state: RootState;
 const mockStore = configureStore();

--- a/src/app/base/components/ArchitectureSelect/ArchitectureSelect.test.tsx
+++ b/src/app/base/components/ArchitectureSelect/ArchitectureSelect.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -10,6 +9,7 @@ import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/ArrowPagination/ArrowPagination.test.tsx
+++ b/src/app/base/components/ArrowPagination/ArrowPagination.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import ArrowPagination, { Labels, TestIds } from "./ArrowPagination";
+
+import { render, screen } from "testing/utils";
 
 describe("ArrowPagination", () => {
   it("disables both buttons when there are no items", () => {

--- a/src/app/base/components/CertificateDetails/CertificateDetails.test.tsx
+++ b/src/app/base/components/CertificateDetails/CertificateDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -13,6 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/CertificateDownload/CertificateDownload.test.tsx
+++ b/src/app/base/components/CertificateDownload/CertificateDownload.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as fileDownload from "js-file-download";
 
@@ -6,6 +5,7 @@ import CertificateDownload, { Labels, TestIds } from "./CertificateDownload";
 
 import type { GeneratedCertificate } from "app/store/general/types";
 import { generatedCertificate as certFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 jest.mock("js-file-download", () => jest.fn());
 

--- a/src/app/base/components/CertificateFields/CertificateFields.test.tsx
+++ b/src/app/base/components/CertificateFields/CertificateFields.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import { Formik } from "formik";
 
 import CertificateFields, { Labels } from "./CertificateFields";
+
+import { render, screen } from "testing/utils";
 
 describe("CertificateFields", () => {
   it("does not render certificate and key fields if generating a certificate", () => {

--- a/src/app/base/components/ColumnToggle/ColumnToggle.test.tsx
+++ b/src/app/base/components/ColumnToggle/ColumnToggle.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ColumnToggle from "./ColumnToggle";
+
+import { render, screen } from "testing/utils";
 
 const DOM_RECT = {
   height: 0,

--- a/src/app/base/components/ControllerLink/ControllerLink.test.tsx
+++ b/src/app/base/components/ControllerLink/ControllerLink.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -13,6 +12,7 @@ import {
   modelRef as modelRefFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/CopyButton/CopyButton.test.tsx
+++ b/src/app/base/components/CopyButton/CopyButton.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import CopyButton from "./CopyButton";
+
+import { render, screen } from "testing/utils";
 
 describe("CopyButton", () => {
   let execCommand: (

--- a/src/app/base/components/DHCPTable/DHCPTable.test.tsx
+++ b/src/app/base/components/DHCPTable/DHCPTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -20,6 +19,7 @@ import {
   rootState as rootStateFactory,
   subnet as subnetFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/DebounceSearchBox/DebounceSearchBox.test.tsx
+++ b/src/app/base/components/DebounceSearchBox/DebounceSearchBox.test.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import DebounceSearchBox, {
   DEFAULT_DEBOUNCE_INTERVAL,
   Labels,
 } from "./DebounceSearchBox";
+
+import { render, screen, waitFor } from "testing/utils";
 
 describe("DebounceSearchBox", () => {
   beforeEach(() => {

--- a/src/app/base/components/Definition/Definition.test.tsx
+++ b/src/app/base/components/Definition/Definition.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import Definition from "./Definition";
+
+import { render, screen } from "testing/utils";
 
 it("renders term and description correctly", () => {
   render(<Definition description="description text" label="Term" />);

--- a/src/app/base/components/DeviceLink/DeviceLink.test.tsx
+++ b/src/app/base/components/DeviceLink/DeviceLink.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   deviceState as deviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/DhcpForm/DhcpForm.test.tsx
+++ b/src/app/base/components/DhcpForm/DhcpForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   dhcpSnippetState as dhcpSnippetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -26,6 +25,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 const machines = [machineFactory()];

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
@@ -1,10 +1,9 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import MachineSelect, { Labels } from "./MachineSelect";
 
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 it("can open select box on click", async () => {
   renderWithMockStore(

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -9,7 +8,7 @@ import { DEFAULT_DEBOUNCE_INTERVAL } from "app/base/components/DebounceSearchBox
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, waitFor, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/base/components/DhcpSnippetType/DhcpSnippetType.test.tsx
+++ b/src/app/base/components/DhcpSnippetType/DhcpSnippetType.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -17,6 +16,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/DomainSelect/DomainSelect.test.tsx
+++ b/src/app/base/components/DomainSelect/DomainSelect.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -9,6 +8,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/DoubleRow/DoubleRow.test.tsx
+++ b/src/app/base/components/DoubleRow/DoubleRow.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import DoubleRow, { TestIds } from "./DoubleRow";
+
+import { render, screen } from "testing/utils";
 
 describe("DoubleRow ", () => {
   it("can render without a secondary row", () => {

--- a/src/app/base/components/DoughnutChart/DoughnutChart.test.tsx
+++ b/src/app/base/components/DoughnutChart/DoughnutChart.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import DoughnutChart, { TestIds } from "./DoughnutChart";
+
+import { render, screen } from "testing/utils";
 
 describe("DoughnutChart", () => {
   it("renders", () => {

--- a/src/app/base/components/DynamicSelect/DynamicSelect.test.tsx
+++ b/src/app/base/components/DynamicSelect/DynamicSelect.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import DynamicSelect from "./DynamicSelect";
 import type { Props as DynamicSelectProps } from "./DynamicSelect";
+
+import { fireEvent, render, screen, waitFor } from "testing/utils";
 
 describe("DynamicSelect", () => {
   it("resets to the first option if the options change and the value no longer exists", async () => {

--- a/src/app/base/components/EditableSection/EditableSection.test.tsx
+++ b/src/app/base/components/EditableSection/EditableSection.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import EditableSection, { Labels } from "./EditableSection";
+
+import { render, screen } from "testing/utils";
 
 it("can toggle showing content depending on editing state", async () => {
   render(

--- a/src/app/base/components/ErrorBoundary/ErrorBoundary.test.tsx
+++ b/src/app/base/components/ErrorBoundary/ErrorBoundary.test.tsx
@@ -1,5 +1,4 @@
 import * as Sentry from "@sentry/browser";
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -12,6 +11,7 @@ import {
   rootState as rootStateFactory,
   versionState as versionStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/FabricLink/FabricLink.test.tsx
+++ b/src/app/base/components/FabricLink/FabricLink.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/FabricSelect/FabricSelect.test.tsx
+++ b/src/app/base/components/FabricSelect/FabricSelect.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -11,6 +10,7 @@ import {
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/FilterAccordion/FilterAccordion.test.tsx
+++ b/src/app/base/components/FilterAccordion/FilterAccordion.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import FilterAccordion, { Labels } from "./FilterAccordion";
@@ -7,6 +6,7 @@ import type { Props as FilterAccordionProps } from "./FilterAccordion";
 import type { MachineDetails, MachineMeta } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { machineDetails as machineDetailsFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 describe("FilterAccordion", () => {
   let items: MachineDetails[];

--- a/src/app/base/components/Footer/Footer.test.tsx
+++ b/src/app/base/components/Footer/Footer.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import MockDate from "mockdate";
 
 import Footer from "./Footer";
@@ -9,7 +8,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 const originalEnv = process.env;
 

--- a/src/app/base/components/FormCard/FormCard.test.tsx
+++ b/src/app/base/components/FormCard/FormCard.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from "@testing-library/react";
-
 import FormCard, { TestIds } from "./FormCard";
 
 import { COL_SIZES } from "app/base/constants";
+import { render, screen } from "testing/utils";
 
 const { CARD_TITLE, SIDEBAR, TOTAL } = COL_SIZES;
 

--- a/src/app/base/components/FormikField/FormikField.test.tsx
+++ b/src/app/base/components/FormikField/FormikField.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import { Formik } from "formik";
 
 import FormikField from "./FormikField";
+
+import { render, screen } from "testing/utils";
 
 describe("FormikField", () => {
   it("can set a different component", () => {

--- a/src/app/base/components/FormikForm/FormikForm.test.tsx
+++ b/src/app/base/components/FormikForm/FormikForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -13,6 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
+++ b/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
@@ -1,8 +1,9 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import FormikFormButtons from "./FormikFormButtons";
+
+import { render, screen } from "testing/utils";
 
 it("can display a cancel button", () => {
   render(

--- a/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Field, Formik } from "formik";
 import { Provider } from "react-redux";
@@ -18,7 +17,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { render, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 const mockUseNavigate = jest.fn();

--- a/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/base/components/GroupCheckbox/GroupCheckbox.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import GroupCheckbox from "./GroupCheckbox";
+
+import { render, screen } from "testing/utils";
 
 describe("GroupCheckbox", () => {
   it("shows as mixed when some items are checked", () => {

--- a/src/app/base/components/Header/Header.test.tsx
+++ b/src/app/base/components/Header/Header.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, waitFor, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -22,7 +21,14 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import {
+  screen,
+  render,
+  waitFor,
+  within,
+  act,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockUseNavigate = jest.fn();
 jest.mock("react-router-dom-v5-compat", () => ({

--- a/src/app/base/components/IpAssignmentSelect/IpAssignmentSelect.test.tsx
+++ b/src/app/base/components/IpAssignmentSelect/IpAssignmentSelect.test.tsx
@@ -1,10 +1,10 @@
-import { screen, render } from "@testing-library/react";
 import { Formik } from "formik";
 
 import IpAssignmentSelect from "./IpAssignmentSelect";
 
 import { DeviceIpAssignment } from "app/store/device/types";
 import { getIpAssignmentDisplay } from "app/store/device/utils";
+import { screen, render } from "testing/utils";
 
 const staticDisplay = getIpAssignmentDisplay(DeviceIpAssignment.STATIC);
 

--- a/src/app/base/components/LabelledList/LabelledList.test.tsx
+++ b/src/app/base/components/LabelledList/LabelledList.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import LabelledList from "./LabelledList";
+
+import { render, screen } from "testing/utils";
 
 describe("LabelledList ", () => {
   it("can add additional classes", () => {

--- a/src/app/base/components/LinkModeSelect/LinkModeSelect.test.tsx
+++ b/src/app/base/components/LinkModeSelect/LinkModeSelect.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -8,6 +7,7 @@ import LinkModeSelect, { Label } from "./LinkModeSelect";
 import { NetworkInterfaceTypes, NetworkLinkMode } from "app/store/types/enum";
 import { LINK_MODE_DISPLAY } from "app/store/utils";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/Login/Login.test.tsx
+++ b/src/app/base/components/Login/Login.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/MacAddressField/MacAddressField.test.tsx
+++ b/src/app/base/components/MacAddressField/MacAddressField.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -7,6 +6,7 @@ import configureStore from "redux-mock-store";
 import MacAddressField from "./MacAddressField";
 
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/MachineLink/MachineLink.test.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,6 +13,7 @@ import {
   rootState as rootStateFactory,
   machineStateDetailsItem as machineStateDetailsItemFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import MachineSelectTable, { Label } from "./MachineSelectTable";
@@ -12,7 +11,7 @@ import {
   tagState as tagStateFactory,
   machineState as machineStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("MachineSelectTable", () => {
   let machines: Machine[];

--- a/src/app/base/components/Meter/Meter.test.tsx
+++ b/src/app/base/components/Meter/Meter.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import Meter, { DEFAULT_SEPARATOR_COLOR, TestIds } from "./Meter";
+
+import { render, screen } from "testing/utils";
 
 const mockClientRect = ({
   bottom = 0,

--- a/src/app/base/components/MinimumKernelSelect/MinimumKernelSelect.test.tsx
+++ b/src/app/base/components/MinimumKernelSelect/MinimumKernelSelect.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -10,6 +9,7 @@ import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/ModelListSubtitle/ModelListSubtitle.test.tsx
+++ b/src/app/base/components/ModelListSubtitle/ModelListSubtitle.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ModelListSubtitle, { TestIds } from "./ModelListSubtitle";
+
+import { render, screen } from "testing/utils";
 
 describe("ModelListSubtitle", () => {
   it("correctly displays when one model is available and none selected", () => {

--- a/src/app/base/components/ModelNotFound/ModelNotFound.test.tsx
+++ b/src/app/base/components/ModelNotFound/ModelNotFound.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -7,6 +6,7 @@ import configureStore from "redux-mock-store";
 import ModelNotFound from "./ModelNotFound";
 
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/NetworkActionRow/NetworkActionRow.test.tsx
+++ b/src/app/base/components/NetworkActionRow/NetworkActionRow.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -12,7 +11,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.test.tsx
+++ b/src/app/base/components/NodeActionConfirmationText/NodeActionConfirmationText.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from "@testing-library/react";
-
 import NodeActionConfirmationText from "./NodeActionConfirmationText";
 
 import { NodeActions } from "app/store/types/node";
+import { render, screen } from "testing/utils";
 
 it("displays correct confirmation text for deleting a single node", () => {
   render(

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import NodeActionMenu, { Label } from "./NodeActionMenu";
@@ -6,6 +5,7 @@ import NodeActionMenu, { Label } from "./NodeActionMenu";
 import { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 import { machine as machineFactory } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 describe("NodeActionMenu", () => {
   const openMenu = async () =>

--- a/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
+++ b/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -21,6 +20,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/base/components/NonBreakingSpace/NonBreakingSpace.test.tsx
+++ b/src/app/base/components/NonBreakingSpace/NonBreakingSpace.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, getDefaultNormalizer } from "@testing-library/react";
-
 import NonBreakingSpace from "./NonBreakingSpace";
+
+import { render, screen, getDefaultNormalizer } from "testing/utils";
 
 it("renders a non breaking space correctly", () => {
   render(

--- a/src/app/base/components/OutsideClickHandler/OutsideClickHandler.test.tsx
+++ b/src/app/base/components/OutsideClickHandler/OutsideClickHandler.test.tsx
@@ -1,7 +1,8 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import OutsideClickHandler from "./OutsideClickHandler";
+
+import { screen, render } from "testing/utils";
 
 it("calls the onClick handler when clicking outside of the component", async () => {
   const onClick = jest.fn();

--- a/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.test.tsx
+++ b/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import { Formik } from "formik";
 
 import IPMIPowerFields, {
@@ -9,6 +8,7 @@ import IPMIPowerFields, {
 import type { PowerField } from "app/store/general/types";
 import { PowerFieldType } from "app/store/general/types";
 import { powerField as powerFieldFactory } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 let workaroundsField: PowerField;
 beforeEach(() => {

--- a/src/app/base/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/app/base/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import SegmentedControl from "./SegmentedControl";
+
+import { render, screen } from "testing/utils";
 
 const options = [
   {

--- a/src/app/base/components/SelectButton/SelectButton.test.tsx
+++ b/src/app/base/components/SelectButton/SelectButton.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import SelectButton from "./SelectButton";
+
+import { render, screen } from "testing/utils";
 
 it("displays a button", () => {
   render(<SelectButton>Test</SelectButton>);

--- a/src/app/base/components/SideNav/SideNav.test.tsx
+++ b/src/app/base/components/SideNav/SideNav.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { RouteProps } from "react-router-dom";
 import { MemoryRouter, Route } from "react-router-dom";
@@ -6,6 +5,8 @@ import { CompatRouter } from "react-router-dom-v5-compat";
 
 import type { NavItem } from "./SideNav";
 import { SideNav } from "./SideNav";
+
+import { screen, render } from "testing/utils";
 
 let items: NavItem[];
 

--- a/src/app/base/components/SpaceLink/SpaceLink.test.tsx
+++ b/src/app/base/components/SpaceLink/SpaceLink.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   space as spaceFactory,
   spaceState as spaceStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
+++ b/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -12,6 +11,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import StatusBar from "./StatusBar";
 
 import { ConfigNames } from "app/store/config/types";
@@ -16,7 +14,7 @@ import {
   rootState as rootStateFactory,
   versionState as versionStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 let state: RootState;
 beforeEach(() => {

--- a/src/app/base/components/SubnetLink/SubnetLink.test.tsx
+++ b/src/app/base/components/SubnetLink/SubnetLink.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/TableMenu/TableMenu.test.tsx
+++ b/src/app/base/components/TableMenu/TableMenu.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import TableMenu from "./TableMenu";
+
+import { render, screen } from "testing/utils";
 
 describe("TableMenu ", () => {
   it("expands the menu on click", async () => {

--- a/src/app/base/components/TitledSection/TitledSection.test.tsx
+++ b/src/app/base/components/TitledSection/TitledSection.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, within } from "@testing-library/react";
-
 import TitledSection from "./TitledSection";
+
+import { render, screen, within } from "testing/utils";
 
 it("displays the provided title and content", () => {
   const title = "echidna says";

--- a/src/app/base/components/TooltipButton/TooltipButton.test.tsx
+++ b/src/app/base/components/TooltipButton/TooltipButton.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import TooltipButton from "./TooltipButton";
 
 import { breakLines, unindentString } from "app/utils";
+import { render, screen } from "testing/utils";
 
 it("renders with default options correctly", async () => {
   render(<TooltipButton data-testid="tooltip-portal" message="Tooltip" />);

--- a/src/app/base/components/VLANLink/VLANLink.test.tsx
+++ b/src/app/base/components/VLANLink/VLANLink.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/VaultNotification/VaultNotification.test.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import VaultNotification from "./VaultNotification";
 
 import { NodeType } from "app/store/types/node";
@@ -7,7 +5,7 @@ import {
   rootState as rootStateFactory,
   controller as controllerFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 it("does not display a notification when data has not loaded", async () => {
   const state = rootStateFactory();

--- a/src/app/base/components/VisuallyHidden/VisuallyHidden.test.tsx
+++ b/src/app/base/components/VisuallyHidden/VisuallyHidden.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import VisuallyHidden from "./VisuallyHidden";
+
+import { render, screen } from "testing/utils";
 
 it("renders children correctly", () => {
   render(<VisuallyHidden>test content</VisuallyHidden>);

--- a/src/app/base/components/node/HardwareCard/HardwareCard.test.tsx
+++ b/src/app/base/components/node/HardwareCard/HardwareCard.test.tsx
@@ -1,5 +1,3 @@
-import { screen, within } from "@testing-library/react";
-
 import HardwareCard, { Labels as HardwareCardLabels } from "./HardwareCard";
 
 import {
@@ -7,7 +5,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 it("renders with system data", () => {
   const machine = machineDetailsFactory({ system_id: "abc123" });

--- a/src/app/base/components/node/NodeActionWarning/NodeActionWarning.test.tsx
+++ b/src/app/base/components/node/NodeActionWarning/NodeActionWarning.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from "@testing-library/react";
-
 import NodeActionWarning from "./NodeActionWarning";
 
 import { NodeActions } from "app/store/types/node";
+import { render, screen } from "testing/utils";
 
 it("displays a warning for selectedCount of 0", () => {
   render(

--- a/src/app/base/components/node/NodeLink/NodeLink.test.tsx
+++ b/src/app/base/components/node/NodeLink/NodeLink.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -17,6 +16,7 @@ import {
   modelRef as modelRefFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/NodeLogs/DownloadMenu/DownloadMenu.test.tsx
+++ b/src/app/base/components/node/NodeLogs/DownloadMenu/DownloadMenu.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as fileDownload from "js-file-download";
 
@@ -26,7 +25,7 @@ import {
   scriptResultState as scriptResultStateFactory,
   nodeScriptResultState as nodeScriptResultStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 jest.mock("js-file-download", () => jest.fn());
 

--- a/src/app/base/components/node/NodeLogs/EventLogs/EventLogs.test.tsx
+++ b/src/app/base/components/node/NodeLogs/EventLogs/EventLogs.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,7 +16,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { render, screen, within, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/NodeLogs/EventLogs/EventLogsTable/EventLogsTable.test.tsx
+++ b/src/app/base/components/node/NodeLogs/EventLogs/EventLogsTable/EventLogsTable.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import EventLogsTable, { Label } from "./EventLogsTable";
 
 import type { RootState } from "app/store/root/types";
@@ -10,7 +8,7 @@ import {
   machineDetails as machineDetailsFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("EventLogsTable", () => {
   let state: RootState;

--- a/src/app/base/components/node/NodeLogs/InstallationOutput/InstallationOutput.test.tsx
+++ b/src/app/base/components/node/NodeLogs/InstallationOutput/InstallationOutput.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import InstallationOutput, { Label } from "./InstallationOutput";
 
 import type { MachineDetails } from "app/store/machine/types";
@@ -20,7 +18,7 @@ import {
   scriptResultState as scriptResultStateFactory,
   nodeScriptResultState as nodeScriptResultStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("InstallationOutput", () => {
   let state: RootState;

--- a/src/app/base/components/node/NodeLogs/NodeLogs.test.tsx
+++ b/src/app/base/components/node/NodeLogs/NodeLogs.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import { Label as EventLogsLabel } from "./EventLogs/EventLogs";
 import { Label as InstallationOutputLabel } from "./InstallationOutput/InstallationOutput";
 import NodeLogs from "./NodeLogs";
@@ -12,7 +10,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("NodeLogs", () => {
   let state: RootState;

--- a/src/app/base/components/node/NodePowerParameters/NodePowerDefinitions/PowerParameterDefinition/PowerParameterDefinition.test.tsx
+++ b/src/app/base/components/node/NodePowerParameters/NodePowerDefinitions/PowerParameterDefinition/PowerParameterDefinition.test.tsx
@@ -1,9 +1,8 @@
-import { render, screen } from "@testing-library/react";
-
 import PowerParameterDefinition from "./PowerParameterDefinition";
 
 import { PowerFieldType } from "app/store/general/types";
 import { powerField as powerFieldFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 it("renders the value of a power parameter", () => {
   const field = powerFieldFactory({

--- a/src/app/base/components/node/NodePowerParameters/NodePowerParameters.test.tsx
+++ b/src/app/base/components/node/NodePowerParameters/NodePowerParameters.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -18,6 +17,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/OverviewCard/ControllerStatusCard/ControllerStatusCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/ControllerStatusCard/ControllerStatusCard.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -23,6 +22,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import DetailsCard, { Labels as DetailsCardLabels } from "./DetailsCard";
 
 import urls from "app/base/urls";
@@ -19,7 +17,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 let state: RootState;
 beforeEach(() => {

--- a/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/OverviewCard/OverviewCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/OverviewCard.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -13,6 +12,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
+++ b/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,6 +15,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -21,6 +20,7 @@ import {
   nodePartition as partitionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -17,6 +16,7 @@ import {
   nodeDisk as diskFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -17,6 +16,7 @@ import {
   nodeFilesystem as fsFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,6 +15,7 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -20,6 +19,7 @@ import {
   nodePartition as partitionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/StorageTables.test.tsx
+++ b/src/app/base/components/node/StorageTables/StorageTables.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,6 +13,7 @@ import {
   nodeFilesystem as fsFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -14,6 +13,7 @@ import {
   machineDetails as machineDetailsFactory,
   nodeDisk as diskFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 it("can show an empty message", () => {
   const node = machineDetailsFactory({

--- a/src/app/base/components/node/networking/NetworkTable/IPColumn/IPColumn.test.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/IPColumn/IPColumn.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import IPColumn from "./IPColumn";
 
 import { HardwareType } from "app/base/enum";
@@ -24,7 +22,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("IPColumn", () => {
   let state: RootState;

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import NetworkTable, { Label } from "./NetworkTable";
@@ -24,7 +23,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 describe("NetworkTable", () => {
   let state: RootState;

--- a/src/app/base/hooks/node.test.tsx
+++ b/src/app/base/hooks/node.test.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-import { render, screen } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
@@ -32,6 +31,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
@@ -1,4 +1,3 @@
-import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import AddController from "./AddController";
@@ -11,7 +10,12 @@ import {
   rootState as rootStateFactory,
   versionState as versionStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import {
+  screen,
+  waitFor,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 describe("AddController", () => {
   let state: RootState;

--- a/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.test.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -11,7 +10,7 @@ import {
   controller as controllerFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.test.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/ControllerHeaderForms.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import ControllerHeaderForms from "./ControllerHeaderForms";
 
 import { ControllerHeaderViews } from "app/controllers/constants";
@@ -7,7 +5,7 @@ import {
   controller as controllerFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("ControllerHeaderForms", () => {
   it("can render a warning if an action cannot be taken", () => {

--- a/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
+++ b/src/app/controllers/components/ControllerStatus/ControllerStatus.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import { ControllerStatus } from "./ControllerStatus";
 
 import type { RootState } from "app/store/root/types";
@@ -11,7 +9,7 @@ import {
   service as serviceFactory,
   serviceState as serviceStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const getIcon = () => screen.getByTestId("controller-status-icon");
 

--- a/src/app/controllers/components/ImageStatus/ImageStatus.test.tsx
+++ b/src/app/controllers/components/ImageStatus/ImageStatus.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import { ImageStatus } from "./ImageStatus";
@@ -13,7 +12,7 @@ import {
   controllerStatuses as controllerStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerCommissioning/ControllerCommissioning.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerCommissioning/ControllerCommissioning.test.tsx
@@ -1,5 +1,4 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -19,6 +18,7 @@ import {
   scriptResultState as scriptResultStateFactory,
   testStatus as testStatusFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 jest.mock("@canonical/react-components/dist/hooks", () => {
   const hooks = jest.requireActual("@canonical/react-components/dist/hooks");

--- a/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -31,6 +30,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,6 +15,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,6 +15,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerName/ControllerName.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerName/ControllerName.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -18,6 +17,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerLogs/ControllerLogs.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerLogs/ControllerLogs.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import ControllerLogs, { Label } from "./ControllerLogs";
 
 import { Label as EventLogsLabel } from "app/base/components/node/NodeLogs/EventLogs/EventLogs";
@@ -11,7 +9,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("ControllerLogs", () => {
   let state: RootState;

--- a/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerNetwork/ControllerNetwork.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import ControllerNetwork from "./ControllerNetwork";
 
 import {
@@ -7,7 +5,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 it("displays a spinner if controller is loading", () => {
   const state = rootStateFactory({

--- a/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -10,6 +9,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServiceStatus/ServiceStatus.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServiceStatus/ServiceStatus.test.tsx
@@ -1,5 +1,3 @@
-import { render, screen } from "@testing-library/react";
-
 import ServiceStatus from "./ServiceStatus";
 
 import {
@@ -7,6 +5,7 @@ import {
   ServiceStatus as ServiceStatusName,
 } from "app/store/service/types";
 import { service as serviceFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 it("correctly renders a running service", () => {
   const service = serviceFactory({ status: ServiceStatusName.RUNNING });

--- a/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -15,6 +14,7 @@ import {
   service as serviceFactory,
   serviceState as serviceStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.test.tsx
@@ -1,5 +1,3 @@
-import { screen, within } from "@testing-library/react";
-
 import ControllerVLANsTable from "./ControllerVLANsTable";
 import { ControllerVLANsColumns } from "./constants";
 
@@ -17,7 +15,7 @@ import {
   controllerDetails as controllerDetailsFactory,
   controllerState as controllerStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 const createNetwork = () => {
   const systemId = "abc123";

--- a/src/app/controllers/views/ControllerList/ControllerList.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { useLocation } from "react-router";
@@ -10,6 +9,7 @@ import ControllerList from "./ControllerList";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
+import { screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerList/ControllerListControls/ControllerListControls.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListControls/ControllerListControls.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -7,6 +6,7 @@ import ControllerListControls from "./ControllerListControls";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ControllerListHeader from "./ControllerListHeader";
@@ -10,7 +9,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("ControllerListHeader", () => {
   let state: RootState;

--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ControllerListTable from "./ControllerListTable";
@@ -15,7 +14,7 @@ import {
   rootState as rootStateFactory,
   vaultEnabledState as vaultEnabledStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 describe("ControllerListTable", () => {
   let controller: Controller;

--- a/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/StatusColumn/StatusColumn.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import { StatusColumn } from "./StatusColumn";
 
 import { ControllerVersionIssues } from "app/store/controller/types";
@@ -13,7 +11,7 @@ import {
   service as serviceFactory,
   serviceState as serviceStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("StatusColumn", () => {
   let state: RootState;

--- a/src/app/controllers/views/ControllerList/ControllerListTable/VLANsColumn/VLANsColumn.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/VLANsColumn/VLANsColumn.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import { VLANsColumn } from "./VLANsColumn";
 
 import type { RootState } from "app/store/root/types";
@@ -9,7 +7,7 @@ import {
   controllerVlansHA as controllerVlansHAFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("VLANsColumn", () => {
   let state: RootState;

--- a/src/app/controllers/views/ControllerList/ControllerListTable/VersionColumn/VersionColumn.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/VersionColumn/VersionColumn.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import { VersionColumn } from "./VersionColumn";
 
 import { ControllerInstallType } from "app/store/controller/types";
@@ -11,7 +9,7 @@ import {
   controllerVersionInfo as controllerVersionInfoFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("VersionColumn", () => {
   let state: RootState;

--- a/src/app/dashboard/views/Dashboard.test.tsx
+++ b/src/app/dashboard/views/Dashboard.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import Dashboard, { Label } from "./Dashboard";
 import { Label as DashboardConfigurationFormLabel } from "./DashboardConfigurationForm/DashboardConfigurationForm";
 import { Labels as DiscoveriesListLabel } from "./DiscoveriesList/DiscoveriesList";
@@ -15,7 +13,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("Dashboard", () => {
   let state: RootState;

--- a/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
+++ b/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -17,7 +16,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -13,7 +12,7 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, waitFor, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import DashboardHeader, {
@@ -12,7 +11,7 @@ import {
   discoveryState as discoveryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("DashboardHeader", () => {
   let state: RootState;

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesFilterAccordion/DiscoveriesFilterAccordion.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import DiscoveriesFilterAccordion, {
   Labels as DiscoveriesFilterAccordionLabels,
 } from "./DiscoveriesFilterAccordion";
@@ -9,7 +7,7 @@ import {
   discoveryState as discoveryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const route = "/discoveries";
 

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -30,7 +29,12 @@ import {
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import {
+  screen,
+  waitFor,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = "/dashboard";

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -36,7 +35,12 @@ import {
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { renderWithBrowserRouter } from "testing/utils";
+import {
+  screen,
+  waitFor,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
@@ -18,7 +17,7 @@ import {
   discoveryState as discoveryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 describe("DiscoveryAddFormFields", () => {
   let state: RootState;

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -20,7 +19,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import configureStore from "redux-mock-store";
@@ -13,7 +12,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -11,7 +10,7 @@ import {
   device as deviceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import DeviceHeaderForms from "./DeviceHeaderForms";
@@ -15,7 +14,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -23,6 +22,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetails.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import { Label as DeviceConfigurationLabel } from "./DeviceConfiguration/DeviceConfiguration";
@@ -16,7 +15,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import DeviceDetailsHeader from "./DeviceDetailsHeader";
@@ -11,7 +10,7 @@ import {
   deviceState as deviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -15,7 +14,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -20,7 +19,7 @@ import {
   subnetState as subnetStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 const createNewInterface = async () => {

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import DeviceNetwork from "./DeviceNetwork";
@@ -9,7 +8,7 @@ import {
   deviceState as deviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import DeviceNetworkTable from "./DeviceNetworkTable";
@@ -20,7 +19,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/RemoveInterface.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/RemoveInterface.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -16,7 +15,7 @@ import {
   deviceStatuses as deviceStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterface.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterface.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -22,7 +21,7 @@ import {
   subnetState as subnetStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterfaceTable/EditInterfaceTable.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import EditInterfaceTable from "./EditInterfaceTable";
@@ -19,7 +18,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceForm.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import InterfaceForm from "./InterfaceForm";
@@ -21,7 +20,7 @@ import {
   subnetState as subnetStateFactory,
   vlan as vlanFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import configureStore from "redux-mock-store";
@@ -14,7 +13,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceSummary/DeviceOverviewCard/DeviceOverviewCard.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceSummary/DeviceOverviewCard/DeviceOverviewCard.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import DeviceOverviewCard from "./DeviceOverviewCard";
@@ -12,7 +11,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceSummary/DeviceSummary.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceSummary/DeviceSummary.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import DeviceSummary from "./DeviceSummary";
@@ -9,7 +8,7 @@ import {
   deviceState as deviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/domains/components/RecordFields/RecordFields.test.tsx
+++ b/src/app/domains/components/RecordFields/RecordFields.test.tsx
@@ -1,9 +1,9 @@
-import { screen, render } from "@testing-library/react";
 import { Formik } from "formik";
 
 import RecordFields, { Labels as RecordFieldsLabels } from "./RecordFields";
 
 import { RecordType } from "app/store/domain/types";
+import { screen, render } from "testing/utils";
 
 describe("RecordFields", () => {
   it("disables record type field if in editing state", () => {

--- a/src/app/domains/views/DomainDetails/DomainDetails.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetails.test.tsx
@@ -1,12 +1,10 @@
-import { screen } from "@testing-library/react";
-
 import DomainDetails from "./DomainDetails";
 
 import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("DomainDetails", () => {
   it("renders 'Not Found' header if domains loaded and domain not found", () => {

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -14,7 +13,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -14,7 +13,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import DomainDetailsHeader, {
   Labels as DomainDetailsHeaderLabels,
 } from "./DomainDetailsHeader";
@@ -10,7 +8,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("DomainDetailsHeader", () => {
   it("shows a spinner if domain details has not loaded yet", () => {

--- a/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,7 +16,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,7 +15,7 @@ import {
   domainResource as resourceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -19,7 +18,7 @@ import {
   domainResource as resourceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import ResourceRecords, {
   Labels as ResourceRecordsLabels,
 } from "./ResourceRecords";
@@ -9,7 +7,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("ResourceRecords", () => {
   it("shows a message if domain has no records", () => {

--- a/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Labels as DomainListHeaderFormLabels } from "../DomainListHeaderForm/DomainListHeaderForm";
@@ -13,7 +12,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("DomainListHeader", () => {
   let initialState: RootState;

--- a/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -11,7 +10,7 @@ import DomainListHeaderForm, {
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainsList/DomainsList.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,7 +12,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, within, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.test.tsx
+++ b/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -14,7 +13,7 @@ import {
   bootResourceState as bootResourceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import MockDate from "mockdate";
 
@@ -13,7 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 beforeEach(() => {
   MockDate.set("Fri, 18 Nov. 2022 10:55:00");

--- a/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.test.tsx
+++ b/src/app/images/components/NonUbuntuImageSelect/NonUbuntuImageSelect.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { Formik } from "formik";
 
 import NonUbuntuImageSelect from "./NonUbuntuImageSelect";
@@ -13,7 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("NonUbuntuImageSelect", () => {
   let state: RootState;

--- a/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
+++ b/src/app/images/components/UbuntuImageSelect/ArchSelect/ArchSelect.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { Formik } from "formik";
 
 import ArchSelect, { Labels as ArchSelectLabels } from "./ArchSelect";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("ArchSelect", () => {
   let state: RootState;

--- a/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.test.tsx
+++ b/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.test.tsx
@@ -1,9 +1,9 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ReleaseSelect from "./ReleaseSelect";
 
 import { bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 describe("ReleaseSelect", () => {
   it("separates ubuntu releases by LTS and non-LTS, sorted descending by title", () => {

--- a/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
+++ b/src/app/images/components/UbuntuImageSelect/UbuntuImageSelect.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { Formik } from "formik";
 
 import UbuntuImageSelect from "./UbuntuImageSelect";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("UbuntuImageSelect", () => {
   let state: RootState;

--- a/src/app/images/views/ImageList/CustomImages/CustomImages.test.tsx
+++ b/src/app/images/views/ImageList/CustomImages/CustomImages.test.tsx
@@ -1,5 +1,3 @@
-import { screen, within } from "@testing-library/react";
-
 import CustomImages from "./CustomImages";
 
 import { Labels as ImagesTableLabels } from "app/images/components/ImagesTable/ImagesTable";
@@ -9,7 +7,7 @@ import {
   bootResourceState as bootResourceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("CustomImages", () => {
   it("does not render if there are no uploaded resources", () => {

--- a/src/app/images/views/ImageList/GeneratedImages/GeneratedImages.test.tsx
+++ b/src/app/images/views/ImageList/GeneratedImages/GeneratedImages.test.tsx
@@ -1,5 +1,3 @@
-import { screen, within } from "@testing-library/react";
-
 import GeneratedImages from "./GeneratedImages";
 
 import { Labels as ImagesTableLabels } from "app/images/components/ImagesTable/ImagesTable";
@@ -9,7 +7,7 @@ import {
   bootResourceState as bootResourceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("GeneratedImages", () => {
   it("does not render if there are no generated resources", () => {

--- a/src/app/images/views/ImageList/ImageList.test.tsx
+++ b/src/app/images/views/ImageList/ImageList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
+++ b/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -18,7 +17,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
@@ -1,5 +1,4 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
-import { screen, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -19,6 +18,7 @@ import {
   bootResourceStatuses as bootResourceStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
@@ -7,6 +6,7 @@ import FetchImagesFormFields, {
 } from "./FetchImagesFormFields";
 
 import { BootResourceSourceType } from "app/store/bootresource/types";
+import { render, screen } from "testing/utils";
 
 describe("FetchImagesFormFields", () => {
   it("does not show extra fields if maas.io source is selected", async () => {

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
@@ -1,5 +1,4 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
-import { screen, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -22,6 +21,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render, waitFor } from "testing/utils";
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
   ...jest.requireActual("@canonical/react-components/dist/hooks"),

--- a/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -15,7 +14,7 @@ import {
   bootResourceState as bootResourceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import SyncedImages, { Labels as SyncedImagesLabels } from "./SyncedImages";
@@ -11,7 +10,7 @@ import {
   bootResourceUbuntu as ubuntuFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 describe("SyncedImages", () => {
   it("can render the form in a card", async () => {

--- a/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,7 +16,7 @@ import {
   bootResourceState as bootResourceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -19,7 +18,7 @@ import {
   bootResourceUbuntuSource as sourceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, within, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/intro/components/IntroCard/IntroCard.test.tsx
+++ b/src/app/intro/components/IntroCard/IntroCard.test.tsx
@@ -1,6 +1,6 @@
-import { screen, render } from "@testing-library/react";
-
 import IntroCard from "./IntroCard";
+
+import { screen, render } from "testing/utils";
 
 describe("IntroCard", () => {
   it("displays a title link if supplied", () => {

--- a/src/app/intro/components/IntroSection/IntroSection.test.tsx
+++ b/src/app/intro/components/IntroSection/IntroSection.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,11 @@ import {
   userEventError as userEventErrorFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, renderWithMockStore } from "testing/utils";
+import {
+  screen,
+  renderWithBrowserRouter,
+  renderWithMockStore,
+} from "testing/utils";
 
 describe("IntroSection", () => {
   let state: RootState;

--- a/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
+++ b/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,7 @@ import {
   bootResourceUbuntuSource as bootResourceUbuntuSourceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
+++ b/src/app/intro/views/IncompleteCard/IncompleteCard.test.tsx
@@ -1,12 +1,10 @@
-import { screen } from "@testing-library/react";
-
 import IncompleteCard, {
   Labels as IncompleteCardLabels,
 } from "./IncompleteCard";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("IncompleteCard", () => {
   let state: RootState;

--- a/src/app/intro/views/Intro.test.tsx
+++ b/src/app/intro/views/Intro.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import Intro from "./Intro";
 
 import urls from "app/base/urls";
@@ -12,7 +10,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("Intro", () => {
   let state: RootState;

--- a/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.test.tsx
+++ b/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
@@ -7,6 +6,8 @@ import { MaasIntroSchema } from "../MaasIntro";
 import ConnectivityCard, {
   Labels as ConnectivityCardLabels,
 } from "./ConnectivityCard";
+
+import { screen, render } from "testing/utils";
 
 const renderTestCase = () =>
   render(

--- a/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -22,7 +21,11 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, renderWithMockStore } from "testing/utils";
+import {
+  screen,
+  renderWithBrowserRouter,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/intro/views/MaasIntro/NameCard/NameCard.test.tsx
+++ b/src/app/intro/views/MaasIntro/NameCard/NameCard.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
@@ -16,7 +15,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("NameCard", () => {
   let state: RootState;

--- a/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
+++ b/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -20,7 +19,11 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, renderWithMockStore } from "testing/utils";
+import {
+  screen,
+  renderWithBrowserRouter,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,7 +18,12 @@ import {
   userEventError as userEventErrorFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, renderWithMockStore } from "testing/utils";
+import {
+  screen,
+  within,
+  renderWithBrowserRouter,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
+++ b/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
@@ -1,4 +1,3 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -20,6 +19,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { fireEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.test.tsx
+++ b/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.test.tsx
@@ -1,10 +1,8 @@
-import { screen } from "@testing-library/react";
-
 import KVMDetailsHeader from "./KVMDetailsHeader";
 
 import urls from "app/base/urls";
 import { KVMHeaderViews } from "app/kvm/constants";
-import { getTestState, renderWithBrowserRouter } from "testing/utils";
+import { screen, getTestState, renderWithBrowserRouter } from "testing/utils";
 
 describe("KVMDetailsHeader", () => {
   let state: ReturnType<typeof getTestState>;

--- a/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
@@ -25,6 +24,7 @@ import {
   vmClusterStatuses as vmClusterStatusesFactory,
 } from "testing/factories";
 import {
+  screen,
   renderWithBrowserRouter,
   waitForComponentToPaint,
 } from "testing/utils";

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,7 +15,7 @@ import {
   podStatus as podStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -9,6 +8,7 @@ import LXDVMsTable from "./LXDVMsTable";
 import { actions as machineActions } from "app/store/machine";
 import { FetchSortDirection, FetchGroupKey } from "app/store/machine/types";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -10,6 +9,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen, within } from "@testing-library/react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -21,7 +20,7 @@ import {
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/kvm/components/VmResources/VmResources.test.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -18,7 +17,11 @@ import {
   pod as podFactory,
   podState as podStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, renderWithMockStore } from "testing/utils";
+import {
+  screen,
+  renderWithBrowserRouter,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/kvm/views/KVM.test.tsx
+++ b/src/app/kvm/views/KVM.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import KVM from "./KVM";
 
 import urls from "app/base/urls";
@@ -16,7 +14,7 @@ import {
   vmCluster as vmClusterFactory,
   vmClusterState as vmClusterStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 let state: RootState;
 

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import LXDClusterDetails from "./LXDClusterDetails";
 
 import urls from "app/base/urls";
@@ -18,7 +16,7 @@ import {
   vmCluster as vmClusterFactory,
   vmClusterState as vmClusterStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("LXDClusterDetails", () => {
   let state: RootState;

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -19,6 +18,7 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsRedirect/LXDClusterDetailsRedirect.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsRedirect/LXDClusterDetailsRedirect.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { Router } from "react-router";
@@ -17,7 +16,12 @@ import {
   vmCluster as vmClusterFactory,
   vmClusterState as vmClusterStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import {
+  render,
+  screen,
+  waitFor,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 let state: RootState;
 

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import LXDClusterHostSettings, { Label } from "./LXDClusterHostSettings";
 
 import urls from "app/base/urls";
@@ -10,7 +8,7 @@ import {
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("LXDClusterHostSettings", () => {
   let state: RootState;

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import LXDClusterHostVMs, { Label } from "./LXDClusterHostVMs";
 
 import urls from "app/base/urls";
@@ -13,7 +11,7 @@ import {
   vmClusterState as vmClusterStateFactory,
   vmHost as vmHostFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 let state: RootState;
 

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import LXDClusterHosts from "./LXDClusterHosts";
 
 import urls from "app/base/urls";
@@ -13,7 +11,7 @@ import {
   vmHost as vmHostFactory,
   vmClusterState as vmClusterStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("LXDClusterHosts", () => {
   let state: RootState;

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import LXDSingleDetails from "./LXDSingleDetails";
 
 import urls from "app/base/urls";
@@ -17,7 +15,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("LXDSingleDetails", () => {
   let state: RootState;

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -21,6 +20,7 @@ import {
   zone as zoneFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshDetails.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import VirshDetails from "./VirshDetails";
 
 import urls from "app/base/urls";
@@ -16,7 +14,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("VirshDetails", () => {
   let state: RootState;

--- a/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -27,6 +26,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineDetails/SourceMachineDetails.test.tsx
@@ -1,11 +1,10 @@
-import { screen, render } from "@testing-library/react";
-
 import SourceMachineDetails, {
   Labels as SourceMachineDetailsLabels,
 } from "./SourceMachineDetails";
 
 import { NodeStatus } from "app/store/types/node";
 import { machineDetails as machineDetailsFactory } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 describe("SourceMachineDetails", () => {
   it("renders a list of the source machine's details", () => {

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Labels as SourceMachineDetailsLabel } from "./SourceMachineDetails/SourceMachineDetails";
@@ -17,7 +16,7 @@ import {
   machineStateList,
   machineStateListGroup,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("SourceMachineSelect", () => {
   let machines: Machine[];

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -20,6 +19,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -17,7 +16,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { renderWithBrowserRouter } from "testing/utils";
+import { render, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -28,7 +27,7 @@ import {
   machineStateDetailsItem as machineStateDetailsItemFactory,
   scriptResultState as scriptResultStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagChip/TagChip.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagChip/TagChip.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from "@testing-library/react";
-
 import TagChip from "./TagChip";
 
 import { tag as tagFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const tags = [
   tagFactory({ name: "chip1", id: 1 }),

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -21,6 +20,7 @@ import {
 } from "testing/factories";
 import { tagStateListFactory } from "testing/factories/state";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -19,6 +18,7 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import { tagStateListFactory } from "testing/factories/state";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -23,6 +22,7 @@ import {
 } from "testing/factories";
 import { tagStateListFactory } from "testing/factories/state";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/hooks.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/hooks.test.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
 import reduxToolkit from "@reduxjs/toolkit";
-import { waitFor } from "@testing-library/react";
 import { renderHook } from "@testing-library/react-hooks";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -15,6 +14,7 @@ import {
   tagState as tagStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/TableCheckbox/TableCheckbox.test.tsx
+++ b/src/app/machines/components/TableCheckbox/TableCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -11,7 +10,7 @@ import {
   machineStateList as machineStateListFactory,
   machineState as machineStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, waitFor, renderWithMockStore } from "testing/utils";
 
 let state: RootState;
 const callId = "123456";

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -19,6 +18,7 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -23,6 +22,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -21,6 +20,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import MachineLogs, { Label } from "./MachineLogs";
 
 import { Label as EventLogsLabel } from "app/base/components/node/NodeLogs/EventLogs/EventLogs";
@@ -11,7 +9,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("MachineLogs", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -31,7 +30,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = urls.machines.index;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlanFields/AddAliasOrVlanFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { Formik } from "formik";
 
 import AddAliasOrVlanFields from "./AddAliasOrVlanFields";
@@ -7,7 +6,7 @@ import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import { rootState as rootStateFactory } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const route = urls.machines.index;
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -22,7 +21,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = urls.machines.index;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -20,7 +19,7 @@ import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = urls.machines.index;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -20,7 +19,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = urls.machines.index;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
@@ -23,7 +22,7 @@ import {
   bondOptionsState as bondOptionsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const route = urls.machines.index;
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondModeSelect/BondModeSelect.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondModeSelect/BondModeSelect.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import { Formik } from "formik";
 
 import BondModeSelect from "./BondModeSelect";
@@ -11,7 +10,7 @@ import {
   bondOptionsState as bondOptionsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("BondModeSelect", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/HashPolicySelect/HashPolicySelect.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/HashPolicySelect/HashPolicySelect.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import { Formik } from "formik";
 
 import HashPolicySelect from "./HashPolicySelect";
@@ -11,7 +10,7 @@ import {
   bondOptionsState as bondOptionsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("HashPolicySelect", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/LACPRateSelect/LACPRateSelect.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/LACPRateSelect/LACPRateSelect.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import { Formik } from "formik";
 
 import LACPRateSelect from "./LACPRateSelect";
@@ -11,7 +10,7 @@ import {
   bondOptionsState as bondOptionsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("LACPRateSelect", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/ToggleMembers/ToggleMembers.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import ToggleMembers from "./ToggleMembers";
@@ -9,7 +8,7 @@ import {
   machineInterface as machineInterfaceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import configureStore from "redux-mock-store";
@@ -7,7 +6,7 @@ import BridgeFormFields from "./BridgeFormFields";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -22,7 +21,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import MachineNetwork from "./MachineNetwork";
 
 import {
@@ -7,7 +5,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 it("displays a spinner if machine is loading", () => {
   const state = rootStateFactory({

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -30,6 +29,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNotifications/MachineNotifications.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import MachineNotifications from "./MachineNotifications";
+
+import { render, screen } from "testing/utils";
 
 it("ignores inactive notifications", () => {
   render(

--- a/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCard.test.tsx
@@ -1,5 +1,3 @@
-import { screen, within } from "@testing-library/react";
-
 import NumaCard, { Labels as NumaCardLabels } from "./NumaCard";
 import { Labels as NumaCardDetailsLabels } from "./NumaCardDetails/NumaCardDetails";
 
@@ -10,7 +8,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 describe("NumaCard", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import NumaCardDetails, {
@@ -13,7 +12,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("NumaCardDetails", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,6 +18,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineList/ErrorsNotification/ErrorsNotification.test.tsx
+++ b/src/app/machines/views/MachineList/ErrorsNotification/ErrorsNotification.test.tsx
@@ -1,7 +1,8 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ErrorsNotification from "./ErrorsNotification";
+
+import { screen, render } from "testing/utils";
 
 it("can display and close an error message", async () => {
   render(<ErrorsNotification errors={{ title: "error message" }} />);

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
@@ -38,7 +37,7 @@ import {
   controllerState as controllerStateFactory,
   controller as controllerFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import GroupSelect from "./GroupSelect";
+
+import { render, screen } from "testing/utils";
 
 it("executes setGrouping and setHiddenGroups functions on change", async () => {
   const setGrouping = jest.fn();

--- a/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
@@ -1,10 +1,9 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import HiddenColumnsSelect from "./HiddenColumnsSelect";
 
 import { columnToggles } from "app/machines/constants";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 it("calls setHiddenColumns correctly on click of a checkbox", async () => {
   const hiddenColumns: Array<""> = [];

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import MachinesFilterAccordion, { Label } from "./MachinesFilterAccordion";
@@ -10,7 +9,7 @@ import {
   rootState as rootStateFactory,
   machineFilterGroup as machineFilterGroupFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("MachinesFilterAccordion", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
@@ -1,4 +1,3 @@
-import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -13,7 +12,7 @@ import {
   rootState as rootStateFactory,
   machineFilterGroup as machineFilterGroupFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, waitFor, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -1,6 +1,5 @@
 import { ContextualMenu } from "@canonical/react-components";
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen, waitFor } from "@testing-library/react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -24,7 +23,7 @@ import {
   machineStateListGroup as machineStateListGroupFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, waitFor, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineList/MachineListTable/AllCheckbox/AllCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/AllCheckbox/AllCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -11,7 +10,7 @@ import {
   machineStateList as machineStateListFactory,
   machineState as machineStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -13,7 +12,7 @@ import {
   machineState as machineStateFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListTable/MachineCheckbox/MachineCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineCheckbox/MachineCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -12,7 +11,7 @@ import {
   machineState as machineStateFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import MachineListPagination, { Label } from "./MachineListPagination";
+
+import { render, screen } from "testing/utils";
 
 it("displays pagination if there are machines", () => {
   render(

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { screen, within } from "@testing-library/react";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -35,7 +34,12 @@ import {
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, renderWithMockStore } from "testing/utils";
+import {
+  screen,
+  within,
+  renderWithBrowserRouter,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -15,7 +14,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/pools/views/PoolAdd/PoolAdd.test.tsx
+++ b/src/app/pools/views/PoolAdd/PoolAdd.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -6,7 +5,7 @@ import { PoolAdd, Label as PoolAddLabel } from "./PoolAdd";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("PoolAdd", () => {
   let state: RootState;

--- a/src/app/pools/views/PoolList/PoolList.test.tsx
+++ b/src/app/pools/views/PoolList/PoolList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,7 +12,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, within, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/pools/views/Pools.test.tsx
+++ b/src/app/pools/views/Pools.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import { Label as PoolAddLabel } from "./PoolAdd/PoolAdd";
 import { Label as PoolEditLabel } from "./PoolEdit/PoolEdit";
 import { Label as PoolListLabel } from "./PoolList/PoolList";
@@ -13,7 +11,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("Pools", () => {
   let state: RootState;

--- a/src/app/preferences/components/Nav/Nav.test.tsx
+++ b/src/app/preferences/components/Nav/Nav.test.tsx
@@ -1,8 +1,9 @@
-import { screen, render } from "@testing-library/react";
 import { MemoryRouter, Route } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
 import { Nav } from "./Nav";
+
+import { screen, render } from "testing/utils";
 
 describe("Nav", () => {
   it("renders", () => {

--- a/src/app/preferences/components/Routes/Routes.test.tsx
+++ b/src/app/preferences/components/Routes/Routes.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import Routes from "./Routes";
 
 import urls from "app/base/urls";
@@ -17,7 +15,7 @@ import {
   tokenState as tokenStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 let state: RootState;
 

--- a/src/app/preferences/views/APIKeys/APIKeyAdd/APIKeyAdd.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyAdd/APIKeyAdd.test.tsx
@@ -1,11 +1,9 @@
-import { screen } from "@testing-library/react";
-
 import { Label as APIKeyFormLabels } from "../APIKeyForm/APIKeyForm";
 
 import { APIKeyAdd } from "./APIKeyAdd";
 
 import type { RootState } from "app/store/root/types";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("APIKeyAdd", () => {
   let state: RootState;

--- a/src/app/preferences/views/APIKeys/APIKeyEdit/APIKeyEdit.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyEdit/APIKeyEdit.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 
@@ -12,7 +11,7 @@ import {
   tokenState as tokenStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("APIKeyEdit", () => {
   let state: RootState;

--- a/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,7 +12,7 @@ import {
   tokenState as tokenStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -10,7 +9,7 @@ import {
   tokenState as tokenStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("APIKeyList", () => {
   let state: RootState;

--- a/src/app/preferences/views/Details/Details.test.tsx
+++ b/src/app/preferences/views/Details/Details.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,7 +15,7 @@ import {
   userState as userStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/preferences/views/Preferences.test.tsx
+++ b/src/app/preferences/views/Preferences.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -7,6 +6,7 @@ import configureStore from "redux-mock-store";
 import Preferences, { Labels as PreferencesLabels } from "./Preferences";
 
 import { routerState as routerStateFactory } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -11,7 +10,7 @@ import {
   sshKeyState as sshKeyStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("AddSSHKey", () => {
   let state: RootState;

--- a/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.tsx
+++ b/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -10,7 +9,7 @@ import {
   sshKeyState as sshKeyStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("SSHKeyList", () => {
   let state: RootState;

--- a/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
+++ b/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -14,7 +13,7 @@ import {
   sslKeyState as sslKeyStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.tsx
+++ b/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,7 +12,7 @@ import {
   sslKeyState as sslKeyStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, within, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/components/Nav/Nav.test.tsx
+++ b/src/app/settings/components/Nav/Nav.test.tsx
@@ -1,8 +1,9 @@
-import { screen, render } from "@testing-library/react";
 import { MemoryRouter, Route } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
 import { Nav } from "./Nav";
+
+import { screen, render } from "testing/utils";
 
 describe("Nav", () => {
   it("renders", () => {

--- a/src/app/settings/components/SettingsTable/SettingsTable.test.tsx
+++ b/src/app/settings/components/SettingsTable/SettingsTable.test.tsx
@@ -1,8 +1,6 @@
-import { screen } from "@testing-library/react";
-
 import SettingsTable from "./SettingsTable";
 
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("SettingsTable", () => {
   it("can render", () => {

--- a/src/app/settings/views/Configuration/Commissioning/Commissioning.test.tsx
+++ b/src/app/settings/views/Configuration/Commissioning/Commissioning.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,6 +15,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
+++ b/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,6 +14,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/Deploy/Deploy.test.tsx
+++ b/src/app/settings/views/Configuration/Deploy/Deploy.test.tsx
@@ -1,4 +1,3 @@
-import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -6,6 +5,7 @@ import Deploy from "./Deploy";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
+++ b/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,6 +15,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/General/General.test.tsx
+++ b/src/app/settings/views/Configuration/General/General.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,6 +13,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -14,6 +13,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/ThemedRadioButton.test.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/ThemedRadioButton.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
-
 import ThemedRadioButton from "./ThemedRadioButton";
+
+import { render, screen } from "testing/utils";
 
 describe("ThemedRadioButton", () => {
   it("displays a radio button", () => {

--- a/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,6 +15,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,6 +13,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Dhcp/DhcpAdd/DhcpAdd.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpAdd/DhcpAdd.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -6,7 +5,7 @@ import { DhcpAdd } from "./DhcpAdd";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("DhcpAdd", () => {
   let state: RootState;

--- a/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 
@@ -11,7 +10,7 @@ import {
   dhcpSnippetState as dhcpSnippetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("DhcpEdit", () => {
   let state: RootState;

--- a/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { MemoryRouter, Router } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   dhcpSnippetState as dhcpSnippetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("DhcpForm", () => {
   let state: RootState;

--- a/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -20,7 +19,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, within, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -17,7 +16,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("DhcpTarget", () => {
   let state: RootState;

--- a/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.tsx
+++ b/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,6 +14,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.tsx
+++ b/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,6 +13,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Images/VMWare/VMWare.test.tsx
+++ b/src/app/settings/views/Images/VMWare/VMWare.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,6 +14,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
+++ b/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Images/Windows/Windows.test.tsx
+++ b/src/app/settings/views/Images/Windows/Windows.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,6 +14,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Images/WindowsForm/WindowsForm.test.tsx
+++ b/src/app/settings/views/Images/WindowsForm/WindowsForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -18,6 +17,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -23,6 +22,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyFormFields/LicenseKeyFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
@@ -1,4 +1,3 @@
-import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,6 +14,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
+++ b/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -12,6 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
+++ b/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/ProxyForm/ProxyForm.test.tsx
+++ b/src/app/settings/views/Network/ProxyForm/ProxyForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { reduceInitialState } from "testing/utils";
+import { screen, render, reduceInitialState } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.test.tsx
+++ b/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
+++ b/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -15,7 +14,7 @@ import {
   packageRepositoryState as packageRepositoryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, within, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 
@@ -14,7 +13,7 @@ import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("RepositoryAdd", () => {
   let state: RootState;

--- a/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 
@@ -16,7 +15,7 @@ import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("RepositoryEdit", () => {
   let state: RootState;

--- a/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -21,7 +20,7 @@ import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Repositories/RepositoryFormFields/RepositoryFormFields.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryFormFields/RepositoryFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -15,7 +14,7 @@ import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, within, renderWithMockStore } from "testing/utils";
 
 describe("RepositoryFormFields", () => {
   let state: RootState;

--- a/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -13,7 +12,7 @@ import {
   scriptState as scriptStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,7 +16,7 @@ import {
   scriptState as scriptStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, within, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import type { FileWithPath } from "react-dropzone";
@@ -18,7 +17,13 @@ import {
   scriptState as scriptStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import {
+  screen,
+  render,
+  waitFor,
+  fireEvent,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Security/IpmiSettings/IpmiFormFields/IpmiFormFields.test.tsx
+++ b/src/app/settings/views/Security/IpmiSettings/IpmiFormFields/IpmiFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import IpmiSettings from "../IpmiSettings";
@@ -11,7 +10,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/settings/views/Security/IpmiSettings/IpmiSettings.test.tsx
+++ b/src/app/settings/views/Security/IpmiSettings/IpmiSettings.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
@@ -11,7 +10,7 @@ import {
   rootState as rootStateFactory,
   configState as configStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/settings/views/Security/SecretStorage/SecretStorage.test.tsx
+++ b/src/app/settings/views/Security/SecretStorage/SecretStorage.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import SecretStorage from "./SecretStorage";
 
 import {
@@ -9,7 +7,7 @@ import {
   controllerState as controllerStateFactory,
   vaultEnabledState as vaultEnabledStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 it("displays loading text if Vault Status has not loaded", () => {
   const state = rootStateFactory({

--- a/src/app/settings/views/Security/SecretStorage/VaultSettings/VaultSettings.test.tsx
+++ b/src/app/settings/views/Security/SecretStorage/VaultSettings/VaultSettings.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import VaultSettings, { Labels as VaultSettingsLabels } from "./VaultSettings";
 
 import type { Controller } from "app/store/controller/types";
@@ -12,7 +10,7 @@ import {
   rootState as rootStateFactory,
   vaultEnabledState as vaultEnabledStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("VaultSettings", () => {
   let controllers: Controller[];

--- a/src/app/settings/views/Security/SecurityProtocols/SecurityProtocols.test.tsx
+++ b/src/app/settings/views/Security/SecurityProtocols/SecurityProtocols.test.tsx
@@ -1,5 +1,3 @@
-import { screen } from "@testing-library/react";
-
 import SecurityProtocols from "./SecurityProtocols";
 
 import {
@@ -8,7 +6,7 @@ import {
   tlsCertificate as tlsCertificateFactory,
   tlsCertificateState as tlsCertificateStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 it("displays loading text if TLS certificate has not loaded", () => {
   const state = rootStateFactory({

--- a/src/app/settings/views/Security/SecurityProtocols/TLSEnabled/TLSEnabled.test.tsx
+++ b/src/app/settings/views/Security/SecurityProtocols/TLSEnabled/TLSEnabled.test.tsx
@@ -1,4 +1,3 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   tlsCertificate as tlsCertificateFactory,
   tlsCertificateState as tlsCertificateStateFactory,
 } from "testing/factories";
+import { fireEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Settings.test.tsx
+++ b/src/app/settings/views/Settings.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
 import Settings from "./Settings";
@@ -10,7 +9,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Users/UserAdd/UserAdd.test.tsx
+++ b/src/app/settings/views/Users/UserAdd/UserAdd.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -9,7 +8,7 @@ import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("UserAdd", () => {
   let state: RootState;

--- a/src/app/settings/views/Users/UserEdit/UserEdit.test.tsx
+++ b/src/app/settings/views/Users/UserEdit/UserEdit.test.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 
@@ -11,7 +10,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, renderWithMockStore } from "testing/utils";
 
 describe("UserEdit", () => {
   let state: RootState;

--- a/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -17,7 +16,7 @@ import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Users/UsersList/UsersList.test.tsx
+++ b/src/app/settings/views/Users/UsersList/UsersList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,7 +15,7 @@ import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import { renderWithMockStore } from "testing/utils";
+import { screen, render, within, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/components/DHCPSnippets/DHCPSnippets.test.tsx
+++ b/src/app/subnets/components/DHCPSnippets/DHCPSnippets.test.tsx
@@ -1,4 +1,3 @@
-import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -13,6 +12,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render } from "testing/utils";
 
 const mockStore = configureStore();
 const mockDHCPTable = jest.fn();

--- a/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -16,6 +15,7 @@ import {
   ipRange as ipRangeFactory,
   ipRangeState as ipRangeStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -24,6 +23,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let ipRange: IPRange;

--- a/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
+++ b/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within, waitFor } from "testing/utils";
 
 const getRootState = () =>
   rootStateFactory({

--- a/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -13,6 +12,7 @@ import {
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
@@ -15,6 +14,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -15,6 +14,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/FabricController.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricSummary/FabricController/FabricController.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -11,6 +10,7 @@ import {
   rootState as rootStateFactory,
   fabric as fabricFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   controllerState as controllerStateFactory,
   modelRef as modelRefFactory,
 } from "testing/factories";
+import { render, screen, within, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,6 +18,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -9,6 +8,7 @@ import AddFabric from "./AddFabric";
 
 import { actions as fabricActions } from "app/store/fabric";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const renderTestCase = () => {
   const store = configureStore()(rootStateFactory());

--- a/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -9,6 +8,7 @@ import AddSpace from "./AddSpace";
 
 import { actions as spaceActions } from "app/store/space";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 test("correctly dispatches space cleanup and create actions on form submit", async () => {
   const store = configureStore()(rootStateFactory());

--- a/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -15,6 +14,7 @@ import {
   fabricState as fabricSpaceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 it("correctly dispatches subnet cleanup and create actions on form submit", async () => {
   const vlan1 = vlanFactory({ id: 111, fabric: 5 });

--- a/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -15,6 +14,7 @@ import {
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 it("displays validation messages for VID", async () => {
   const store = configureStore()(rootStateFactory());

--- a/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -13,6 +12,7 @@ import {
   space as spaceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -15,6 +14,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const renderTestCase = (
   space = spaceFactory({

--- a/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,6 +18,7 @@ import {
   subnetState as subnetStateFactory,
   subnetStatistics,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 const getRootState = () =>

--- a/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -12,6 +11,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within, waitFor } from "testing/utils";
 
 const getRootState = () =>
   rootStateFactory({

--- a/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within, waitFor } from "testing/utils";
 
 const getRootState = () =>
   rootStateFactory({

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -19,6 +18,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   staticRoute as staticRouteFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor, within } from "testing/utils";
 
 it("displays loading text on load", async () => {
   const mockStore = configureStore();

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -19,6 +18,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -13,6 +12,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within, waitFor } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { Router } from "react-router";
@@ -19,6 +18,7 @@ import {
   vlan as vlanFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within, waitFor } from "testing/utils";
 
 const subnetId = 1;
 const getRootState = () => {

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/BootArchitecturesTable/BootArchitecturesTable.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/BootArchitecturesTable/BootArchitecturesTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -13,6 +12,7 @@ import {
   knownBootArchitecturesState as knownBootArchitecturesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 let initialValues: FormValues;

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { subnetActionLabels } from "../constants";
@@ -9,6 +8,7 @@ import {
   subnet as subnetFactory,
   subnetDetails as subnetDetailsFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 it("shows the subnet name as the section title", () => {
   const subnet = subnetFactory({ id: 1, name: "subnet-1" });

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -20,6 +19,7 @@ import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 it("can dispatch an action to update the subnet", async () => {
   const fabrics = [

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -13,6 +12,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 it("updates to use the fabric's default VLAN on fabric change", async () => {
   const fabrics = [

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ActiveDiscoveryLabel from "./ActiveDiscoveryLabel";
+
+import { render, screen } from "testing/utils";
 
 it("displays a tooltip", async () => {
   render(<ActiveDiscoveryLabel />);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/AllowDNSResolutionLabel/AllowDNSResolutionLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/AllowDNSResolutionLabel/AllowDNSResolutionLabel.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import AllowDNSResolutionLabel from "./AllowDNSResolutionLabel";
+
+import { render, screen } from "testing/utils";
 
 it("shows a tooltip when DNS is allowed", async () => {
   render(<AllowDNSResolutionLabel allowDNS />);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ManagedAllocationLabel from "./ManagedAllocationLabel";
+
+import { render, screen } from "testing/utils";
 
 it("shows a tooltip", async () => {
   render(<ManagedAllocationLabel />);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ProxyAccessLabel/ProxyAccessLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ProxyAccessLabel/ProxyAccessLabel.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import ProxyAccessLabel from "./ProxyAccessLabel";
+
+import { render, screen } from "testing/utils";
 
 it("shows a tooltip when proxy access is allowed", async () => {
   render(<ProxyAccessLabel allowProxy />);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/SubnetSpace/SubnetSpace.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/SubnetSpace/SubnetSpace.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -6,6 +5,7 @@ import configureStore from "redux-mock-store";
 import SubnetSpace from "./SubnetSpace";
 
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetUsedIPs/SubnetUsedIPs.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetUsedIPs/SubnetUsedIPs.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -10,6 +9,7 @@ import {
   subnetDetails as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/Utilisation/SubnetUtilisation.test.tsx
@@ -1,8 +1,7 @@
-import { render, screen } from "@testing-library/react";
-
 import SubnetUtilisation from "./SubnetUtilisation";
 
 import { subnetStatistics as subnetStatisticsFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 it("renders subnet utilisation statistics", () => {
   const subnetStatistics = subnetStatisticsFactory({

--- a/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import SubnetsControls from "./SubnetsControls";
+
+import { render, screen, waitFor } from "testing/utils";
 
 it("renders select element correctly", () => {
   render(

--- a/src/app/subnets/views/SubnetsList/SubnetsList.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsList.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import SubnetsList from "./SubnetsList";
@@ -11,7 +10,13 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { getUrlParam, renderWithBrowserRouter } from "testing/utils";
+import {
+  screen,
+  within,
+  waitFor,
+  getUrlParam,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const getMockState = () => {
   return rootStateFactory({

--- a/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, within, waitFor } from "testing/utils";
 
 const getMockState = ({ numberOfFabrics } = { numberOfFabrics: 50 }) => {
   const fabrics = [

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -21,6 +20,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -23,6 +22,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 let initialValues: ConfigureDHCPValues;

--- a/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
+++ b/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,6 +17,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
+++ b/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -19,6 +18,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -13,6 +12,7 @@ import {
   vlanState as vlanStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
@@ -15,6 +14,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -19,6 +18,7 @@ import {
   vlanDetails as vlanDetailsFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,6 +14,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -17,6 +16,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -28,6 +27,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
@@ -17,6 +16,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
+++ b/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -13,6 +12,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
+++ b/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -14,6 +13,7 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/components/KernelOptionsField/KernelOptionsField.test.tsx
+++ b/src/app/tags/components/KernelOptionsField/KernelOptionsField.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
@@ -21,6 +20,7 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
+++ b/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 
@@ -8,6 +7,7 @@ import urls from "app/base/urls";
 import { ControllerMeta } from "app/store/controller/types";
 import { DeviceMeta } from "app/store/device/types";
 import { MachineMeta } from "app/store/machine/types";
+import { render, screen } from "testing/utils";
 
 it("create a link to machines", () => {
   render(

--- a/src/app/tags/components/TagDetails/TagDetails.test.tsx
+++ b/src/app/tags/components/TagDetails/TagDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,6 +13,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -21,6 +20,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -1,6 +1,5 @@
 import { NotificationSeverity } from "@canonical/react-components";
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -23,6 +22,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,6 +17,7 @@ import {
   machineStateCount as machineStateCountFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/components/TagsHeader/TagHeaderForms/TagHeaderForms.test.tsx
+++ b/src/app/tags/components/TagsHeader/TagHeaderForms/TagHeaderForms.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let scrollToSpy: jest.Mock;

--- a/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
+++ b/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let scrollToSpy: jest.Mock;

--- a/src/app/tags/views/TagDetails/TagDetails.test.tsx
+++ b/src/app/tags/views/TagDetails/TagDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -19,6 +18,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/views/TagList/TagList.test.tsx
+++ b/src/app/tags/views/TagList/TagList.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,6 +11,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/views/TagList/TagListControls/TagListControls.test.tsx
+++ b/src/app/tags/views/TagList/TagListControls/TagListControls.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -12,6 +11,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -17,6 +16,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen, within } from "testing/utils";
 
 jest.mock("../constants", () => ({
   __esModule: true,

--- a/src/app/tags/views/TagMachines/TagMachines.test.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -24,6 +23,7 @@ import {
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
@@ -20,6 +19,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.test.tsx
+++ b/src/app/tags/views/TagUpdate/TagUpdateFormFields/TagUpdateFormFields.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,6 +12,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/views/Tags.test.tsx
+++ b/src/app/tags/views/Tags.test.tsx
@@ -1,4 +1,3 @@
-import { screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { Label as TagsHeaderLabel } from "../components/TagsHeader/TagsHeader";
@@ -16,7 +15,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 describe("Tags", () => {
   let scrollToSpy: jest.Mock;

--- a/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -16,6 +15,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -14,6 +13,7 @@ import {
   zoneState as zoneStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/DeleteConfirm/DeleteConfirm.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/DeleteConfirm/DeleteConfirm.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -11,6 +10,7 @@ import {
   zoneState as zoneStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import { screen, render, within } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,6 +15,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
+import { screen, render, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZonesList/ZonesList.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesList.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -11,6 +10,7 @@ import {
   zoneState as zoneStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -10,6 +9,7 @@ import ZonesListForm from "./ZonesListForm";
 import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -9,6 +8,7 @@ import ZonesListHeader from "./ZonesListHeader";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 


### PR DESCRIPTION
## Done

- refactor: use single testing/utils import
  - replace all `@testing-library/react` imports with `testing/utils`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
