### PR TITLE
fix: add `sudo` to config command to enable root permissions

### DIFF
--- a/src/app/settings/views/Security/SecurityProtocols/TLSDisabled/TLSDisabled.tsx
+++ b/src/app/settings/views/Security/SecurityProtocols/TLSDisabled/TLSDisabled.tsx
@@ -21,7 +21,7 @@ const TLSDisabled = (): JSX.Element => {
         blocks={[
           {
             appearance: CodeSnippetBlockAppearance.LINUX_PROMPT,
-            code: "maas config-tls enable $key $cert --port YYYY",
+            code: "sudo maas config-tls enable $key $cert --port YYYY",
           },
         ]}
       />


### PR DESCRIPTION
## Done

- Added `sudo` to config-tls command to specify root permissions

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.
- Visit MAAS site locally
- Navigate to `/settings/security/security-protocols`

## Fixes

Fixes: # .
[https://github.com/canonical/maas-ui/issues/4533](https://github.com/canonical/maas-ui/issues/4533)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.
lp#1995053

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/47540149/215702150-a988d34b-1a1c-481a-916a-c2c6dc78f29d.png">

