### PR TITLE
feat(images): update machineCount field

### DIFF
--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -242,7 +242,7 @@ describe("ImagesTable", () => {
         arch: "amd64",
         name: "ubuntu/focal",
         lastDeployed: "Fri, 18 Nov. 2022 09:55:21",
-        numberOfNodes: 768,
+        machineCount: 768,
       }),
     ];
     const image = {
@@ -296,7 +296,7 @@ describe("ImagesTable", () => {
         arch: "amd64",
         name: "ubuntu/focal",
         lastDeployed: "",
-        numberOfNodes: 768,
+        machineCount: 768,
       }),
     ];
     const image = {
@@ -352,7 +352,7 @@ describe("ImagesTable", () => {
         name: "ubuntu/focal",
         title: "20.04 LTS",
         lastDeployed: "Thu, 17 Nov. 2022 09:55:21",
-        numberOfNodes: 768,
+        machineCount: 768,
       }),
       resourceFactory({
         name: "ubuntu/bionic",
@@ -410,7 +410,7 @@ describe("ImagesTable", () => {
         name: "ubuntu/focal",
         title: "20.04 LTS",
         lastDeployed: "Thu, 17 Nov. 2022 09:55:21",
-        numberOfNodes: 768,
+        machineCount: 768,
       }),
       resourceFactory({
         name: "ubuntu/bionic",

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -172,7 +172,7 @@ const generateResourceRow = ({
         className: "last-deployed-col",
       },
       {
-        content: `${resource.numberOfNodes || "—"}`,
+        content: `${resource.machineCount || "—"}`,
         className: "machines-col",
       },
       {
@@ -203,7 +203,7 @@ const generateResourceRow = ({
       size: sizeStringToNumber(resource.size),
       status: resource.status,
       lastDeployed: parseUtcDatetime(resource.lastDeployed),
-      machineCount: resource.numberOfNodes,
+      machineCount: resource.machineCount,
     },
   };
 };

--- a/src/app/store/bootresource/types/base.ts
+++ b/src/app/store/bootresource/types/base.ts
@@ -16,6 +16,7 @@ export type BootResource = Model & {
   icon: "in-progress" | "queued" | "succeeded" | "waiting";
   lastUpdate: string;
   lastDeployed: string;
+  machineCount: number;
   name: string;
   numberOfNodes: number;
   rtype: BootResourceType;

--- a/src/testing/factories/bootresource.ts
+++ b/src/testing/factories/bootresource.ts
@@ -32,6 +32,7 @@ export const bootResource = extend<Model, BootResource>(model, {
   status: "Waiting for rack controller(s) to sync",
   icon: "waiting",
   downloading: false,
+  machineCount: 0,
   numberOfNodes: 0,
   lastUpdate: "Tue, 08 Jun. 2021 02:12:47",
   lastDeployed: "Tue, 08 Jun. 2021 02:12:47",


### PR DESCRIPTION
## Done

- feat(images): update machineCount field
  - this aligns the UI with a back-end change: https://code.launchpad.net/~lloydwaltersj/maas/+git/maas/+merge/436064

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to images page
- Make sure the page renders and no errors are thrown

## Fixes

Fixes: MAASENG-1264

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
