### PR TITLE
Fix: 1316 build button to collapse scripts

### DIFF
--- a/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.test.tsx
@@ -91,4 +91,34 @@ describe("ScriptDetails", () => {
 
     expect(screen.getByText("test script contents")).toBeInTheDocument();
   });
+
+  it("displays a collapse button if 'isCollapsible' prop is provided", () => {
+    jest.spyOn(fileContextStore, "get").mockReturnValue("some random text");
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <FileContext.Provider value={fileContextStore}>
+          <ScriptDetails id={1} isCollapsible />
+        </FileContext.Provider>
+      </MemoryRouter>,
+      { state }
+    );
+
+    expect(
+      screen.getByRole("button", { name: /hide details/i })
+    ).toBeInTheDocument();
+  });
+
+  it("doesn't display a collapse button if 'isCollapsible' prop is not provided", () => {
+    jest.spyOn(fileContextStore, "get").mockReturnValue("some random text");
+    renderWithMockStore(
+      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
+        <FileContext.Provider value={fileContextStore}>
+          <ScriptDetails id={1} />
+        </FileContext.Provider>
+      </MemoryRouter>,
+      { state }
+    );
+
+    expect(screen.queryByRole("button", { name: /hide details/i })).toBeNull();
+  });
 });

--- a/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.test.tsx
@@ -12,12 +12,7 @@ import {
   scriptState as scriptStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import {
-  screen,
-  render,
-  renderWithMockStore,
-  renderWithBrowserRouter,
-} from "testing/utils";
+import { screen, render, renderWithBrowserRouter } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -64,34 +59,22 @@ describe("ScriptDetails", () => {
 
   it("displays a spinner while loading", () => {
     state.script.loading = true;
-    renderWithMockStore(
-      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ScriptDetails id={1} />
-      </MemoryRouter>,
-      { state }
-    );
+    renderWithBrowserRouter(<ScriptDetails id={1} />, { state, route: "/" });
     expect(screen.getByText("Loading")).toBeInTheDocument();
   });
 
   it("displays a message when the script does not exist", () => {
-    renderWithMockStore(
-      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <ScriptDetails id={1} />
-      </MemoryRouter>,
-      { state }
-    );
+    renderWithBrowserRouter(<ScriptDetails id={1} />, { state, route: "/" });
     expect(screen.getByText("Script could not be found")).toBeInTheDocument();
   });
 
   it("can display the script", () => {
     jest.spyOn(fileContextStore, "get").mockReturnValue("test script contents");
-    renderWithMockStore(
-      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <FileContext.Provider value={fileContextStore}>
-          <ScriptDetails id={1} />
-        </FileContext.Provider>
-      </MemoryRouter>,
-      { state }
+    renderWithBrowserRouter(
+      <FileContext.Provider value={fileContextStore}>
+        <ScriptDetails id={1} />
+      </FileContext.Provider>,
+      { state, route: "/" }
     );
 
     expect(screen.getByText("test script contents")).toBeInTheDocument();

--- a/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.test.tsx
@@ -12,7 +12,12 @@ import {
   scriptState as scriptStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithMockStore } from "testing/utils";
+import {
+  screen,
+  render,
+  renderWithMockStore,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -94,31 +99,29 @@ describe("ScriptDetails", () => {
 
   it("displays a collapse button if 'isCollapsible' prop is provided", () => {
     jest.spyOn(fileContextStore, "get").mockReturnValue("some random text");
-    renderWithMockStore(
-      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <FileContext.Provider value={fileContextStore}>
-          <ScriptDetails id={1} isCollapsible />
-        </FileContext.Provider>
-      </MemoryRouter>,
-      { state }
+    renderWithBrowserRouter(
+      <FileContext.Provider value={fileContextStore}>
+        <ScriptDetails id={1} isCollapsible />
+      </FileContext.Provider>,
+      { state, route: "/" }
     );
 
     expect(
-      screen.getByRole("button", { name: /hide details/i })
+      screen.getByRole("button", { name: /close snippet/i })
     ).toBeInTheDocument();
   });
 
   it("doesn't display a collapse button if 'isCollapsible' prop is not provided", () => {
     jest.spyOn(fileContextStore, "get").mockReturnValue("some random text");
-    renderWithMockStore(
-      <MemoryRouter initialEntries={[{ pathname: "/" }]}>
-        <FileContext.Provider value={fileContextStore}>
-          <ScriptDetails id={1} />
-        </FileContext.Provider>
-      </MemoryRouter>,
-      { state }
+    renderWithBrowserRouter(
+      <FileContext.Provider value={fileContextStore}>
+        <ScriptDetails id={1} />
+      </FileContext.Provider>,
+      { state, route: "/" }
     );
 
-    expect(screen.queryByRole("button", { name: /hide details/i })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: /close snippet/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.tsx
+++ b/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.tsx
@@ -1,6 +1,13 @@
 import { useContext, useEffect, useRef } from "react";
 
-import { Code, Col, Row, Spinner } from "@canonical/react-components";
+import {
+  Button,
+  Code,
+  Col,
+  Icon,
+  Row,
+  Spinner,
+} from "@canonical/react-components";
 import { nanoid } from "@reduxjs/toolkit";
 import { useDispatch, useSelector } from "react-redux";
 
@@ -11,9 +18,15 @@ import type { Script } from "app/store/script/types";
 
 type Props = {
   id: Script["id"];
+  isCollapsible?: boolean;
+  onCollapse?: () => void;
 };
 
-const ScriptDetails = ({ id }: Props): JSX.Element => {
+const ScriptDetails = ({
+  id,
+  isCollapsible,
+  onCollapse,
+}: Props): JSX.Element => {
   const dispatch = useDispatch();
   const loading = useSelector(scriptSelectors.loading);
   const scriptKey = useRef(nanoid());
@@ -43,11 +56,29 @@ const ScriptDetails = ({ id }: Props): JSX.Element => {
   }
 
   return (
-    <Row>
-      <Col size={10}>
-        <Code className="u-no-margin--bottom">{script}</Code>
-      </Col>
-    </Row>
+    <>
+      <Row>
+        <Col size={10}>
+          <Code className="u-no-margin--bottom">{script}</Code>
+        </Col>
+      </Row>
+      {isCollapsible && (
+        <Row>
+          <Col className="u-flex--end" emptyLarge={8} size={4}>
+            <Button
+              appearance="link"
+              aria-label="Hide details"
+              className="u-flex--between u-flex--align-center script-details--collapse-button"
+              dense
+              onClick={onCollapse}
+            >
+              <span className="u-nudge-left--small">Close snippet</span>
+              <Icon className="" name="chevron-up" />
+            </Button>
+          </Col>
+        </Row>
+      )}
+    </>
   );
 };
 

--- a/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.tsx
+++ b/src/app/settings/views/Scripts/ScriptDetails/ScriptDetails.tsx
@@ -67,7 +67,6 @@ const ScriptDetails = ({
           <Col className="u-flex--end" emptyLarge={8} size={4}>
             <Button
               appearance="link"
-              aria-label="Hide details"
               className="u-flex--between u-flex--align-center script-details--collapse-button"
               dense
               onClick={onCollapse}

--- a/src/app/settings/views/Scripts/ScriptDetails/_index.scss
+++ b/src/app/settings/views/Scripts/ScriptDetails/_index.scss
@@ -1,0 +1,5 @@
+@mixin ScriptDetails {
+  .script-details--collapse-button {
+    color: $color-mid-dark;
+  }
+}

--- a/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
+++ b/src/app/settings/views/Scripts/ScriptsList/ScriptsList.tsx
@@ -107,7 +107,11 @@ const generateRows = (
             />
           </div>
         ) : (
-          <ScriptDetails id={script.id} />
+          <ScriptDetails
+            id={script.id}
+            isCollapsible
+            onCollapse={hideExpanded}
+          />
         )),
       key: script.id,
       sortData: {

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -271,6 +271,7 @@
 @import "~app/settings/views/Repositories/RepositoryFormFields";
 @import "~app/settings/views/Scripts/ScriptsList";
 @import "~app/settings/views/Scripts/ScriptsUpload";
+@import "~app/settings/views/Scripts/ScriptDetails";
 @import "~app/settings/views/Users/UsersList";
 @include SettingsTable;
 @include DhcpList;
@@ -283,6 +284,7 @@
 @include UsersList;
 @include GeneralForm;
 @include ThemedRadioButton;
+@include ScriptDetails;
 
 // subnets
 @import "~app/subnets/components/ReservedRanges";


### PR DESCRIPTION
## Done

- Added an optional collapse button to the commissioning scripts to hide the scripts

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.
- Navigate to `/MAAS/r/settings/scripts/commissioning`
- Click on a script name to expand the script, you should notice a button at the bottom-right corner  of the script that reads `Close snippet`

## Fixes

Fixes #878
Fixes [MAASENG-1316](https://warthogs.atlassian.net/browse/MAASENG-1316)

## Screenshots

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/47540149/217507177-975c9052-69ad-461a-9965-1e963a012521.png">



[MAASENG-1316]: https://warthogs.atlassian.net/browse/MAASENG-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ