### PR TITLE
fix: set pool with machine filter - 3.3 backport (#4719)

### DIFF
--- a/cypress/e2e/with-users/machines/actions.spec.ts
+++ b/cypress/e2e/with-users/machines/actions.spec.ts
@@ -1,4 +1,4 @@
-import { generateMAASURL } from "../../utils";
+import { generateMAASURL, generateName } from "../../utils";
 
 const MACHINE_ACTIONS = [
   "Commission",
@@ -30,6 +30,18 @@ const selectFirstMachine = () =>
       .within(() => cy.findByRole("checkbox").click({ force: true }));
   });
 
+const openMachineActionForm = (action: string) => {
+  cy.findByTestId("section-header-buttons").within(() => {
+    cy.findByRole("button", { name: /Take action/i }).click();
+  });
+  cy.findByLabelText("submenu").within(() => {
+    cy.findAllByRole("button", {
+      name: new RegExp(`${action}...`),
+    }).click();
+  });
+  cy.findByTestId("section-header-title").contains(action).should("exist");
+};
+
 context("Machine listing - actions", () => {
   before(() => {
     cy.login();
@@ -55,21 +67,29 @@ context("Machine listing - actions", () => {
   MACHINE_ACTIONS.forEach((action) =>
     it(`loads machine ${action} form`, () => {
       selectFirstMachine();
-      cy.findByRole("button", { name: /Take action/i }).click();
-      cy.findByLabelText("submenu").within(() => {
-        cy.findAllByRole("button", {
-          name: new RegExp(`${action}...`),
-        }).click();
-      });
-      cy.findByTestId("section-header-title").contains(action).should("exist");
+      openMachineActionForm(action);
       cy.get("[data-testid='section-header-content']").within(() => {
         cy.findAllByText(/Loading/).should("have.length", 0);
         cy.findByRole("button", { name: /Cancel/i }).click();
       });
       // expect the action form to be closed
-      cy.findByTestId("section-header-title")
-        .contains(action)
-        .should("not.exist");
+      cy.findByRole("complementary", { name: action }).should("not.exist");
     })
   );
+
+  it("can create and set the zone of a machine", () => {
+    const poolName = generateName("pool");
+    selectFirstMachine();
+    openMachineActionForm("Set pool");
+    // eslint-disable-next-line cypress/no-force
+    cy.findByLabelText(/Create pool/i).click({ force: true });
+    cy.findByLabelText(/Name/i).type(poolName);
+    cy.findByRole("button", { name: /Set pool for machine/i }).click();
+    cy.findByTestId("section-header-title")
+      .contains(/Set pool/i)
+      .should("exist");
+    cy.findByRole("grid", { name: /Machines/i })
+      .within(() => cy.findByText(poolName))
+      .should("exist");
+  });
 });

--- a/src/app/base/components/node/SetZoneForm/SetZoneForm.tsx
+++ b/src/app/base/components/node/SetZoneForm/SetZoneForm.tsx
@@ -37,6 +37,7 @@ export const SetZoneForm = <E,>({
   clearHeaderContent,
   cleanup,
   errors,
+  actionStatus,
   nodes,
   modelName,
   onSubmit,
@@ -47,6 +48,7 @@ export const SetZoneForm = <E,>({
   return (
     <ActionForm<SetZoneFormValues, E>
       actionName={NodeActions.SET_ZONE}
+      actionStatus={actionStatus}
       cleanup={cleanup}
       errors={errors}
       initialValues={{

--- a/src/app/base/hooks/node.ts
+++ b/src/app/base/hooks/node.ts
@@ -23,6 +23,7 @@ export type MachineMenuAction = Exclude<
   | NodeActions.SET_POOL
   | NodeActions.SET_ZONE
   | NodeActions.TAG
+  | NodeActions.UNTAG
 >;
 
 /**

--- a/src/app/base/sagas/actions.test.ts
+++ b/src/app/base/sagas/actions.test.ts
@@ -6,6 +6,7 @@ import WebSocketClient from "../../../websocket-client";
 import {
   createPoolWithMachines,
   deleteDomainRecord,
+  generateMachineFilterPoolActionCreators,
   generateMachinePoolActionCreators,
   generateNextDeleteRecordAction,
   generateNextUpdateRecordAction,
@@ -28,10 +29,37 @@ describe("websocket sagas", () => {
     const action = {
       type: "resourcepoo/createWithMachines",
       payload: { params: { machineIDs: ["machine1"], pool } },
+      meta: {},
     };
     return expectSaga(createPoolWithMachines, socketClient, sendMessage, action)
       .provide([
         [matchers.call.fn(generateMachinePoolActionCreators), actionCreators],
+      ])
+      .call(
+        sendMessage,
+        socketClient,
+        resourcePoolActions.create(pool),
+        actionCreators
+      )
+      .run();
+  });
+
+  it("can send a message to create a pool then attach machines using filter", () => {
+    const socketClient = new WebSocketClient();
+    const sendMessage = jest.fn();
+    const actionCreators = [jest.fn()];
+    const pool = { name: "pool1", description: "a pool" };
+    const action = {
+      type: "resourcepoo/createWithMachines",
+      payload: { params: { filter: { id: ["abcd123"] }, pool } },
+      meta: {},
+    };
+    return expectSaga(createPoolWithMachines, socketClient, sendMessage, action)
+      .provide([
+        [
+          matchers.call.fn(generateMachineFilterPoolActionCreators),
+          actionCreators,
+        ],
       ])
       .call(
         sendMessage,

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.tsx
@@ -76,12 +76,21 @@ export const SetPoolForm = ({
       onSubmit={(values) => {
         dispatch(machineActions.cleanup());
         if (values.poolSelection === "create") {
-          dispatch(
-            resourcePoolActions.createWithMachines({
-              machineIDs: machines?.map(({ system_id }) => system_id) || [],
-              pool: values,
-            })
-          );
+          if (selectedMachines) {
+            dispatchForSelectedMachines(
+              resourcePoolActions.createWithMachines,
+              {
+                pool: values,
+              }
+            );
+          } else {
+            dispatch(
+              resourcePoolActions.createWithMachines({
+                machineIDs: machines?.map(({ system_id }) => system_id) || [],
+                pool: values,
+              })
+            );
+          }
         } else {
           const pool = resourcePools.find((pool) => pool.name === values.name);
           if (pool) {

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -2000,14 +2000,17 @@ const machineSlice = createSlice({
     updateVmfsDatastoreSuccess: statusHandlers.updateVmfsDatastore.success,
     markAsUpdated: {
       prepare: (callId: string) => ({
-        payload: { callId },
+        meta: {
+          callId,
+        },
+        payload: null,
       }),
       reducer: (
         state: MachineState,
-        action: PayloadAction<{ callId: string }>
+        action: PayloadAction<null, string, GenericMeta>
       ) => {
-        if (state.lists?.[action.payload.callId]) {
-          state.lists[action.payload.callId].needsUpdate = false;
+        if (action.meta.callId && state.lists?.[action.meta.callId]) {
+          state.lists[action.meta.callId].needsUpdate = false;
         }
       },
     },

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -54,13 +54,14 @@ export type ApplyStorageLayoutParams = {
 export type BaseMachineActionParams =
   | BaseNodeActionParams
   | {
+      system_id?: never;
       filter: FetchFilters;
-      system_id?: Machine[MachineMeta.PK];
       callId?: string;
     };
 
 export type CloneParams = BaseMachineActionParams & {
-  system_id: Machine[MachineMeta.PK];
+  system_id: Node["system_id"];
+  filter: FetchFilters;
   interfaces: boolean;
   storage: boolean;
 };
@@ -500,7 +501,7 @@ export type SetZoneParams = BaseMachineActionParams &
   Omit<NodeSetZoneParams, "system_id">;
 
 export type TagParams = BaseMachineActionParams & {
-  tags: Tag[TagMeta.PK][];
+  tags?: Tag[TagMeta.PK][];
 };
 
 export type TestParams = BaseMachineActionParams &

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -42,6 +42,7 @@ import type {
   MachineStateListGroup,
   SelectedMachines,
 } from "app/store/machine/types";
+import type { actions as resourcePoolActions } from "app/store/resourcepool";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import type { Host } from "app/store/types/host";
@@ -172,7 +173,9 @@ export const useSelectedMachinesActionsDispatch = ({
   searchFilter?: string;
 }): MachineActionData & {
   dispatch: (
-    a: ValueOf<typeof machineActions>,
+    a:
+      | ValueOf<typeof machineActions>
+      | typeof resourcePoolActions.createWithMachines,
     args?: Record<string, unknown> & { filter?: never }
   ) => void;
 } => {

--- a/src/app/store/resourcepool/types/actions.ts
+++ b/src/app/store/resourcepool/types/actions.ts
@@ -1,17 +1,30 @@
 import type { ResourcePool } from "./base";
 import type { ResourcePoolMeta } from "./enum";
 
-import type { Machine, MachineMeta } from "app/store/machine/types";
+import type {
+  FetchFilters,
+  Machine,
+  MachineMeta,
+} from "app/store/machine/types";
 
 export type CreateParams = {
   description: ResourcePool["description"];
   name: ResourcePool["name"];
 };
 
-export type CreateWithMachinesParams = {
-  machineIDs: Machine[MachineMeta.PK][];
+type CreateWithFilterParams = {
   pool: CreateParams;
+  filter: FetchFilters;
 };
+
+type CreateWithMachineIdsParams = {
+  pool: CreateParams;
+  machineIDs: Machine[MachineMeta.PK][];
+};
+
+export type CreateWithMachinesParams =
+  | CreateWithMachineIdsParams
+  | CreateWithFilterParams;
 
 export type UpdateParams = CreateParams & {
   [ResourcePoolMeta.PK]: ResourcePool[ResourcePoolMeta.PK];

--- a/src/app/utils/kebabToCamelCase.ts
+++ b/src/app/utils/kebabToCamelCase.ts
@@ -1,3 +1,8 @@
+type KebabToCamelCase<S extends string> =
+  S extends `${infer FirstPart}-${infer FirstLetter}${infer LastPart}`
+    ? `${FirstPart}${Uppercase<FirstLetter>}${KebabToCamelCase<LastPart>}`
+    : S;
+
 /**
  * Convert a kebab case string into a camel case string,
  * e.g. my-string => myString
@@ -5,5 +10,10 @@
  * @param {string} string - the kebab case string to convert
  * @returns {string} camel case string
  */
-export const kebabToCamelCase = (str: string): string =>
-  str.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+export function kebabToCamelCase<S extends string>(
+  str: S
+): KebabToCamelCase<S> {
+  return str.replace(/-([a-z])/g, (g) =>
+    g[1].toUpperCase()
+  ) as KebabToCamelCase<S>;
+}


### PR DESCRIPTION
## Done

- Backport of https://github.com/canonical/maas-ui/pull/4719

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- No steps required

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
