### PR TITLE
feat(machines): add full username option to machines table

### DIFF
--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -1,5 +1,3 @@
-import type { ValueOf } from "@canonical/react-components";
-
 import { NodeActions } from "app/store/types/node";
 
 export const MachineActionHeaderViews = {
@@ -51,7 +49,7 @@ export const columns = [
   "disks",
   "storage",
 ] as const;
-export type MachineColumn = ValueOf<typeof columns>;
+export type MachineColumn = (typeof columns)[number];
 export type MachineColumnToggle = Exclude<MachineColumn, "fqdn">;
 function isMachineColumnToggle(
   column: MachineColumn

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -90,6 +90,7 @@ type GenerateRowParams = {
   getToggleHandler: GetToggleHandler;
   showActions: Props["showActions"];
   showMAC: boolean;
+  showFullName: boolean;
 };
 
 type RowContent = {
@@ -312,6 +313,7 @@ const generateRows = ({
   getToggleHandler,
   showActions,
   showMAC,
+  showFullName,
 }: GenerateRowParams) => {
   const getMenuHandler: GetToggleHandler = (...args) =>
     showActions ? getToggleHandler(...args) : () => undefined;
@@ -348,6 +350,7 @@ const generateRows = ({
         <OwnerColumn
           data-testid="owner-column"
           onToggleMenu={getMenuHandler(MachineColumns.OWNER)}
+          showFullName={showFullName}
           systemId={row.system_id}
         />
       ),
@@ -544,7 +547,7 @@ export const MachineListTable = ({
     null
   );
   const [showMAC, setShowMAC] = useState(false);
-
+  const [showFullName, setShowFullName] = useState(false);
   useEffect(() => {
     dispatch(generalActions.fetchArchitectures());
     dispatch(generalActions.fetchDefaultMinHweKernel());
@@ -590,6 +593,7 @@ export const MachineListTable = ({
     getToggleHandler,
     showActions,
     showMAC,
+    showFullName,
   };
 
   const headers = [
@@ -678,10 +682,28 @@ export const MachineListTable = ({
           <TableHeader
             currentSort={currentSort}
             data-testid="owner-header"
-            onClick={() => updateSort(FetchGroupKey.Owner)}
+            onClick={() => {
+              setShowFullName(false);
+              updateSort(FetchGroupKey.Owner);
+            }}
             sortKey={FetchGroupKey.Owner}
           >
             {columnLabels[MachineColumns.OWNER]}
+          </TableHeader>
+          &nbsp;<strong>|</strong>&nbsp;
+          <TableHeader
+            currentSort={currentSort}
+            data-testid="owner-name-header"
+            onClick={() => {
+              sendAnalytics(
+                "Machine list",
+                "Column header",
+                "Show owner full name"
+              );
+              setShowFullName(true);
+            }}
+          >
+            Name
           </TableHeader>
           <TableHeader>Tags</TableHeader>
         </>

--- a/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.test.tsx
@@ -14,8 +14,11 @@ import {
   machineActionsState as machineActionsStateFactory,
   machineState as machineStateFactory,
   rootState as rootStateFactory,
+  user as userFactory,
+  userState as userStateFactory,
   tag as tagFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter, screen } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -48,6 +51,9 @@ describe("OwnerColumn", () => {
           }),
         ],
       }),
+      user: userStateFactory({
+        items: [userFactory()],
+      }),
     });
   });
 
@@ -68,18 +74,25 @@ describe("OwnerColumn", () => {
 
   it("displays owner", () => {
     state.machine.items[0].owner = "user1";
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <OwnerColumn onToggleMenu={jest.fn()} systemId="abc123" />
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <OwnerColumn onToggleMenu={jest.fn()} showFullName systemId="abc123" />,
+      { state }
     );
 
-    expect(wrapper.find('[data-testid="owner"]').text()).toEqual("user1");
+    expect(screen.getByTestId("owner")).toHaveTextContent("user1");
+  });
+
+  it("displays owner's full name", () => {
+    state.machine.items[0].owner = "user1";
+    state.user.items = [
+      userFactory({ username: "user1", last_name: "User Full Name" }),
+    ];
+    renderWithBrowserRouter(
+      <OwnerColumn onToggleMenu={jest.fn()} showFullName systemId="abc123" />,
+      { state }
+    );
+
+    expect(screen.getByTestId("owner")).toHaveTextContent("User Full Name");
   });
 
   it("displays tags", () => {

--- a/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.tsx
@@ -12,13 +12,19 @@ import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import { getTagsDisplay } from "app/store/tag/utils";
 import { NodeActions } from "app/store/types/node";
+import userSelectors from "app/store/user/selectors";
 
 type Props = {
   onToggleMenu?: (systemId: Machine[MachineMeta.PK], open: boolean) => void;
   systemId: Machine[MachineMeta.PK];
+  showFullName?: boolean;
 };
 
-export const OwnerColumn = ({ onToggleMenu, systemId }: Props): JSX.Element => {
+export const OwnerColumn = ({
+  onToggleMenu,
+  systemId,
+  showFullName,
+}: Props): JSX.Element => {
   const [updating, setUpdating] = useState<Machine["status"] | null>(null);
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
@@ -27,7 +33,12 @@ export const OwnerColumn = ({ onToggleMenu, systemId }: Props): JSX.Element => {
     tagSelectors.getByIDs(state, machine?.tags || null)
   );
   const toggleMenu = useToggleMenu(onToggleMenu || null, systemId);
-  const ownerDisplay = machine?.owner || "-";
+  const user = useSelector((state: RootState) =>
+    userSelectors.getByUsername(state, machine?.owner || "")
+  );
+  const ownerDisplay = showFullName
+    ? user?.last_name || machine?.owner || "-"
+    : machine?.owner || "-";
   const tagsDisplay = getTagsDisplay(machineTags);
 
   const menuLinks = useMachineActions(

--- a/src/app/store/user/selectors.test.ts
+++ b/src/app/store/user/selectors.test.ts
@@ -82,6 +82,19 @@ describe("users selectors", () => {
     expect(user.getById(state, 909)).toEqual(items[1]);
   });
 
+  it("can get a user by username", () => {
+    const items = [
+      userFactory({ username: "maas-user", id: 808 }),
+      userFactory({ username: "maas-user-1", id: 909 }),
+    ];
+    const state = rootStateFactory({
+      user: userStateFactory({
+        items,
+      }),
+    });
+    expect(user.getByUsername(state, "maas-user-1")).toEqual(items[1]);
+  });
+
   it("can search items", () => {
     const state = rootStateFactory({
       user: userStateFactory({

--- a/src/app/store/user/selectors.ts
+++ b/src/app/store/user/selectors.ts
@@ -2,7 +2,7 @@ import { createSelector } from "@reduxjs/toolkit";
 
 import type { RootState } from "app/store/root/types";
 import { UserMeta } from "app/store/user/types";
-import type { User, UserState } from "app/store/user/types";
+import type { UserState, User } from "app/store/user/types";
 import { generateBaseSelectors } from "app/store/utils";
 
 const searchFunction = (user: User, term: string) =>
@@ -61,8 +61,27 @@ const markingIntroCompleteErrors = createSelector(
       ?.error || null
 );
 
+/**
+ * Get the user by username
+ * @param state - The redux state.
+ * @returns User.
+ */
+const getByUsername = createSelector(
+  [
+    defaultSelectors.all,
+    (_state: RootState, username: string | null | undefined) => username,
+  ],
+  (items, username) => {
+    if (username === null || username === undefined) {
+      return null;
+    }
+    return items.find((item) => item.username === username) || null;
+  }
+);
+
 const selectors = {
   ...defaultSelectors,
+  getByUsername,
   eventErrors,
   markingIntroComplete,
   markingIntroCompleteErrors,


### PR DESCRIPTION
## Done

- add full username to machines table

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Make sure you have machines with owners that have a defined full name 
- Click on the "name" next to the owner table header
- Displayed owner usernames in the table should be replaced with full names

## Fixes

Fixes: #1531 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

#### owner - displaying full name
![image](https://user-images.githubusercontent.com/7452681/213194487-6756bc41-4c27-445a-a482-0461d90ef0eb.png)

#### owner - displaying username
![image](https://user-images.githubusercontent.com/7452681/213193883-72d1cfb5-8082-49fc-a4f3-ebf30bf0b1a6.png)