### PR TITLE
feat(machines): Show filtered machine count and machines on page count MAASENG-1367 & MAASENG-1368

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -45,6 +45,28 @@ context("Machine listing", () => {
     });
   });
 
+  it("displays machine counts with active filters", () => {
+    const searchFilter = "status:(=commissioning) hostname:(machine-)";
+    cy.addMachines(["machine-1", "machine-2"]);
+    cy.findByRole("combobox", { name: "Group by" }).select("Group by status");
+    cy.findByRole("searchbox").type(searchFilter);
+    cy.findByText(/Showing 2 out of 2 machines/).should("exist");
+    cy.findByRole("grid", { name: "Machines" }).within(() =>
+      // eslint-disable-next-line cypress/no-force
+      cy
+        .findByRole("checkbox", { name: /Commissioning/i })
+        .click({ force: true })
+    );
+    cy.findByRole("button", { name: /Take action/i }).click();
+    cy.findByLabelText("submenu").within(() => {
+      cy.findAllByRole("button", { name: /Delete/i }).click();
+    });
+    cy.findByRole("button", { name: /Delete 2 machines/ }).should("exist");
+    cy.findByRole("button", { name: /Delete 2 machines/ }).click();
+    cy.findByRole("searchbox").should("have.value", searchFilter);
+    cy.findByText(/No machines match the search criteria./).should("exist");
+  });
+
   it("can hide machine table columns", () => {
     const allHeadersCount = 11;
     cy.findAllByRole("columnheader").should("have.length", allHeadersCount);

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/MachineListDisplayCount.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/MachineListDisplayCount.test.tsx
@@ -1,0 +1,33 @@
+import MachineListDisplayCount from "./MachineListDisplayCount";
+
+import { render, screen } from "testing/utils";
+
+describe("MachineListDisplayCount", () => {
+  it("shows the true number of machines on a page if it is under the maximum items per page limit.", () => {
+    render(
+      <MachineListDisplayCount
+        currentPage={3}
+        machineCount={135}
+        pageSize={50}
+      />
+    );
+
+    expect(
+      screen.getByText("Showing 35 out of 135 machines")
+    ).toBeInTheDocument();
+  });
+
+  it("shows the maximum number of items per page if that limit is reached", () => {
+    render(
+      <MachineListDisplayCount
+        currentPage={2}
+        machineCount={135}
+        pageSize={50}
+      />
+    );
+
+    expect(
+      screen.getByText("Showing 50 out of 135 machines")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/MachineListDisplayCount.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/MachineListDisplayCount.tsx
@@ -1,0 +1,34 @@
+export const MachineListDisplayCount = ({
+  machineCount,
+  pageSize,
+  currentPage,
+}: {
+  machineCount: number;
+  pageSize: number;
+  currentPage: number;
+}): JSX.Element => {
+  const getCurrentPageDisplayedMachineCount = () => {
+    if (!machineCount) {
+      return null;
+    }
+
+    const totalPages = Math.ceil(machineCount / pageSize);
+
+    if (currentPage === totalPages) {
+      return pageSize - (totalPages * pageSize - machineCount);
+    } else {
+      return pageSize;
+    }
+  };
+
+  return (
+    <>
+      <strong>
+        Showing {getCurrentPageDisplayedMachineCount()} out of {machineCount}{" "}
+        machines
+      </strong>
+    </>
+  );
+};
+
+export default MachineListDisplayCount;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/index.ts
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineListDisplayCount";

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -16,6 +16,7 @@ import CoresColumn from "./CoresColumn";
 import DisksColumn from "./DisksColumn";
 import FabricColumn from "./FabricColumn";
 import GroupCheckbox from "./GroupCheckbox";
+import MachineListDisplayCount from "./MachineListDisplayCount";
 import MachineListPagination from "./MachineListPagination";
 import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
@@ -846,27 +847,15 @@ export const MachineListTable = ({
     [hiddenColumns, showActions]
   );
 
-  const getMachinesDisplayed = () => {
-    if (!machineCount) {
-      return null;
-    }
-
-    const totalPages = Math.ceil(machineCount / pageSize);
-
-    if (currentPage === totalPages) {
-      return pageSize - (totalPages * pageSize - machineCount);
-    } else {
-      return pageSize;
-    }
-  };
-
   return (
     <>
       {machineCount ? (
         <div className="u-flex--between u-flex--align-center">
-          <strong>
-            Showing {getMachinesDisplayed()} out of {machineCount} machines
-          </strong>
+          <MachineListDisplayCount
+            currentPage={currentPage}
+            machineCount={machineCount}
+            pageSize={pageSize}
+          />
           <MachineListPagination
             currentPage={currentPage}
             itemsPerPage={pageSize}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -846,8 +846,36 @@ export const MachineListTable = ({
     [hiddenColumns, showActions]
   );
 
+  const getMachinesDisplayed = () => {
+    if (!machineCount) {
+      return null;
+    }
+
+    const totalPages = Math.ceil(machineCount / pageSize);
+
+    if (currentPage === totalPages) {
+      return pageSize - (totalPages * pageSize - machineCount);
+    } else {
+      return pageSize;
+    }
+  };
+
   return (
     <>
+      {machineCount ? (
+        <div className="u-flex--between u-flex--align-center">
+          <strong>
+            Showing {getMachinesDisplayed()} out of {machineCount} machines
+          </strong>
+          <MachineListPagination
+            currentPage={currentPage}
+            itemsPerPage={pageSize}
+            machineCount={machineCount}
+            machinesLoading={machinesLoading}
+            paginate={setCurrentPage}
+          />
+        </div>
+      ) : null}
       <MainTable
         aria-label={machinesLoading ? Label.Loading : Label.Machines}
         className={classNames("p-table-expanding--light", "machine-list", {
@@ -858,13 +886,6 @@ export const MachineListTable = ({
         headers={filterColumns(headers, hiddenColumns, showActions)}
         rows={machinesLoading ? skeletonRows : rows}
         {...props}
-      />
-      <MachineListPagination
-        currentPage={currentPage}
-        itemsPerPage={pageSize}
-        machineCount={machineCount}
-        machinesLoading={machinesLoading}
-        paginate={setCurrentPage}
       />
     </>
   );


### PR DESCRIPTION
## Done

- Add text showing machines shown on page out of total filtered machines
- Move pagination controls to top of page
- Add Cypress E2E test for showing correct filtered machine counts

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine listing
- Ensure the "out of" number of machines is the same as the total at the top
- Ensure the "Showing" number of machines is correct (should match page size)
- Filter the machines with a combination of filters
- Ensure the numbers shown are correct
- Set a combination of filters that uses multiple pages
- Navigate to the last page
- Ensure the "Showing" number is correct

## Fixes

Fixes [MAASENG-1367](https://warthogs.atlassian.net/browse/MAASENG-1367)
Fixes [MAASENG-1368](https://warthogs.atlassian.net/browse/MAASENG-1368)

## Screenshots

### Filtered 
![image](https://user-images.githubusercontent.com/35104482/219018570-06cce8d2-f363-49be-abda-d837632a70a5.png)

### Unfiltered
![image](https://user-images.githubusercontent.com/35104482/219018650-0a0b769c-e597-4602-8ebc-f4476ad59edd.png)



[MAASENG-1367]: https://warthogs.atlassian.net/browse/MAASENG-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ