### PR TITLE
feat: show image last sync time #1166

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "redux-saga-test-plan": "4.0.6",
     "sass": "1.57.1",
     "start-server-and-test": "1.15.3",
+    "timezone-mock": "1.3.6",
     "wait-on": "7.0.1"
   },
   "browserslist": {

--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -94,6 +94,27 @@ describe("ImagesTable", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders the time of last update", () => {
+    const status = "Synced";
+    const lastUpdate = "Mon, 30 Jan. 2023 15:54:44";
+    const resource = resourceFactory({
+      arch: "amd64",
+      complete: true,
+      name: "ubuntu/focal",
+      title: "20.04 LTS",
+      status,
+      lastUpdate,
+    });
+    state.bootresource.resources = [resource];
+    renderWithMockStore(<ImagesTable images={[]} resources={[resource]} />, {
+      state,
+    });
+
+    const row = screen.getByRole("row", { name: resource.title });
+
+    expect(within(row).getByText(lastUpdate)).toBeInTheDocument();
+  });
+
   it("renders the correct data for a new image", () => {
     const image = {
       arch: "arch",

--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -1,4 +1,5 @@
 import MockDate from "mockdate";
+import timezoneMock from "timezone-mock";
 
 import ImagesTable, { Labels as ImagesTableLabels } from "./ImagesTable";
 
@@ -15,6 +16,7 @@ import { userEvent, screen, within, renderWithMockStore } from "testing/utils";
 
 beforeEach(() => {
   MockDate.set("Fri, 18 Nov. 2022 10:55:00");
+  timezoneMock.register("Etc/GMT-1");
 });
 
 afterEach(() => {
@@ -95,15 +97,13 @@ describe("ImagesTable", () => {
   });
 
   it("renders the time of last update", () => {
-    const status = "Synced";
-    const lastUpdate = "Mon, 30 Jan. 2023 15:54:44";
     const resource = resourceFactory({
       arch: "amd64",
       complete: true,
       name: "ubuntu/focal",
       title: "20.04 LTS",
-      status,
-      lastUpdate,
+      status: "Synced",
+      lastUpdate: "Mon, 30 Jan. 2023 15:54:44",
     });
     state.bootresource.resources = [resource];
     renderWithMockStore(<ImagesTable images={[]} resources={[resource]} />, {
@@ -112,7 +112,9 @@ describe("ImagesTable", () => {
 
     const row = screen.getByRole("row", { name: resource.title });
 
-    expect(within(row).getByText(lastUpdate)).toBeInTheDocument();
+    expect(
+      within(row).getByText("Mon, 30 Jan. 2023 16:54:44")
+    ).toBeInTheDocument();
   });
 
   it("renders the correct data for a new image", () => {
@@ -257,11 +259,12 @@ describe("ImagesTable", () => {
   });
 
   it("displays a correct last deployed time and machine count", () => {
+    const lastDeployed = "Fri, 18 Nov. 2022 09:55:21";
     const resources = [
       resourceFactory({
         arch: "amd64",
         name: "ubuntu/focal",
-        lastDeployed: "Fri, 18 Nov. 2022 09:55:21",
+        lastDeployed,
         machineCount: 768,
       }),
     ];
@@ -300,7 +303,7 @@ describe("ImagesTable", () => {
     ).toBeInTheDocument();
     const row = screen.getByRole("row", { name: "18.04 LTS" });
     expect(
-      within(row).getByText(/Fri, 18 Nov. 2022 09:55:21/)
+      within(row).getByText(/Fri, 18 Nov. 2022 10:55:21/)
     ).toBeInTheDocument();
     expect(
       within(row).getByRole("gridcell", { name: /about 1 hour ago/ })

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -13,7 +13,11 @@ import type { BootResource } from "app/store/bootresource/types";
 import { splitResourceName } from "app/store/bootresource/utils";
 import configSelectors from "app/store/config/selectors";
 import { sizeStringToNumber } from "app/utils/formatBytes";
-import { getTimeDistanceString, parseUtcDatetime } from "app/utils/time";
+import {
+  formatUtcDatetime,
+  getTimeDistanceString,
+  parseUtcDatetime,
+} from "app/utils/time";
 
 type Props = {
   handleClear?: (image: ImageValue) => void;
@@ -156,6 +160,9 @@ const generateResourceRow = ({
             data-testid="resource-status"
             icon={statusIcon}
             primary={statusText}
+            secondary={
+              resource.lastUpdate ? formatUtcDatetime(resource.lastUpdate) : "—"
+            }
           />
         ),
         className: "status-col",

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -171,7 +171,7 @@ const generateResourceRow = ({
         content: resource.lastDeployed ? (
           <DoubleRow
             primary={getTimeDistanceString(resource.lastDeployed)}
-            secondary={resource.lastDeployed}
+            secondary={formatUtcDatetime(resource.lastDeployed)}
           />
         ) : (
           "—"

--- a/src/app/utils/time.test.ts
+++ b/src/app/utils/time.test.ts
@@ -1,6 +1,7 @@
 import MockDate from "mockdate";
+import timezoneMock from "timezone-mock";
 
-import { getTimeDistanceString } from "./time";
+import { formatUtcDatetime, getTimeDistanceString } from "./time";
 
 beforeEach(() => {
   MockDate.set("Fri, 18 Nov. 2022 01:01:00");
@@ -19,6 +20,20 @@ describe("getTimeDistanceString", () => {
   it("returns time distance for UTC TimeString in the future", () => {
     expect(getTimeDistanceString("Fri, 18 Nov. 2022 01:01:10")).toEqual(
       "in less than a minute"
+    );
+  });
+});
+
+describe("formatUtcDatetime", () => {
+  it("returns UTC date time in a correct format", () => {
+    expect(formatUtcDatetime("Fri, 18 Nov. 2022 01:00:50")).toEqual(
+      "Fri, 18 Nov. 2022 01:00:50"
+    );
+  });
+  it("returns UTC date time in local time", () => {
+    timezoneMock.register("Etc/GMT-1");
+    expect(formatUtcDatetime("Fri, 18 Nov. 2022 03:00:00")).toEqual(
+      "Fri, 18 Nov. 2022 04:00:00"
     );
   });
 });

--- a/src/app/utils/time.ts
+++ b/src/app/utils/time.ts
@@ -1,4 +1,4 @@
-import { formatDistance, parse } from "date-fns";
+import { format, formatDistance, parse } from "date-fns";
 
 const DATETIME_FORMAT = "E, dd LLL. yyyy HH:mm:ss";
 const UTC_DATETIME_FORMAT = `${DATETIME_FORMAT} x`;
@@ -14,3 +14,6 @@ export const getTimeDistanceString = (utcTimeString: string): string =>
   formatDistance(parseUtcDatetime(utcTimeString), new Date(), {
     addSuffix: true,
   });
+
+export const formatUtcDatetime = (utcTimeString: string): string =>
+  format(parseUtcDatetime(utcTimeString), DATETIME_FORMAT);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12495,6 +12495,11 @@ thunky@^1.0.2:
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
 
+timezone-mock@1.3.6:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.3.6.tgz#44e4c5aeb57e6c07ae630a05c528fc4d9aab86f4"
+  integrity sha512-YcloWmZfLD9Li5m2VcobkCDNVaLMx8ohAb/97l/wYS3m+0TIEK5PFNMZZfRcusc6sFjIfxu8qcJT0CNnOdpqmg==
+
 tiny-invariant@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"


### PR DESCRIPTION
## Done

- feat: show image last sync time
- update lastDeployed secondary row time offset

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to MAAS/r/images
- Add a new image (e.g. CentOS 7)
- Update selection
- Wait for the image to sync
- Change your system's time zone to GMT+1
- Make sure the last sync time is still displaying the correct time - indicating the last sync occurred just a few minutes ago

## Fixes

Fixes: #1166 #4717

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/7452681/215713752-d81d9037-889f-4b30-b2d5-608f0fcedf78.png)

### After
![image](https://user-images.githubusercontent.com/7452681/215713697-bdc19973-efd8-478d-b41d-91c15fc8a406.png)

