### PR TITLE
feat(nav): Re-order and re-group items in side navigation MAASENG-1333

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -26,28 +26,6 @@ import { actions as statusActions } from "app/store/status";
 
 const navGroups: NavGroup[] = [
   {
-    navLinks: [
-      {
-        label: "Images",
-        url: urls.images.index,
-      },
-      {
-        highlight: [urls.tags.index, urls.tags.tag.index(null)],
-        label: "Tags",
-        url: urls.tags.index,
-      },
-      {
-        highlight: [urls.zones.index, urls.zones.details(null)],
-        label: "AZs",
-        url: urls.zones.index,
-      },
-      {
-        label: "Pools",
-        url: urls.pools.index,
-      },
-    ],
-  },
-  {
     groupTitle: "Hardware",
     groupIcon: "machines-light",
     navLinks: [
@@ -83,6 +61,36 @@ const navGroups: NavGroup[] = [
       {
         label: "Virsh",
         url: urls.kvm.virsh.index,
+      },
+    ],
+  },
+  {
+    groupTitle: "Organisation",
+    groupIcon: "tag-light",
+    navLinks: [
+      {
+        highlight: [urls.tags.index, urls.tags.tag.index(null)],
+        label: "Tags",
+        url: urls.tags.index,
+      },
+      {
+        highlight: [urls.zones.index, urls.zones.details(null)],
+        label: "AZs",
+        url: urls.zones.index,
+      },
+      {
+        label: "Pools",
+        url: urls.pools.index,
+      },
+    ],
+  },
+  {
+    groupTitle: "Configuration",
+    groupIcon: "units-light",
+    navLinks: [
+      {
+        label: "Images",
+        url: urls.images.index,
       },
     ],
   },

--- a/src/app/base/components/AppSideNavigation/_index.scss
+++ b/src/app/base/components/AppSideNavigation/_index.scss
@@ -30,6 +30,7 @@
       .p-navigation__banner {
         height: 2.3rem;
         padding-left: 1.5rem;
+        margin-bottom: $spv--x-large;;
 
         .p-navigation__logo-tag {
           left: $spv--large;

--- a/src/scss/_patterns_icons.scss
+++ b/src/scss/_patterns_icons.scss
@@ -97,7 +97,7 @@
 
   .p-icon--security-tick {
     @extend %icon;
-    @include maas-icon-security-tick($color-mid-dark)
+    @include maas-icon-security-tick($color-mid-dark);
   }
 
   .p-icon--security-warning {
@@ -112,7 +112,17 @@
 
   .p-icon--warning-grey {
     @extend %icon;
-    @include vf-icon-warning-grey($color-white)
+    @include vf-icon-warning-grey($color-white);
+  }
+
+  .p-icon--units-light {
+    @extend %icon;
+    @include vf-icon-units($color-white);
+  }
+
+  .p-icon--tag-light {
+    @extend %icon;
+    @include vf-icon-tag($color-white);
   }
 
   // TODO: Remove alias and replace with .p-icon--status-waiting


### PR DESCRIPTION
## Done

- Moved "Hardware" group to the top
- Split ungrouped items into "Organisation" and "Configuration"
- Added icons for new groups
- Added margin beneath nav banner

**Note: Conditionally displaying "Virsh" will be done in a follow-up PR https://warthogs.atlassian.net/jira/software/c/projects/MAASENG/boards/302?modal=detail&selectedIssue=MAASENG-1334**

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure the nav displays correctly
- Ensure the icons for the new groups are rendered
- Ensure the nav links still work

## Fixes

Fixes [MAASENG-1333](https://warthogs.atlassian.net/jira/software/c/projects/MAASENG/boards/302?modal=detail&selectedIssue=MAASENG-1333)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/217849247-e13d30eb-a479-4d6b-8cae-80560cdc61df.png)

### After
![image](https://user-images.githubusercontent.com/35104482/217849454-3fdeaebe-ed1d-45a6-bf55-5407f0efdb5f.png)



[MAASENG-1333]: https://warthogs.atlassian.net/browse/MAASENG-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ