### PR TITLE
feat: update device form narrow side panel

### DIFF
--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
@@ -113,56 +113,54 @@ describe("AddDeviceForm", () => {
       screen.getByRole("button", { name: "Add interface" })
     );
 
-    const rows = screen.getAllByTestId("interface-row");
+    const cards = screen.getAllByTestId("interface-card");
 
-    const getFieldFromRow = (index: number, name: string, type: string) => {
-      return within(
-        within(rows[index]).getByRole("gridcell", { name: name })
-      ).getByRole(type);
+    const getFieldFromCard = (index: number, name: string, type: string) => {
+      return within(cards[index]).getByRole(type, { name });
     };
 
     await userEvent.type(
-      getFieldFromRow(0, "* MAC address", "textbox"),
+      getFieldFromCard(0, "MAC address", "textbox"),
       "11:11:11:11:11:11"
     );
 
     await userEvent.selectOptions(
-      getFieldFromRow(0, "* IP assignment", "combobox"),
+      getFieldFromCard(0, "IP assignment", "combobox"),
       DeviceIpAssignment.STATIC
     );
 
     await userEvent.selectOptions(
-      getFieldFromRow(0, "Subnet", "combobox"),
+      getFieldFromCard(0, "Subnet", "combobox"),
       "0"
     );
 
     await userEvent.type(
-      getFieldFromRow(0, "IP address", "textbox"),
+      getFieldFromCard(0, "IP address", "textbox"),
       "192.168.1.1"
     );
 
     await userEvent.type(
-      getFieldFromRow(1, "* MAC address", "textbox"),
+      getFieldFromCard(1, "MAC address", "textbox"),
       "22:22:22:22:22:22"
     );
 
     await userEvent.selectOptions(
-      getFieldFromRow(1, "* IP assignment", "combobox"),
+      getFieldFromCard(1, "IP assignment", "combobox"),
       DeviceIpAssignment.EXTERNAL
     );
 
     await userEvent.type(
-      getFieldFromRow(1, "IP address", "textbox"),
+      getFieldFromCard(1, "IP address", "textbox"),
       "192.168.1.2"
     );
 
     await userEvent.type(
-      getFieldFromRow(2, "* MAC address", "textbox"),
+      getFieldFromCard(2, "MAC address", "textbox"),
       "33:33:33:33:33:33"
     );
 
     await userEvent.selectOptions(
-      getFieldFromRow(2, "* IP assignment", "combobox"),
+      getFieldFromCard(2, "IP assignment", "combobox"),
       DeviceIpAssignment.DYNAMIC
     );
 

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
@@ -90,26 +90,26 @@ describe("AddDeviceInterfaces", () => {
       { store }
     );
 
-    const getRowCount = () => screen.getAllByTestId("interface-row").length;
+    const getCardCount = () => screen.getAllByTestId("interface-card").length;
     const getAddButton = () => screen.getByTestId("add-interface");
     const getRemoveButton = () =>
-      screen.getAllByTestId("table-actions-delete")[0];
+      screen.getAllByRole("button", { name: /delete/i })[0];
 
     // There is only one interface by default. Since at least one interface must
     // be defined, the remove button should be disabled.
-    expect(getRowCount()).toBe(1);
+    expect(getCardCount()).toBe(1);
     expect(getRemoveButton()).toBeDisabled();
 
     // Add an interface.
     await userEvent.click(getAddButton());
 
-    expect(getRowCount()).toBe(2);
+    expect(getCardCount()).toBe(2);
     expect(getRemoveButton()).not.toBeDisabled();
 
     // Remove an interface.
     await userEvent.click(getRemoveButton());
 
-    expect(getRowCount()).toBe(1);
+    expect(getCardCount()).toBe(1);
     expect(getRemoveButton()).toBeDisabled();
   });
 });

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
@@ -1,8 +1,7 @@
 import type { ChangeEvent } from "react";
 import { useRef } from "react";
 
-import { Button, Icon, MainTable } from "@canonical/react-components";
-import classNames from "classnames";
+import { Button, Card, Icon } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import type { AddDeviceValues } from "../types";
@@ -11,7 +10,6 @@ import FormikField from "app/base/components/FormikField";
 import IpAssignmentSelect from "app/base/components/IpAssignmentSelect";
 import MacAddressField from "app/base/components/MacAddressField";
 import SubnetSelect from "app/base/components/SubnetSelect";
-import TableActions from "app/base/components/TableActions";
 import { DeviceIpAssignment } from "app/store/device/types";
 import { getNextName } from "app/utils";
 
@@ -51,111 +49,61 @@ export const AddDeviceInterfaces = (): JSX.Element => {
   return (
     <>
       <h4>Interfaces</h4>
-      <MainTable
-        className="add-device-interfaces p-form--table"
-        headers={[
-          { className: "name-col u-no-padding--left", content: "Name" },
-          { className: "mac-col", content: "* MAC address" },
-          { className: "ip-assignment-col", content: "* IP assignment" },
-          { className: "subnet-col", content: "Subnet" },
-          { className: "ip-address-col", content: "IP address" },
-          {
-            className: "actions-col u-align--right u-no-padding--right",
-            content: "Actions",
-          },
-        ]}
-        responsive
-        rows={interfaces.map((iface, i) => {
-          const showSubnetField =
-            iface.ip_assignment === DeviceIpAssignment.STATIC;
-          const showIpAddressField =
-            iface.ip_assignment === DeviceIpAssignment.STATIC ||
-            iface.ip_assignment === DeviceIpAssignment.EXTERNAL;
-          const deleteDisabled = interfaces.length <= 1;
+      {interfaces.map((iface, i) => {
+        const showSubnetField =
+          iface.ip_assignment === DeviceIpAssignment.STATIC;
+        const showIpAddressField =
+          iface.ip_assignment === DeviceIpAssignment.STATIC ||
+          iface.ip_assignment === DeviceIpAssignment.EXTERNAL;
+        const deleteDisabled = interfaces.length <= 1;
 
-          return {
-            columns: [
-              {
-                "aria-label": "Name",
-                className: "name-col u-no-padding--left",
-                content: (
-                  <FormikField name={`interfaces[${i}].name`} type="text" />
-                ),
-              },
-              {
-                "aria-label": "* MAC address",
-                className: "mac-col",
-                content: (
-                  <MacAddressField name={`interfaces[${i}].mac`} required />
-                ),
-              },
-              {
-                "aria-label": "* IP assignment",
-                className: "ip-assignment-col",
-                content: (
-                  <IpAssignmentSelect
-                    label={null}
-                    name={`interfaces[${i}].ip_assignment`}
-                    onChange={(e: ChangeEvent<HTMLSelectElement>) => {
-                      handleChange(e);
-                      setFieldValue(`interfaces[${i}].subnet`, "");
-                      setFieldValue(`interfaces[${i}].ip_address`, "");
-                    }}
-                    required
-                  />
-                ),
-              },
-              {
-                "aria-label": "Subnet",
-                className: classNames("subnet-col", {
-                  "u-align-non-field": !showSubnetField,
-                }),
-                content: showSubnetField ? (
-                  <SubnetSelect
-                    data-testid="subnet-field"
-                    labelClassName="u-hide"
-                    name={`interfaces[${i}].subnet`}
-                  />
-                ) : (
-                  <span>N/A</span>
-                ),
-              },
-              {
-                "aria-label": "IP address",
-                className: classNames("ip-address-col", {
-                  "u-align-non-field": !showIpAddressField,
-                }),
-                content: showIpAddressField ? (
-                  <FormikField
-                    data-testid="ip-address-field"
-                    name={`interfaces[${i}].ip_address`}
-                    type="text"
-                  />
-                ) : (
-                  <span>N/A</span>
-                ),
-              },
-              {
-                "aria-label": "Actions",
-                className:
-                  "actions-col u-align--right u-align-non-field u-no-padding--right",
-                content: (
-                  <TableActions
-                    deleteDisabled={deleteDisabled}
-                    deleteTooltip={
-                      deleteDisabled
-                        ? "At least one interface must be defined"
-                        : null
-                    }
-                    onDelete={() => removeInterface(iface.id)}
-                  />
-                ),
-              },
-            ],
-            "data-testid": "interface-row",
-          };
-        })}
-      />
+        return (
+          <Card data-testid="interface-card" key={iface.id}>
+            <FormikField
+              label="Name"
+              name={`interfaces[${i}].name`}
+              type="text"
+            />
+            <MacAddressField
+              label="MAC address"
+              name={`interfaces[${i}].mac`}
+              required
+            />
+            <IpAssignmentSelect
+              name={`interfaces[${i}].ip_assignment`}
+              onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+                handleChange(e);
+                setFieldValue(`interfaces[${i}].subnet`, "");
+                setFieldValue(`interfaces[${i}].ip_address`, "");
+              }}
+              required
+            />
+            {showSubnetField ? (
+              <SubnetSelect
+                data-testid="subnet-field"
+                name={`interfaces[${i}].subnet`}
+              />
+            ) : null}
+            {showIpAddressField ? (
+              <FormikField
+                data-testid="ip-address-field"
+                label="IP address"
+                name={`interfaces[${i}].ip_address`}
+                type="text"
+              />
+            ) : null}
+            <div className="u-align--right">
+              <Button
+                disabled={deleteDisabled}
+                onClick={() => removeInterface(iface.id)}
+                type="button"
+              >
+                Delete
+              </Button>
+            </div>
+          </Card>
+        );
+      })}
       <Button
         data-testid="add-interface"
         hasIcon

--- a/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
+++ b/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.tsx
@@ -11,7 +11,7 @@ import type {
   DeviceSidePanelContent,
   DeviceSetSidePanelContent,
 } from "app/devices/types";
-import { getHeaderSize, getHeaderTitle } from "app/devices/utils";
+import { getHeaderTitle } from "app/devices/utils";
 import deviceSelectors from "app/store/device/selectors";
 
 type Props = {
@@ -57,9 +57,6 @@ const DeviceListHeader = ({
           showCount
         />,
       ]}
-      headerSize={
-        sidePanelContent ? getHeaderSize(sidePanelContent) : undefined
-      }
       sidePanelContent={
         sidePanelContent && (
           <DeviceHeaderForms


### PR DESCRIPTION
## Done

- update device form to to fit in the narrow side panel

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to devices page
- Click Add device
- Complete the form and add 3 interfaces (with dynamic, static and external IP assignment options)
- Verify the form has been submitted with the correct information via websocket API `device.create` endpoint

## Fixes

Fixes: MAASENG-1251

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
<img width="1498" alt="image" src="https://user-images.githubusercontent.com/7452681/213173988-c6e07dd9-592c-42f3-9851-ae7c4be6ba61.png">

