### PR TITLE
feat: Allow minutes as a time unit for session timeout

### DIFF
--- a/src/app/settings/views/Security/SessionTimeout/SessionTimeout.tsx
+++ b/src/app/settings/views/Security/SessionTimeout/SessionTimeout.tsx
@@ -25,8 +25,8 @@ const SessionTimeoutSchema = Yup.object().shape({
   session_length: Yup.string()
     .required("Timeout length is required")
     .matches(
-      /^((\d)+ ?(hour|day|week)(s)? ?(and)? ?)+$/,
-      "Unit must be `string` type with a value of weeks, days, and/or hours."
+      /^((\d)+ ?(hour|day|week|minute)(s)? ?(and)? ?)+$/,
+      "Unit must be `string` type with a value of weeks, days, hours, and/or minutes."
     )
     .test(
       "session-length-boundary-check",
@@ -97,7 +97,7 @@ const SessionTimeout = (): JSX.Element => {
         validationSchema={SessionTimeoutSchema}
       >
         <FormikField
-          help="Maximum session length is 14 days / 2 weeks. Format options are weeks, days, hours."
+          help="Maximum session length is 14 days / 2 weeks. Format options are weeks, days, hours, and/or minutes."
           label={Labels.Expiration}
           name="session_length"
           required={true}


### PR DESCRIPTION
## Done

- Allowed minutes as a time unit option for session timeout

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to `/settings/security/session-timeout`
- Enter a timeout length in minutes, e.g `12 minutes`
- Click "Save"
- Ensure the form saves without errors
- Refresh the page
- Ensure the value persists
- Enter a timeout length using a combination of units including minutes (e.g. `1 hour 9 minutes`)
- Click "Save"
- Ensure the form saves without errors
- Refresh the page
- Ensure the value persists

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/214555288-bf4941ec-59b0-4c82-b990-f7340ac84497.png)

### After
![image](https://user-images.githubusercontent.com/35104482/214555322-b63ff3ee-04a0-40bf-97f8-e9ac3353a59f.png)

