### PR TITLE
fix: collapsing multi word machine groups - 3.3 backport #4730

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -18,6 +18,7 @@ import { actions as machineActions } from "app/store/machine";
 import { FetchGroupKey, FilterGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
+  FetchNodeStatus,
   NodeStatus,
   NodeStatusCode,
   NodeType,
@@ -163,7 +164,7 @@ describe("MachineList", () => {
         pool: modelRefFactory(),
         pxe_mac: "66:77:88:99:00:11",
         spaces: [],
-        status: NodeStatus.RELEASING,
+        status: NodeStatus.FAILED_TESTING,
         status_code: NodeStatusCode.DEPLOYED,
         status_message: "",
         storage: 16,
@@ -209,10 +210,17 @@ describe("MachineList", () => {
               machineStateListGroupFactory({
                 items: [machines[0].system_id, machines[2].system_id],
                 name: "Deployed",
+                value: FetchNodeStatus.DEPLOYED,
               }),
               machineStateListGroupFactory({
                 items: [machines[1].system_id],
                 name: "Releasing",
+                value: FetchNodeStatus.RELEASING,
+              }),
+              machineStateListGroupFactory({
+                items: [machines[2].system_id],
+                name: "Failed testing",
+                value: FetchNodeStatus.FAILED_TESTING,
               }),
             ],
           }),
@@ -242,11 +250,11 @@ describe("MachineList", () => {
     // Click the button to toggle the group.
     await user.click(
       within(
-        screen.getByRole("row", { name: "Deployed machines group" })
+        screen.getByRole("row", { name: "Failed testing machines group" })
       ).getByRole("button", { name: Label.HideGroup })
     );
     const expected = machineActions.fetch("123456", {
-      group_collapsed: ["Deployed"],
+      group_collapsed: ["failed_testing"],
     });
     const fetches = store
       .getActions()
@@ -254,7 +262,7 @@ describe("MachineList", () => {
     expect(fetches).toHaveLength(2);
     expect(
       fetches[fetches.length - 1].payload.params.group_collapsed
-    ).toStrictEqual(["Deployed"]);
+    ).toStrictEqual(["failed_testing"]);
   });
 
   it("uses the default fallback value for invalid stored grouping values", () => {
@@ -398,14 +406,14 @@ describe("MachineList", () => {
       { store: store2 }
     );
     const expected2 = machineActions.fetch("123456", {
-      group_collapsed: ["Deployed"],
+      group_collapsed: ["deployed"],
     });
     const fetches2 = store2
       .getActions()
       .filter((action) => action.type === expected2.type);
     expect(
       fetches2[fetches.length - 1].payload.params.group_collapsed
-    ).toStrictEqual(["Deployed"]);
+    ).toStrictEqual(["deployed"]);
   });
 
   it("can display an error", () => {

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -412,7 +412,7 @@ const generateGroupRows = ({
   let rows: MainTableRow[] = [];
 
   groups?.forEach((group) => {
-    const { collapsed, count, items: machineIDs, name } = group;
+    const { collapsed, count, items: machineIDs, name, value } = group;
     // When the table is set to ungrouped then there are no group headers.
     if (grouping) {
       rows.push({
@@ -451,11 +451,15 @@ const generateGroupRows = ({
                       if (collapsed) {
                         setHiddenGroups &&
                           setHiddenGroups(
-                            hiddenGroups.filter((group) => group !== name)
+                            hiddenGroups.filter(
+                              (hiddenGroup) => hiddenGroup !== value
+                            )
                           );
                       } else {
                         setHiddenGroups &&
-                          setHiddenGroups(hiddenGroups.concat([name]));
+                          setHiddenGroups(
+                            hiddenGroups.concat([value as string])
+                          );
                       }
                     }}
                   >


### PR DESCRIPTION
## Done

- fix: collapsing multi word machine groups - 3.3 backport #4730

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- No QA steps necessary

## Fixes

Fixes: #4730

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
