### PR TITLE
feat: Node action button group on MachineDetails MAASENG-1223

### DIFF
--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
@@ -158,9 +158,15 @@ describe("NodeActionMenu", () => {
 
     await openMenu();
 
-    expect(within(getActionCount(NodeActions.COMMISSION)).getByText("3"));
-    expect(within(getActionCount(NodeActions.RELEASE)).getByText("2"));
-    expect(within(getActionCount(NodeActions.DEPLOY)).getByText("1"));
+    expect(
+      within(getActionCount(NodeActions.COMMISSION)).getByText("3")
+    ).toBeInTheDocument();
+    expect(
+      within(getActionCount(NodeActions.RELEASE)).getByText("2")
+    ).toBeInTheDocument();
+    expect(
+      within(getActionCount(NodeActions.DEPLOY)).getByText("1")
+    ).toBeInTheDocument();
   });
 
   it("fires onActionClick function on action button click", async () => {

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
@@ -37,6 +37,7 @@ type Props = {
   showCount?: boolean;
   toggleAppearance?: ValueOf<typeof ButtonAppearance>;
   toggleClassName?: string | null;
+  toggleLabel?: string;
 };
 
 const actionGroups: ActionGroup[] = [
@@ -162,6 +163,7 @@ export const NodeActionMenu = ({
   showCount,
   toggleAppearance = "positive",
   toggleClassName,
+  toggleLabel = Label.TakeAction,
 }: Props): JSX.Element => {
   return (
     <Tooltip
@@ -188,7 +190,7 @@ export const NodeActionMenu = ({
         toggleAppearance={toggleAppearance}
         toggleClassName={toggleClassName}
         toggleDisabled={!hasSelection}
-        toggleLabel={Label.TakeAction}
+        toggleLabel={toggleLabel}
       />
     </Tooltip>
   );

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
@@ -1,0 +1,20 @@
+import userEvent from "@testing-library/user-event";
+
+import NodeActionMenuGroup, { Labels } from "./NodeActionMenuGroup";
+
+// import { NodeActions } from "app/store/types/node";
+// import { getNodeActionTitle } from "app/store/utils";
+// import { machine as machineFactory } from "testing/factories";
+import { render, screen, within } from "testing/utils";
+
+describe("NodeActionMenuGroup", () => {
+  const openMenu = async (name: string) => {
+    await userEvent.click(screen.getByRole("button", { name: name }));
+  };
+
+  it("exists", () => {
+    render(
+      <NodeActionMenuGroup hasSelection={false} onActionClick={jest.fn()} />
+    );
+  });
+});

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
@@ -202,13 +202,13 @@ describe("NodeActionMenuGroup", () => {
 
     expect(
       within(getActionCount(actionsMenu, NodeActions.COMMISSION)).getByText("3")
-    );
+    ).toBeInTheDocument();
     expect(
       within(getActionCount(actionsMenu, NodeActions.RELEASE)).getByText("2")
-    );
+    ).toBeInTheDocument();
     expect(
       within(getActionCount(actionsMenu, NodeActions.DEPLOY)).getByText("1")
-    );
+    ).toBeInTheDocument();
   });
 
   it("fires onActionClick function on action button click", async () => {

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
@@ -2,9 +2,9 @@ import userEvent from "@testing-library/user-event";
 
 import NodeActionMenuGroup, { Labels } from "./NodeActionMenuGroup";
 
-// import { NodeActions } from "app/store/types/node";
-// import { getNodeActionTitle } from "app/store/utils";
-// import { machine as machineFactory } from "testing/factories";
+import { NodeActions } from "app/store/types/node";
+import { getNodeActionTitle } from "app/store/utils";
+import { machine as machineFactory } from "testing/factories";
 import { render, screen, within } from "testing/utils";
 
 describe("NodeActionMenuGroup", () => {
@@ -12,9 +12,305 @@ describe("NodeActionMenuGroup", () => {
     await userEvent.click(screen.getByRole("button", { name: name }));
   };
 
-  it("exists", () => {
+  const getSubMenu = (name: string) => screen.getByLabelText(`${name} submenu`);
+
+  const getActionButton = (submenu: HTMLElement, name: NodeActions) =>
+    within(submenu).getByRole("button", {
+      name: RegExp(getNodeActionTitle(name)),
+    });
+
+  const queryActionButton = (submenu: HTMLElement, name: NodeActions) =>
+    within(submenu).queryByRole("button", {
+      name: RegExp(getNodeActionTitle(name)),
+    });
+
+  const getActionCount = (submenu: HTMLElement, action: NodeActions) =>
+    within(submenu).getByTestId(`action-count-${action}`);
+
+  it("renders", () => {
     render(
       <NodeActionMenuGroup hasSelection={false} onActionClick={jest.fn()} />
     );
+
+    Object.values(Labels).forEach((label) => {
+      expect(screen.getByRole("button", { name: label })).toBeInTheDocument();
+    });
+  });
+
+  it("only shows actions that can be performed by the nodes", async () => {
+    const nodes = [
+      machineFactory({ actions: [NodeActions.DELETE] }),
+      machineFactory({ actions: [NodeActions.SET_ZONE] }),
+    ];
+    render(
+      <NodeActionMenuGroup
+        filterActions
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: Labels.Categorise })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: Labels.Delete })
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole("button", { name: Labels.Actions })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: Labels.Lock })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: Labels.PowerCycle })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: Labels.Troubleshoot })
+    ).not.toBeInTheDocument();
+
+    await openMenu(Labels.Categorise);
+    const categoriseMenu = getSubMenu(Labels.Categorise);
+
+    expect(
+      getActionButton(categoriseMenu, NodeActions.SET_ZONE)
+    ).toBeInTheDocument();
+    expect(
+      queryActionButton(categoriseMenu, NodeActions.SET_POOL)
+    ).not.toBeInTheDocument();
+    expect(
+      queryActionButton(categoriseMenu, NodeActions.TAG)
+    ).not.toBeInTheDocument();
+  });
+
+  it(`can be made to always show lifecycle actions, disabling the actions that
+      cannot be performed`, async () => {
+    const nodes = [machineFactory({ actions: [NodeActions.DEPLOY] })];
+    render(
+      <NodeActionMenuGroup
+        alwaysShowLifecycle
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount
+      />
+    );
+
+    await openMenu(Labels.Actions);
+    const actionsMenu = getSubMenu(Labels.Actions);
+
+    expect(
+      getActionButton(actionsMenu, NodeActions.DEPLOY)
+    ).toBeInTheDocument();
+    expect(
+      queryActionButton(actionsMenu, NodeActions.DEPLOY)
+    ).not.toBeDisabled();
+    expect(
+      getActionButton(actionsMenu, NodeActions.RELEASE)
+    ).toBeInTheDocument();
+    expect(getActionButton(actionsMenu, NodeActions.RELEASE)).toBeDisabled();
+  });
+
+  it(`disables the actions that cannot be performed when nodes are provided`, async () => {
+    const nodes = [machineFactory({ actions: [NodeActions.DEPLOY] })];
+    render(
+      <NodeActionMenuGroup
+        alwaysShowLifecycle
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount={false}
+      />
+    );
+
+    await openMenu(Labels.Actions);
+    const actionsMenu = getSubMenu(Labels.Actions);
+
+    expect(
+      getActionButton(actionsMenu, NodeActions.DEPLOY)
+    ).toBeInTheDocument();
+    expect(
+      queryActionButton(actionsMenu, NodeActions.DEPLOY)
+    ).not.toBeDisabled();
+    expect(
+      getActionButton(actionsMenu, NodeActions.RELEASE)
+    ).toBeInTheDocument();
+    expect(getActionButton(actionsMenu, NodeActions.RELEASE)).toBeDisabled();
+  });
+
+  it("shows all actions that can be performed when nodes are not provided", async () => {
+    render(<NodeActionMenuGroup hasSelection onActionClick={jest.fn()} />);
+
+    expect(
+      screen.getByRole("button", { name: Labels.Delete })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: Labels.Delete })
+    ).not.toBeDisabled();
+
+    await openMenu(Labels.Categorise);
+    const categoriseMenu = getSubMenu(Labels.Categorise);
+
+    expect(
+      getActionButton(categoriseMenu, NodeActions.SET_ZONE)
+    ).toBeInTheDocument();
+    expect(
+      queryActionButton(categoriseMenu, NodeActions.SET_ZONE)
+    ).not.toBeDisabled();
+
+    await openMenu(Labels.Troubleshoot);
+    const troubleshootMenu = getSubMenu(Labels.Troubleshoot);
+
+    expect(
+      getActionButton(troubleshootMenu, NodeActions.TEST)
+    ).toBeInTheDocument();
+    expect(
+      queryActionButton(troubleshootMenu, NodeActions.TEST)
+    ).not.toBeDisabled();
+  });
+
+  it("correctly calculates number of nodes that can perform each action", async () => {
+    const nodes = [
+      machineFactory({
+        actions: [
+          NodeActions.COMMISSION,
+          NodeActions.RELEASE,
+          NodeActions.DEPLOY,
+        ],
+      }),
+      machineFactory({
+        actions: [NodeActions.COMMISSION, NodeActions.RELEASE],
+      }),
+      machineFactory({
+        actions: [NodeActions.COMMISSION],
+      }),
+    ];
+    render(
+      <NodeActionMenuGroup
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount
+      />
+    );
+
+    await openMenu(Labels.Actions);
+    const actionsMenu = getSubMenu(Labels.Actions);
+
+    expect(
+      within(getActionCount(actionsMenu, NodeActions.COMMISSION)).getByText("3")
+    );
+    expect(
+      within(getActionCount(actionsMenu, NodeActions.RELEASE)).getByText("2")
+    );
+    expect(
+      within(getActionCount(actionsMenu, NodeActions.DEPLOY)).getByText("1")
+    );
+  });
+
+  it("fires onActionClick function on action button click", async () => {
+    const nodes = [
+      machineFactory({
+        actions: [NodeActions.DEPLOY],
+      }),
+    ];
+    const onActionClick = jest.fn();
+    render(
+      <NodeActionMenuGroup
+        hasSelection
+        nodes={nodes}
+        onActionClick={onActionClick}
+        showCount
+      />
+    );
+
+    await openMenu(Labels.Actions);
+    const actionsMenu = getSubMenu(Labels.Actions);
+    await userEvent.click(getActionButton(actionsMenu, NodeActions.DEPLOY));
+
+    expect(onActionClick).toHaveBeenCalledWith(NodeActions.DEPLOY);
+  });
+
+  it("can exclude actions from being shown", async () => {
+    const nodes = [
+      machineFactory({
+        actions: [NodeActions.DEPLOY, NodeActions.DELETE],
+      }),
+    ];
+    render(
+      <NodeActionMenuGroup
+        excludeActions={[NodeActions.DELETE]}
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount
+      />
+    );
+
+    await openMenu(Labels.Actions);
+    const actionMenu = getSubMenu(Labels.Actions);
+
+    expect(getActionButton(actionMenu, NodeActions.DEPLOY)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: RegExp(NodeActions.DELETE) })
+    ).not.toBeInTheDocument();
+  });
+
+  it("can change the display text of the nodes in the disabled tooltip", async () => {
+    render(
+      <NodeActionMenuGroup
+        hasSelection={false}
+        nodeDisplay="foobar"
+        nodes={[]}
+        onActionClick={jest.fn()}
+        showCount
+      />
+    );
+
+    expect(
+      screen.getByRole("tooltip", {
+        name: "Select foobars below to perform an action.",
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("can change the position of the disabled tooltip", async () => {
+    render(
+      <NodeActionMenuGroup
+        disabledTooltipPosition="top-left"
+        hasSelection={false}
+        nodes={[]}
+        onActionClick={jest.fn()}
+        showCount
+      />
+    );
+
+    expect(screen.getByTestId("tooltip-portal")).toHaveClass(
+      "p-tooltip--top-left"
+    );
+  });
+
+  it("can override action titles", async () => {
+    const nodes = [
+      machineFactory({
+        actions: [NodeActions.TAG],
+      }),
+    ];
+    render(
+      <NodeActionMenuGroup
+        getTitle={() => "Overridden"}
+        hasSelection
+        nodes={nodes}
+        onActionClick={jest.fn()}
+        showCount
+      />
+    );
+    await openMenu(Labels.Categorise);
+    expect(
+      within(screen.getByTestId("action-link-tag")).getByText(/Overridden/)
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -232,6 +232,13 @@ export const NodeActionMenuGroup = ({
         <span className="p-contextual-menu p-contextual-menu--center">
           <Switch
             checked={isNodeLocked}
+            disabled={
+              nodes &&
+              !(
+                canOpenActionForm(nodes[0], NodeActions.LOCK) ||
+                canOpenActionForm(nodes[0], NodeActions.UNLOCK)
+              )
+            }
             label="Lock"
             onChange={() => {
               onActionClick(

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -1,0 +1,254 @@
+import type { ButtonProps } from "@canonical/react-components";
+import {
+  Button,
+  Switch,
+  ContextualMenu,
+  Icon,
+  Tooltip,
+} from "@canonical/react-components";
+
+import type { DataTestElement } from "app/base/types";
+import type { Node } from "app/store/types/node";
+import { NodeActions } from "app/store/types/node";
+import { canOpenActionForm, getNodeActionTitle } from "app/store/utils";
+
+type ActionGroup = {
+  actions: NodeActions[];
+  icon?: string;
+  name: string;
+  title: string;
+};
+
+type ActionLink = DataTestElement<ButtonProps>;
+
+type Props = {
+  alwaysShowLifecycle?: boolean;
+  disabledTooltipPosition?: "left" | "top-left";
+  excludeActions?: NodeActions[];
+  filterActions?: boolean;
+  hasSelection: boolean;
+  isNodeLocked?: boolean;
+  nodeDisplay?: string;
+  nodes?: Node[];
+  onActionClick: (action: NodeActions) => void;
+  singleNode?: boolean;
+  showCount?: boolean;
+};
+
+export enum Labels {
+  Actions = "Actions",
+  PowerCycle = "Power cycle",
+  Troubleshoot = "Troubleshoot",
+  Categorise = "Categorise",
+  Lock = "Lock",
+  Delete = "Delete",
+}
+
+const actionGroups: ActionGroup[] = [
+  {
+    name: "lifecycle",
+    actions: [
+      NodeActions.COMMISSION,
+      NodeActions.ACQUIRE,
+      NodeActions.DEPLOY,
+      NodeActions.RELEASE,
+      NodeActions.ABORT,
+      NodeActions.CLONE,
+    ],
+    title: Labels.Actions,
+  },
+  {
+    name: "power",
+    actions: [NodeActions.ON, NodeActions.OFF],
+    title: Labels.PowerCycle,
+  },
+  {
+    name: "testing",
+    actions: [
+      NodeActions.TEST,
+      NodeActions.RESCUE_MODE,
+      NodeActions.EXIT_RESCUE_MODE,
+      NodeActions.MARK_FIXED,
+      NodeActions.MARK_BROKEN,
+      NodeActions.OVERRIDE_FAILED_TESTING,
+    ],
+    title: Labels.Troubleshoot,
+  },
+  {
+    name: "misc",
+    actions: [
+      NodeActions.TAG,
+      NodeActions.SET_ZONE,
+      NodeActions.SET_POOL,
+      NodeActions.IMPORT_IMAGES,
+    ],
+    title: Labels.Categorise,
+  },
+  {
+    name: "lock",
+    actions: [NodeActions.LOCK, NodeActions.UNLOCK],
+    title: "Lock",
+  },
+  {
+    name: "delete",
+    actions: [NodeActions.DELETE],
+    icon: "delete",
+    title: "Delete",
+  },
+];
+
+const generateActionMenus = (
+  alwaysShowLifecycle: boolean,
+  excludeActions: NodeActions[],
+  onActionClick: (action: NodeActions) => void,
+  filterActions?: boolean,
+  nodes?: Node[],
+  showCount?: boolean,
+  singleNode?: boolean
+) => {
+  return actionGroups.reduce<JSX.Element[]>((menus, group) => {
+    const groupLinks = group.actions.reduce<ActionLink[]>(
+      (groupLinks, action) => {
+        if (excludeActions.includes(action)) {
+          return groupLinks;
+        }
+
+        if (action === NodeActions.DELETE) {
+          // Delete is displayed as a discrete button
+          return groupLinks;
+        }
+
+        if (
+          singleNode &&
+          (action === NodeActions.LOCK || action === NodeActions.UNLOCK)
+        ) {
+          // If the lock/unlock actions are to be displayed as a switch, don't show a menu
+          return groupLinks;
+        }
+        // When nodes are not provided then counts should not be visible.
+        const count =
+          nodes?.reduce(
+            (sum, node) => (canOpenActionForm(node, action) ? sum + 1 : sum),
+            0
+          ) ?? 0;
+        // If alwaysShowLifecycle is true, we display lifecycle actions
+        // regardless of whether any of the provided nodes can perform them.
+        // Otherwise, the action is not rendered.
+        if (
+          (filterActions &&
+            (count > 0 ||
+              (group.name === "lifecycle" && alwaysShowLifecycle))) ||
+          // When there are no counts the actions should always be visible.
+          !filterActions
+        ) {
+          groupLinks.push({
+            children: (
+              <div className="u-flex--between">
+                <span>
+                  {getNodeActionTitle(action)}
+                  ...
+                </span>
+                {showCount && (
+                  <span
+                    className="u-nudge-right--small"
+                    data-testid={`action-count-${action}`}
+                  >
+                    {count || ""}
+                  </span>
+                )}
+              </div>
+            ),
+            "data-testid": `action-link-${action}`,
+            // When nodes are not provided actions should always be enabled.
+            disabled: nodes ? count === 0 : false,
+            onClick: () => onActionClick(action),
+          });
+        }
+        return groupLinks;
+      },
+      []
+    );
+
+    if (groupLinks.length > 0) {
+      menus.push(
+        <ContextualMenu
+          hasToggleIcon
+          links={groupLinks}
+          position="center"
+          toggleLabel={
+            !group.icon ? (
+              group.title
+            ) : (
+              <>
+                <Icon name={group.icon} />
+                {group.title}
+              </>
+            )
+          }
+        />
+      );
+    }
+    return menus;
+  }, []);
+};
+
+export const NodeActionMenuGroup = ({
+  alwaysShowLifecycle = false,
+  disabledTooltipPosition = "left",
+  excludeActions = [],
+  filterActions,
+  hasSelection,
+  isNodeLocked,
+  nodeDisplay = "node",
+  nodes,
+  onActionClick,
+  showCount,
+  singleNode = false,
+}: Props): JSX.Element => {
+  const menus = generateActionMenus(
+    alwaysShowLifecycle,
+    excludeActions,
+    onActionClick,
+    filterActions,
+    nodes,
+    showCount,
+    singleNode
+  );
+
+  return (
+    <Tooltip
+      className="p-button-group"
+      message={
+        !hasSelection
+          ? `Select ${nodeDisplay}s below to perform an action.`
+          : null
+      }
+      position={disabledTooltipPosition}
+    >
+      {menus.map((menu) => (
+        <>{menu}</>
+      ))}
+      {singleNode && (
+        <span className="p-contextual-menu p-contextual-menu--center">
+          <Switch
+            checked={isNodeLocked}
+            label="Lock"
+            onChange={() => {
+              onActionClick(
+                isNodeLocked ? NodeActions.UNLOCK : NodeActions.LOCK
+              );
+            }}
+          />
+        </span>
+      )}
+      <span className="p-contextual-menu p-contextual-menu--center">
+        <Button onClick={() => onActionClick(NodeActions.DELETE)}>
+          <Icon name="delete" />
+          Delete
+        </Button>
+      </span>
+    </Tooltip>
+  );
+};
+
+export default NodeActionMenuGroup;

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -240,8 +240,11 @@ export const NodeActionMenuGroup = ({
       ))}
       {singleNode &&
         nodes &&
-        (canOpenActionForm(nodes[0], NodeActions.LOCK) ||
-          canOpenActionForm(nodes[0], NodeActions.UNLOCK)) && (
+        // Only check if the node can lock/unlock if filterActions is true, else render regardless
+        (filterActions
+          ? canOpenActionForm(nodes[0], NodeActions.LOCK) ||
+            canOpenActionForm(nodes[0], NodeActions.UNLOCK)
+          : true) && (
           <span className="p-action-button--wrapper">
             <Switch
               checked={isNodeLocked}

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import type { ButtonProps } from "@canonical/react-components";
 import {
   Button,
@@ -26,6 +28,7 @@ type Props = {
   disabledTooltipPosition?: "left" | "top-left";
   excludeActions?: NodeActions[];
   filterActions?: boolean;
+  getTitle?: (action: NodeActions) => ReactNode | null;
   hasSelection: boolean;
   isNodeLocked?: boolean;
   nodeDisplay?: string;
@@ -102,6 +105,7 @@ const generateActionMenus = (
   excludeActions: NodeActions[],
   onActionClick: (action: NodeActions) => void,
   filterActions?: boolean,
+  getTitle?: Props["getTitle"],
   nodes?: Node[],
   showCount?: boolean,
   singleNode?: boolean
@@ -145,7 +149,7 @@ const generateActionMenus = (
             children: (
               <div className="u-flex--between">
                 <span>
-                  {getNodeActionTitle(action)}
+                  {getTitle?.(action) ?? getNodeActionTitle(action)}
                   ...
                 </span>
                 {showCount && (
@@ -172,6 +176,7 @@ const generateActionMenus = (
     if (groupLinks.length > 0) {
       menus.push(
         <ContextualMenu
+          dropdownProps={{ "aria-label": `${group.title} submenu` }}
           hasToggleIcon
           links={groupLinks}
           position="center"
@@ -197,6 +202,7 @@ export const NodeActionMenuGroup = ({
   disabledTooltipPosition = "left",
   excludeActions = [],
   filterActions,
+  getTitle,
   hasSelection,
   isNodeLocked,
   nodeDisplay = "node",
@@ -210,6 +216,7 @@ export const NodeActionMenuGroup = ({
     excludeActions,
     onActionClick,
     filterActions,
+    getTitle,
     nodes,
     showCount,
     singleNode
@@ -238,7 +245,7 @@ export const NodeActionMenuGroup = ({
           <span className="p-action-button--wrapper">
             <Switch
               checked={isNodeLocked}
-              label="Lock"
+              label={Labels.Lock}
               onChange={() => {
                 onActionClick(
                   isNodeLocked ? NodeActions.UNLOCK : NodeActions.LOCK
@@ -250,7 +257,7 @@ export const NodeActionMenuGroup = ({
       <span className="p-action-button--wrapper">
         <Button onClick={() => onActionClick(NodeActions.DELETE)}>
           <Icon name="delete" />
-          Delete
+          {Labels.Delete}
         </Button>
       </span>
     </Tooltip>

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -224,7 +224,7 @@ export const NodeActionMenuGroup = ({
 
   return (
     <Tooltip
-      className="p-button-group"
+      className="p-node-action-menu-group"
       message={
         !hasSelection
           ? `Select ${nodeDisplay}s below to perform an action.`

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -225,14 +225,17 @@ export const NodeActionMenuGroup = ({
       }
       position={disabledTooltipPosition}
     >
-      {menus.map((menu) => (
-        <>{menu}</>
+      {menus.map((menu, i) => (
+        <span className="p-action-button--wrapper" key={i}>
+          {menu}
+        </span>
+        // <>{menu}</>
       ))}
       {singleNode &&
         nodes &&
         (canOpenActionForm(nodes[0], NodeActions.LOCK) ||
           canOpenActionForm(nodes[0], NodeActions.UNLOCK)) && (
-          <span className="p-contextual-menu p-contextual-menu--center">
+          <span className="p-action-button--wrapper">
             <Switch
               checked={isNodeLocked}
               label="Lock"
@@ -244,7 +247,7 @@ export const NodeActionMenuGroup = ({
             />
           </span>
         )}
-      <span className="p-contextual-menu p-contextual-menu--center">
+      <span className="p-action-button--wrapper">
         <Button onClick={() => onActionClick(NodeActions.DELETE)}>
           <Icon name="delete" />
           Delete

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -228,26 +228,22 @@ export const NodeActionMenuGroup = ({
       {menus.map((menu) => (
         <>{menu}</>
       ))}
-      {singleNode && (
-        <span className="p-contextual-menu p-contextual-menu--center">
-          <Switch
-            checked={isNodeLocked}
-            disabled={
-              nodes &&
-              !(
-                canOpenActionForm(nodes[0], NodeActions.LOCK) ||
-                canOpenActionForm(nodes[0], NodeActions.UNLOCK)
-              )
-            }
-            label="Lock"
-            onChange={() => {
-              onActionClick(
-                isNodeLocked ? NodeActions.UNLOCK : NodeActions.LOCK
-              );
-            }}
-          />
-        </span>
-      )}
+      {singleNode &&
+        nodes &&
+        (canOpenActionForm(nodes[0], NodeActions.LOCK) ||
+          canOpenActionForm(nodes[0], NodeActions.UNLOCK)) && (
+          <span className="p-contextual-menu p-contextual-menu--center">
+            <Switch
+              checked={isNodeLocked}
+              label="Lock"
+              onChange={() => {
+                onActionClick(
+                  isNodeLocked ? NodeActions.UNLOCK : NodeActions.LOCK
+                );
+              }}
+            />
+          </span>
+        )}
       <span className="p-contextual-menu p-contextual-menu--center">
         <Button onClick={() => onActionClick(NodeActions.DELETE)}>
           <Icon name="delete" />

--- a/src/app/base/components/NodeActionMenuGroup/index.scss
+++ b/src/app/base/components/NodeActionMenuGroup/index.scss
@@ -1,8 +1,8 @@
 @mixin NodeActionMenuGroup {
   .p-button-group {
     display: inline-flex;
-    margin: 0 0 0 $spv--large;
-    flex-wrap: wrap;
+    margin: 0;
+    flex-wrap: nowrap;
     border: 1px solid #d9d9d9;
 
     .p-button {

--- a/src/app/base/components/NodeActionMenuGroup/index.scss
+++ b/src/app/base/components/NodeActionMenuGroup/index.scss
@@ -1,0 +1,25 @@
+@mixin NodeActionMenuGroup {
+  .p-button-group {
+    display: inline-flex;
+    margin: 0 0 0 $spv--large;
+    flex-wrap: wrap;
+    border: 1px solid #d9d9d9;
+
+    .p-button {
+      .p-icon--delete {
+        margin-right: $spv--x-small;
+      }
+    }
+
+    .p-contextual-menu, .p-button, .p-switch {
+      margin: 0 0 0 0;
+      padding: 0 $spv--small 0 $spv--small;
+      border: 0;
+    }
+
+    .p-contextual-menu + .p-contextual-menu, .p-contextual-menu + .p-switch, .p-contextual-menu + .p-button, .p-switch + .p-button {
+      border-left: 1px solid #d9d9d9;
+      border-radius: 0;
+    }
+  }
+}

--- a/src/app/base/components/NodeActionMenuGroup/index.scss
+++ b/src/app/base/components/NodeActionMenuGroup/index.scss
@@ -11,13 +11,13 @@
       }
     }
 
-    .p-contextual-menu, .p-button, .p-switch {
+    .p-button, .p-switch {
       margin: 0 0 0 0;
-      padding: 0 $spv--small 0 $spv--small;
+      padding: 0 $spv--large 0 $spv--large;
       border: 0;
     }
 
-    .p-contextual-menu + .p-contextual-menu, .p-contextual-menu + .p-switch, .p-contextual-menu + .p-button, .p-switch + .p-button {
+    .p-action-button--wrapper + .p-action-button--wrapper {
       border-left: 1px solid #d9d9d9;
       border-radius: 0;
     }

--- a/src/app/base/components/NodeActionMenuGroup/index.scss
+++ b/src/app/base/components/NodeActionMenuGroup/index.scss
@@ -1,9 +1,8 @@
 @mixin NodeActionMenuGroup {
   .p-button-group {
     display: inline-flex;
-    margin: 0;
     flex-wrap: nowrap;
-    border: 1px solid #d9d9d9;
+    border: 1px solid #757575;
 
     .p-button {
       .p-icon--delete {
@@ -12,14 +11,16 @@
     }
 
     .p-button, .p-switch {
-      margin: 0 0 0 0;
-      padding: 0 $spv--large 0 $spv--large;
+      margin: $spv--x-small 0;
+      padding: $spv--x-small $spv--large;
       border: 0;
     }
 
     .p-action-button--wrapper + .p-action-button--wrapper {
-      border-left: 1px solid #d9d9d9;
-      border-radius: 0;
+      .p-button, .p-switch {
+        border-left: 1px solid #d9d9d9;
+        border-radius: 0;
+      }
     }
   }
 }

--- a/src/app/base/components/NodeActionMenuGroup/index.scss
+++ b/src/app/base/components/NodeActionMenuGroup/index.scss
@@ -1,8 +1,8 @@
 @mixin NodeActionMenuGroup {
-  .p-button-group {
+  .p-node-action-menu-group {
     display: inline-flex;
     flex-wrap: nowrap;
-    border: 1px solid #757575;
+    border: 1px solid $colors--light-theme--border-high-contrast;
 
     .p-button {
       .p-icon--delete {

--- a/src/app/base/components/NodeActionMenuGroup/index.ts
+++ b/src/app/base/components/NodeActionMenuGroup/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NodeActionMenuGroup";

--- a/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -10,6 +10,7 @@ import AppSidePanel from "app/base/components/AppSidePanel";
 import type { DataTestElement } from "app/base/types";
 
 export type Props<P = LinkProps> = {
+  actionMenuGroup?: JSX.Element | null;
   buttons?: JSX.Element[] | null;
   className?: ClassName;
   sidePanelContent?: ReactNode | null;
@@ -60,6 +61,7 @@ const generateSubtitle = (
 };
 
 const SectionHeader = <P,>({
+  actionMenuGroup,
   buttons = [],
   className,
   sidePanelContent,
@@ -125,6 +127,7 @@ const SectionHeader = <P,>({
         size={headerSize}
         title={sidePanelTitle}
       />
+      {actionMenuGroup && <>{actionMenuGroup}</>}
       {tabLinks?.length ? (
         <div className="section-header__tabs" data-testid="section-header-tabs">
           <hr className="u-no-margin--bottom" />

--- a/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -80,7 +80,7 @@ const SectionHeader = <P,>({
   return (
     <div className={classNames("section-header", className)} {...props}>
       <div className="section-header__main-row u-flex--between u-flex--wrap">
-        <div className="section-header__titles u-flex--align-baseline u-flex--grow u-flex--wrap">
+        <div className="section-header__titles u-flex--align-center u-flex--grow u-flex--wrap">
           {loading || !title ? (
             <h4
               aria-label="loading"

--- a/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -127,7 +127,7 @@ const SectionHeader = <P,>({
         size={headerSize}
         title={sidePanelTitle}
       />
-      {actionMenuGroup && <>{actionMenuGroup}</>}
+      {actionMenuGroup ? <>{actionMenuGroup}</> : null}
       {tabLinks?.length ? (
         <div className="section-header__tabs" data-testid="section-header-tabs">
           <hr className="u-no-margin--bottom" />

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -9,7 +9,6 @@ import MachineHeader from "./MachineHeader";
 import { MachineHeaderViews } from "app/machines/constants";
 import type { RootState } from "app/store/root/types";
 import { PowerState } from "app/store/types/enum";
-import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -181,70 +180,6 @@ describe("MachineHeader", () => {
   });
 
   describe("power menu", () => {
-    it("can dispatch the power on action", () => {
-      state.machine.items[0].actions = [NodeActions.ON];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <CompatRouter>
-              <MachineHeader
-                setSidePanelContent={jest.fn()}
-                sidePanelContent={null}
-                systemId="abc123"
-              />
-            </CompatRouter>
-          </MemoryRouter>
-        </Provider>
-      );
-
-      // Open the power menu dropdown
-      wrapper.find("TableMenu Button").simulate("click");
-      // Click the "Power on" link
-      wrapper
-        .find("TableMenu .p-contextual-menu__link")
-        .at(0)
-        .simulate("click");
-
-      expect(
-        store.getActions().some((action) => action.type === "machine/on")
-      ).toBe(true);
-    });
-
-    it("can dispatch the power off action", () => {
-      state.machine.items[0].actions = [NodeActions.OFF];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <CompatRouter>
-              <MachineHeader
-                setSidePanelContent={jest.fn()}
-                sidePanelContent={null}
-                systemId="abc123"
-              />
-            </CompatRouter>
-          </MemoryRouter>
-        </Provider>
-      );
-
-      // Open the power menu dropdown
-      wrapper.find("TableMenu Button").simulate("click");
-      // Click the "Power off" link
-      wrapper
-        .find("TableMenu .p-contextual-menu__link")
-        .at(0)
-        .simulate("click");
-
-      expect(
-        store.getActions().some((action) => action.type === "machine/off")
-      ).toBe(true);
-    });
-
     it("can dispatch the check power action", () => {
       state.machine.items[0].actions = [];
       const store = mockStore(state);

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -149,6 +149,7 @@ const MachineHeader = ({
               <NodeActionMenuGroup
                 alwaysShowLifecycle
                 excludeActions={[NodeActions.IMPORT_IMAGES]}
+                filterActions
                 hasSelection={true}
                 isNodeLocked={machine.locked}
                 nodeDisplay="machine"

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -68,29 +68,6 @@ const MachineHeader = ({
 
   return (
     <SectionHeader
-      // actionMenuGroup={
-      //   <NodeActionMenuGroup
-      //     alwaysShowLifecycle
-      //     excludeActions={[NodeActions.IMPORT_IMAGES]}
-      //     filterActions
-      //     hasSelection={true}
-      //     nodeDisplay="machine"
-      //     nodes={[machine]}
-      //     onActionClick={(action) => {
-      //       sendAnalytics(
-      //         "Machine details action form",
-      //         getNodeActionTitle(action),
-      //         "Open"
-      //       );
-      //       const view = Object.values(MachineHeaderViews).find(
-      //         ([, actionName]) => actionName === action
-      //       );
-      //       if (view) {
-      //         setSidePanelContent({ view });
-      //       }
-      //     }}
-      //   />
-      // }
       sidePanelContent={
         sidePanelContent ? (
           <MachineHeaderForms

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -80,7 +80,7 @@ const MachineHeader = ({
       sidePanelTitle={getHeaderTitle(machine.hostname, sidePanelContent)}
       subtitle={
         editingName ? null : (
-          <div className="u-flex--wrap">
+          <div className="u-flex--wrap u-flex--align-center">
             <div className="u-nudge-left">
               {machine.locked ? (
                 <TooltipButton
@@ -90,7 +90,6 @@ const MachineHeader = ({
                   position="btm-left"
                 />
               ) : null}
-              {machine.status}
             </div>
             <div>
               <PowerIcon
@@ -162,7 +161,7 @@ const MachineHeader = ({
                   }
                 }}
                 toggleAppearance=""
-                toggleClassName="p-action-menu"
+                toggleClassName="p-action-menu u-no-margin--bottom"
                 toggleLabel="Menu"
               />
             </div>

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -120,7 +120,7 @@ const MachineHeader = ({
               <NodeActionMenuGroup
                 alwaysShowLifecycle
                 excludeActions={[NodeActions.IMPORT_IMAGES]}
-                // filterActions
+                filterActions
                 hasSelection={true}
                 isNodeLocked={machine.locked}
                 nodeDisplay="machine"

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom-v5-compat";
 
 import MachineName from "./MachineName";
 
-import NodeActionMenu from "app/base/components/NodeActionMenu";
+import NodeActionMenuGroup from "app/base/components/NodeActionMenuGroup";
 import PowerIcon from "app/base/components/PowerIcon";
 import ScriptStatus from "app/base/components/ScriptStatus";
 import SectionHeader from "app/base/components/SectionHeader";
@@ -68,30 +68,29 @@ const MachineHeader = ({
 
   return (
     <SectionHeader
-      buttons={[
-        <NodeActionMenu
-          alwaysShowLifecycle
-          excludeActions={[NodeActions.IMPORT_IMAGES]}
-          filterActions
-          hasSelection={true}
-          key="action-dropdown"
-          nodeDisplay="machine"
-          nodes={[machine]}
-          onActionClick={(action) => {
-            sendAnalytics(
-              "Machine details action form",
-              getNodeActionTitle(action),
-              "Open"
-            );
-            const view = Object.values(MachineHeaderViews).find(
-              ([, actionName]) => actionName === action
-            );
-            if (view) {
-              setSidePanelContent({ view });
-            }
-          }}
-        />,
-      ]}
+      // actionMenuGroup={
+      //   <NodeActionMenuGroup
+      //     alwaysShowLifecycle
+      //     excludeActions={[NodeActions.IMPORT_IMAGES]}
+      //     filterActions
+      //     hasSelection={true}
+      //     nodeDisplay="machine"
+      //     nodes={[machine]}
+      //     onActionClick={(action) => {
+      //       sendAnalytics(
+      //         "Machine details action form",
+      //         getNodeActionTitle(action),
+      //         "Open"
+      //       );
+      //       const view = Object.values(MachineHeaderViews).find(
+      //         ([, actionName]) => actionName === action
+      //       );
+      //       if (view) {
+      //         setSidePanelContent({ view });
+      //       }
+      //     }}
+      //   />
+      // }
       sidePanelContent={
         sidePanelContent ? (
           <MachineHeaderForms
@@ -144,6 +143,30 @@ const MachineHeader = ({
                 ]}
                 positionNode={powerMenuRef?.current}
                 title="Take action:"
+              />
+            </div>
+            <div>
+              <NodeActionMenuGroup
+                alwaysShowLifecycle
+                excludeActions={[NodeActions.IMPORT_IMAGES]}
+                hasSelection={true}
+                isNodeLocked={machine.locked}
+                nodeDisplay="machine"
+                nodes={[machine]}
+                onActionClick={(action) => {
+                  sendAnalytics(
+                    "Machine details action form",
+                    getNodeActionTitle(action),
+                    "Open"
+                  );
+                  const view = Object.values(MachineHeaderViews).find(
+                    ([, actionName]) => actionName === action
+                  );
+                  if (view) {
+                    setSidePanelContent({ view });
+                  }
+                }}
+                singleNode
               />
             </div>
           </div>

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -102,7 +102,7 @@ const MachineHeader = ({
                   : `Power ${machine.power_state}`}
               </PowerIcon>
               <TableMenu
-                className="u-nudge-right--small p-table-menu"
+                className="u-nudge-right--small p-table-menu u-nudge-left--large"
                 links={[
                   {
                     children: "Check power",

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -12,7 +12,7 @@ import ScriptStatus from "app/base/components/ScriptStatus";
 import SectionHeader from "app/base/components/SectionHeader";
 import TableMenu from "app/base/components/TableMenu";
 import TooltipButton from "app/base/components/TooltipButton";
-import { useMachineActions, useSendAnalytics } from "app/base/hooks";
+import { useSendAnalytics } from "app/base/hooks";
 import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
 import { MachineHeaderViews } from "app/machines/constants";
 import type {
@@ -52,10 +52,6 @@ const MachineHeader = ({
     machineSelectors.getStatuses(state, systemId)
   );
   const powerMenuRef = useRef<HTMLSpanElement>(null);
-  const powerMenuLinks = useMachineActions(systemId, [
-    NodeActions.OFF,
-    NodeActions.ON,
-  ]);
   const isDetails = isMachineDetails(machine);
   useFetchMachine(systemId);
 
@@ -108,9 +104,6 @@ const MachineHeader = ({
               <TableMenu
                 className="u-nudge-right--small"
                 links={[
-                  ...(Array.isArray(powerMenuLinks)
-                    ? powerMenuLinks
-                    : [powerMenuLinks]),
                   {
                     children: "Check power",
                     onClick: () => {

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -6,6 +6,7 @@ import { Link } from "react-router-dom-v5-compat";
 
 import MachineName from "./MachineName";
 
+import NodeActionMenu from "app/base/components/NodeActionMenu";
 import NodeActionMenuGroup from "app/base/components/NodeActionMenuGroup";
 import PowerIcon from "app/base/components/PowerIcon";
 import ScriptStatus from "app/base/components/ScriptStatus";
@@ -102,7 +103,7 @@ const MachineHeader = ({
                   : `Power ${machine.power_state}`}
               </PowerIcon>
               <TableMenu
-                className="u-nudge-right--small"
+                className="u-nudge-right--small p-table-menu"
                 links={[
                   {
                     children: "Check power",
@@ -119,7 +120,7 @@ const MachineHeader = ({
               <NodeActionMenuGroup
                 alwaysShowLifecycle
                 excludeActions={[NodeActions.IMPORT_IMAGES]}
-                filterActions
+                // filterActions
                 hasSelection={true}
                 isNodeLocked={machine.locked}
                 nodeDisplay="machine"
@@ -138,6 +139,31 @@ const MachineHeader = ({
                   }
                 }}
                 singleNode
+              />
+              <NodeActionMenu
+                alwaysShowLifecycle
+                excludeActions={[NodeActions.IMPORT_IMAGES]}
+                filterActions
+                hasSelection={true}
+                key="action-dropdown"
+                nodeDisplay="machine"
+                nodes={[machine]}
+                onActionClick={(action) => {
+                  sendAnalytics(
+                    "Machine details action form",
+                    getNodeActionTitle(action),
+                    "Open"
+                  );
+                  const view = Object.values(MachineHeaderViews).find(
+                    ([, actionName]) => actionName === action
+                  );
+                  if (view) {
+                    setSidePanelContent({ view });
+                  }
+                }}
+                toggleAppearance=""
+                toggleClassName="p-action-menu"
+                toggleLabel="Menu"
               />
             </div>
           </div>

--- a/src/app/machines/views/MachineDetails/MachineHeader/index.scss
+++ b/src/app/machines/views/MachineDetails/MachineHeader/index.scss
@@ -1,17 +1,14 @@
 @mixin MachineHeader {
-  .p-table-menu {
-    margin-right: $spv--large;
-  }
 
   // These media queries are for when the screen is too small to display the action group without wrapping.
   // Wrapping begins before $breakpoint-small, hence the direct reference to pixel width.
-  @media screen and (max-width: 792px) {
-    .p-button-group {
+  @media screen and (max-width: ($breakpoint-node-action-menu-group - 1)) {
+    .p-node-action-menu-group {
       display: none;
     }
   }
 
-  @media screen and (min-width: 793px) {
+  @media screen and (min-width: $breakpoint-node-action-menu-group) {
     .p-action-menu {
       display: none;
     }

--- a/src/app/machines/views/MachineDetails/MachineHeader/index.scss
+++ b/src/app/machines/views/MachineDetails/MachineHeader/index.scss
@@ -1,0 +1,19 @@
+@mixin MachineHeader {
+  .p-table-menu {
+    margin-right: $spv--large;
+  }
+
+  // These media queries are for when the screen is too small to display the action group without wrapping.
+  // Wrapping begins before $breakpoint-small, hence the direct reference to pixel width.
+  @media screen and (max-width: 792px) {
+    .p-button-group {
+      display: none;
+    }
+  }
+
+  @media screen and (min-width: 793px) {
+    .p-action-menu {
+      display: none;
+    }
+  }
+}

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -4,6 +4,7 @@ $grid-max-width: math.div(1440, 16) * 1rem; // express in rems for easier calcul
 $color-navigation-background: #666;
 $color-navigation-background--hover: darken($color-navigation-background, 3%);
 
+$breakpoint-node-action-menu-group: 793px; 
 $breakpoint-kvm-resources-card: 1300px;
 $breakpoint-x-large: 1440px;
 $breakpoint-navigation-threshold: 925px;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -236,12 +236,14 @@
 @import "~app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneResults";
 @import "~app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MarkBrokenForm/MarkBrokenFormFields";
 @import "~app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm";
+@import "~app/machines/views/MachineDetails/MachineHeader";
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
 @import "~app/machines/views/MachineList";
 @include CloneFormFields;
 @include CloneResults;
 @include MachineList;
+@include MachineHeader;
 @include MachineSummary;
 @include MarkBrokenFormFields;
 @include NumaCard;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -93,6 +93,7 @@
 @import "~app/base/components/node/NodeLogs/EventLogs/EventLogsTable";
 @import "~app/base/components/node/NodeTestsTable";
 @import "~app/base/components/node/OverviewCard";
+@import "~app/base/components/NodeActionMenuGroup";
 @import "~app/base/components/NodeName";
 @import "~app/base/components/NodeSummaryNetworkCard";
 @import "~app/base/components/NodeSummaryNetworkCard/NetworkCardTable";
@@ -126,6 +127,7 @@
 @include Meter;
 @include NetworkCardTable;
 @include NetworkTable;
+@include NodeActionMenuGroup;
 @include NodeDevices;
 @include NodeName;
 @include NodeSummaryNetworkCard;


### PR DESCRIPTION
## Done

- Added group of contextual menus and buttons to replace "Take action" dropdown
- Implemented on machine details
- Hide group and replace with "Menu dropdown" on smaller screens

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to the details page for a machine
- Ensure the action group renders correctly
- Click on each available action
- Ensure it opens the correct form
- Shrink your window horizontally
- Ensure the group is replaced by a "Menu" dropdown wrapping occurs within the button group
- Ensure that each available action in the menu opens the correct form

## Fixes

Fixes https://warthogs.atlassian.net/browse/MAASENG-1223

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/213667607-288e1af7-1216-4911-bebb-2e415ec228b7.png)

### After
![image](https://user-images.githubusercontent.com/35104482/213728100-db2160e7-bba5-4adf-af02-faac30c083ae.png)

#### With lock switch
![image](https://user-images.githubusercontent.com/35104482/213728195-fa44647b-74a4-4f92-86b0-f4897d04d7fe.png)

#### Small screen
![image](https://user-images.githubusercontent.com/35104482/213728285-5312e547-abcc-47c2-9a94-f9bd4b215747.png)

