### PR TITLE
fix(upload-assets): fail when upload fails

### DIFF
--- a/scripts/upload-assets.py
+++ b/scripts/upload-assets.py
@@ -22,4 +22,5 @@ response = requests.post(
         'token': api_token
     }
 )
+response.raise_for_status()
 print(response.text)


### PR DESCRIPTION
Make the small python script for uploading assets raise errors on non-ok responses from the upload

## Done

- Fix scripts/upload-assets

## QA

### MAAS deployment

N/A

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Note the upload fails due to being too big :/
