### PR TITLE
test: fix cypress pools test

### DIFF
--- a/cypress/e2e/with-users/machines/actions.spec.ts
+++ b/cypress/e2e/with-users/machines/actions.spec.ts
@@ -42,9 +42,10 @@ const openMachineActionForm = (action) => {
 };
 
 context("Machine listing - actions", () => {
+  const machineName = generateName("machine");
   before(() => {
     cy.login();
-    cy.addMachine();
+    cy.addMachine(machineName);
   });
   beforeEach(() => {
     cy.login();
@@ -92,5 +93,7 @@ context("Machine listing - actions", () => {
     cy.findByRole("grid", { name: /Machines/i })
       .within(() => cy.findByText(poolName))
       .should("exist");
+    cy.deleteMachine(machineName);
+    cy.deletePool(poolName);
   });
 });

--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -49,7 +49,7 @@ context("Machine listing", () => {
     cy.findByRole("combobox", { name: "Group by" }).select("Group by status");
     cy.findByRole("searchbox").type(searchFilter);
     cy.findByText(/2 machines available/).should("exist");
-    cy.waitForTableToLoad({ name: "Machines" }).within(() =>
+    cy.findByRole("grid", { name: "Machines" }).within(() =>
       // eslint-disable-next-line cypress/no-force
       cy
         .findByRole("checkbox", { name: /Commissioning/i })

--- a/cypress/e2e/with-users/pools/list.spec.ts
+++ b/cypress/e2e/with-users/pools/list.spec.ts
@@ -7,6 +7,7 @@ context("Pools list", () => {
   });
 
   it("renders a heading", () => {
-    cy.contains("1 Resource pool");
+    cy.contains(/Resource pool/i);
+    cy.findByLabelText(/Pool list/i);
   });
 });

--- a/cypress/e2e/with-users/settings/dhcp.spec.ts
+++ b/cypress/e2e/with-users/settings/dhcp.spec.ts
@@ -1,10 +1,14 @@
 import { generateMAASURL, generateName } from "../../utils";
 
 context("Settings - DHCP Snippets", () => {
+  const machineName = generateName("machine");
   beforeEach(() => {
     cy.login();
-    cy.addMachine();
+    cy.addMachine(machineName);
     cy.visit(generateMAASURL("/settings/dhcp/add"));
+  });
+  afterEach(() => {
+    cy.deleteMachine(machineName);
   });
 
   it("can add a Global DHCP snippet", () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -50,6 +50,40 @@ Cypress.Commands.add("addMachine", (hostname = generateName()) => {
   });
 });
 
+Cypress.Commands.add("deleteMachine", (hostname: string) => {
+  cy.visit(generateMAASURL("/machines"));
+  cy.findByRole("combobox", { name: "Group by" }).select("No grouping");
+  cy.findByRole("searchbox").type(hostname);
+  cy.findByText(/1 machine available/).should("exist");
+  cy.findByRole("grid", { name: "Machines" }).within(() =>
+    // eslint-disable-next-line cypress/no-force
+    cy
+      .findByRole("checkbox", { name: new RegExp(hostname) })
+      .click({ force: true })
+  );
+  cy.findByTestId("section-header-buttons").within(() =>
+    cy.findByRole("button", { name: /Take action/i }).click()
+  );
+  cy.findByLabelText("submenu").within(() => {
+    cy.findAllByRole("button", { name: /Delete/i }).click();
+  });
+  cy.findByRole("button", { name: /Delete machine/ }).click();
+  cy.findByRole("complementary", { name: /Delete/i }).should("not.exist");
+  cy.findByText(/No machines match the search criteria/).should("exist");
+});
+
+Cypress.Commands.add("deletePool", (pool: string) => {
+  cy.visit(generateMAASURL("/pools"));
+  cy.findByRole("row", { name: new RegExp(`${pool}`) }).within(() => {
+    cy.findByRole("button", { name: /Delete/i }).click();
+    cy.findByTestId("action-confirm").click();
+  });
+  cy.get(`[data-testid='message']:contains(${pool} removed successfully.)`, {
+    timeout: LONG_TIMEOUT,
+  });
+  cy.findByRole("row", { name: new RegExp(`${pool}`) }).should("not.exist");
+});
+
 Cypress.Commands.add("addMachines", (hostnames: string[]) => {
   cy.visit(generateMAASURL("/machines"));
   cy.get("[data-testid='add-hardware-dropdown'] button").click();

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -11,6 +11,8 @@ declare global {
     interface Chainable {
       addMachine(hostname?: string): void;
       addMachines(hostname: string[]): void;
+      deleteMachine(hostname: string): void;
+      deletePool(pool: string): void;
       login(options?: {
         username?: string;
         password?: string;


### PR DESCRIPTION
## Done

- test: fix cypress pools test
- add `deleteMachine` `deletePool` cypress util functions to help clean up after each test

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
