### PR TITLE
feat: update status bar MAASENG-1340

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -23,7 +23,6 @@ import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
 import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
-import { version as versionSelectors } from "app/store/general/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as statusActions } from "app/store/status";
 
@@ -35,8 +34,6 @@ const AppSideNavigation = (): JSX.Element => {
   const configLoaded = useSelector(configSelectors.loaded);
   const { theme, setTheme } = useContext(ThemePreviewContext);
   const authUser = useSelector(authSelectors.get);
-  const version = useSelector(versionSelectors.get);
-  const maasName = useSelector(configSelectors.maasName);
   const isAdmin = useSelector(authSelectors.isAdmin);
   const path = location.pathname;
   const completedIntro = useCompletedIntro();
@@ -148,14 +145,6 @@ const AppSideNavigation = (): JSX.Element => {
                   showLinks={showLinks}
                   vaultIncomplete={vaultIncomplete}
                 />
-                {showLinks ? (
-                  <span
-                    className="p-side-navigation__footer is-fading-when-collapsed"
-                    id="maas-info"
-                  >
-                    {maasName} MAAS v{version}
-                  </span>
-                ) : null}
               </div>
             </div>
           </div>

--- a/src/scss/_patterns_status-bar.scss
+++ b/src/scss/_patterns_status-bar.scss
@@ -1,6 +1,6 @@
 @mixin maas-status-bar {
   .p-status-bar {
-    background-color: $colors--dark-theme--background-default;
+    background-color: #cce0f5;
     bottom: 0;
     left: 0;
     padding: $spv--small 0;
@@ -11,7 +11,6 @@
 
   .p-status-bar__row {
     @extend %fixed-width-container;
-    color: $color-x-light;
     column-gap: $sph--small;
     flex-direction: column;
 

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -308,9 +308,3 @@
 // tags
 @import "~app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/_index.scss";
 @include DeleteTagFormWarnings;
-
-#maas-ui {
-  min-height: 100vh;
-  display: grid;
-  grid-template-rows: auto 1fr auto;
-}


### PR DESCRIPTION
## Done

- update status bar style according to latest design
- hide MAAS info in the side bar
- display MAAS info in the status bar

Note: the footer that contains the status bar it extends to full width in the design but we're following the existing vanilla implementation for application layout here where it only takes the width of the main area).

Once we have a better idea of what should go in the footer we'll update: https://warthogs.atlassian.net/browse/MAASENG-1358

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify that status bar content is visible across all breakpoints.

## Fixes

Fixes: MAASENG-1340

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

<img width="1161" alt="image" src="https://user-images.githubusercontent.com/7452681/218758162-49757c99-591d-429d-9189-4a9b18dcd3b3.png">

