### PR TITLE
fix: contextual menu hidden

### DIFF
--- a/src/scss/_vanilla-overrides.scss
+++ b/src/scss/_vanilla-overrides.scss
@@ -31,6 +31,7 @@
 
 // 24-01-2023 Peter: tooltip message is hidden behind side panel
 // https://github.com/canonical/vanilla-framework/issues/4607
+.p-contextual-menu__dropdown,
 .p-tooltip__message {
   z-index: $side-panel-z-index + 1;
 }


### PR DESCRIPTION
## Done

- fix: contextual menu hidden behind side panel

_temporary workaround for until a bug in vanilla gets fixed_

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to KVM -> KVM Host
- Without scrolling further down the page, select a VM from the list and click "Take action"

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4702

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
