### PR TITLE
MAAS new layout QA review fixes

### DIFF
--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
@@ -44,7 +44,7 @@ it("fetches machines on mount", async () => {
     group_collapsed: undefined,
     group_key: null,
     page_number: 1,
-    page_size: 15,
+    page_size: 5,
     sort_direction: null,
     sort_key: null,
   });
@@ -62,23 +62,21 @@ it("requests machines filtered by the free text input value", async () => {
 
   const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   await user.type(screen.getByRole("combobox"), "test-machine");
-  const expectedInitialAction = machineActions.fetch("mocked-nanoid-1", {
-    filter: { free_text: "" },
+  const expectedActionParams = {
     group_collapsed: undefined,
     group_key: null,
     page_number: 1,
-    page_size: 15,
+    page_size: 5,
     sort_direction: null,
     sort_key: null,
+  };
+  const expectedInitialAction = machineActions.fetch("mocked-nanoid-1", {
+    filter: { free_text: "" },
+    ...expectedActionParams,
   });
   const expectedAction = machineActions.fetch("mocked-nanoid-2", {
     filter: { free_text: "test-machine" },
-    group_collapsed: undefined,
-    group_key: null,
-    page_number: 1,
-    page_size: 15,
-    sort_direction: null,
-    sort_key: null,
+    ...expectedActionParams,
   });
   await waitFor(() => {
     jest.advanceTimersByTime(DEFAULT_DEBOUNCE_INTERVAL);

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.tsx
@@ -9,7 +9,7 @@ import { useFetchMachines } from "app/store/machine/utils/hooks";
 
 const MachineSelectBox = ({
   onSelect,
-  pageSize = 15,
+  pageSize = 5,
   filters,
 }: {
   pageSize?: number;
@@ -49,6 +49,7 @@ const MachineSelectBox = ({
           onMachineClick={(machine) => {
             onSelect(machine);
           }}
+          pageSize={pageSize}
           searchText={searchText}
           setSearchText={setSearchText}
         />

--- a/src/app/base/components/FormikForm/FormikForm.tsx
+++ b/src/app/base/components/FormikForm/FormikForm.tsx
@@ -13,6 +13,7 @@ const FormikForm = <V extends object, E = null>({
   buttonsAlign,
   buttonsBordered,
   buttonsClassName,
+  buttonsHelpClassName,
   buttonsHelp,
   cancelDisabled,
   children,
@@ -52,6 +53,7 @@ const FormikForm = <V extends object, E = null>({
         buttonsBordered={buttonsBordered}
         buttonsClassName={buttonsClassName}
         buttonsHelp={buttonsHelp}
+        buttonsHelpClassName={buttonsHelpClassName}
         cancelDisabled={cancelDisabled}
         className={className}
         cleanup={cleanup}

--- a/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
+++ b/src/app/base/components/FormikFormButtons/FormikFormButtons.tsx
@@ -16,6 +16,7 @@ export type Props<V> = {
   buttonsBordered?: boolean;
   buttonsClassName?: string;
   buttonsHelp?: ReactNode;
+  buttonsHelpClassName?: string;
   cancelDisabled?: boolean;
   cancelLabel?: string;
   inline?: boolean;
@@ -50,6 +51,7 @@ export const FormikFormButtons = <V,>({
   buttonsBordered = true,
   buttonsClassName,
   buttonsHelp,
+  buttonsHelpClassName,
   cancelDisabled,
   cancelLabel = "Cancel",
   inline,
@@ -116,7 +118,10 @@ export const FormikFormButtons = <V,>({
       >
         {buttonsHelp && (
           <div
-            className="formik-form-buttons__help"
+            className={classNames(
+              "formik-form-buttons__help",
+              buttonsHelpClassName
+            )}
             data-testid={TestIds.ButtonsHelp}
           >
             {buttonsHelp}

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -51,6 +51,7 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={machines}
         onMachineClick={jest.fn()}
+        pageSize={machines.length}
         searchText=""
         setSearchText={jest.fn()}
       />,
@@ -64,6 +65,7 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={[machines[0]]}
         onMachineClick={jest.fn()}
+        pageSize={machines.length}
         searchText="fir"
         setSearchText={jest.fn()}
       />,
@@ -84,6 +86,7 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={machines}
         onMachineClick={onMachineClick}
+        pageSize={machines.length}
         searchText=""
         setSearchText={jest.fn()}
       />,
@@ -99,6 +102,7 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={machines}
         onMachineClick={jest.fn()}
+        pageSize={machines.length}
         searchText=""
         setSearchText={jest.fn()}
       />,
@@ -117,6 +121,7 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={machines}
         onMachineClick={onMachineClick}
+        pageSize={machines.length}
         searchText=""
         setSearchText={jest.fn()}
       />,
@@ -137,6 +142,7 @@ describe("MachineSelectTable", () => {
       <MachineSelectTable
         machines={machines}
         onMachineClick={onMachineClick}
+        pageSize={machines.length}
         searchText="id:("
         setSearchText={jest.fn()}
       />,

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.tsx
@@ -23,6 +23,7 @@ export enum Label {
 }
 
 type Props = {
+  pageSize: number;
   machines: Machine[];
   onMachineClick: (machine: Machine | null) => void;
   searchText: string;
@@ -95,9 +96,8 @@ const generateRows = (
   }));
 };
 
-const getSkeletonRows = () =>
-  Array.from(Array(3)).map((_, i) => ({
-    className: "machine-select-table__row",
+const getSkeletonRows = (count = 3) =>
+  Array.from(Array(count)).map((_, i) => ({
     columns: [
       {
         content: (
@@ -124,6 +124,7 @@ const getSkeletonRows = () =>
 export const MachineSelectTable = ({
   machines,
   machinesLoading,
+  pageSize,
   onMachineClick,
   searchText,
   setSearchText,
@@ -146,7 +147,7 @@ export const MachineSelectTable = ({
     tags
   );
 
-  const skeletonRows = getSkeletonRows();
+  const skeletonRows = getSkeletonRows(pageSize);
 
   return (
     <>

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
@@ -12,7 +12,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter, within } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 
@@ -91,25 +91,34 @@ describe("AddDeviceInterfaces", () => {
     );
 
     const getCardCount = () => screen.getAllByTestId("interface-card").length;
-    const getAddButton = () => screen.getByTestId("add-interface");
-    const getRemoveButton = () =>
-      screen.getAllByRole("button", { name: /delete/i })[0];
 
     // There is only one interface by default. Since at least one interface must
-    // be defined, the remove button should be disabled.
+    // be defined, the remove button should be hidden.
     expect(getCardCount()).toBe(1);
-    expect(getRemoveButton()).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: /delete/i })
+    ).not.toBeInTheDocument();
 
     // Add an interface.
-    await userEvent.click(getAddButton());
+    await userEvent.click(
+      screen.getByRole("button", { name: /Add interface/i })
+    );
 
     expect(getCardCount()).toBe(2);
-    expect(getRemoveButton()).not.toBeDisabled();
+    expect(screen.queryAllByRole("button", { name: /delete/i })).toHaveLength(
+      2
+    );
 
     // Remove an interface.
-    await userEvent.click(getRemoveButton());
+    await userEvent.click(
+      within(screen.getAllByTestId("interface-card")[0]).getByRole("button", {
+        name: /delete/i,
+      })
+    );
 
     expect(getCardCount()).toBe(1);
-    expect(getRemoveButton()).toBeDisabled();
+    expect(
+      screen.queryByRole("button", { name: /delete/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
@@ -92,15 +92,13 @@ export const AddDeviceInterfaces = (): JSX.Element => {
                 type="text"
               />
             ) : null}
-            <div className="u-align--right">
-              <Button
-                disabled={deleteDisabled}
-                onClick={() => removeInterface(iface.id)}
-                type="button"
-              >
-                Delete
-              </Button>
-            </div>
+            {!deleteDisabled ? (
+              <div className="u-align--right">
+                <Button onClick={() => removeInterface(iface.id)} type="button">
+                  Delete
+                </Button>
+              </div>
+            ) : null}
           </Card>
         );
       })}

--- a/src/app/domains/components/RecordFields/RecordFields.tsx
+++ b/src/app/domains/components/RecordFields/RecordFields.tsx
@@ -73,7 +73,7 @@ const RecordFields = ({ editing }: Props): JSX.Element => {
 
   return (
     <Row>
-      <Col size={6}>
+      <Col size={12}>
         <FormikField
           label={Labels.Name}
           name="name"

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
@@ -39,7 +39,7 @@ const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
     domainSelectors.getById(state, id)
   );
   const dispatch = useDispatch();
-  const [formOpen, setFormOpen] = useState<"delete" | "add-record" | null>(
+  const [formOpen, setFormOpen] = useState<"DeleteDomain" | "AddRecord" | null>(
     null
   );
 
@@ -59,7 +59,7 @@ const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
     <Button
       data-testid="add-record"
       key="add-record"
-      onClick={() => setFormOpen("add-record")}
+      onClick={() => setFormOpen("AddRecord")}
     >
       {Labels.AddRecord}
     </Button>,
@@ -70,7 +70,7 @@ const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
         appearance="negative"
         data-testid="delete-domain"
         key="delete-domain"
-        onClick={() => setFormOpen("delete")}
+        onClick={() => setFormOpen("DeleteDomain")}
       >
         {Labels.DeleteDomain}
       </Button>
@@ -84,15 +84,16 @@ const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
       sidePanelContent={
         formOpen === null ? null : (
           <>
-            {formOpen === "delete" && (
+            {formOpen === "DeleteDomain" && (
               <DeleteDomainForm closeForm={closeForm} id={id} />
             )}
-            {formOpen === "add-record" && (
+            {formOpen === "AddRecord" && (
               <AddRecordForm closeForm={closeForm} id={id} />
             )}
           </>
         )
       }
+      sidePanelTitle={formOpen ? Labels[formOpen] : null}
       subtitle={`${pluralizeString("host", hostsCount, "")}${
         hostsCount > 1 ? "; " : ""
       }${pluralizeString(

--- a/src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisForm/AddChassisForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisForm/AddChassisForm.tsx
@@ -85,6 +85,7 @@ export const AddChassisForm = ({
               </Link>
             </p>
           }
+          buttonsHelpClassName="u-align--right"
           cleanup={machineActions.cleanup}
           errors={machineErrors}
           initialValues={{

--- a/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.tsx
@@ -135,6 +135,7 @@ export const AddMachineForm = ({
               </Link>
             </p>
           }
+          buttonsHelpClassName="u-align--right"
           cleanup={machineActions.cleanup}
           errors={machineErrors}
           initialValues={{

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -66,14 +66,6 @@ describe("SourceMachineSelect", () => {
     jest.restoreAllMocks();
   });
 
-  it("shows a spinner while data is loading", () => {
-    renderWithMockStore(
-      <SourceMachineSelect loadingData onMachineClick={jest.fn()} />,
-      { state }
-    );
-    expect(screen.getByLabelText(Label.Loading)).toBeInTheDocument();
-  });
-
   it("shows an error if no machines are available to select", () => {
     state.machine.lists["123456"] = machineStateList({
       loaded: true,

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 
-import { Notification, Spinner, Strip } from "@canonical/react-components";
+import { Notification } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch } from "react-redux";
 
@@ -22,7 +22,6 @@ export enum Label {
 
 type Props = {
   className?: string;
-  loadingData?: boolean;
   loadingMachineDetails?: boolean;
   pageSize?: number;
   onMachineClick: (machine: Machine | null) => void;
@@ -31,8 +30,7 @@ type Props = {
 
 export const SourceMachineSelect = ({
   className,
-  loadingData = false,
-  pageSize = 15,
+  pageSize = 5,
   loadingMachineDetails = false,
   onMachineClick,
   selectedMachine = null,
@@ -58,13 +56,7 @@ export const SourceMachineSelect = ({
   }, [dispatch]);
 
   let content: ReactNode;
-  if (loadingData) {
-    content = (
-      <Strip shallow>
-        <Spinner aria-label={Label.Loading} text={Label.Loading} />
-      </Strip>
-    );
-  } else if (loadingMachineDetails || selectedMachine) {
+  if (loadingMachineDetails || selectedMachine) {
     content = <SourceMachineDetails machine={selectedMachine} />;
   } else if (!loading && machineCount === 0) {
     content = (
@@ -79,11 +71,12 @@ export const SourceMachineSelect = ({
     );
   } else {
     content = (
-      <div className="source-machine-select__table">
+      <>
         <MachineSelectTable
           machines={machines}
           machinesLoading={loading}
           onMachineClick={onMachineClick}
+          pageSize={pageSize}
           searchText={searchText}
           setSearchText={setSearchText}
         />
@@ -93,8 +86,9 @@ export const SourceMachineSelect = ({
           machineCount={machineCount}
           machinesLoading={loading}
           paginate={setCurrentPage}
+          truncateThreshold={6}
         />
-      </div>
+      </>
     );
   }
   return (

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/_index.scss
@@ -4,9 +4,4 @@
     @extend %vf-has-round-corners;
     padding: $spv--medium $sph--large 0 $sph--large;
   }
-
-  .source-machine-select__table {
-    max-height: 22rem;
-    overflow: auto;
-  }
 }


### PR DESCRIPTION
## Done

- MAAS new layout QA review fixes
- fix an issue where loading skeleton rows had and cursor pointer and hover style
- update clone from form to display smaller number of items that fits in single page view
- display skeleton rows in a number equal to selected pageSize

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open Clone from form and verify it's displayed correctly and no content overflows
- Open add device form on devices page and make sure delete button works correctly (appears only for 2 or more interfaces)

## Fixes

Fixes: MAASENG-1254

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
<img width="1606" alt="image" src="https://user-images.githubusercontent.com/7452681/213685323-dc0aa1a6-fb8d-434c-bd98-892a5e01ab32.png">

### After
![image](https://user-images.githubusercontent.com/7452681/213683826-daba7b24-fa69-44a0-89c4-d84b2240fccd.png)

### Before
<img width="1410" alt="image" src="https://user-images.githubusercontent.com/7452681/213685492-2aa93f5b-e692-4e4f-b5cb-070a08263f2a.png">

### After
<img width="1453" alt="Pasted Graphic 8" src="https://user-images.githubusercontent.com/7452681/213683853-187c5467-9717-49ae-8da2-3e2b53a00918.png">


