### PR TITLE
feat(machines): update settings toggle

### DIFF
--- a/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.tsx
@@ -1,4 +1,8 @@
-import { CheckboxInput, ContextualMenu } from "@canonical/react-components";
+import {
+  CheckboxInput,
+  ContextualMenu,
+  Icon,
+} from "@canonical/react-components";
 
 import type { MachineListControlsProps } from "../MachineListControls";
 
@@ -29,11 +33,14 @@ const HiddenColumnsSelect = ({
       className="filter-accordion"
       constrainPanelWidth
       dropdownProps={{ "aria-label": "columns menu" }}
-      hasToggleIcon
       position="left"
-      toggleClassName="filter-accordion__toggle"
-      /* TODO: add <Icon name="settings" /> after updating to latest react-components  */
-      toggleLabel="Columns"
+      toggleClassName="hidden-columns-toggle has-icon"
+      toggleLabel={
+        <>
+          <Icon name="settings" /> Columns
+        </>
+      }
+      toggleLabelFirst={true}
     >
       <div className="hidden-columns-select-wrapper u-no-padding--bottom">
         <CheckboxInput

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -140,15 +140,15 @@
     padding: $sph--small $sph--large;
   }
 
-  .hidden-columns-toggle {
-    width: 100%;
+  [class^="p-button"].has-icon.hidden-columns-toggle {
+    @extend %vf-input-elements;
     padding-left: $spv--small;
     text-align: left;
+    width: 100%;
 
-    .p-contextual-menu__indicator {
-      position: absolute;
-      right: $spv--large;
-      top: calc(#{$spv--medium} - 1px);
+    i[class*="p-icon"]:last-child {
+      margin-left: 0;
+      margin-right: $spv--x-small;
     }
   }
 }


### PR DESCRIPTION
## Done

- update machine list settings toggle icon

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list and verify the columns toggle has a settings icon
- Check that it works on different screen sizes

## Fixes

Fixes: MAASENG-1230

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
<img width="253" alt="image" src="https://user-images.githubusercontent.com/7452681/213149873-55710d61-212f-4dbc-83fd-90746a42e21c.png">
