### PR TITLE
feat: Add machine and pool count to header and remove tab nav MAASENG-1341

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -7,7 +7,9 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-testid='section-header-title']").contains("Machines");
+    cy.get("[data-testid='section-header-title']").contains(
+      /machines in 1 pool/
+    );
   });
 
   it("highlights the correct navigation link", () => {
@@ -41,30 +43,6 @@ context("Machine listing", () => {
       getGroupBySelect().select(option);
       cy.waitForTableToLoad({ name: "Machines" });
     });
-  });
-
-  it("displays machine counts with active filters", () => {
-    const searchFilter = "status:(=commissioning) hostname:(machine-)";
-    cy.addMachines(["machine-1", "machine-2"]);
-    cy.findByRole("combobox", { name: "Group by" }).select("Group by status");
-    cy.findByRole("searchbox").type(searchFilter);
-    cy.findByText(/2 machines available/).should("exist");
-    cy.findByRole("grid", { name: "Machines" }).within(() =>
-      // eslint-disable-next-line cypress/no-force
-      cy
-        .findByRole("checkbox", { name: /Commissioning/i })
-        .click({ force: true })
-    );
-    cy.findByText(/All machines selected/).should("exist");
-    cy.findByRole("button", { name: /Take action/i }).click();
-    cy.findByLabelText("submenu").within(() => {
-      cy.findAllByRole("button", { name: /Delete/i }).click();
-    });
-    cy.findByRole("button", { name: /Delete 2 machines/ }).should("exist");
-    cy.findByRole("button", { name: /Delete 2 machines/ }).click();
-    cy.findByRole("searchbox").should("have.value", searchFilter);
-    cy.findByText(/All machines selected/).should("not.exist");
-    cy.findByText(/No machines match the search criteria./).should("exist");
   });
 
   it("can hide machine table columns", () => {

--- a/cypress/e2e/with-users/pools/list.spec.ts
+++ b/cypress/e2e/with-users/pools/list.spec.ts
@@ -7,7 +7,7 @@ context("Pools list", () => {
   });
 
   it("renders a heading", () => {
-    cy.contains(/Resource pool/i);
+    cy.contains(/machines in 1 pool/i);
     cy.findByLabelText(/Pool list/i);
   });
 });

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
@@ -14,11 +14,7 @@ import {
   machineStateCount as machineStateCountFactory,
   machineStateCounts as machineStateCountsFactory,
   machineStatus as machineStatusFactory,
-  resourcePool as resourcePoolFactory,
-  resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
-  tag as tagFactory,
-  tagState as tagStateFactory,
 } from "testing/factories";
 
 const mockStore = configureStore();
@@ -47,18 +43,6 @@ describe("MachinesHeader", () => {
           def456: machineStatusFactory({}),
         },
       }),
-      resourcepool: resourcePoolStateFactory({
-        errors: {},
-        loaded: false,
-        items: [
-          resourcePoolFactory({ id: 0, name: "default" }),
-          resourcePoolFactory({ id: 1, name: "other" }),
-        ],
-      }),
-      tag: tagStateFactory({
-        loaded: true,
-        items: [tagFactory(), tagFactory()],
-      }),
     });
   });
 
@@ -66,10 +50,8 @@ describe("MachinesHeader", () => {
     jest.restoreAllMocks();
   });
 
-  it("displays machine, resource pool and tag counts if loaded", () => {
+  it("renders", () => {
     state.machine.loaded = true;
-    state.resourcepool.loaded = true;
-    state.tag.loaded = true;
     const store = mockStore(state);
     const wrapper = mount(
       <Provider store={store}>
@@ -82,9 +64,8 @@ describe("MachinesHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    const tabs = wrapper.find('[data-testid="section-header-tabs"]');
-    expect(tabs.find("Link").at(0).text()).toBe("2 Machines");
-    expect(tabs.find("Link").at(1).text()).toBe("2 Resource pools");
-    expect(tabs.find("Link").at(2).text()).toBe("2 Tags");
+    expect(wrapper.find('[data-testid="section-header-title"]').text()).toBe(
+      "Machines"
+    );
   });
 });

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.tsx
@@ -1,18 +1,11 @@
 import { useEffect } from "react";
 
-import pluralize from "pluralize";
-import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom";
-import { matchPath, Link } from "react-router-dom-v5-compat";
+import { useDispatch } from "react-redux";
 
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
 import SectionHeader from "app/base/components/SectionHeader";
-import urls from "app/base/urls";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
-import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { actions as tagActions } from "app/store/tag";
-import tagSelectors from "app/store/tag/selectors";
-
 type Props = SectionHeaderProps & { machineCount: number };
 
 export const MachinesHeader = ({
@@ -20,9 +13,6 @@ export const MachinesHeader = ({
   ...props
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const location = useLocation();
-  const poolCount = useSelector(resourcePoolSelectors.count);
-  const tagCount = useSelector(tagSelectors.count);
 
   useEffect(() => {
     dispatch(resourcePoolActions.fetch());
@@ -32,31 +22,6 @@ export const MachinesHeader = ({
   return (
     <SectionHeader
       {...props}
-      tabLinks={[
-        {
-          active: !!matchPath(urls.machines.index, location.pathname),
-          component: Link,
-          label: `${pluralize("Machine", machineCount, true)}`,
-          to: urls.machines.index,
-        },
-        {
-          active: !!matchPath(urls.pools.index, location.pathname),
-          component: Link,
-          label: `${pluralize("Resource pool", poolCount, true)}`,
-          to: urls.pools.index,
-        },
-        {
-          active:
-            !!matchPath(urls.tags.index, location.pathname) ||
-            !!matchPath(
-              { path: urls.tags.tag.index(null), end: false },
-              location.pathname
-            ),
-          component: Link,
-          label: `${pluralize("Tag", tagCount, true)}`,
-          to: urls.tags.index,
-        },
-      ]}
       title={"title" in props && !!props.title ? props.title : "Machines"}
     />
   );

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -21,6 +21,8 @@ import {
   machineStatus as machineStatusFactory,
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
+  resourcePool as resourcePoolFactory,
+  resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
 import { screen, waitFor, renderWithBrowserRouter } from "testing/utils";
@@ -54,6 +56,10 @@ describe("MachineListHeader", () => {
           abc123: machineStatusFactory({}),
           def456: machineStatusFactory({}),
         },
+      }),
+      resourcepool: resourcePoolStateFactory({
+        loaded: true,
+        items: [resourcePoolFactory()],
       }),
     });
   });
@@ -113,8 +119,8 @@ describe("MachineListHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find('[data-testid="section-header-subtitle"]').text()).toBe(
-      "2 machines available"
+    expect(wrapper.find('[data-testid="section-header-title"]').text()).toBe(
+      "2 machines in 1 pool"
     );
   });
 
@@ -157,183 +163,6 @@ describe("MachineListHeader", () => {
       { state }
     );
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
-  });
-
-  it("displays a selected count if some machines have been selected", () => {
-    state.machine.selectedMachines = { items: ["abc123"] };
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
-      count: 2,
-      loaded: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        searchFilter=""
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(screen.getByText("1 of 10 machines selected")).toBeInTheDocument();
-  });
-
-  it("displays a selected count if some groups have been selected", () => {
-    state.machine.selectedMachines = {
-      groups: ["admin"],
-      grouping: FetchGroupKey.Owner,
-    };
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 2,
-      loaded: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        searchFilter=""
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(screen.getByText("2 of 10 machines selected")).toBeInTheDocument();
-  });
-
-  it("displays a selected count if some machines and groups have been selected", () => {
-    state.machine.selectedMachines = {
-      items: ["abc123"],
-      groups: ["admin"],
-      grouping: FetchGroupKey.Owner,
-    };
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 2,
-      loaded: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        searchFilter=""
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(screen.getByText("3 of 10 machines selected")).toBeInTheDocument();
-  });
-
-  it("displays correct count for selected machines", () => {
-    state.machine.selectedMachines = { items: ["abc123", "def456"] };
-    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        searchFilter=""
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(screen.getByText("2 of 10 machines selected")).toBeInTheDocument();
-  });
-
-  it("displays correct machine counts when clearing an active filter", () => {
-    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 5,
-      loaded: true,
-    });
-    const { rerender } = renderWithBrowserRouter(
-      <MachineListHeader
-        searchFilter="owner:(admin)"
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(
-      screen.getByRole("link", { name: /10 Machines/i })
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("section-header-subtitle")).toHaveTextContent(
-      /5 machines available/i
-    );
-    rerender(
-      <MachineListHeader
-        searchFilter=""
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />
-    );
-    expect(
-      screen.getByRole("link", { name: /10 Machines/i })
-    ).toBeInTheDocument();
-    expect(screen.getByTestId("section-header-subtitle")).toHaveTextContent(
-      /10 machines available/i
-    );
-  });
-
-  it("displays correct machine counts for selected groups with an active filter", () => {
-    state.machine.selectedMachines = {
-      groups: ["admin"],
-      grouping: FetchGroupKey.Owner,
-    };
-    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 5,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
-      count: 2,
-      loaded: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        searchFilter="owner:(admin)"
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(
-      screen.getByRole("link", { name: /10 Machines/i })
-    ).toBeInTheDocument();
-    expect(screen.getByText("2 of 5 machines selected")).toBeInTheDocument();
-  });
-
-  it("displays a message when all machines have been selected", () => {
-    state.machine.selectedMachines = { filter: {} };
-    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        searchFilter=""
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(screen.getByText("All machines selected")).toBeInTheDocument();
   });
 
   it("disables the add hardware menu when machines are selected", () => {
@@ -413,7 +242,7 @@ describe("MachineListHeader", () => {
       </Provider>
     );
     expect(wrapper.find('[data-testid="section-header-title"]').text()).toBe(
-      "Machines"
+      "0 machines in 1 pool"
     );
     expect(
       wrapper.find('[data-testid="section-header-content"] h3').text()

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -72,7 +72,7 @@ export const MachineListHeader = ({
     dispatch(resourcePoolActions.fetch());
   }, [dispatch]);
 
-  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const resourcePoolsCount = useSelector(resourcePoolSelectors.count);
 
   const getTitle = useCallback(
     (action: NodeActions) => {
@@ -145,7 +145,7 @@ export const MachineListHeader = ({
         <>
           {allMachineCount} machines in{" "}
           <Link to={urls.pools.index}>
-            {resourcePools.length} {pluralize("pool", resourcePools.length)}
+            {resourcePoolsCount} {pluralize("pool", resourcePoolsCount)}
           </Link>
         </>
       }

--- a/src/app/pools/views/Pools.tsx
+++ b/src/app/pools/views/Pools.tsx
@@ -1,4 +1,8 @@
+import { useEffect } from "react";
+
 import { Button } from "@canonical/react-components";
+import pluralize from "pluralize";
+import { useDispatch, useSelector } from "react-redux";
 import { Link, Route, Routes } from "react-router-dom-v5-compat";
 
 import PoolList from "./PoolList";
@@ -10,11 +14,21 @@ import NotFound from "app/base/views/NotFound";
 import PoolAdd from "app/pools/views/PoolAdd";
 import PoolEdit from "app/pools/views/PoolEdit";
 import { useFetchMachineCount } from "app/store/machine/utils/hooks";
+import { actions as resourcePoolActions } from "app/store/resourcepool";
+import resourcePoolSelectors from "app/store/resourcepool/selectors";
 import { getRelativeRoute } from "app/utils";
 
 const Pools = (): JSX.Element => {
   const base = urls.pools.index;
+  const dispatch = useDispatch();
   const { machineCount } = useFetchMachineCount();
+
+  useEffect(() => {
+    dispatch(resourcePoolActions.fetch());
+  }, [dispatch]);
+
+  const resourcePools = useSelector(resourcePoolSelectors.all);
+
   return (
     <MainContentSection
       header={
@@ -25,6 +39,13 @@ const Pools = (): JSX.Element => {
             </Button>,
           ]}
           machineCount={machineCount}
+          title={
+            <>
+              <Link to={urls.machines.index}>{machineCount} machines </Link>
+              in {resourcePools.length}{" "}
+              {pluralize("pool", resourcePools.length)}
+            </>
+          }
         />
       }
     >

--- a/src/app/pools/views/Pools.tsx
+++ b/src/app/pools/views/Pools.tsx
@@ -27,7 +27,7 @@ const Pools = (): JSX.Element => {
     dispatch(resourcePoolActions.fetch());
   }, [dispatch]);
 
-  const resourcePools = useSelector(resourcePoolSelectors.all);
+  const resourcePoolsCount = useSelector(resourcePoolSelectors.count);
 
   return (
     <MainContentSection
@@ -42,8 +42,7 @@ const Pools = (): JSX.Element => {
           title={
             <>
               <Link to={urls.machines.index}>{machineCount} machines </Link>
-              in {resourcePools.length}{" "}
-              {pluralize("pool", resourcePools.length)}
+              in {resourcePoolsCount} {pluralize("pool", resourcePoolsCount)}
             </>
           }
         />

--- a/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
+++ b/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
@@ -44,9 +44,7 @@ it("can display the add tag form", () => {
   expect(
     screen.getByRole("complementary", { name: "Create new tag" })
   ).toBeInTheDocument();
-  expect(screen.getByTestId("section-header-title").textContent).toBe(
-    "Machines"
-  );
+  expect(screen.getByTestId("section-header-title").textContent).toBe("Tags");
 });
 
 it("can display the delete tag form", () => {
@@ -80,9 +78,7 @@ it("can display the delete tag form", () => {
   expect(
     screen.getByRole("heading", { name: "Delete tag" })
   ).toBeInTheDocument();
-  expect(screen.getByTestId("section-header-title").textContent).toBe(
-    "Machines"
-  );
+  expect(screen.getByTestId("section-header-title").textContent).toBe("Tags");
 });
 
 it("displays the default title", () => {
@@ -97,9 +93,7 @@ it("displays the default title", () => {
     </Provider>
   );
   expect(
-    screen.getByRole("heading", { level: 1, name: "Machines" })
+    screen.getByRole("heading", { level: 1, name: "Tags" })
   ).toBeInTheDocument();
-  expect(screen.getByTestId("section-header-title").textContent).toBe(
-    "Machines"
-  );
+  expect(screen.getByTestId("section-header-title").textContent).toBe("Tags");
 });

--- a/src/app/tags/components/TagsHeader/TagsHeader.tsx
+++ b/src/app/tags/components/TagsHeader/TagsHeader.tsx
@@ -33,7 +33,7 @@ export const getHeaderTitle = (
         return "Delete tag";
     }
   }
-  return "Machines";
+  return "Tags";
 };
 
 export const TagsHeader = ({
@@ -69,7 +69,7 @@ export const TagsHeader = ({
         )
       }
       sidePanelTitle={getHeaderTitle(sidePanelContent)}
-      title="Machines"
+      title="Tags"
     />
   );
 };


### PR DESCRIPTION
## Done

- Added machine/pool count in header title for machine list and pool list
- Removed tab navigation from machine list, pool list, and tag list.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Ensure the number of machines/pools is displayed correctly in the machine list header
- Click on the link "(number) pools"
- Ensure you are navigated to the Pools list
- Ensure the counts are still correct
- Click on the link "(number) machines"
- Ensure you are navigated to the Machine list
- Ensure the counts are still correct

## Fixes

Fixes [MAASENG-1341](https://warthogs.atlassian.net/browse/MAASENG-1341)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/218433119-a4ef4a4b-4a93-4d63-a2b5-8619f90ad861.png)

![image](https://user-images.githubusercontent.com/35104482/218433185-44b5d549-d321-4212-8d3f-a4a4d04bbdc9.png)

![image](https://user-images.githubusercontent.com/35104482/218433340-2702bb89-e1f9-4401-b47a-f52bc3767d69.png)

### After
![image](https://user-images.githubusercontent.com/35104482/218433066-168083ab-4c70-4cdf-bddf-a099da377437.png)

![image](https://user-images.githubusercontent.com/35104482/218433237-39d3d0ea-5a2e-4e59-8d15-83e6f77c533a.png)

![image](https://user-images.githubusercontent.com/35104482/218433408-8e8ceef8-09af-4bdb-aad9-5d0a649d21c5.png)


[MAASENG-1341]: https://warthogs.atlassian.net/browse/MAASENG-1341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ