### PR TITLE
feat: update grid max width and adjust sidenav

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavCollapseToggle/AppSideNavCollapseToggle.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavCollapseToggle/AppSideNavCollapseToggle.tsx
@@ -23,7 +23,7 @@ const AppSideNavCollapseToggle = ({
         appearance="base"
         aria-label={`${!isCollapsed ? "collapse" : "expand"} main navigation`}
         className={classNames(
-          "is-dense has-icon is-dark u-no-margin l-navigation-collapse-toggle u-hide--large",
+          "is-dense has-icon is-dark u-no-margin l-navigation-collapse-toggle",
           className
         )}
         onClick={(e) => {

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -81,7 +81,7 @@ describe("GlobalSideNav", () => {
     });
   });
 
-  it("renders", () => {
+  it("displays navigation", () => {
     renderWithBrowserRouter(<AppSideNavigation />, { route: "/", state });
 
     expect(screen.getByRole("navigation")).toBeInTheDocument();
@@ -367,5 +367,28 @@ describe("GlobalSideNav", () => {
     expect(
       screen.queryByRole("link", { name: "Virsh" })
     ).not.toBeInTheDocument();
+  });
+
+  it("is collapsed by default", () => {
+    renderWithBrowserRouter(<AppSideNavigation />, {
+      route: "/",
+      state,
+    });
+
+    expect(screen.getByRole("navigation")).toHaveClass("is-collapsed");
+  });
+
+  it("persists collapsed state", () => {
+    state.user.auth.user = null;
+    const { rerender } = renderWithBrowserRouter(<AppSideNavigation />, {
+      route: "/",
+      state,
+    });
+
+    const primaryNavigation = screen.getByRole("navigation");
+    screen.getByRole("button", { name: "expand main navigation" }).click();
+    expect(primaryNavigation).toHaveClass("is-pinned");
+    rerender(<AppSideNavigation />);
+    expect(primaryNavigation).toHaveClass("is-pinned");
   });
 });

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -144,7 +144,7 @@ const AppSideNavigation = (): JSX.Element => {
       </header>
       <nav
         aria-label="main navigation"
-        className={classNames(`l-navigation is-maas-${themeColor}`, {
+        className={classNames(`l-navigation is-maas is-maas-${themeColor}`, {
           "is-collapsed": isCollapsed,
           "is-pinned": !isCollapsed,
         })}
@@ -178,13 +178,6 @@ const AppSideNavigation = (): JSX.Element => {
           </div>
         </div>
       </nav>
-      <div className="l-navigation-expand">
-        <AppSideNavCollapseToggle
-          className={`is-maas-${themeColor}`}
-          isCollapsed={isCollapsed}
-          setIsCollapsed={setIsCollapsed}
-        />
-      </div>
     </>
   );
 };

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -128,7 +128,7 @@ const AppSideNavigation = (): JSX.Element => {
         <div className={classNames("p-panel is-dark", `is-maas-${themeColor}`)}>
           <div className="p-panel__header">
             <NavigationBanner />
-            <div className="p-panel__controls u-nudge-down--small u-no-margin--top u-hide--large">
+            <div className="p-panel__controls u-nudge-down--small u-no-margin--top">
               <Button
                 appearance="base"
                 className="has-icon is-dark"

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable react/no-multi-comp */
-import { useEffect, useContext, useState, useMemo } from "react";
+import { useEffect, useContext, useMemo } from "react";
 
 import { Button } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate, useLocation, useMatch } from "react-router-dom-v5-compat";
+import { useStorageState } from "react-storage-hooks";
 
 import AppSideNavCollapseToggle from "./AppSideNavCollapseToggle";
 import AppSideNavItems from "./AppSideNavItems";
@@ -97,8 +97,11 @@ const AppSideNavigation = (): JSX.Element => {
 
   const vaultIncomplete =
     unconfiguredControllers.length >= 1 && configuredControllers.length >= 1;
-
-  const [isCollapsed, setIsCollapsed] = useState(true);
+  const [isCollapsed, setIsCollapsed] = useStorageState<boolean>(
+    localStorage,
+    "appSideNavIsCollapsed",
+    true
+  );
   useGlobalKeyShortcut("[", () => {
     setIsCollapsed(!isCollapsed);
   });

--- a/src/app/base/components/AppSideNavigation/_index.scss
+++ b/src/app/base/components/AppSideNavigation/_index.scss
@@ -51,6 +51,9 @@
         padding-top: 0;
         transform: translateX(1rem) translateY(2.6rem);
       }
+      @media only screen and (min-width: ($breakpoint-xx-large)) {
+        display: none;
+      }
     }
     .l-navigation--item-icon {
       margin-right: $sph--small;

--- a/src/app/base/components/AppSideNavigation/_index.scss
+++ b/src/app/base/components/AppSideNavigation/_index.scss
@@ -1,5 +1,72 @@
 @mixin AppSideNavigation {
-  .p-panel {
+  .l-navigation.is-maas {
+    @include vf-transition(
+      $property: #{width,
+      box-shadow,
+      background},
+      $duration: fast
+    );
+    &:hover,
+    &:focus-within,
+    &.is-pinned {
+      .l-navigation__controls {
+        opacity: 1;
+        visibility: visible;
+        button {
+          background-color: rgba(255, 255, 255, 0.05);
+        }
+        @media only screen and (min-width: ($breakpoint-small + 1)) {
+          transform: translateX(
+              #{$application-layout--side-nav-width-expanded - 3rem}
+            )
+            translateY(0.8rem);
+        }
+      }
+    }
+    &.is-collapsed {
+      .l-navigation-collapse-toggle,
+      .l-navigation__controls {
+        i {
+          transform: rotate(180deg);
+        }
+      }
+    }
+    .l-navigation__controls {
+      margin-left: auto;
+      padding-top: 0.65rem;
+      z-index: $side-navigation-z-index + 1;
+      @include vf-transition(
+        $property: #{opacity,
+        visibility,
+        transform,
+        background},
+        $duration: fast
+      );
+      @media only screen and (min-width: ($breakpoint-small + 1)) {
+        opacity: 1;
+        visibility: visible;
+        position: absolute;
+        top: 0;
+        left: 0;
+        padding-top: 0;
+        transform: translateX(1rem) translateY(2.6rem);
+      }
+    }
+    .l-navigation--item-icon {
+      margin-right: $sph--small;
+    }
+  }
+  .p-panel.is-dark {
+    background: inherit;
+    .p-panel__header {
+      background-color: inherit;
+      @include vf-transition(
+        $property: #{width,
+        box-shadow,
+        background},
+        $duration: fast
+      );
+    }
     .p-panel__logo {
       color: $colors--dark-theme--text-default;
       text-decoration: none;
@@ -59,111 +126,5 @@
       .p-side-navigation__link {
       padding-left: 4rem;
     }
-  }
-  .l-navigation {
-    @include vf-transition(
-      $property: #{width,
-      box-shadow,
-      background},
-      $duration: fast
-    );
-    .p-panel.is-dark,
-    .p-panel.is-dark .p-panel__header.is-sticky {
-      @include vf-transition(
-        $property: #{width,
-        box-shadow,
-        background},
-        $duration: fast
-      );
-      background: inherit;
-    }
-    &.is-collapsed {
-      .l-navigation-collapse-toggle,
-      .l-navigation__controls {
-        i {
-          transform: rotate(180deg);
-        }
-      }
-    }
-    &:hover,
-    &:focus-within,
-    &.is-pinned {
-      .l-navigation__controls {
-        opacity: 1;
-        visibility: visible;
-      }
-    }
-
-    .l-navigation__controls {
-      margin-left: auto;
-      padding-top: 0.65rem;
-      button {
-        background-color: rgba(255, 255, 255, 0.05);
-      }
-
-      @media only screen and (min-width: ($breakpoint-small + 1)) {
-        opacity: 1;
-        visibility: visible;
-        position: absolute;
-        top: 0;
-        left: 0;
-        padding-top: 0;
-        transform: translateX(
-            #{$application-layout--side-nav-width-expanded - 3.5rem}
-          )
-          translateY(0.8rem);
-      }
-    }
-  }
-
-  .l-navigation .l-navigation__controls,
-  .l-navigation-expand {
-    z-index: $side-navigation-z-index + 1;
-    @include vf-transition(
-      $property: #{opacity,
-      visibility,
-      transform,
-      background},
-      $duration: fast
-    );
-  }
-
-  .l-navigation-expand {
-    position: absolute;
-    top: 0;
-    left: 0;
-    opacity: 1;
-    transform: translateX(
-        #{$application-layout--side-nav-width-collapsed - 1.5rem}
-      )
-      translateY(2.65rem);
-    i {
-      transform: rotate(180deg);
-    }
-    @media only screen and (min-width: ($breakpoint-large)) {
-      display: none;
-    }
-    @media only screen and (max-width: ($breakpoint-small)) {
-      display: none;
-    }
-  }
-  .l-navigation:hover,
-  .l-navigation:focus-within,
-  .l-navigation.is-pinned {
-    & + .l-navigation-expand {
-      visibility: hidden;
-      opacity: 0;
-      transform: translateX(
-          #{$application-layout--side-nav-width-expanded - 1.5rem}
-        )
-        translateY(0.8rem);
-    }
-  }
-
-  .p-panel.is-dark .p-panel__header {
-    background-color: inherit;
-  }
-  .l-navigation--item-icon {
-    margin-right: $sph--small;
   }
 }

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -1,5 +1,5 @@
 // Vanilla settings:
-$grid-max-width: math.div(1440, 16) * 1rem; // express in rems for easier calculations
+$grid-max-width: math.div(1920, 16) * 1rem; // express in rems for easier calculations
 
 $color-navigation-background: #666;
 $color-navigation-background--hover: darken($color-navigation-background, 3%);
@@ -7,9 +7,10 @@ $color-navigation-background--hover: darken($color-navigation-background, 3%);
 $breakpoint-node-action-menu-group: 793px;
 $breakpoint-kvm-resources-card: 1300px;
 $breakpoint-x-large: 1440px;
+$breakpoint-xx-large: 1920px;
 $breakpoint-navigation-threshold: 925px;
 $increase-font-size-on-larger-screens: false;
 $side-panel-z-index: 101;
 $side-navigation-z-index: 103;
-
+$application-layout--breakpoint-side-nav-expanded: $breakpoint-xx-large;
 $assets-path: "~/assets/fonts/";


### PR DESCRIPTION
## Done

- set grid max width to 1920px
- adjust sidenav toggle button position
  - remove additional toggle button that was rendered outside of the nav
- persist collapsed state using localstorage

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify that the button is within the side nav when collapsed
- Verify that the side nav works as expected across all breakpoints
- Click the expand navigation button
- Refresh the page
- Verify that the navigation is expanded

## Fixes
Fixes: https://warthogs.atlassian.net/browse/MAASENG-1365
Fixes: https://warthogs.atlassian.net/browse/MAASENG-1356
Fixes: https://warthogs.atlassian.net/browse/MAASENG-1384

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
