### PR TITLE
fix(subnet): Visible error message when rack controller is not selected for DHCP MAASENG-1256

### DIFF
--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -103,7 +103,7 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
           dhcpType: DHCPType.CONTROLLERS | DHCPType.RELAY
         ) => dhcpEnabled && dhcpType === DHCPType.CONTROLLERS,
         then: Yup.string().required(
-          "Rack controller must be selected to provide DHCP"
+          "Primary rack is required"
         ),
       }),
       relayVLAN: Yup.string(),

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -102,9 +102,7 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
           dhcpEnabled: boolean,
           dhcpType: DHCPType.CONTROLLERS | DHCPType.RELAY
         ) => dhcpEnabled && dhcpType === DHCPType.CONTROLLERS,
-        then: Yup.string().required(
-          "Primary rack is required"
-        ),
+        then: Yup.string().required("Primary rack is required"),
       }),
       relayVLAN: Yup.string(),
       secondaryRack: Yup.string(),

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -97,7 +97,15 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
         then: Yup.string().required("End IP address is required"),
       }),
       gatewayIP: Yup.string(),
-      primaryRack: Yup.string(),
+      primaryRack: Yup.string().when(["enableDHCP", "dhcpType"], {
+        is: (
+          dhcpEnabled: boolean,
+          dhcpType: DHCPType.CONTROLLERS | DHCPType.RELAY
+        ) => dhcpEnabled && dhcpType === DHCPType.CONTROLLERS,
+        then: Yup.string().required(
+          "Rack controller must be selected to provide DHCP"
+        ),
+      }),
       relayVLAN: Yup.string(),
       secondaryRack: Yup.string(),
       startIP: Yup.string().when("subnet", {

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
@@ -94,6 +94,7 @@ const ConfigureDHCPFields = ({ vlan }: Props): JSX.Element => {
                             simpleSortByKey("label", { alphanumeric: true })
                           ),
                       ]}
+                      required
                       wrapperClassName="u-nudge-right--x-large"
                     />
                     {connectedControllers.length > 1 && (


### PR DESCRIPTION
## Done

- Made "Rack controller" field required in DHCP form
- Added error message for DHCP configuration if "Provide DHCP from rack controller(s)" is selected but no controller is selected

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to `/MAAS/r/networks?by=fabric&q=` (or click "Subnets" in the nav)
- Click on a VLAN
- Click "Configure DHCP"
- Ensure an asterisk is present before the "Rack controller" field label
- Select a controller and then select "Select a rack controller"
- Ensure an appropriate error message is displayed
- Select "Relay to another VLAN" and complete the form
- Ensure that the form can still be submitted

## Fixes

Fixes [MAASENG-1256](https://warthogs.atlassian.net/browse/MAASENG-1256) and #4689

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
![image](https://user-images.githubusercontent.com/35104482/213689548-ea615976-b628-4fc8-8de7-65a3cca121da.png)


[MAASENG-1256]: https://warthogs.atlassian.net/browse/MAASENG-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ