### PR TITLE
test: fix cypress failed

### DIFF
--- a/cypress/e2e/with-users/machines/actions.spec.ts
+++ b/cypress/e2e/with-users/machines/actions.spec.ts
@@ -65,9 +65,9 @@ context("Machine listing - actions", () => {
           name: new RegExp(`${action}...`),
         }).click();
       });
-      cy.findByTestId("section-header-title").contains(action).should("exist");
-      cy.get("[data-testid='section-header-content']").within(() => {
+      cy.findByRole("complementary", { name: action }).within(() => {
         cy.findAllByText(/Loading/).should("have.length", 0);
+        cy.findByRole("heading", { name: action });
         cy.findByRole("button", { name: /Cancel/i }).click();
       });
       // expect the action form to be closed

--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -68,7 +68,8 @@ context("Machine listing", () => {
   });
 
   it("can hide machine table columns", () => {
-    cy.findAllByRole("columnheader").should("have.length", 8);
+    const allHeadersCount = 11;
+    cy.findAllByRole("columnheader").should("have.length", allHeadersCount);
 
     cy.findAllByRole("button", { name: "Columns" }).click();
     cy.findByLabelText("columns menu").within(() =>
@@ -76,13 +77,13 @@ context("Machine listing", () => {
       cy.findByRole("checkbox", { name: "Status" }).click({ force: true })
     );
 
-    cy.findAllByRole("columnheader").should("have.length", 7);
+    cy.findAllByRole("columnheader").should("have.length", allHeadersCount - 1);
     cy.findByRole("header", { name: "Status" }).should("not.exist");
 
     cy.reload();
 
     // verify that the hidden column is still hidden after refresh
-    cy.findAllByRole("columnheader").should("have.length", 7);
+    cy.findAllByRole("columnheader").should("have.length", allHeadersCount - 1);
     cy.findByRole("header", { name: "Status" }).should("not.exist");
   });
 });

--- a/src/app/base/components/MainContentSection/MainContentSection.test.tsx
+++ b/src/app/base/components/MainContentSection/MainContentSection.test.tsx
@@ -1,6 +1,6 @@
 import MainContentSection from "./MainContentSection";
 
-import { renderWithMockStore, screen, within } from "testing/utils";
+import { renderWithMockStore, screen } from "testing/utils";
 
 describe("MainContentSection", () => {
   it("renders sidebar", () => {
@@ -30,7 +30,7 @@ describe("MainContentSection", () => {
       </MainContentSection>
     );
     expect(
-      within(screen.getByRole("banner")).getByRole("heading", {
+      screen.getByRole("heading", {
         name: "Node title",
         level: 5,
       })

--- a/src/app/base/components/MainContentSection/MainContentSection.tsx
+++ b/src/app/base/components/MainContentSection/MainContentSection.tsx
@@ -25,11 +25,11 @@ const MainContentSection = ({
     <div className="section" {...props} id="main-content-section">
       <div>
         {header ? (
-          <header className="section__header-wrapper">
+          <div className="section__header-wrapper">
             <Row>
               <Col size={12}>{header}</Col>
             </Row>
-          </header>
+          </div>
         ) : null}
         <Strip
           element="section"


### PR DESCRIPTION
## Done

- test: fix failing cypress tests
  - replace header within main section with a div (this will need to be updated again once we complete maas new layout work and have the new navigation as this will affect semantic structure of the document)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4665

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
