### PR TITLE
chore(styles): Clean up icon patterns MAASENG-1342

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -81,7 +81,7 @@ export const AppSideNavItems = ({
             </>
           ) : null}
           <AppSideNavItem
-            icon="profile-light"
+            icon="profile"
             navLink={{
               label: `${authUser?.username}`,
               url: urls.preferences.index,

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -27,7 +27,7 @@ import { actions as statusActions } from "app/store/status";
 const navGroups: NavGroup[] = [
   {
     groupTitle: "Hardware",
-    groupIcon: "machines-light",
+    groupIcon: "machines",
     navLinks: [
       {
         highlight: [urls.machines.index, urls.machines.machine.index(null)],
@@ -66,7 +66,7 @@ const navGroups: NavGroup[] = [
   },
   {
     groupTitle: "Organisation",
-    groupIcon: "tag-light",
+    groupIcon: "tag",
     navLinks: [
       {
         highlight: [urls.tags.index, urls.tags.tag.index(null)],
@@ -86,7 +86,7 @@ const navGroups: NavGroup[] = [
   },
   {
     groupTitle: "Configuration",
-    groupIcon: "units-light",
+    groupIcon: "units",
     navLinks: [
       {
         label: "Images",
@@ -96,7 +96,7 @@ const navGroups: NavGroup[] = [
   },
   {
     groupTitle: "Networking",
-    groupIcon: "connected-light",
+    groupIcon: "connected",
     navLinks: [
       {
         highlight: [

--- a/src/scss/_patterns_icons.scss
+++ b/src/scss/_patterns_icons.scss
@@ -65,11 +65,6 @@
     @include maas-icon-cluster($color-white);
   }
 
-  .p-icon--connected-light {
-    @extend %icon;
-    @include vf-icon-connected($color-white);
-  }
-
   .p-icon--disconnected {
     @extend %icon;
     @include vf-icon-disconnect($color-negative);
@@ -78,16 +73,6 @@
   // TODO: Remove alias and replace with .p-icon--lock-locked-active
   .p-icon--locked {
     @extend .p-icon--lock-locked-active;
-  }
-
-  .p-icon--machines-light {
-    @extend %icon;
-    @include vf-icon-machines($color-white);
-  }
-
-  .p-icon--profile-light {
-    @extend %icon;
-    @include vf-icon-profile($color-white);
   }
 
   .p-icon--security {
@@ -113,16 +98,6 @@
   .p-icon--warning-grey {
     @extend %icon;
     @include vf-icon-warning-grey($color-white);
-  }
-
-  .p-icon--units-light {
-    @extend %icon;
-    @include vf-icon-units($color-white);
-  }
-
-  .p-icon--tag-light {
-    @extend %icon;
-    @include vf-icon-tag($color-white);
   }
 
   // TODO: Remove alias and replace with .p-icon--status-waiting

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -22,6 +22,11 @@
 @include vf-p-icon-success-grey;
 @include vf-p-icon-task-outstanding;
 @include vf-p-icon-unit-running;
+@include vf-p-icon-machines;
+@include vf-p-icon-profile;
+@include vf-p-icon-units;
+@include vf-p-icon-tag;
+@include vf-p-icon-connected;
 
 // Import MAAS overrides of Vanilla patterns
 @import "./vanilla-overrides";


### PR DESCRIPTION
## Done

- Removed unnecessary icon classes for light versions of icons
- Added base icon imports to base SCSS file

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure side nav icons load correctly

## Fixes

Fixes [MAASENG-1342](https://warthogs.atlassian.net/browse/MAASENG-1342)


[MAASENG-1342]: https://warthogs.atlassian.net/browse/MAASENG-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ