### PR TITLE
Fix: MAASENG-1332 - stack form buttons on smaller screens

### DIFF
--- a/src/app/base/components/FormikFormButtons/_index.scss
+++ b/src/app/base/components/FormikFormButtons/_index.scss
@@ -43,5 +43,18 @@
         width: 100%;
       }
     }
+
+    @media only screen and (max-width: $breakpoint-large) {
+      .formik-form-buttons__container {
+        display: flex;
+        flex-direction: column-reverse;
+        gap: $spv--medium;
+        padding: $spv--medium 0;
+
+        .formik-form-buttons__button {
+          margin-right: 0;
+        }
+      }
+    }
   }
 }

--- a/src/app/base/components/FormikFormButtons/_index.scss
+++ b/src/app/base/components/FormikFormButtons/_index.scss
@@ -47,7 +47,7 @@
     @media only screen and (max-width: $breakpoint-large) {
       .formik-form-buttons__container {
         display: flex;
-        flex-direction: column-reverse;
+        flex-direction: column;
         gap: $spv--medium;
         padding: $spv--medium 0;
 


### PR DESCRIPTION
## Done

- Stacked form buttons on smaller screens (< 1036px).

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Navigate to `/MAAS/r/devices`
- Click the `Add Device` button
- Examine the form buttons at the base on different screen sizes

## Fixes

Fixes: # .
closes #3334 
[https://warthogs.atlassian.net/browse/MAASENG-1332](https://warthogs.atlassian.net/browse/MAASENG-1332)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

<img width="448" alt="image" src="https://user-images.githubusercontent.com/47540149/217838865-250d4c38-fff1-4dbb-af8c-ec9ebeeb5004.png">

