### PR TITLE
fix: set pool with machine filter

### DIFF
--- a/src/app/base/sagas/actions.test.ts
+++ b/src/app/base/sagas/actions.test.ts
@@ -28,6 +28,7 @@ describe("websocket sagas", () => {
     const action = {
       type: "resourcepoo/createWithMachines",
       payload: { params: { machineIDs: ["machine1"], pool } },
+      meta: {},
     };
     return expectSaga(createPoolWithMachines, socketClient, sendMessage, action)
       .provide([

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.tsx
@@ -76,12 +76,21 @@ export const SetPoolForm = ({
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
         if (values.poolSelection === "create") {
-          dispatch(
-            resourcePoolActions.createWithMachines({
-              machineIDs: machines?.map(({ system_id }) => system_id) || [],
-              pool: values,
-            })
-          );
+          if (selectedMachines) {
+            dispatchForSelectedMachines(
+              resourcePoolActions.createWithMachines,
+              {
+                pool: values,
+              }
+            );
+          } else {
+            dispatch(
+              resourcePoolActions.createWithMachines({
+                machineIDs: machines?.map(({ system_id }) => system_id) || [],
+                pool: values,
+              })
+            );
+          }
         } else {
           const pool = resourcePools.find((pool) => pool.name === values.name);
           if (pool) {

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -42,6 +42,7 @@ import type {
   MachineStateListGroup,
   SelectedMachines,
 } from "app/store/machine/types";
+import type { actions as resourcePoolActions } from "app/store/resourcepool";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import type { Host } from "app/store/types/host";
@@ -172,7 +173,9 @@ export const useSelectedMachinesActionsDispatch = ({
   searchFilter?: string;
 }): MachineActionData & {
   dispatch: (
-    a: ValueOf<typeof machineActions>,
+    a:
+      | ValueOf<typeof machineActions>
+      | typeof resourcePoolActions.createWithMachines,
     args?: Record<string, unknown> & { filter?: never }
   ) => void;
 } => {

--- a/src/app/store/resourcepool/types/actions.ts
+++ b/src/app/store/resourcepool/types/actions.ts
@@ -1,17 +1,30 @@
 import type { ResourcePool } from "./base";
 import type { ResourcePoolMeta } from "./enum";
 
-import type { Machine, MachineMeta } from "app/store/machine/types";
+import type {
+  FetchFilters,
+  Machine,
+  MachineMeta,
+} from "app/store/machine/types";
 
 export type CreateParams = {
   description: ResourcePool["description"];
   name: ResourcePool["name"];
 };
 
-export type CreateWithMachinesParams = {
-  machineIDs: Machine[MachineMeta.PK][];
+type CreateWithFilterParams = {
   pool: CreateParams;
+  filter: FetchFilters;
 };
+
+type CreateWithMachineIdsParams = {
+  pool: CreateParams;
+  machineIDs: Machine[MachineMeta.PK][];
+};
+
+export type CreateWithMachinesParams =
+  | CreateWithMachineIdsParams
+  | CreateWithFilterParams;
 
 export type UpdateParams = CreateParams & {
   [ResourcePoolMeta.PK]: ResourcePool[ResourcePoolMeta.PK];


### PR DESCRIPTION
## Done

- fix: set pool with machine filter

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Select a few machines
- Select "Take action" -> Set pool
- Select "Create pool"
- Enter a name for the new pool
- Submit by clicking "Set pool for machines"
- Verify that the side panel closes, a new pool gets created and selected machines are assigned to that pool

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4715

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
