### PR TITLE
feat: add .l-aside visibility transition

### DIFF
--- a/src/scss/_patterns_application.scss
+++ b/src/scss/_patterns_application.scss
@@ -4,8 +4,16 @@
     grid-template-rows: auto 1fr auto;
   }
   .l-aside {
+    // TODO: remove .l-aside visibility workaround once https://github.com/canonical/vanilla-framework/issues/4629 is fixed
+    @include vf-transition(
+      $property: #{transform,
+      box-shadow,
+      visibility},
+      $duration: snap
+    );
     background-color: $color-x-light;
   }
+  // TODO: remove .l-aside visibility workaround once https://github.com/canonical/vanilla-framework/issues/4629 is fixed
   .l-aside.is-collapsed {
     visibility: hidden;
   }


### PR DESCRIPTION
## Done

- feat: add .l-aside visibility transition (this ensures panel collapse action is animated as well)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Open take action menu and select an action
- Cancel the action
- Ensure that panel transition functions properly both on open and collapse

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
