### PR TITLE
fix(MAASENG-1313): Remove duplicated tab navigation items

### DIFF
--- a/src/app/Routes.test.tsx
+++ b/src/app/Routes.test.tsx
@@ -61,7 +61,7 @@ const routes: { title: string; path: string }[] = [
     path: urls.images.index,
   },
   {
-    title: "KVM",
+    title: "LXD",
     path: urls.kvm.index,
   },
   {

--- a/src/app/kvm/views/KVMList/KVMList.tsx
+++ b/src/app/kvm/views/KVMList/KVMList.tsx
@@ -39,7 +39,8 @@ const KVMList = (): JSX.Element => {
   const hasVirsh = virshKvms.length > 0;
   const showingLXD = location.pathname.endsWith(urls.kvm.lxd.index);
   const showingVirsh = location.pathname.endsWith(urls.kvm.virsh.index);
-  useWindowTitle(showingLXD ? "LXD" : "Virsh");
+  const title = showingLXD ? "LXD" : showingVirsh ? "Virsh" : "KVM";
+  useWindowTitle(title);
 
   useEffect(() => {
     dispatch(podActions.fetch());
@@ -95,7 +96,7 @@ const KVMList = (): JSX.Element => {
         <KVMListHeader
           setSidePanelContent={setSidePanelContent}
           sidePanelContent={sidePanelContent}
-          title={showingLXD ? "LXD" : "Virsh"}
+          title={title}
         />
       }
     >

--- a/src/app/kvm/views/KVMList/KVMList.tsx
+++ b/src/app/kvm/views/KVMList/KVMList.tsx
@@ -39,7 +39,7 @@ const KVMList = (): JSX.Element => {
   const hasVirsh = virshKvms.length > 0;
   const showingLXD = location.pathname.endsWith(urls.kvm.lxd.index);
   const showingVirsh = location.pathname.endsWith(urls.kvm.virsh.index);
-  useWindowTitle("KVM");
+  useWindowTitle(showingLXD ? "LXD" : "Virsh");
 
   useEffect(() => {
     dispatch(podActions.fetch());
@@ -95,6 +95,7 @@ const KVMList = (): JSX.Element => {
         <KVMListHeader
           setSidePanelContent={setSidePanelContent}
           sidePanelContent={sidePanelContent}
+          title={showingLXD ? "LXD" : "Virsh"}
         />
       }
     >

--- a/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -71,48 +71,6 @@ describe("KVMListHeader", () => {
     );
   });
 
-  it("sets the LXD tab as active when at the LXD URL", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.lxd.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMListHeader
-              setSidePanelContent={jest.fn()}
-              sidePanelContent={null}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("a[data-testid='lxd-tab']").prop("aria-selected")).toBe(
-      true
-    );
-  });
-
-  it("sets the Virsh tab as active when at the Virsh URL", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.virsh.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMListHeader
-              setSidePanelContent={jest.fn()}
-              sidePanelContent={null}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(
-      wrapper.find("a[data-testid='virsh-tab']").prop("aria-selected")
-    ).toBe(true);
-  });
-
   it("can open the add LXD form at the LXD URL", () => {
     const setSidePanelContent = jest.fn();
     const store = mockStore(state);

--- a/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -43,6 +43,7 @@ describe("KVMListHeader", () => {
             <KVMListHeader
               setSidePanelContent={jest.fn()}
               sidePanelContent={null}
+              title="some text"
             />
           </CompatRouter>
         </MemoryRouter>
@@ -61,6 +62,7 @@ describe("KVMListHeader", () => {
             <KVMListHeader
               setSidePanelContent={jest.fn()}
               sidePanelContent={null}
+              title="some text"
             />
           </CompatRouter>
         </MemoryRouter>
@@ -83,6 +85,7 @@ describe("KVMListHeader", () => {
             <KVMListHeader
               setSidePanelContent={setSidePanelContent}
               sidePanelContent={null}
+              title="LXD"
             />
           </CompatRouter>
         </MemoryRouter>
@@ -109,6 +112,7 @@ describe("KVMListHeader", () => {
             <KVMListHeader
               setSidePanelContent={setSidePanelContent}
               sidePanelContent={null}
+              title="Virsh"
             />
           </CompatRouter>
         </MemoryRouter>

--- a/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -4,8 +4,8 @@ import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
 
+import type { SectionHeaderProps } from "app/base/components/SectionHeader";
 import SectionHeader from "app/base/components/SectionHeader";
 import urls from "app/base/urls";
 import KVMHeaderForms from "app/kvm/components/KVMHeaderForms";
@@ -18,7 +18,7 @@ import { getFormTitle } from "app/kvm/utils";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 
-type Props = {
+type Props = SectionHeaderProps & {
   sidePanelContent: KVMSidePanelContent | null;
   setSidePanelContent: KVMSetSidePanelContent;
 };
@@ -26,13 +26,13 @@ type Props = {
 const KVMListHeader = ({
   sidePanelContent,
   setSidePanelContent,
+  ...props
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const location = useLocation();
   const kvms = useSelector(podSelectors.kvms);
   const podsLoaded = useSelector(podSelectors.loaded);
   const lxdTabActive = location.pathname.endsWith(urls.kvm.lxd.index);
-  const virshTabActive = location.pathname.endsWith(urls.kvm.virsh.index);
 
   useEffect(() => {
     dispatch(podActions.fetch());
@@ -67,23 +67,7 @@ const KVMListHeader = ({
       sidePanelTitle={sidePanelContent ? getFormTitle(sidePanelContent) : "KVM"}
       subtitle={`${pluralize("KVM host", kvms.length, true)} available`}
       subtitleLoading={!podsLoaded}
-      tabLinks={[
-        {
-          active: lxdTabActive,
-          component: Link,
-          "data-testid": "lxd-tab",
-          label: "LXD",
-          to: urls.kvm.lxd.index,
-        },
-        {
-          active: virshTabActive,
-          component: Link,
-          "data-testid": "virsh-tab",
-          label: "Virsh",
-          to: urls.kvm.virsh.index,
-        },
-      ]}
-      title="KVM"
+      title={"title" in props && !!props.title ? props.title : "KVM"}
     />
   );
 };

--- a/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -18,7 +18,7 @@ import { getFormTitle } from "app/kvm/utils";
 import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 
-type Props = SectionHeaderProps & {
+type Props = Required<Pick<SectionHeaderProps, "title">> & {
   sidePanelContent: KVMSidePanelContent | null;
   setSidePanelContent: KVMSetSidePanelContent;
 };
@@ -26,7 +26,7 @@ type Props = SectionHeaderProps & {
 const KVMListHeader = ({
   sidePanelContent,
   setSidePanelContent,
-  ...props
+  title,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const location = useLocation();
@@ -67,7 +67,7 @@ const KVMListHeader = ({
       sidePanelTitle={sidePanelContent ? getFormTitle(sidePanelContent) : "KVM"}
       subtitle={`${pluralize("KVM host", kvms.length, true)} available`}
       subtitleLoading={!podsLoaded}
-      title={"title" in props && !!props.title ? props.title : "KVM"}
+      title={title}
     />
   );
 };


### PR DESCRIPTION
## Done

- Removed duplicated tab navigation items on KVM pages
- Updated KVM header to display "LXD" or "Virsh" instead of "KVM"

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to `/kvm/lxd`
- Ensure the title is "LXD" (window and page header)
- Ensure the old tab links are not rendered
- Navigate to `/kvm/virsh`
- Ensure the title is "Virsh" (window and page header)
- Ensure the old tab links are not rendered

## Fixes

Fixes [MAASENG-1313](https://warthogs.atlassian.net/browse/MAASENG-1313?atlOrigin=eyJpIjoiNzExYTAxMWY0MjMyNGUyMTk0NGNjZTkxMTBlZjczYzMiLCJwIjoiaiJ9)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/217522226-f0fcf53a-4f31-40d6-83ea-73d5ae2125f9.png)

### After
![image](https://user-images.githubusercontent.com/35104482/217522165-d7c3e637-219b-4b09-9497-50e011ef8128.png)
****


[MAASENG-1313]: https://warthogs.atlassian.net/browse/MAASENG-1313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ