### PR TITLE
fix: navigation toggle buttons

### DIFF
--- a/cypress/e2e/with-users/base/header.spec.ts
+++ b/cypress/e2e/with-users/base/header.spec.ts
@@ -99,4 +99,20 @@ context("Header - admin", () => {
       Cypress.env("username")
     );
   });
+
+  it("opens and closes the menu on mobile", () => {
+    cy.viewport("iphone-8");
+    const getMainNavigation = () =>
+      cy.findByRole("navigation", {
+        name: /main navigation/i,
+      });
+    getMainNavigation().should("not.be.visible");
+    cy.findByRole("banner").within(() =>
+      cy.findByRole("button", { name: "Menu" }).click()
+    );
+    getMainNavigation()
+      .should("be.visible")
+      .within(() => cy.findByRole("button", { name: /Close/i }).click());
+    getMainNavigation().should("not.be.visible");
+  });
 });

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useContext, useState } from "react";
 
-import { Icon } from "@canonical/react-components";
+import { Button, Icon } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useLocation, useMatch } from "react-router-dom-v5-compat";
@@ -194,18 +194,22 @@ const AppSideNavigation = (): JSX.Element => {
             <div className="l-navigation__wrapper">
               <NavigationBanner />
             </div>
-            <div className="p-panel__controls">
-              <span
-                className="p-panel__toggle js-menu-toggle"
-                onClick={() => setIsCollapsed(!isCollapsed)}
+            <div className="p-panel__controls u-nudge-down--small u-no-margin--top u-hide--large">
+              <Button
+                appearance="base"
+                className="has-icon is-dark"
+                onClick={() => {
+                  setIsCollapsed(false);
+                }}
               >
                 Menu
-              </span>
+              </Button>
             </div>
           </div>
         </div>
       </header>
       <nav
+        aria-label="main navigation"
         className={classNames(
           `l-navigation is-pinned l-navigation--${themeColor}`,
           {
@@ -214,7 +218,23 @@ const AppSideNavigation = (): JSX.Element => {
         )}
       >
         <div className="l-navigation__wrapper">
-          <NavigationBanner />
+          <NavigationBanner>
+            <div className="u-nudge-down--small u-hide--large">
+              <Button
+                appearance="base"
+                aria-label="Close"
+                className="has-icon is-dark u-no-margin"
+                onClick={(e) => {
+                  setIsCollapsed(true);
+                  // Make sure the button does not have focus
+                  // .l-navigation remains open with :focus-within
+                  e.currentTarget.blur();
+                }}
+              >
+                <Icon light name="close" />
+              </Button>
+            </div>
+          </NavigationBanner>
           <AppSideNavItems
             authUser={authUser}
             groups={navGroups}
@@ -230,12 +250,6 @@ const AppSideNavigation = (): JSX.Element => {
               {maasName} MAAS v{version}
             </span>
           ) : null}
-          <span
-            className="l-navigation__toggle p-panel__toggle js-menu-toggle"
-            onClick={() => setIsCollapsed(!isCollapsed)}
-          >
-            <Icon light name="close" />
-          </span>
         </div>
       </nav>
     </>

--- a/src/app/base/components/AppSideNavigation/NavigationBanner/NavigationBanner.tsx
+++ b/src/app/base/components/AppSideNavigation/NavigationBanner/NavigationBanner.tsx
@@ -6,7 +6,11 @@ import { isSelected } from "../utils";
 import urls from "app/base/urls";
 import authSelectors from "app/store/auth/selectors";
 
-const NavigationBanner = (): JSX.Element => {
+const NavigationBanner = ({
+  children,
+}: {
+  children?: React.ReactNode;
+}): JSX.Element => {
   const isAdmin = useSelector(authSelectors.isAdmin);
   const location = useLocation();
 
@@ -44,6 +48,7 @@ const NavigationBanner = (): JSX.Element => {
           <div className="p-navigation__logo-title">Canonical MAAS</div>
         </div>
       </Link>
+      {children}
     </div>
   );
 };

--- a/src/app/base/components/AppSideNavigation/_index.scss
+++ b/src/app/base/components/AppSideNavigation/_index.scss
@@ -4,7 +4,7 @@
   }
   .l-navigation,
   .l-navigation-bar {
-    @include vf-animation("background-color");
+    transition-property: transform, box-shadow, background-color;
 
     .l-navigation__wrapper {
       color: $colors--dark-theme--text-default;
@@ -48,6 +48,7 @@
       hr {
         background: rgba(255, 255, 255, 0.15);
         margin: $spv--small 0 $spv--small $spv--large;
+        width: auto;
       }
 
       .p-muted-heading {


### PR DESCRIPTION
## Done

- fix: navigation toggle buttons
  - use semantic button elements for buttons
  - fix close button position
- fix `<hr />` element overflow
- bring back transform transition (was overwritten by `@include vf-animation("background-color");`)
- add cypress test for opening and closing the mobile navigation

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Open developer tools
- Display the page using mobile device viewport
- Click on the menu button
- Click on the close button
- Make sure the menu has closed


## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1322

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
<img width="367" alt="image" src="https://user-images.githubusercontent.com/7452681/217537992-361b9f5f-0956-4e83-a234-76250be34cbb.png">

### After
<img width="367" alt="image" src="https://user-images.githubusercontent.com/7452681/217537853-3fe7cf3c-4ac8-409d-8e3a-96da75e022c0.png">

