### PR TITLE
fix: machine list grouping (#4710)

### DIFF
--- a/src/app/kvm/components/VmResources/VmResources.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.tsx
@@ -42,6 +42,7 @@ const VmResources = ({ filters, podId }: Props): JSX.Element => {
     loading,
     machineCount,
     machines: vms,
+    groups,
   } = useFetchMachines({
     filters: {
       ...filters,
@@ -71,6 +72,7 @@ const VmResources = ({ filters, podId }: Props): JSX.Element => {
           <MachineListTable
             callId={callId}
             currentPage={currentPage}
+            groups={groups}
             hiddenColumns={[
               "owner",
               "pool",

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -18,7 +18,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
-import { useFetchMachines } from "app/store/machine/utils/hooks";
+import { useFetchMachinesWithGroupingUpdates } from "app/store/machine/utils/hooks";
 
 type Props = {
   headerFormOpen?: boolean;
@@ -76,8 +76,8 @@ const MachineList = ({
     []
   );
 
-  const { callId, loading, machineCount, machines, machinesErrors } =
-    useFetchMachines({
+  const { callId, loading, machineCount, machines, machinesErrors, groups } =
+    useFetchMachinesWithGroupingUpdates({
       collapsedGroups: hiddenGroups,
       filters: FilterMachines.parseFetchFilters(searchFilter),
       grouping,
@@ -124,6 +124,7 @@ const MachineList = ({
         currentPage={currentPage}
         filter={searchFilter}
         grouping={grouping}
+        groups={groups}
         hiddenGroups={hiddenGroups}
         machineCount={machineCount}
         machines={machines}

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -19,19 +19,17 @@ const mockStore = configureStore<RootState, {}>();
 
 let state: RootState;
 const callId = "123456";
-
+const group = machineStateListGroupFactory({
+  count: 2,
+  name: "admin2",
+  value: "admin-2",
+});
 beforeEach(() => {
   state = rootStateFactory({
     machine: machineStateFactory({
       lists: {
         [callId]: machineStateListFactory({
-          groups: [
-            machineStateListGroupFactory({
-              count: 2,
-              name: "admin2",
-              value: "admin-2",
-            }),
-          ],
+          groups: [group],
         }),
       },
     }),
@@ -47,6 +45,7 @@ it("is disabled if all machines are selected", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -58,16 +57,16 @@ it("is disabled if all machines are selected", () => {
 });
 
 it("is disabled if there are no machines in the group", () => {
-  state.machine.lists[callId].groups = [
-    machineStateListGroupFactory({
-      count: 0,
-      name: "admin2",
-      value: "admin-2",
-    }),
-  ];
+  const group = machineStateListGroupFactory({
+    count: 0,
+    name: "admin2",
+    value: "admin-2",
+  });
+  state.machine.lists[callId].groups = [group];
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -89,6 +88,7 @@ it("is not disabled if there are machines in the group", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -104,6 +104,7 @@ it("is unchecked if there are no filters, groups or items selected", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -123,6 +124,7 @@ it("is checked if all machines are selected", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -140,6 +142,7 @@ it("is checked if the group is selected", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -151,20 +154,20 @@ it("is checked if the group is selected", () => {
 });
 
 it("is partially checked if a machine in the group is selected", () => {
-  state.machine.lists[callId].groups = [
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123", "def456"],
-      name: "admin2",
-      value: "admin-2",
-    }),
-  ];
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123", "def456"],
+    name: "admin2",
+    value: "admin-2",
+  });
+  state.machine.lists[callId].groups = [group];
   state.machine.selectedMachines = {
     items: ["abc123"],
   };
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -176,18 +179,19 @@ it("is partially checked if a machine in the group is selected", () => {
 });
 
 it("is not checked if a selected machine is in another group", () => {
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123"],
+    name: "admin2",
+    value: "admin-2",
+  });
   state.machine.lists[callId].groups = [
     machineStateListGroupFactory({
       count: 2,
       items: ["def456"],
       name: "admin1",
     }),
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123"],
-      name: "admin2",
-      value: "admin-2",
-    }),
+    group,
   ];
   state.machine.selectedMachines = {
     items: ["def456"],
@@ -195,6 +199,7 @@ it("is not checked if a selected machine is in another group", () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -210,6 +215,7 @@ it("can dispatch an action to select the group", async () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -228,14 +234,13 @@ it("can dispatch an action to select the group", async () => {
 });
 
 it("removes selected machines that are in the group that was clicked", async () => {
-  state.machine.lists[callId].groups = [
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123"],
-      name: "admin2",
-      value: "admin-2",
-    }),
-  ];
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123"],
+    name: "admin2",
+    value: "admin-2",
+  });
+  state.machine.lists[callId].groups = [group];
   state.machine.selectedMachines = {
     items: ["abc123", "def456"],
   };
@@ -243,6 +248,7 @@ it("removes selected machines that are in the group that was clicked", async () 
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -261,18 +267,19 @@ it("removes selected machines that are in the group that was clicked", async () 
 });
 
 it("does not overwrite selected machines in different groups", async () => {
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123"],
+    name: "admin2",
+    value: "admin-2",
+  });
   state.machine.lists[callId].groups = [
     machineStateListGroupFactory({
       count: 2,
       items: ["def456"],
       name: "admin1",
     }),
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123"],
-      name: "admin2",
-      value: "admin-2",
-    }),
+    group,
   ];
   state.machine.selectedMachines = {
     items: ["def456"],
@@ -281,6 +288,7 @@ it("does not overwrite selected machines in different groups", async () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,
@@ -300,6 +308,12 @@ it("does not overwrite selected machines in different groups", async () => {
 });
 
 it("can dispatch an action to unselect the group", async () => {
+  const group = machineStateListGroupFactory({
+    count: 2,
+    items: ["abc123"],
+    name: "admin2",
+    value: "admin-2",
+  });
   state.machine.lists[callId].groups = [
     machineStateListGroupFactory({
       count: 2,
@@ -307,12 +321,7 @@ it("can dispatch an action to unselect the group", async () => {
       name: "admin1",
       value: "admin-1",
     }),
-    machineStateListGroupFactory({
-      count: 2,
-      items: ["abc123"],
-      name: "admin2",
-      value: "admin-2",
-    }),
+    group,
   ];
   state.machine.selectedMachines = {
     groups: ["admin-1", "admin-2"],
@@ -322,6 +331,7 @@ it("can dispatch an action to unselect the group", async () => {
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
+      group={group}
       groupName="admin2"
       grouping={FetchGroupKey.AgentName}
     />,

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
@@ -8,23 +8,21 @@ import type {
   MachineStateListGroup,
   FetchGroupKey,
 } from "app/store/machine/types";
-import type { RootState } from "app/store/root/types";
 
 type Props = {
   callId?: string | null;
+  group: MachineStateListGroup | null;
   grouping: FetchGroupKey | null;
   groupName: MachineStateListGroup["name"];
 };
 
 const GroupCheckbox = ({
   callId,
+  group,
   grouping,
   groupName,
 }: Props): JSX.Element | null => {
   const selected = useSelector(machineSelectors.selectedMachines);
-  const group = useSelector((state: RootState) =>
-    machineSelectors.listGroup(state, callId, groupName)
-  );
   const allSelected = !!selected && "filter" in selected;
   if (!group) {
     return null;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -10,7 +10,7 @@ import { MachineListTable, Label } from "./MachineListTable";
 
 import { SortDirection } from "app/base/types";
 import { MachineColumns, columnLabels } from "app/machines/constants";
-import type { Machine } from "app/store/machine/types";
+import type { Machine, MachineStateListGroup } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
@@ -42,6 +42,7 @@ const mockStore = configureStore();
 describe("MachineListTable", () => {
   let state: RootState;
   let machines: Machine[] = [];
+  let groups: MachineStateListGroup[] = [];
 
   beforeEach(() => {
     jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
@@ -173,6 +174,16 @@ describe("MachineListTable", () => {
         zone: modelRefFactory(),
       }),
     ];
+    groups = [
+      machineStateListGroupFactory({
+        items: [machines[0].system_id, machines[2].system_id],
+        name: "Deployed",
+      }),
+      machineStateListGroupFactory({
+        items: [machines[1].system_id],
+        name: "Releasing",
+      }),
+    ];
     state = rootStateFactory({
       general: generalStateFactory({
         machineActions: machineActionsStateFactory({
@@ -191,16 +202,7 @@ describe("MachineListTable", () => {
         lists: {
           "123456": machineStateListFactory({
             loading: true,
-            groups: [
-              machineStateListGroupFactory({
-                items: [machines[0].system_id, machines[2].system_id],
-                name: "Deployed",
-              }),
-              machineStateListGroupFactory({
-                items: [machines[1].system_id],
-                name: "Releasing",
-              }),
-            ],
+            groups,
           }),
         },
       }),
@@ -243,6 +245,7 @@ describe("MachineListTable", () => {
         currentPage={1}
         filter=""
         grouping={FetchGroupKey.Status}
+        groups={groups}
         hiddenGroups={[]}
         machineCount={10}
         machines={machines}
@@ -272,21 +275,24 @@ describe("MachineListTable", () => {
   });
 
   it("displays a message if there are no search results", () => {
+    groups = [];
     state.machine = machineStateFactory({
       items: [],
       lists: {
         "123456": machineStateListFactory({
           loading: false,
-          groups: [],
+          groups,
         }),
       },
     });
+
     renderWithBrowserRouter(
       <MachineListTable
         callId="123456"
         currentPage={1}
         filter="this does not match anything"
         grouping={FetchGroupKey.Status}
+        groups={groups}
         hiddenGroups={[]}
         machineCount={10}
         machines={machines}
@@ -316,6 +322,7 @@ describe("MachineListTable", () => {
               currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -353,6 +360,7 @@ describe("MachineListTable", () => {
               currentPage={1}
               filter=""
               grouping={null}
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -384,6 +392,7 @@ describe("MachineListTable", () => {
               currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -434,6 +443,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -472,6 +482,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -510,6 +521,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -548,6 +560,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -586,6 +599,7 @@ describe("MachineListTable", () => {
               callId="123456"
               currentPage={1}
               filter=""
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -624,6 +638,7 @@ describe("MachineListTable", () => {
               currentPage={1}
               filter=""
               grouping={FetchGroupKey.Status}
+              groups={groups}
               hiddenGroups={[]}
               machineCount={10}
               machines={machines}
@@ -658,6 +673,7 @@ describe("MachineListTable", () => {
             <MachineListTable
               callId="123456"
               currentPage={1}
+              groups={groups}
               machineCount={10}
               machines={machines}
               pageSize={20}
@@ -695,6 +711,7 @@ describe("MachineListTable", () => {
               <MachineListTable
                 callId="123456"
                 currentPage={1}
+                groups={groups}
                 hiddenColumns={["power", "zone"]}
                 machineCount={10}
                 machines={machines}
@@ -729,6 +746,7 @@ describe("MachineListTable", () => {
               <MachineListTable
                 callId="123456"
                 currentPage={1}
+                groups={groups}
                 hiddenColumns={["fqdn"]}
                 machineCount={10}
                 machines={machines}
@@ -760,6 +778,7 @@ describe("MachineListTable", () => {
               <MachineListTable
                 callId="123456"
                 currentPage={1}
+                groups={groups}
                 hiddenColumns={["fqdn"]}
                 machineCount={10}
                 machines={machines}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -9,7 +9,7 @@ import type {
 } from "@canonical/react-components/dist/components/MainTable/MainTable";
 import classNames from "classnames";
 import pluralize from "pluralize";
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import AllCheckbox from "./AllCheckbox";
 import CoresColumn from "./CoresColumn";
@@ -33,7 +33,6 @@ import { useSendAnalytics } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
 import { columnLabels, columns, MachineColumns } from "app/machines/constants";
 import { actions as generalActions } from "app/store/general";
-import machineSelectors from "app/store/machine/selectors";
 import type {
   Machine,
   MachineMeta,
@@ -42,7 +41,6 @@ import type {
 import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
-import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { actions as userActions } from "app/store/user";
 import { actions as zoneActions } from "app/store/zone";
@@ -60,6 +58,7 @@ type Props = {
   currentPage: number;
   filter?: string;
   grouping?: FetchGroupKey | null;
+  groups: MachineStateListGroup[] | null;
   hiddenColumns?: string[];
   hiddenGroups?: (string | null)[];
   machineCount: number | null;
@@ -430,6 +429,7 @@ const generateGroupRows = ({
                     showActions ? (
                       <GroupCheckbox
                         callId={callId}
+                        group={group}
                         groupName={name}
                         grouping={grouping}
                       />
@@ -502,6 +502,7 @@ export const MachineListTable = ({
   callId,
   currentPage,
   filter = "",
+  groups,
   grouping,
   hiddenColumns = [],
   hiddenGroups = [],
@@ -520,9 +521,7 @@ export const MachineListTable = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const sendAnalytics = useSendAnalytics();
-  const groups = useSelector((state: RootState) =>
-    machineSelectors.listGroups(state, callId)
-  );
+
   const currentSort = {
     direction: sortDirection,
     key: sortKey,

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -222,6 +222,7 @@ export type MachineStateList = {
   groups: MachineStateListGroup[] | null;
   loaded: boolean;
   loading: boolean;
+  needsUpdate: boolean;
   stale: boolean;
   num_pages: number | null;
 };

--- a/src/app/store/machine/utils/common.ts
+++ b/src/app/store/machine/utils/common.ts
@@ -8,6 +8,7 @@ import type {
   MachineDetails,
   SelectedMachines,
   FilterGroupOptionType,
+  MachineStateListGroup,
 } from "app/store/machine/types";
 import { FetchSortDirection, FilterGroupKey } from "app/store/machine/types";
 import type { Tag, TagMeta } from "app/store/tag/types";
@@ -172,4 +173,43 @@ export const selectedToSeparateFilters = (
     groupFilters,
     itemFilters,
   };
+};
+
+export const mergeGroupUpdates = ({
+  initialGroups,
+  updatedCollapsedGroups,
+  updatedExpandedGroups,
+}: Record<string, MachineStateListGroup[] | null>):
+  | MachineStateListGroup[]
+  | null => {
+  let groups: MachineStateListGroup[] = [];
+  if (
+    initialGroups &&
+    updatedCollapsedGroups &&
+    updatedExpandedGroups &&
+    updatedCollapsedGroups.length > 0 &&
+    updatedExpandedGroups.length > 0
+  ) {
+    const initialCollapsedGroups = initialGroups.reduce((acc, curr) => {
+      if (curr.collapsed && curr.name) {
+        acc.push(curr.name);
+      }
+      return acc;
+    }, [] as string[]);
+    const filteredUpdatedCollapsedGroups = updatedCollapsedGroups?.filter(
+      (group) =>
+        !!group.collapsed &&
+        initialCollapsedGroups.includes(group.name as string)
+    );
+    const filteredUpdatedExpandedGroups = updatedExpandedGroups?.filter(
+      (group) => !group.collapsed
+    );
+    groups = [
+      ...(filteredUpdatedCollapsedGroups ?? []),
+      ...(filteredUpdatedExpandedGroups ?? []),
+    ];
+  } else {
+    return initialGroups;
+  }
+  return groups;
 };

--- a/src/app/tags/views/TagMachines/TagMachines.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.tsx
@@ -45,7 +45,7 @@ const TagMachines = (): JSX.Element => {
   if (tag) {
     filters.tags = [tag.name];
   }
-  const { callId, loading, machineCount, machines, machinesErrors } =
+  const { callId, loading, machineCount, machines, groups, machinesErrors } =
     useFetchMachines({
       filters,
       sortDirection,
@@ -78,6 +78,7 @@ const TagMachines = (): JSX.Element => {
         aria-label={Label.Machines}
         callId={callId}
         currentPage={currentPage}
+        groups={groups}
         machineCount={machineCount}
         machines={machines}
         machinesLoading={loading}

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -267,6 +267,7 @@ export const machineStateList = define<MachineStateList>({
   loaded: false,
   loading: false,
   stale: false,
+  needsUpdate: false,
   num_pages: null,
 });
 


### PR DESCRIPTION
## Done

- fix: machine list grouping (#4710)
backport of https://github.com/canonical/maas-ui/pull/4710

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- check out this branch locally
- run `yarn clean`
- run `yarn && yarn start`
- Follow QA steps from https://github.com/canonical/maas-ui/pull/4710

## Fixes

Fixes: #4710

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
