### PR TITLE
fix(nav): Break out nav items into separate components and add discrete logout button MAASENG-1314

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
@@ -1,0 +1,51 @@
+import { Icon } from "@canonical/react-components";
+import { Link } from "react-router-dom-v5-compat";
+
+import type { NavItem } from "../types";
+import { isSelected } from "../utils";
+
+import { useId } from "app/base/hooks/base";
+
+type Props = {
+  navLink: NavItem;
+  icon?: string;
+  hasWarningIcon?: boolean;
+  path: string;
+};
+
+export const AppSideNavItem = ({
+  navLink,
+  icon,
+  hasWarningIcon,
+  path,
+}: Props): JSX.Element => {
+  const id = useId();
+  return (
+    <li
+      aria-labelledby={`${navLink.label}-${id}`}
+      className={`l-navigation__item${
+        isSelected(path, navLink) ? " is-selected" : ""
+      }`}
+      key={navLink.label}
+    >
+      <Link
+        aria-current={isSelected(path, navLink) ? "page" : undefined}
+        className="l-navigation__link"
+        id={`${navLink.label}-${id}`}
+        to={navLink.url}
+      >
+        {hasWarningIcon ? (
+          <Icon
+            aria-label="warning"
+            data-testid="warning-icon"
+            name="security-warning-grey"
+          />
+        ) : null}
+        {icon ? <Icon light name={icon} /> : null}
+        <span className="l-navigation__link-text">{navLink.label}</span>
+      </Link>
+    </li>
+  );
+};
+
+export default AppSideNavItem;

--- a/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
@@ -26,7 +26,6 @@ export const AppSideNavItem = ({
       className={`l-navigation__item${
         isSelected(path, navLink) ? " is-selected" : ""
       }`}
-      key={navLink.label}
     >
       <Link
         aria-current={isSelected(path, navLink) ? "page" : undefined}

--- a/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 import { Icon } from "@canonical/react-components";
 import { Link } from "react-router-dom-v5-compat";
 
@@ -8,17 +10,11 @@ import { useId } from "app/base/hooks/base";
 
 type Props = {
   navLink: NavItem;
-  icon?: string;
-  hasWarningIcon?: boolean;
+  icon?: string | ReactNode;
   path: string;
 };
 
-export const AppSideNavItem = ({
-  navLink,
-  icon,
-  hasWarningIcon,
-  path,
-}: Props): JSX.Element => {
+export const AppSideNavItem = ({ navLink, icon, path }: Props): JSX.Element => {
   const id = useId();
   return (
     <li
@@ -33,14 +29,13 @@ export const AppSideNavItem = ({
         id={`${navLink.label}-${id}`}
         to={navLink.url}
       >
-        {hasWarningIcon ? (
-          <Icon
-            aria-label="warning"
-            data-testid="warning-icon"
-            name="security-warning-grey"
-          />
+        {icon ? (
+          typeof icon === "string" ? (
+            <Icon light name={icon} />
+          ) : (
+            <>{icon}</>
+          )
         ) : null}
-        {icon ? <Icon light name={icon} /> : null}
         <span className="l-navigation__link-text">{navLink.label}</span>
       </Link>
     </li>

--- a/src/app/base/components/AppSideNavigation/AppSideNavItem/index.ts
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AppSideNavItem";

--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -36,7 +36,7 @@ export const AppSideNavItems = ({
     <>
       {showLinks
         ? groups.map((group) => (
-            <span key={group.groupTitle}>
+            <span key={`${group.groupTitle}-${id}`}>
               <div className="p-muted-heading" id={`${group.groupTitle}-${id}`}>
                 {group.groupIcon ? <Icon light name={group.groupIcon} /> : null}
                 {group.groupTitle}
@@ -65,7 +65,7 @@ export const AppSideNavItems = ({
         : null}
       {isAuthenticated ? (
         <ul className="l-navigation__items">
-          <hr key="break" />
+          <hr />
           {isAdmin && showLinks ? (
             <>
               <AppSideNavItem
@@ -83,7 +83,6 @@ export const AppSideNavItems = ({
                 ? "is-selected"
                 : null
             }`}
-            key="user"
           >
             <ContextualMenu
               aria-current={
@@ -104,10 +103,10 @@ export const AppSideNavItems = ({
               }
             >
               <ul>
-                <li key="prefs">
+                <li>
                   <Link to={urls.preferences.index}>Preferences</Link>
                 </li>
-                <li key="logout">
+                <li>
                   <Button appearance="link" onClick={() => logout()}>
                     Log out
                   </Button>

--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -47,8 +47,14 @@ export const AppSideNavItems = ({
                   if (!navLink.adminOnly || isAdmin) {
                     return (
                       <AppSideNavItem
-                        hasWarningIcon={
-                          navLink.label === "Controllers" && vaultIncomplete
+                        icon={
+                          navLink.label === "Controllers" && vaultIncomplete ? (
+                            <Icon
+                              aria-label="warning"
+                              data-testid="warning-icon"
+                              name="security-warning-grey"
+                            />
+                          ) : undefined
                         }
                         key={navLink.label}
                         navLink={navLink}

--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -1,0 +1,125 @@
+import { Button, ContextualMenu, Icon } from "@canonical/react-components";
+import { Link } from "react-router-dom-v5-compat";
+
+import AppSideNavItem from "../AppSideNavItem";
+import type { NavGroup } from "../types";
+import { isSelected } from "../utils";
+
+import { useId } from "app/base/hooks/base";
+import urls from "app/base/urls";
+import type { User } from "app/store/user/types";
+
+type Props = {
+  authUser: User | null;
+  groups: NavGroup[];
+  isAdmin: boolean;
+  isAuthenticated: boolean;
+  logout: () => void;
+  path: string;
+  showLinks: boolean;
+  vaultIncomplete: boolean;
+};
+
+export const AppSideNavItems = ({
+  authUser,
+  groups,
+  isAdmin,
+  isAuthenticated,
+  logout,
+  path,
+  showLinks,
+  vaultIncomplete,
+}: Props): JSX.Element => {
+  const id = useId();
+
+  return (
+    <>
+      {showLinks
+        ? groups.map((group) => (
+            <span key={group.groupTitle}>
+              <div className="p-muted-heading" id={`${group.groupTitle}-${id}`}>
+                {group.groupIcon ? <Icon light name={group.groupIcon} /> : null}
+                {group.groupTitle}
+              </div>
+              <ul
+                aria-labelledby={`${group.groupTitle}-${id}`}
+                className="l-navigation__items"
+              >
+                {group.navLinks.map((navLink) => {
+                  if (!navLink.adminOnly || isAdmin) {
+                    return (
+                      <AppSideNavItem
+                        hasWarningIcon={
+                          navLink.label === "Controllers" && vaultIncomplete
+                        }
+                        key={navLink.label}
+                        navLink={navLink}
+                        path={path}
+                      />
+                    );
+                  } else return null;
+                })}
+              </ul>
+            </span>
+          ))
+        : null}
+      {isAuthenticated ? (
+        <ul className="l-navigation__items">
+          <hr key="break" />
+          {isAdmin && showLinks ? (
+            <>
+              <AppSideNavItem
+                icon="settings"
+                navLink={{ label: "Settings", url: urls.settings.index }}
+                path={path}
+              />
+              <hr />
+            </>
+          ) : null}
+
+          <li
+            className={`l-navigation__item ${
+              isSelected(path, { label: "", url: urls.preferences.index })
+                ? "is-selected"
+                : null
+            }`}
+            key="user"
+          >
+            <ContextualMenu
+              aria-current={
+                isSelected(path, { label: "", url: urls.preferences.index })
+                  ? "page"
+                  : undefined
+              }
+              className="l-navigation__link is-dark"
+              position="right"
+              toggleAppearance="link"
+              toggleLabel={
+                <>
+                  <Icon light name="profile-light" />
+                  <span className="l-navigation__link-text">
+                    {authUser?.username}
+                  </span>
+                </>
+              }
+            >
+              <ul>
+                <li key="prefs">
+                  <Link to={urls.preferences.index}>Preferences</Link>
+                </li>
+                <li key="logout">
+                  <Button appearance="link" onClick={() => logout()}>
+                    Log out
+                  </Button>
+                </li>
+              </ul>
+            </ContextualMenu>
+          </li>
+          <hr />
+        </ul>
+      ) : null}
+    </>
+  );
+};
+
+export default AppSideNavItems;

--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -1,9 +1,7 @@
-import { Button, ContextualMenu, Icon } from "@canonical/react-components";
-import { Link } from "react-router-dom-v5-compat";
+import { Button, Icon } from "@canonical/react-components";
 
 import AppSideNavItem from "../AppSideNavItem";
 import type { NavGroup } from "../types";
-import { isSelected } from "../utils";
 
 import { useId } from "app/base/hooks/base";
 import urls from "app/base/urls";
@@ -76,43 +74,24 @@ export const AppSideNavItems = ({
               <hr />
             </>
           ) : null}
+          <AppSideNavItem
+            icon="profile-light"
+            navLink={{
+              label: `${authUser?.username}`,
+              url: urls.preferences.index,
+            }}
+            path={path}
+          />
+          <hr />
 
-          <li
-            className={`l-navigation__item ${
-              isSelected(path, { label: "", url: urls.preferences.index })
-                ? "is-selected"
-                : null
-            }`}
-          >
-            <ContextualMenu
-              aria-current={
-                isSelected(path, { label: "", url: urls.preferences.index })
-                  ? "page"
-                  : undefined
-              }
-              className="l-navigation__link is-dark"
-              position="right"
-              toggleAppearance="link"
-              toggleLabel={
-                <>
-                  <Icon light name="profile-light" />
-                  <span className="l-navigation__link-text">
-                    {authUser?.username}
-                  </span>
-                </>
-              }
+          <li className="l-navigation__item">
+            <Button
+              appearance="link"
+              className="l-navigation__link"
+              onClick={() => logout()}
             >
-              <ul>
-                <li>
-                  <Link to={urls.preferences.index}>Preferences</Link>
-                </li>
-                <li>
-                  <Button appearance="link" onClick={() => logout()}>
-                    Log out
-                  </Button>
-                </li>
-              </ul>
-            </ContextualMenu>
+              <span className="l-navigation__link-text">Log out</span>
+            </Button>
           </li>
           <hr />
         </ul>

--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/index.ts
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AppSideNavItems";

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -105,7 +105,6 @@ describe("GlobalSideNav", () => {
       </Provider>
     );
 
-    await userEvent.click(screen.getByRole("button", { name: "koala" }));
     await userEvent.click(screen.getByRole("button", { name: "Log out" }));
 
     const expectedAction = statusActions.logout();
@@ -116,7 +115,7 @@ describe("GlobalSideNav", () => {
     });
   });
 
-  it("hides nav links if not completed intro", async () => {
+  it("hides nav links if not completed intro", () => {
     state.user.auth.user = userFactory({
       completed_intro: false,
       username: "koala",
@@ -130,7 +129,7 @@ describe("GlobalSideNav", () => {
     expect(within(mainNav).getAllByRole("link")[0]).toHaveAccessibleName(
       "Homepage"
     );
-    await userEvent.click(screen.getByRole("button", { name: "koala" }));
+
     expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
   });
 

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -225,16 +225,6 @@ const AppSideNavigation = (): JSX.Element => {
             showLinks={showLinks}
             vaultIncomplete={vaultIncomplete}
           />
-          {/* {generateItems({
-            authUser,
-            groups: navGroups,
-            isAdmin,
-            isAuthenticated,
-            logout,
-            path,
-            showLinks,
-            vaultIncomplete,
-          })} */}
           {showLinks ? (
             <span id="maas-info">
               {maasName} MAAS v{version}

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -1,18 +1,13 @@
 import { useEffect, useContext, useState } from "react";
 
-import { Button, ContextualMenu, Icon } from "@canonical/react-components";
+import { Icon } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
-import {
-  Link,
-  useNavigate,
-  useLocation,
-  useMatch,
-} from "react-router-dom-v5-compat";
+import { useNavigate, useLocation, useMatch } from "react-router-dom-v5-compat";
 
+import AppSideNavItems from "./AppSideNavItems";
 import NavigationBanner from "./NavigationBanner";
 import type { NavGroup } from "./types";
-import { isSelected } from "./utils";
 
 import {
   useCompletedIntro,
@@ -28,7 +23,6 @@ import controllerSelectors from "app/store/controller/selectors";
 import { version as versionSelectors } from "app/store/general/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as statusActions } from "app/store/status";
-import type { User } from "app/store/user/types";
 
 const navGroups: NavGroup[] = [
   {
@@ -120,165 +114,7 @@ const navGroups: NavGroup[] = [
   },
 ];
 
-const generateItems = ({
-  authUser,
-  groups,
-  isAdmin,
-  isAuthenticated,
-  logout,
-  path,
-  showLinks,
-  vaultIncomplete,
-}: {
-  authUser: User | null;
-  groups: NavGroup[];
-  isAdmin: boolean;
-  isAuthenticated: boolean;
-  logout: () => void;
-  path: string;
-  showLinks: boolean;
-  vaultIncomplete: boolean;
-}) => {
-  const items = [];
-
-  if (showLinks) {
-    groups.forEach((group) => {
-      items.push(
-        <>
-          <div className="p-muted-heading" id={group.groupTitle}>
-            {group.groupIcon ? <Icon light name={group.groupIcon} /> : null}
-            {group.groupTitle}
-          </div>
-          <ul
-            aria-labelledby={group.groupTitle}
-            className="l-navigation__items"
-          >
-            {group.navLinks.map((navLink) => {
-              if (!navLink.adminOnly || isAdmin) {
-                return (
-                  <li
-                    aria-labelledby={navLink.label}
-                    className={`l-navigation__item ${
-                      isSelected(path, navLink) ? "is-selected" : null
-                    }`}
-                  >
-                    {navLink.label === "Controllers" && vaultIncomplete ? (
-                      // If Vault setup is incomplete (started but not finished), display a warning icon
-                      <Icon
-                        aria-label="warning"
-                        className="p-navigation--item-icon"
-                        data-testid="warning-icon"
-                        name="security-warning-grey"
-                      />
-                    ) : null}
-                    <Link
-                      aria-current={
-                        isSelected(path, navLink) ? "page" : undefined
-                      }
-                      className="l-navigation__link"
-                      id={navLink.label}
-                      to={navLink.url}
-                    >
-                      <span className="l-navigation__link-text">
-                        {navLink.label}
-                      </span>
-                    </Link>
-                  </li>
-                );
-              } else return null;
-            })}
-          </ul>
-        </>
-      );
-    });
-  }
-
-  if (isAuthenticated) {
-    items.push(
-      <ul className="l-navigation__items">
-        <hr />
-        {isAdmin && showLinks ? (
-          <>
-            <li
-              aria-labelledby="Settings"
-              className={`l-navigation__item ${
-                isSelected(path, {
-                  label: "Settings",
-                  url: urls.settings.index,
-                })
-                  ? "is-selected"
-                  : null
-              }`}
-            >
-              <Link
-                aria-current={
-                  isSelected(path, {
-                    label: "Settings",
-                    url: urls.settings.index,
-                  })
-                    ? "page"
-                    : undefined
-                }
-                className="l-navigation__link"
-                id="Settings"
-                to={urls.settings.index}
-              >
-                <Icon light name="settings" />
-                <span className="l-navigation__link-text">Settings</span>
-              </Link>
-            </li>
-            <hr />
-          </>
-        ) : null}
-
-        <li
-          className={`l-navigation__item ${
-            isSelected(path, { label: "", url: urls.preferences.index })
-              ? "is-selected"
-              : null
-          }`}
-        >
-          <ContextualMenu
-            aria-current={
-              isSelected(path, { label: "", url: urls.preferences.index })
-                ? "page"
-                : undefined
-            }
-            aria-labelledby={authUser?.username}
-            className="l-navigation__link is-dark"
-            id={authUser?.username}
-            position="right"
-            toggleAppearance="link"
-            toggleLabel={
-              <>
-                <Icon light name="profile-light" />
-                <span className="l-navigation__link-text">
-                  {authUser?.username}
-                </span>
-              </>
-            }
-          >
-            <ul>
-              <li>
-                <Link to={urls.preferences.index}>Preferences</Link>
-              </li>
-              <li>
-                <Button appearance="link" onClick={() => logout()}>
-                  Log out
-                </Button>
-              </li>
-            </ul>
-          </ContextualMenu>
-        </li>
-        <hr />
-      </ul>
-    );
-  }
-
-  return items;
-};
-
-const GlobalSideNav = (): JSX.Element => {
+const AppSideNavigation = (): JSX.Element => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const location = useLocation();
@@ -379,8 +215,17 @@ const GlobalSideNav = (): JSX.Element => {
       >
         <div className="l-navigation__wrapper">
           <NavigationBanner />
-
-          {generateItems({
+          <AppSideNavItems
+            authUser={authUser}
+            groups={navGroups}
+            isAdmin={isAdmin}
+            isAuthenticated={isAuthenticated}
+            logout={logout}
+            path={path}
+            showLinks={showLinks}
+            vaultIncomplete={vaultIncomplete}
+          />
+          {/* {generateItems({
             authUser,
             groups: navGroups,
             isAdmin,
@@ -389,7 +234,7 @@ const GlobalSideNav = (): JSX.Element => {
             path,
             showLinks,
             vaultIncomplete,
-          })}
+          })} */}
           {showLinks ? (
             <span id="maas-info">
               {maasName} MAAS v{version}
@@ -407,4 +252,4 @@ const GlobalSideNav = (): JSX.Element => {
   );
 };
 
-export default GlobalSideNav;
+export default AppSideNavigation;

--- a/src/app/base/components/AppSideNavigation/_index.scss
+++ b/src/app/base/components/AppSideNavigation/_index.scss
@@ -74,6 +74,7 @@
             display: inline-block;
             width: 100%;
             height: 100%;
+            text-align: left;
 
             .l-navigation__link-text {
               padding-left: $spv--small;


### PR DESCRIPTION
## Done

- Create AppSideNavItem
- Create AppSideNavItems
- Add useId for component IDs (used in aria-labelledby)
- Fix keys on nav item mapping
- Swap the contextual menu for discrete buttons for preferences and logging out

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Check that the nav renders normally
- Ensure clicking on your username directs you to preferences
- Click the logout button
- Ensure you are logged out and directed to the login screen

## Fixes

Fixes [MAASENG-1314](https://warthogs.atlassian.net/browse/MAASENG-1314)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/217511245-d9d463f5-9257-4d7e-ac32-99d4a7fe4f72.png)

### After
![image](https://user-images.githubusercontent.com/35104482/217511359-94a9b5c2-e313-47a0-b137-bbe8eeae0e7c.png)


[MAASENG-1314]: https://warthogs.atlassian.net/browse/MAASENG-1314?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ