### PR TITLE
refactor: use userEvent import from testing/utils

### DIFF
--- a/src/app/base/components/ActionForm/ActionForm.test.tsx
+++ b/src/app/base/components/ActionForm/ActionForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -9,7 +8,7 @@ import ActionForm, { Labels } from "./ActionForm";
 import { TestIds } from "app/base/components/FormikFormButtons";
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 let state: RootState;
 const mockStore = configureStore();

--- a/src/app/base/components/CertificateDetails/CertificateDetails.test.tsx
+++ b/src/app/base/components/CertificateDetails/CertificateDetails.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/CertificateDownload/CertificateDownload.test.tsx
+++ b/src/app/base/components/CertificateDownload/CertificateDownload.test.tsx
@@ -1,11 +1,10 @@
-import userEvent from "@testing-library/user-event";
 import * as fileDownload from "js-file-download";
 
 import CertificateDownload, { Labels, TestIds } from "./CertificateDownload";
 
 import type { GeneratedCertificate } from "app/store/general/types";
 import { generatedCertificate as certFactory } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 jest.mock("js-file-download", () => jest.fn());
 

--- a/src/app/base/components/ColumnToggle/ColumnToggle.test.tsx
+++ b/src/app/base/components/ColumnToggle/ColumnToggle.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import ColumnToggle from "./ColumnToggle";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const DOM_RECT = {
   height: 0,

--- a/src/app/base/components/CopyButton/CopyButton.test.tsx
+++ b/src/app/base/components/CopyButton/CopyButton.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import CopyButton from "./CopyButton";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 describe("CopyButton", () => {
   let execCommand: (

--- a/src/app/base/components/DHCPTable/DHCPTable.test.tsx
+++ b/src/app/base/components/DHCPTable/DHCPTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,7 +18,7 @@ import {
   rootState as rootStateFactory,
   subnet as subnetFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/DebounceSearchBox/DebounceSearchBox.test.tsx
+++ b/src/app/base/components/DebounceSearchBox/DebounceSearchBox.test.tsx
@@ -1,13 +1,11 @@
 import { useState } from "react";
 
-import userEvent from "@testing-library/user-event";
-
 import DebounceSearchBox, {
   DEFAULT_DEBOUNCE_INTERVAL,
   Labels,
 } from "./DebounceSearchBox";
 
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 describe("DebounceSearchBox", () => {
   beforeEach(() => {

--- a/src/app/base/components/DhcpForm/DhcpForm.test.tsx
+++ b/src/app/base/components/DhcpForm/DhcpForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   dhcpSnippetState as dhcpSnippetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -25,7 +24,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 const machines = [machineFactory()];

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelect.test.tsx
@@ -1,9 +1,8 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import MachineSelect, { Labels } from "./MachineSelect";
 
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 it("can open select box on click", async () => {
   renderWithMockStore(

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import MachineSelectBox from "./MachineSelectBox";
@@ -8,7 +7,7 @@ import { DEFAULT_DEBOUNCE_INTERVAL } from "app/base/components/DebounceSearchBox
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { screen, waitFor, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, waitFor, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/base/components/DynamicSelect/DynamicSelect.test.tsx
+++ b/src/app/base/components/DynamicSelect/DynamicSelect.test.tsx
@@ -1,10 +1,9 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import DynamicSelect from "./DynamicSelect";
 import type { Props as DynamicSelectProps } from "./DynamicSelect";
 
-import { fireEvent, render, screen, waitFor } from "testing/utils";
+import { userEvent, fireEvent, render, screen, waitFor } from "testing/utils";
 
 describe("DynamicSelect", () => {
   it("resets to the first option if the options change and the value no longer exists", async () => {

--- a/src/app/base/components/EditableSection/EditableSection.test.tsx
+++ b/src/app/base/components/EditableSection/EditableSection.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import EditableSection, { Labels } from "./EditableSection";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("can toggle showing content depending on editing state", async () => {
   render(

--- a/src/app/base/components/FilterAccordion/FilterAccordion.test.tsx
+++ b/src/app/base/components/FilterAccordion/FilterAccordion.test.tsx
@@ -1,12 +1,10 @@
-import userEvent from "@testing-library/user-event";
-
 import FilterAccordion, { Labels } from "./FilterAccordion";
 import type { Props as FilterAccordionProps } from "./FilterAccordion";
 
 import type { MachineDetails, MachineMeta } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { machineDetails as machineDetailsFactory } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 describe("FilterAccordion", () => {
   let items: MachineDetails[];

--- a/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
+++ b/src/app/base/components/FormikFormButtons/FormikFormButtons.test.tsx
@@ -1,9 +1,8 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import FormikFormButtons from "./FormikFormButtons";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("can display a cancel button", () => {
   render(

--- a/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Field, Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -17,7 +16,12 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  render,
+  screen,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 const mockUseNavigate = jest.fn();

--- a/src/app/base/components/Header/Header.test.tsx
+++ b/src/app/base/components/Header/Header.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { BrowserRouter, Router } from "react-router-dom";
@@ -22,6 +21,7 @@ import {
   userState as userStateFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   render,
   waitFor,

--- a/src/app/base/components/Login/Login.test.tsx
+++ b/src/app/base/components/Login/Login.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/MacAddressField/MacAddressField.test.tsx
+++ b/src/app/base/components/MacAddressField/MacAddressField.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -6,7 +5,7 @@ import configureStore from "redux-mock-store";
 import MacAddressField from "./MacAddressField";
 
 import { rootState as rootStateFactory } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
+++ b/src/app/base/components/MachineSelectTable/MachineSelectTable.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import MachineSelectTable, { Label } from "./MachineSelectTable";
 
 import type { Machine } from "app/store/machine/types";
@@ -11,7 +9,7 @@ import {
   tagState as tagStateFactory,
   machineState as machineStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, within, renderWithMockStore } from "testing/utils";
 
 describe("MachineSelectTable", () => {
   let machines: Machine[];

--- a/src/app/base/components/ModelListSubtitle/ModelListSubtitle.test.tsx
+++ b/src/app/base/components/ModelListSubtitle/ModelListSubtitle.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import ModelListSubtitle, { TestIds } from "./ModelListSubtitle";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 describe("ModelListSubtitle", () => {
   it("correctly displays when one model is available and none selected", () => {

--- a/src/app/base/components/NetworkActionRow/NetworkActionRow.test.tsx
+++ b/src/app/base/components/NetworkActionRow/NetworkActionRow.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import NetworkActionRow from "./NetworkActionRow";
@@ -11,7 +10,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.test.tsx
@@ -1,11 +1,9 @@
-import userEvent from "@testing-library/user-event";
-
 import NodeActionMenu, { Label } from "./NodeActionMenu";
 
 import { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 import { machine as machineFactory } from "testing/factories";
-import { render, screen, within } from "testing/utils";
+import { userEvent, render, screen, within } from "testing/utils";
 
 describe("NodeActionMenu", () => {
   const openMenu = async () =>

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
@@ -1,11 +1,9 @@
-import userEvent from "@testing-library/user-event";
-
 import NodeActionMenuGroup, { Labels } from "./NodeActionMenuGroup";
 
 import { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
 import { machine as machineFactory } from "testing/factories";
-import { render, screen, within } from "testing/utils";
+import { userEvent, render, screen, within } from "testing/utils";
 
 describe("NodeActionMenuGroup", () => {
   const openMenu = async (name: string) => {

--- a/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
+++ b/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -20,7 +19,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/base/components/OutsideClickHandler/OutsideClickHandler.test.tsx
+++ b/src/app/base/components/OutsideClickHandler/OutsideClickHandler.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import OutsideClickHandler from "./OutsideClickHandler";
 
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 it("calls the onClick handler when clicking outside of the component", async () => {
   const onClick = jest.fn();

--- a/src/app/base/components/SideNav/SideNav.test.tsx
+++ b/src/app/base/components/SideNav/SideNav.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import type { RouteProps } from "react-router-dom";
 import { MemoryRouter, Route } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -6,7 +5,7 @@ import { CompatRouter } from "react-router-dom-v5-compat";
 import type { NavItem } from "./SideNav";
 import { SideNav } from "./SideNav";
 
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 let items: NavItem[];
 

--- a/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
+++ b/src/app/base/components/SpaceSelect/SpaceSelect.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -11,7 +10,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/TableMenu/TableMenu.test.tsx
+++ b/src/app/base/components/TableMenu/TableMenu.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import TableMenu from "./TableMenu";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 describe("TableMenu ", () => {
   it("expands the menu on click", async () => {

--- a/src/app/base/components/TooltipButton/TooltipButton.test.tsx
+++ b/src/app/base/components/TooltipButton/TooltipButton.test.tsx
@@ -1,9 +1,7 @@
-import userEvent from "@testing-library/user-event";
-
 import TooltipButton from "./TooltipButton";
 
 import { breakLines, unindentString } from "app/utils";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("renders with default options correctly", async () => {
   render(<TooltipButton data-testid="tooltip-portal" message="Tooltip" />);

--- a/src/app/base/components/node/NodeLogs/DownloadMenu/DownloadMenu.test.tsx
+++ b/src/app/base/components/node/NodeLogs/DownloadMenu/DownloadMenu.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import * as fileDownload from "js-file-download";
 
 import DownloadMenu, { Label } from "./DownloadMenu";
@@ -25,7 +24,7 @@ import {
   scriptResultState as scriptResultStateFactory,
   nodeScriptResultState as nodeScriptResultStateFactory,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 jest.mock("js-file-download", () => jest.fn());
 

--- a/src/app/base/components/node/NodeLogs/EventLogs/EventLogs.test.tsx
+++ b/src/app/base/components/node/NodeLogs/EventLogs/EventLogs.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -16,7 +15,13 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, within, renderWithMockStore } from "testing/utils";
+import {
+  userEvent,
+  render,
+  screen,
+  within,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -16,7 +15,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
+++ b/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,7 +14,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -20,7 +19,7 @@ import {
   nodePartition as partitionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -16,7 +15,7 @@ import {
   nodeDisk as diskFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -16,7 +15,7 @@ import {
   nodeFilesystem as fsFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,7 +14,7 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,7 +18,7 @@ import {
   nodePartition as partitionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import NetworkTable, { Label } from "./NetworkTable";
 
 import { ExpandedState } from "app/base/components/NodeNetworkTab/NodeNetworkTab";
@@ -23,7 +21,12 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 describe("NetworkTable", () => {
   let state: RootState;

--- a/src/app/base/hooks/node.test.tsx
+++ b/src/app/base/hooks/node.test.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 
 import { renderHook } from "@testing-library/react-hooks";
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import type { MockStoreEnhanced } from "redux-mock-store";
 import configureStore from "redux-mock-store";
@@ -31,7 +30,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/AddController/AddController.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import AddController from "./AddController";
 
 import { ConfigNames } from "app/store/config/types";
@@ -11,6 +9,7 @@ import {
   versionState as versionStateFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   waitFor,
   within,

--- a/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.test.tsx
+++ b/src/app/controllers/components/ControllerHeaderForms/ControllerActionFormWrapper/ControllerActionFormWrapper.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import ControllerActionFormWrapper from "./ControllerActionFormWrapper";
@@ -10,7 +9,7 @@ import {
   controller as controllerFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -30,7 +29,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -15,7 +14,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,7 +14,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerName/ControllerName.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerName/ControllerName.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -17,7 +16,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerList/ControllerList.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerList.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { useLocation } from "react-router";
 import { MemoryRouter, Route } from "react-router-dom";
@@ -9,7 +8,7 @@ import ControllerList from "./ControllerList";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { screen, render, waitFor } from "testing/utils";
+import { userEvent, screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListHeader/ControllerListHeader.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import ControllerListHeader from "./ControllerListHeader";
 
 import { ControllerHeaderViews } from "app/controllers/constants";
@@ -9,7 +7,7 @@ import {
   controllerState as controllerStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("ControllerListHeader", () => {
   let state: RootState;

--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import ControllerListTable from "./ControllerListTable";
 
 import urls from "app/base/urls";
@@ -14,7 +12,12 @@ import {
   rootState as rootStateFactory,
   vaultEnabledState as vaultEnabledStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 describe("ControllerListTable", () => {
   let controller: Controller;

--- a/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
+++ b/src/app/dashboard/views/DashboardConfigurationForm/DashboardConfigurationSubnetForm/DashboardConfigurationSubnetForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import DashboardConfigurationSubnetForm, {
@@ -16,7 +15,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/ClearAllForm/ClearAllForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import ClearAllForm, { Labels as ClearAllFormLabels } from "./ClearAllForm";
@@ -12,7 +11,12 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { screen, waitFor, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  waitFor,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import DashboardHeader, {
   Labels as DashboardHeaderLabels,
 } from "./DashboardHeader";
@@ -11,7 +9,7 @@ import {
   discoveryState as discoveryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("DashboardHeader", () => {
   let state: RootState;

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import DiscoveriesList, {
@@ -30,6 +29,7 @@ import {
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   waitFor,
   within,

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import DiscoveryAddForm, {
@@ -36,6 +35,7 @@ import {
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
 import {
+  userEvent,
   screen,
   waitFor,
   within,

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import { DeviceType } from "../types";
@@ -17,7 +16,12 @@ import {
   discoveryState as discoveryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 describe("DiscoveryAddFormFields", () => {
   let state: RootState;

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import AddDeviceForm from "./AddDeviceForm";
@@ -19,7 +18,12 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import configureStore from "redux-mock-store";
 
@@ -12,7 +11,12 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter, within } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  renderWithBrowserRouter,
+  within,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/DeviceActionFormWrapper/DeviceActionFormWrapper.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import DeviceActionFormWrapper from "./DeviceActionFormWrapper";
@@ -10,7 +9,7 @@ import {
   device as deviceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -22,7 +21,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceName/DeviceName.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import DeviceName from "./DeviceName";
@@ -14,7 +13,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/AddInterface/AddInterface.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import AddInterface from "./AddInterface";
@@ -19,7 +18,7 @@ import {
   subnetState as subnetStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 const createNewInterface = async () => {

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/RemoveInterface.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/RemoveInterface/RemoveInterface.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import RemoveInterface from "./RemoveInterface";
@@ -15,7 +14,7 @@ import {
   deviceStatuses as deviceStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterface.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/EditInterface/EditInterface.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import EditInterface from "./EditInterface";
@@ -21,7 +20,7 @@ import {
   subnetState as subnetStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/InterfaceForm/InterfaceFormFields/InterfaceFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import configureStore from "redux-mock-store";
 
@@ -13,7 +12,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -13,7 +12,12 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -13,7 +12,12 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,12 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,7 +14,12 @@ import {
   domainResource as resourceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,7 +17,12 @@ import {
   domainResource as resourceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import { Labels as DomainListHeaderFormLabels } from "../DomainListHeaderForm/DomainListHeaderForm";
 
 import DomainListHeader, {
@@ -12,7 +10,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("DomainListHeader", () => {
   let initialState: RootState;

--- a/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -10,7 +9,12 @@ import DomainListHeaderForm, {
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,13 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.test.tsx
+++ b/src/app/images/components/ImagesTable/DeleteImageConfirm/DeleteImageConfirm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -13,7 +12,12 @@ import {
   bootResourceState as bootResourceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import MockDate from "mockdate";
 
 import ImagesTable, { Labels as ImagesTableLabels } from "./ImagesTable";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, within, renderWithMockStore } from "testing/utils";
 
 beforeEach(() => {
   MockDate.set("Fri, 18 Nov. 2022 10:55:00");

--- a/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.test.tsx
+++ b/src/app/images/components/UbuntuImageSelect/ReleaseSelect/ReleaseSelect.test.tsx
@@ -1,9 +1,7 @@
-import userEvent from "@testing-library/user-event";
-
 import ReleaseSelect from "./ReleaseSelect";
 
 import { bootResourceUbuntuRelease as bootResourceUbuntuReleaseFactory } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 describe("ReleaseSelect", () => {
   it("separates ubuntu releases by LTS and non-LTS, sorted descending by title", () => {

--- a/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
+++ b/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -17,7 +16,12 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
@@ -1,5 +1,4 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,7 +17,7 @@ import {
   bootResourceStatuses as bootResourceStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, waitFor } from "testing/utils";
+import { userEvent, screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import FetchImagesFormFields, {
@@ -6,7 +5,7 @@ import FetchImagesFormFields, {
 } from "./FetchImagesFormFields";
 
 import { BootResourceSourceType } from "app/store/bootresource/types";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 describe("FetchImagesFormFields", () => {
   it("does not show extra fields if maas.io source is selected", async () => {

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
@@ -1,5 +1,4 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -21,7 +20,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, waitFor } from "testing/utils";
+import { userEvent, screen, render, waitFor } from "testing/utils";
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
   ...jest.requireActual("@canonical/react-components/dist/hooks"),

--- a/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,12 @@ import {
   bootResourceState as bootResourceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/SyncedImages.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import SyncedImages, { Labels as SyncedImagesLabels } from "./SyncedImages";
 
 import { BootResourceSourceType } from "app/store/bootresource/types";
@@ -10,7 +8,12 @@ import {
   bootResourceUbuntu as ubuntuFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 describe("SyncedImages", () => {
   it("can render the form in a card", async () => {

--- a/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,12 @@ import {
   bootResourceState as bootResourceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,7 +17,13 @@ import {
   bootResourceUbuntuSource as sourceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.test.tsx
+++ b/src/app/intro/views/MaasIntro/ConnectivityCard/ConnectivityCard.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import { MaasIntroSchema } from "../MaasIntro";
@@ -7,7 +6,7 @@ import ConnectivityCard, {
   Labels as ConnectivityCardLabels,
 } from "./ConnectivityCard";
 
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const renderTestCase = () =>
   render(

--- a/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
@@ -22,6 +21,7 @@ import {
   userState as userStateFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   renderWithBrowserRouter,
   renderWithMockStore,

--- a/src/app/intro/views/MaasIntro/NameCard/NameCard.test.tsx
+++ b/src/app/intro/views/MaasIntro/NameCard/NameCard.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import { MaasIntroSchema } from "../MaasIntro";
@@ -15,7 +14,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 describe("NameCard", () => {
   let state: RootState;

--- a/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
+++ b/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
@@ -20,6 +19,7 @@ import {
   userState as userStateFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   renderWithBrowserRouter,
   renderWithMockStore,

--- a/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
@@ -19,6 +18,7 @@ import {
   userState as userStateFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   within,
   renderWithBrowserRouter,

--- a/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
+++ b/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,7 +18,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { fireEvent, render, screen, waitFor } from "testing/utils";
+import { userEvent, fireEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/DeleteForm/DeleteForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -24,6 +23,7 @@ import {
   vmClusterStatuses as vmClusterStatusesFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   renderWithBrowserRouter,
   waitForComponentToPaint,

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -9,7 +8,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, within } from "testing/utils";
+import { userEvent, render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/kvm/components/VmResources/VmResources.test.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import VmResources, { Label } from "./VmResources";
@@ -18,6 +17,7 @@ import {
   podState as podStateFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   renderWithBrowserRouter,
   renderWithMockStore,

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,7 +17,7 @@ import {
   zone as zoneFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -20,7 +19,7 @@ import {
   zone as zoneFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -26,7 +25,7 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 
 import { Labels as SourceMachineDetailsLabel } from "./SourceMachineDetails/SourceMachineDetails";
 import SourceMachineSelect, { Label } from "./SourceMachineSelect";
@@ -16,7 +15,7 @@ import {
   machineStateList,
   machineStateListGroup,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 describe("SourceMachineSelect", () => {
   let machines: Machine[];

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,7 +18,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import OverrideTestForm from "./OverrideTestForm";
@@ -27,7 +26,7 @@ import {
   machineStateDetailsItem as machineStateDetailsItemFactory,
   scriptResultState as scriptResultStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -20,7 +19,7 @@ import {
 } from "testing/factories";
 import { tagStateListFactory } from "testing/factories/state";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -18,7 +17,7 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import { tagStateListFactory } from "testing/factories/state";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -22,7 +21,7 @@ import {
 } from "testing/factories";
 import { tagStateListFactory } from "testing/factories/state";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/machines/components/TableCheckbox/TableCheckbox.test.tsx
+++ b/src/app/machines/components/TableCheckbox/TableCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import TableCheckbox, { Checked } from "./TableCheckbox";
@@ -10,7 +9,7 @@ import {
   machineStateList as machineStateListFactory,
   machineState as machineStateFactory,
 } from "testing/factories";
-import { screen, waitFor, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, waitFor, renderWithMockStore } from "testing/utils";
 
 let state: RootState;
 const callId = "123456";

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,7 +17,7 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -22,7 +21,7 @@ import {
   powerTypesState as powerTypesStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -20,7 +19,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddAliasOrVlan/AddAliasOrVlan.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import AddAliasOrVlan, {
@@ -30,7 +29,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = urls.machines.index;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBondForm/AddBondForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import AddBondForm from "./AddBondForm";
@@ -21,7 +20,12 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = urls.machines.index;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import AddBridgeForm from "./AddBridgeForm";
@@ -19,7 +18,12 @@ import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = urls.machines.index;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import AddInterface from "./AddInterface";
@@ -19,7 +18,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 const route = urls.machines.index;

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 
 import { LinkMonitoring } from "../types";
@@ -22,7 +21,7 @@ import {
   bondOptionsState as bondOptionsStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const route = urls.machines.index;
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BridgeFormFields/BridgeFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import configureStore from "redux-mock-store";
 
@@ -6,7 +5,7 @@ import BridgeFormFields from "./BridgeFormFields";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditAliasOrVlanForm/EditAliasOrVlanForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import EditAliasOrVlanForm from "./EditAliasOrVlanForm";
@@ -21,7 +20,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -29,7 +28,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/NumaCardDetails/NumaCardDetails.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import NumaCardDetails, {
   Labels as NumaCardDetailsLabels,
 } from "./NumaCardDetails";
@@ -12,7 +10,7 @@ import {
   machineState as machineStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("NumaCardDetails", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineList/ErrorsNotification/ErrorsNotification.test.tsx
+++ b/src/app/machines/views/MachineList/ErrorsNotification/ErrorsNotification.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import ErrorsNotification from "./ErrorsNotification";
 
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 it("can display and close an error message", async () => {
   render(<ErrorsNotification errors={{ title: "error message" }} />);

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
 import { act } from "react-dom/test-utils";
 import { Provider } from "react-redux";
@@ -37,7 +36,12 @@ import {
   controllerState as controllerStateFactory,
   controller as controllerFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import GroupSelect from "./GroupSelect";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("executes setGrouping and setHiddenGroups functions on change", async () => {
   const setGrouping = jest.fn();

--- a/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect/HiddenColumnsSelect.test.tsx
@@ -1,9 +1,7 @@
-import userEvent from "@testing-library/user-event";
-
 import HiddenColumnsSelect from "./HiddenColumnsSelect";
 
 import { columnToggles } from "app/machines/constants";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 it("calls setHiddenColumns correctly on click of a checkbox", async () => {
   const hiddenColumns: Array<""> = [];

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import MachinesFilterAccordion, { Label } from "./MachinesFilterAccordion";
 
 import { FilterGroupKey } from "app/store/machine/types";
@@ -9,7 +7,7 @@ import {
   rootState as rootStateFactory,
   machineFilterGroup as machineFilterGroupFactory,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 describe("MachinesFilterAccordion", () => {
   let state: RootState;

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import MachinesFilterOptions, { Label } from "./MachinesFilterOptions";
@@ -12,7 +11,7 @@ import {
   rootState as rootStateFactory,
   machineFilterGroup as machineFilterGroupFactory,
 } from "testing/factories";
-import { screen, waitFor, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, waitFor, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListTable/AllCheckbox/AllCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/AllCheckbox/AllCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import AllCheckbox, { Label } from "./AllCheckbox";
@@ -10,7 +9,7 @@ import {
   machineStateList as machineStateListFactory,
   machineState as machineStateFactory,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import GroupCheckbox from "./GroupCheckbox";
@@ -12,7 +11,7 @@ import {
   machineState as machineStateFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListTable/MachineCheckbox/MachineCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineCheckbox/MachineCheckbox.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import MachineCheckbox from "./MachineCheckbox";
@@ -11,7 +10,7 @@ import {
   machineState as machineStateFactory,
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
-import { screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -38,6 +37,7 @@ import {
   machineStateListGroup as machineStateListGroupFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   within,
   renderWithBrowserRouter,

--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,12 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/pools/views/PoolList/PoolList.test.tsx
+++ b/src/app/pools/views/PoolList/PoolList.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,13 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, within, renderWithMockStore } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  within,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   tokenState as tokenStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/preferences/views/Details/Details.test.tsx
+++ b/src/app/preferences/views/Details/Details.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,7 +14,7 @@ import {
   userState as userStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
+++ b/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
@@ -13,7 +12,7 @@ import {
   sslKeyState as sslKeyStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.tsx
+++ b/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,13 @@ import {
   sslKeyState as sslKeyStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, within, renderWithMockStore } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  within,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
+++ b/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,7 +14,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, within, waitFor } from "testing/utils";
+import { userEvent, render, screen, within, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -13,7 +12,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -19,7 +18,13 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, within, renderWithMockStore } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  within,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
@@ -22,7 +21,7 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, waitFor } from "testing/utils";
+import { userEvent, screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
+++ b/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryFormFields/NetworkDiscoveryFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -11,7 +10,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
+++ b/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
+++ b/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,13 @@ import {
   packageRepositoryState as packageRepositoryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, within, renderWithMockStore } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  within,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
@@ -20,7 +19,7 @@ import {
   generalState as generalStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,13 @@ import {
   scriptState as scriptStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, within, renderWithMockStore } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  within,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import type { FileWithPath } from "react-dropzone";
 import { Provider } from "react-redux";
@@ -18,6 +17,7 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   render,
   waitFor,

--- a/src/app/settings/views/Security/IpmiSettings/IpmiSettings.test.tsx
+++ b/src/app/settings/views/Security/IpmiSettings/IpmiSettings.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import { Labels as FormFieldsLabels } from "./IpmiFormFields/IpmiFormFields";
@@ -10,7 +9,7 @@ import {
   rootState as rootStateFactory,
   configState as configStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/settings/views/Security/SecurityProtocols/TLSEnabled/TLSEnabled.test.tsx
+++ b/src/app/settings/views/Security/SecurityProtocols/TLSEnabled/TLSEnabled.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   tlsCertificate as tlsCertificateFactory,
   tlsCertificateState as tlsCertificateStateFactory,
 } from "testing/factories";
-import { fireEvent, render, screen, waitFor } from "testing/utils";
+import { userEvent, fireEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Security/SessionTimeout/SessionTimeout.test.tsx
+++ b/src/app/settings/views/Security/SessionTimeout/SessionTimeout.test.tsx
@@ -1,5 +1,4 @@
 import { screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import configureStore from "redux-mock-store";
 
 import SessionTimeout, {
@@ -9,7 +8,11 @@ import SessionTimeout, {
 import { actions as configActions } from "app/store/config";
 import type { RootState } from "app/store/root/types";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { renderWithBrowserRouter, getTestState } from "testing/utils";
+import {
+  userEvent,
+  renderWithBrowserRouter,
+  getTestState,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 

--- a/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, waitFor } from "testing/utils";
+import { userEvent, screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   configState as configStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, waitFor } from "testing/utils";
+import { userEvent, screen, render, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
@@ -16,7 +15,7 @@ import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, render, renderWithMockStore } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/settings/views/Users/UsersList/UsersList.test.tsx
+++ b/src/app/settings/views/Users/UsersList/UsersList.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,7 +14,13 @@ import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "testing/factories";
-import { screen, render, within, renderWithMockStore } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  render,
+  within,
+  renderWithMockStore,
+} from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,7 +14,7 @@ import {
   ipRange as ipRangeFactory,
   ipRangeState as ipRangeStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -23,7 +22,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let ipRange: IPRange;

--- a/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
+++ b/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, within, waitFor } from "testing/utils";
+import { userEvent, render, screen, within, waitFor } from "testing/utils";
 
 const getRootState = () =>
   rootStateFactory({

--- a/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   controllerState as controllerStateFactory,
   modelRef as modelRefFactory,
 } from "testing/factories";
-import { render, screen, within, waitFor } from "testing/utils";
+import { userEvent, render, screen, within, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -8,7 +7,7 @@ import AddFabric from "./AddFabric";
 
 import { actions as fabricActions } from "app/store/fabric";
 import { rootState as rootStateFactory } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const renderTestCase = () => {
   const store = configureStore()(rootStateFactory());

--- a/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -8,7 +7,7 @@ import AddSpace from "./AddSpace";
 
 import { actions as spaceActions } from "app/store/space";
 import { rootState as rootStateFactory } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 test("correctly dispatches space cleanup and create actions on form submit", async () => {
   const store = configureStore()(rootStateFactory());

--- a/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,7 @@ import {
   fabricState as fabricSpaceFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 it("correctly dispatches subnet cleanup and create actions on form submit", async () => {
   const vlan1 = vlanFactory({ id: 111, fabric: 5 });

--- a/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,7 @@ import {
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 it("displays validation messages for VID", async () => {
   const store = configureStore()(rootStateFactory());

--- a/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { Router, Route } from "react-router";
@@ -14,7 +13,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const renderTestCase = (
   space = spaceFactory({

--- a/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -11,7 +10,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, within, waitFor } from "testing/utils";
+import { userEvent, render, screen, within, waitFor } from "testing/utils";
 
 const getRootState = () =>
   rootStateFactory({

--- a/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, within, waitFor } from "testing/utils";
+import { userEvent, render, screen, within, waitFor } from "testing/utils";
 
 const getRootState = () =>
   rootStateFactory({

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,7 +17,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   staticRoute as staticRouteFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 it("displays loading text on load", async () => {
   const mockStore = configureStore();

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,7 +17,7 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   subnetState as subnetStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -12,7 +11,7 @@ import {
   subnet as subnetFactory,
   subnetState as subnetStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import { subnetActionLabels } from "../constants";
 
 import SubnetDetailsHeader from "./SubnetDetailsHeader";
@@ -8,7 +6,7 @@ import {
   subnet as subnetFactory,
   subnetDetails as subnetDetailsFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("shows the subnet name as the section title", () => {
   const subnet = subnetFactory({ id: 1, name: "subnet-1" });

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 it("can dispatch an action to update the subnet", async () => {
   const fabrics = [

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryFormFields/SubnetSummaryFormFields.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
@@ -12,7 +11,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 it("updates to use the fabric's default VLAN on fabric change", async () => {
   const fabrics = [

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ActiveDiscoveryLabel/ActiveDiscoveryLabel.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import ActiveDiscoveryLabel from "./ActiveDiscoveryLabel";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("displays a tooltip", async () => {
   render(<ActiveDiscoveryLabel />);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/AllowDNSResolutionLabel/AllowDNSResolutionLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/AllowDNSResolutionLabel/AllowDNSResolutionLabel.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import AllowDNSResolutionLabel from "./AllowDNSResolutionLabel";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("shows a tooltip when DNS is allowed", async () => {
   render(<AllowDNSResolutionLabel allowDNS />);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ManagedAllocationLabel/ManagedAllocationLabel.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import ManagedAllocationLabel from "./ManagedAllocationLabel";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("shows a tooltip", async () => {
   render(<ManagedAllocationLabel />);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ProxyAccessLabel/ProxyAccessLabel.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/ProxyAccessLabel/ProxyAccessLabel.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import ProxyAccessLabel from "./ProxyAccessLabel";
 
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 it("shows a tooltip when proxy access is allowed", async () => {
   render(<ProxyAccessLabel allowProxy />);

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/components/SubnetSpace/SubnetSpace.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/components/SubnetSpace/SubnetSpace.test.tsx
@@ -1,11 +1,10 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import SubnetSpace from "./SubnetSpace";
 
 import { rootState as rootStateFactory } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.test.tsx
@@ -1,8 +1,6 @@
-import userEvent from "@testing-library/user-event";
-
 import SubnetsControls from "./SubnetsControls";
 
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 it("renders select element correctly", () => {
   render(

--- a/src/app/subnets/views/SubnetsList/SubnetsList.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsList.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import SubnetsList from "./SubnetsList";
 
 import urls from "app/subnets/urls";
@@ -11,6 +9,7 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import {
+  userEvent,
   screen,
   within,
   waitFor,

--- a/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, within, waitFor } from "testing/utils";
+import { userEvent, render, screen, within, waitFor } from "testing/utils";
 
 const getMockState = ({ numberOfFabrics } = { numberOfFabrics: 50 }) => {
   const fabrics = [

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -20,7 +19,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -22,7 +21,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 let initialValues: ConfigureDHCPValues;

--- a/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
+++ b/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -18,7 +17,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor, within } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDeleteForm/VLANDeleteForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -14,7 +13,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -27,7 +26,7 @@ import {
   vlan as vlanFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { render, screen, within } from "testing/utils";
+import { userEvent, render, screen, within } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -16,7 +15,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
+++ b/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -13,7 +12,7 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/components/KernelOptionsField/KernelOptionsField.test.tsx
+++ b/src/app/tags/components/KernelOptionsField/KernelOptionsField.test.tsx
@@ -1,5 +1,4 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -20,7 +19,7 @@ import {
   rootState as rootStateFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
@@ -20,7 +19,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -1,6 +1,5 @@
 import { NotificationSeverity } from "@canonical/react-components";
 import reduxToolkit from "@reduxjs/toolkit";
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
@@ -22,7 +21,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/tags/views/TagDetails/TagDetails.test.tsx
+++ b/src/app/tags/views/TagDetails/TagDetails.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
@@ -18,7 +17,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
@@ -16,7 +15,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { render, screen, within } from "testing/utils";
+import { userEvent, render, screen, within } from "testing/utils";
 
 jest.mock("../constants", () => ({
   __esModule: true,

--- a/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
@@ -19,7 +18,7 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;

--- a/src/app/tags/views/Tags.test.tsx
+++ b/src/app/tags/views/Tags.test.tsx
@@ -1,5 +1,3 @@
-import userEvent from "@testing-library/user-event";
-
 import { Label as TagsHeaderLabel } from "../components/TagsHeader/TagsHeader";
 
 import { Label as TagDetailsLabel } from "./TagDetails/TagDetails";
@@ -15,7 +13,12 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { screen, within, renderWithBrowserRouter } from "testing/utils";
+import {
+  userEvent,
+  screen,
+  within,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 describe("Tags", () => {
   let scrollToSpy: jest.Mock;

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -13,7 +12,7 @@ import {
   zoneState as zoneStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/DeleteConfirm/DeleteConfirm.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/DeleteConfirm/DeleteConfirm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -10,7 +9,7 @@ import {
   zoneState as zoneStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render } from "testing/utils";
+import { userEvent, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -9,7 +8,7 @@ import ZonesListForm from "./ZonesListForm";
 import type { RootState } from "app/store/root/types";
 import { actions as zoneActions } from "app/store/zone";
 import { rootState as rootStateFactory } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -8,7 +7,7 @@ import ZonesListHeader from "./ZonesListHeader";
 
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { userEvent, render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 


### PR DESCRIPTION
## Done

- update to use `userEvent` import from `testing/utils`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
