### PR TITLE
fix: machine list grouping #4709

### DIFF
--- a/src/app/kvm/components/VmResources/VmResources.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.tsx
@@ -42,6 +42,7 @@ const VmResources = ({ filters, podId }: Props): JSX.Element => {
     loading,
     machineCount,
     machines: vms,
+    groups,
   } = useFetchMachines({
     filters: {
       ...filters,
@@ -71,6 +72,7 @@ const VmResources = ({ filters, podId }: Props): JSX.Element => {
           <MachineListTable
             callId={callId}
             currentPage={currentPage}
+            groups={groups}
             hiddenColumns={[
               "owner",
               "pool",

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -18,7 +18,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
-import { useFetchMachines } from "app/store/machine/utils/hooks";
+import { useFetchMachinesWithGroupingUpdates } from "app/store/machine/utils/hooks";
 
 type Props = {
   headerFormOpen?: boolean;
@@ -91,8 +91,8 @@ const MachineList = ({
       ? storedPageSize
       : DEFAULT_PAGE_SIZE;
 
-  const { callId, loading, machineCount, machines, machinesErrors } =
-    useFetchMachines({
+  const { callId, loading, machineCount, machines, machinesErrors, groups } =
+    useFetchMachinesWithGroupingUpdates({
       collapsedGroups: hiddenGroups,
       filters: FilterMachines.parseFetchFilters(searchFilter),
       grouping,
@@ -141,6 +141,7 @@ const MachineList = ({
         currentPage={currentPage}
         filter={searchFilter}
         grouping={grouping}
+        groups={groups}
         hiddenColumns={hiddenColumns}
         hiddenGroups={hiddenGroups}
         machineCount={machineCount}

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -17,19 +17,17 @@ const mockStore = configureStore<RootState, {}>();
 
 let state: RootState;
 const callId = "123456";
-
+const group = machineStateListGroupFactory({
+  count: 2,
+  name: "admin2",
+  value: "admin-2",
+});
 beforeEach(() => {
   state = rootStateFactory({
     machine: machineStateFactory({
       lists: {
         [callId]: machineStateListFactory({
-          groups: [
-            machineStateListGroupFactory({
-              count: 2,
-              name: "admin2",
-              value: "admin-2",
-            }),
-          ],
+          groups: [group],
         }),
       },
     }),
@@ -45,6 +43,7 @@ it("is disabled if all machines are selected", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -56,16 +55,16 @@ it("is disabled if all machines are selected", () => {
 });
 
 it("is disabled if there are no machines in the group", () => {
-  state.machine.lists[callId].groups = [
-    machineStateListGroupFactory({
-      count: 0,
-      name: "admin2",
-      value: "admin-2",
-    }),
-  ];
+  const group = machineStateListGroupFactory({
+    count: 0,
+    name: "admin2",
+    value: "admin-2",
+  });
+  state.machine.lists[callId].groups = [group];
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -87,6 +86,7 @@ it("is not disabled if there are machines in the group", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -102,6 +102,7 @@ it("is unchecked if there are no filters, groups or items selected", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -121,6 +122,7 @@ it("is checked if all machines are selected", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -138,6 +140,7 @@ it("is checked if the group is selected", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -149,20 +152,20 @@ it("is checked if the group is selected", () => {
 });
 
 it("is partially checked if a machine in the group is selected", () => {
-  state.machine.lists[callId].groups = [
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123", "def456"],
-      name: "admin2",
-      value: "admin-2",
-    }),
-  ];
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123", "def456"],
+    name: "admin2",
+    value: "admin-2",
+  });
+  state.machine.lists[callId].groups = [group];
   state.machine.selectedMachines = {
     items: ["abc123"],
   };
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -174,18 +177,19 @@ it("is partially checked if a machine in the group is selected", () => {
 });
 
 it("is not checked if a selected machine is in another group", () => {
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123"],
+    name: "admin2",
+    value: "admin-2",
+  });
   state.machine.lists[callId].groups = [
     machineStateListGroupFactory({
       count: 2,
       items: ["def456"],
       name: "admin1",
     }),
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123"],
-      name: "admin2",
-      value: "admin-2",
-    }),
+    group,
   ];
   state.machine.selectedMachines = {
     items: ["def456"],
@@ -193,6 +197,7 @@ it("is not checked if a selected machine is in another group", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -208,6 +213,7 @@ it("can dispatch an action to select the group", async () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -226,14 +232,13 @@ it("can dispatch an action to select the group", async () => {
 });
 
 it("removes selected machines that are in the group that was clicked", async () => {
-  state.machine.lists[callId].groups = [
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123"],
-      name: "admin2",
-      value: "admin-2",
-    }),
-  ];
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123"],
+    name: "admin2",
+    value: "admin-2",
+  });
+  state.machine.lists[callId].groups = [group];
   state.machine.selectedMachines = {
     items: ["abc123", "def456"],
   };
@@ -241,6 +246,7 @@ it("removes selected machines that are in the group that was clicked", async () 
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -259,18 +265,19 @@ it("removes selected machines that are in the group that was clicked", async () 
 });
 
 it("does not overwrite selected machines in different groups", async () => {
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123"],
+    name: "admin2",
+    value: "admin-2",
+  });
   state.machine.lists[callId].groups = [
     machineStateListGroupFactory({
       count: 2,
       items: ["def456"],
       name: "admin1",
     }),
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123"],
-      name: "admin2",
-      value: "admin-2",
-    }),
+    group,
   ];
   state.machine.selectedMachines = {
     items: ["def456"],
@@ -279,6 +286,7 @@ it("does not overwrite selected machines in different groups", async () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -298,6 +306,12 @@ it("does not overwrite selected machines in different groups", async () => {
 });
 
 it("can dispatch an action to unselect the group", async () => {
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123"],
+    name: "admin2",
+    value: "admin-2",
+  });
   state.machine.lists[callId].groups = [
     machineStateListGroupFactory({
       count: 2,
@@ -305,12 +319,7 @@ it("can dispatch an action to unselect the group", async () => {
       name: "admin1",
       value: "admin-1",
     }),
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123"],
-      name: "admin2",
-      value: "admin-2",
-    }),
+    group,
   ];
   state.machine.selectedMachines = {
     groups: ["admin-1", "admin-2"],
@@ -320,6 +329,7 @@ it("can dispatch an action to unselect the group", async () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
@@ -8,23 +8,21 @@ import type {
   MachineStateListGroup,
   FetchGroupKey,
 } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
 
 type Props = {
   callId?: string | null;
+  group: MachineStateListGroup | null;
   grouping: FetchGroupKey | null;
   groupName: MachineStateListGroup["name"];
 };
 
 const GroupCheckbox = ({
   callId,
+  group,
   grouping,
   groupName,
 }: Props): JSX.Element | null => {
   const selected = useSelector(machineSelectors.selectedMachines);
-  const group = useSelector((state: RootState) =>
-    machineSelectors.listGroup(state, callId, groupName)
-  );
   const allSelected = !!selected && "filter" in selected;
   if (!group) {
     return null;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -9,7 +9,7 @@ import { MachineListTable, Label } from "./MachineListTable";
 
 import { SortDirection } from "app/base/types";
 import { MachineColumns, columnLabels } from "app/machines/constants";
-import type { Machine } from "app/store/machine/types";
+import type { Machine, MachineStateListGroup } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
@@ -49,6 +49,7 @@ const mockStore = configureStore();
 describe("MachineListTable", () => {
   let state: RootState;
   let machines: Machine[] = [];
+  let groups: MachineStateListGroup[] = [];
 
   beforeEach(() => {
     jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
@@ -177,6 +178,16 @@ describe("MachineListTable", () => {
         zone: modelRefFactory(),
       }),
     ];
+    groups = [
+      machineStateListGroupFactory({
+        items: [machines[0].system_id, machines[2].system_id],
+        name: "Deployed",
+      }),
+      machineStateListGroupFactory({
+        items: [machines[1].system_id],
+        name: "Releasing",
+      }),
+    ];
     state = rootStateFactory({
       general: generalStateFactory({
         machineActions: machineActionsStateFactory({
@@ -195,16 +206,7 @@ describe("MachineListTable", () => {
         lists: {
           "123456": machineStateListFactory({
             loading: true,
-            groups: [
-              machineStateListGroupFactory({
-                items: [machines[0].system_id, machines[2].system_id],
-                name: "Deployed",
-              }),
-              machineStateListGroupFactory({
-                items: [machines[1].system_id],
-                name: "Releasing",
-              }),
-            ],
+            groups,
           }),
         },
       }),
@@ -247,6 +249,7 @@ describe("MachineListTable", () => {
         currentPage={1}
         filter=""
         grouping={FetchGroupKey.Status}
+        groups={groups}
         hiddenGroups={[]}
         machineCount={10}
         machines={machines}
@@ -276,21 +279,24 @@ describe("MachineListTable", () => {
   });
 
   it("displays a message if there are no search results", () => {
+    groups = [];
     state.machine = machineStateFactory({
       items: [],
       lists: {
         "123456": machineStateListFactory({
           loading: false,
-          groups: [],
+          groups,
         }),
       },
     });
+
     renderWithBrowserRouter(
       <MachineListTable
         callId="123456"
         currentPage={1}
         filter="this does not match anything"
         grouping={FetchGroupKey.Status}
+        groups={groups}
         hiddenGroups={[]}
         machineCount={10}
         machines={machines}
@@ -320,6 +326,7 @@ describe("MachineListTable", () => {
               currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -357,6 +364,7 @@ describe("MachineListTable", () => {
               currentPage={1}
               filter=""
               grouping={null}
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -388,6 +396,7 @@ describe("MachineListTable", () => {
               currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -440,6 +449,7 @@ describe("MachineListTable", () => {
         currentPage={1}
         filter=""
         grouping={null}
+        groups={groups}
         hiddenGroups={[]}
         machineCount={10}
         machines={machines}
@@ -483,6 +493,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -521,6 +532,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -559,6 +571,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -597,6 +610,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -635,6 +649,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -673,6 +688,7 @@ describe("MachineListTable", () => {
               currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -707,6 +723,7 @@ describe("MachineListTable", () => {
             <MachineListTable
               callId="123456"
               currentPage={1}
+              groups={groups}
               machineCount={10}
               machines={machines}
               pageSize={20}
@@ -744,6 +761,7 @@ describe("MachineListTable", () => {
               <MachineListTable
                 callId="123456"
                 currentPage={1}
+                groups={groups}
                 hiddenColumns={["power", "zone"]}
                 machineCount={10}
                 machines={machines}
@@ -778,6 +796,7 @@ describe("MachineListTable", () => {
               <MachineListTable
                 callId="123456"
                 currentPage={1}
+                groups={groups}
                 hiddenColumns={["fqdn"]}
                 machineCount={10}
                 machines={machines}
@@ -809,6 +828,7 @@ describe("MachineListTable", () => {
               <MachineListTable
                 callId="123456"
                 currentPage={1}
+                groups={groups}
                 hiddenColumns={["fqdn"]}
                 machineCount={10}
                 machines={machines}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -9,7 +9,7 @@ import type {
 } from "@canonical/react-components/dist/components/MainTable/MainTable";
 import classNames from "classnames";
 import pluralize from "pluralize";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import AllCheckbox from "./AllCheckbox";
 import CoresColumn from "./CoresColumn";
@@ -33,7 +33,6 @@ import { useSendAnalytics } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
 import { columnLabels, columns, MachineColumns } from "app/machines/constants";
 import { actions as generalActions } from "app/store/general";
-import machineSelectors from "app/store/machine/selectors";
 import type {
   Machine,
   MachineMeta,
@@ -42,7 +41,6 @@ import type {
 import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
-import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { actions as userActions } from "app/store/user";
 import { actions as zoneActions } from "app/store/zone";
@@ -60,6 +58,7 @@ type Props = {
   currentPage: number;
   filter?: string;
   grouping?: FetchGroupKey | null;
+  groups: MachineStateListGroup[] | null;
   hiddenColumns?: string[];
   hiddenGroups?: (string | null)[];
   machineCount: number | null;
@@ -433,6 +432,7 @@ const generateGroupRows = ({
                     showActions ? (
                       <GroupCheckbox
                         callId={callId}
+                        group={group}
                         groupName={name}
                         grouping={grouping}
                       />
@@ -505,6 +505,7 @@ export const MachineListTable = ({
   callId,
   currentPage,
   filter = "",
+  groups,
   grouping,
   hiddenColumns = [],
   hiddenGroups = [],
@@ -523,9 +524,7 @@ export const MachineListTable = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const sendAnalytics = useSendAnalytics();
-  const groups = useSelector((state: RootState) =>
-    machineSelectors.listGroups(state, callId)
-  );
+
   const currentSort = {
     direction: sortDirection,
     key: sortKey,

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -224,6 +224,7 @@ export type MachineStateList = {
   groups: MachineStateListGroup[] | null;
   loaded: boolean;
   loading: boolean;
+  needsUpdate: boolean;
   stale: boolean;
   num_pages: number | null;
 };

--- a/src/app/store/machine/utils/common.ts
+++ b/src/app/store/machine/utils/common.ts
@@ -8,6 +8,7 @@ import type {
   MachineDetails,
   SelectedMachines,
   FilterGroupOptionType,
+  MachineStateListGroup,
 } from "app/store/machine/types";
 import { FetchSortDirection, FilterGroupKey } from "app/store/machine/types";
 import type { Tag, TagMeta } from "app/store/tag/types";
@@ -172,4 +173,43 @@ export const selectedToSeparateFilters = (
     groupFilters,
     itemFilters,
   };
+};
+
+export const mergeGroupUpdates = ({
+  initialGroups,
+  updatedCollapsedGroups,
+  updatedExpandedGroups,
+}: Record<string, MachineStateListGroup[] | null>):
+  | MachineStateListGroup[]
+  | null => {
+  let groups: MachineStateListGroup[] = [];
+  if (
+    initialGroups &&
+    updatedCollapsedGroups &&
+    updatedExpandedGroups &&
+    updatedCollapsedGroups.length > 0 &&
+    updatedExpandedGroups.length > 0
+  ) {
+    const initialCollapsedGroups = initialGroups.reduce((acc, curr) => {
+      if (curr.collapsed && curr.name) {
+        acc.push(curr.name);
+      }
+      return acc;
+    }, [] as string[]);
+    const filteredUpdatedCollapsedGroups = updatedCollapsedGroups?.filter(
+      (group) =>
+        !!group.collapsed &&
+        initialCollapsedGroups.includes(group.name as string)
+    );
+    const filteredUpdatedExpandedGroups = updatedExpandedGroups?.filter(
+      (group) => !group.collapsed
+    );
+    groups = [
+      ...(filteredUpdatedCollapsedGroups ?? []),
+      ...(filteredUpdatedExpandedGroups ?? []),
+    ];
+  } else {
+    return initialGroups;
+  }
+  return groups;
 };

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -22,6 +22,7 @@ import {
   useIsLimitedEditingAllowed,
   useFetchMachine,
   useFetchMachines,
+  useFetchMachinesWithGroupingUpdates,
   useFetchMachineCount,
   useFetchedCount,
 } from "./hooks";
@@ -500,6 +501,133 @@ describe("machine hook utils", () => {
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
+    });
+  });
+
+  describe("useFetchMachinesWithGroupingUpdates", () => {
+    beforeEach(() => {
+      jest
+        .spyOn(reduxToolkit, "nanoid")
+        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce("mocked-nanoid-2")
+        .mockReturnValueOnce("mocked-nanoid-3");
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    const generateWrapper =
+      (store: MockStoreEnhanced<unknown>) =>
+      ({ children }: { children?: ReactNode }) =>
+        <Provider store={store}>{children}</Provider>;
+
+    it("can return the initial set of machines", () => {
+      const store = mockStore(state);
+      renderHook(() => useFetchMachinesWithGroupingUpdates(), {
+        wrapper: generateWrapper(store),
+      });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected);
+    });
+
+    it("fetches again if the query has been marked as needsUpdate", async () => {
+      state.machine.lists = {
+        "mocked-nanoid-1": machineStateListFactory({
+          needsUpdate: true,
+        }),
+      };
+      const store = mockStore(state);
+      renderHook(() => useFetchMachinesWithGroupingUpdates(), {
+        wrapper: generateWrapper(store),
+      });
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected);
+      const getDispatches = () =>
+        store.getActions().filter((action) => action.type === expected.type);
+      expect(getDispatches()).toHaveLength(3);
+    });
+
+    it("returns updated groups if the query has been marked as needsUpdate", async () => {
+      state.machine.lists = {
+        "mocked-nanoid-1": machineStateListFactory({
+          needsUpdate: true,
+          groups: [
+            machineStateListGroupFactory({
+              count: 3,
+              collapsed: true,
+              items: [],
+              name: "Deployed",
+            }),
+            machineStateListGroupFactory({
+              count: 1,
+              collapsed: false,
+              items: ["abcd"],
+              name: "New",
+            }),
+            machineStateListGroupFactory({
+              count: 1,
+              collapsed: false,
+              items: ["efgh"],
+              name: "Testing",
+            }),
+          ],
+        }),
+        "mocked-nanoid-2": machineStateListFactory({
+          groups: [
+            machineStateListGroupFactory({
+              collapsed: false,
+              count: 2,
+              items: ["abcd", "efgh"],
+              name: "Testing",
+            }),
+          ],
+        }),
+        "mocked-nanoid-3": machineStateListFactory({
+          groups: [
+            machineStateListGroupFactory({
+              collapsed: true,
+              count: 4,
+              items: [],
+              name: "Deployed",
+            }),
+          ],
+        }),
+      };
+      const store = mockStore(state);
+      const { result } = renderHook(
+        () => useFetchMachinesWithGroupingUpdates(),
+        {
+          wrapper: generateWrapper(store),
+        }
+      );
+      const expected = machineActions.fetch("mocked-nanoid-1");
+      expect(
+        store.getActions().find((action) => action.type === expected.type)
+      ).toStrictEqual(expected);
+      const getDispatches = () =>
+        store.getActions().filter((action) => action.type === expected.type);
+      expect(getDispatches()).toHaveLength(3);
+      expect(result.current.groups).toEqual([
+        {
+          collapsed: true,
+          count: 4,
+          items: [],
+          name: "Deployed",
+          value: null,
+        },
+        {
+          collapsed: false,
+          count: 2,
+          items: ["abcd", "efgh"],
+          name: "Testing",
+          value: null,
+        },
+      ]);
     });
   });
 

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -45,7 +45,7 @@ const TagMachines = (): JSX.Element => {
   if (tag) {
     filters.tags = [tag.name];
   }
-  const { callId, loading, machineCount, machines, machinesErrors } =
+  const { callId, loading, machineCount, machines, groups, machinesErrors } =
     useFetchMachines({
       filters,
       sortDirection,
@@ -78,6 +78,7 @@ const TagMachines = (): JSX.Element => {
         aria-label={Label.Machines}
         callId={callId}
         currentPage={currentPage}
+        groups={groups}
         machineCount={machineCount}
         machines={machines}
         machinesLoading={loading}

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -267,6 +267,7 @@ export const machineStateList = define<MachineStateList>({
   loaded: false,
   loading: false,
   stale: false,
+  needsUpdate: false,
   num_pages: null,
 });
 


### PR DESCRIPTION
## Done

- fix: update machine list grouping for active page of results
  - expose groups directly from machine fetch hook

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Select a machine and perform an action that will affect it's grouping (e.g. with grouping by status test/abort, grouping by pool set a different pool)
- Ensure the list is updated and it's moved to that group
- Navigate to another page
- select a group of machines and perform and action that will affect their grouping
- Open another machine list in another window
- perform an action that will change machine status
- ensure its grouping has been updated in the other window

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4709

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
