### PR TITLE
fix(KVM): Increase width of KVM details side panel forms

### DIFF
--- a/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.tsx
+++ b/src/app/kvm/components/KVMDetailsHeader/KVMDetailsHeader.tsx
@@ -61,6 +61,7 @@ const KVMDetailsHeader = ({
     <SectionHeader
       buttons={buttons}
       className={classNames("kvm-details-header", className)}
+      headerSize="wide"
       loading={loading}
       sidePanelContent={
         sidePanelContent ? (


### PR DESCRIPTION
## Done

- Increased width of KVM details side panel forms to ensure storage pool table fits properly

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Click "LXD" in the nav
- Click on a host
- Scroll down and click "Add VM"
- Click "Add disk"
- Click the "Location" dropdown"
- Ensure the table headers do not wrap 

## Fixes

Fixes https://warthogs.atlassian.net/jira/software/c/projects/MAASENG/boards/302?modal=detail&selectedIssue=MAASENG-1265

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/217798625-ac492e4b-d6fd-469c-a531-d4463c8799fd.png)

### After
![image](https://user-images.githubusercontent.com/35104482/217798860-87a17757-1b52-43ee-afa8-9e0e5252a490.png)
