### PR TITLE
feat: allow custom machine list page size

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -812,4 +812,40 @@ describe("MachineList", () => {
 
     expect(screen.queryByTestId("vault-notification")).not.toBeInTheDocument();
   });
+
+  it("uses the stored machineListPageSize", () => {
+    localStorage.setItem("machineListPageSize", "20");
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+    const store = mockStore(state);
+    renderWithBrowserRouter(
+      <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
+      { store }
+    );
+    const expected = machineActions.fetch("123456", {
+      page_size: 20,
+    });
+    const fetches = store
+      .getActions()
+      .filter((action) => action.type === expected.type);
+    expect(fetches).toHaveLength(1);
+    expect(fetches.at(-1).payload.params.page_size).toBe(20);
+  });
+
+  it("falls back to default for invalid stored machineListPageSize", () => {
+    localStorage.setItem("machineListPageSize", '"invalid_value"');
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+    const store = mockStore(state);
+    renderWithBrowserRouter(
+      <MachineList searchFilter="" setSearchFilter={jest.fn()} />,
+      { store }
+    );
+    const expected = machineActions.fetch("123456", {
+      page_size: DEFAULTS.pageSize,
+    });
+    const fetches = store
+      .getActions()
+      .filter((action) => action.type === expected.type);
+    expect(fetches).toHaveLength(1);
+    expect(fetches.at(-1).payload.params.page_size).toBe(DEFAULTS.pageSize);
+  });
 });

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -26,7 +26,7 @@ type Props = {
   setSearchFilter: SetSearchFilter;
 };
 
-const PAGE_SIZE = DEFAULTS.pageSize;
+const DEFAULT_PAGE_SIZE = DEFAULTS.pageSize;
 
 const MachineList = ({
   headerFormOpen,
@@ -80,6 +80,16 @@ const MachineList = ({
     "hiddenGroups",
     []
   );
+  const [storedPageSize] = useStorageState<number>(
+    localStorage,
+    "machineListPageSize",
+    DEFAULT_PAGE_SIZE
+  );
+  // fallback to default if the stored value is not valid
+  const pageSize =
+    storedPageSize && typeof storedPageSize === "number"
+      ? storedPageSize
+      : DEFAULT_PAGE_SIZE;
 
   const { callId, loading, machineCount, machines, machinesErrors } =
     useFetchMachines({
@@ -88,7 +98,7 @@ const MachineList = ({
       grouping,
       sortDirection,
       sortKey,
-      pagination: { currentPage, setCurrentPage, pageSize: PAGE_SIZE },
+      pagination: { currentPage, setCurrentPage, pageSize },
     });
 
   useEffect(
@@ -136,7 +146,7 @@ const MachineList = ({
         machineCount={machineCount}
         machines={machines}
         machinesLoading={loading}
-        pageSize={PAGE_SIZE}
+        pageSize={pageSize}
         setCurrentPage={setCurrentPage}
         setHiddenGroups={setHiddenGroups}
         setSortDirection={setSortDirection}


### PR DESCRIPTION
## Done

- feat: allow custom machine list page size

## Why is this needed
This is required for https://github.com/canonical/maas-ui/pull/4705

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps
Note: This is not exposed anywhere in the UI (at least not yet).

- Go to machine list
- Open developer tools
- paste `localStorage.setItem("machineListPageSize", 10)` to the console and execute
- refresh the page
- you should see the total of 10 machines on the machine list page

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

