### PR TITLE
feat(nav): Only display "Virsh" if user has Virsh KVM hosts MAASENG-1334

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -15,6 +15,7 @@ import type { User } from "app/store/user/types";
 type Props = {
   authUser: User | null;
   groups: NavGroup[];
+  hasVirsh: boolean;
   isAdmin: boolean;
   isAuthenticated: boolean;
   logout: () => void;
@@ -28,9 +29,10 @@ const AppSideNavItemGroup = ({
   isAdmin,
   vaultIncomplete,
   path,
+  hasVirsh,
 }: { group: NavGroup } & Pick<
   Props,
-  "isAdmin" | "vaultIncomplete" | "path"
+  "isAdmin" | "vaultIncomplete" | "path" | "hasVirsh"
 >) => {
   const id = useId();
   const hasActiveChild = useMemo(() => {
@@ -72,6 +74,9 @@ const AppSideNavItemGroup = ({
         >
           {group.navLinks.map((navLink) => {
             if (!navLink.adminOnly || isAdmin) {
+              if (navLink.label === "Virsh" && !hasVirsh) {
+                return null;
+              }
               return (
                 <AppSideNavItem
                   icon={
@@ -99,6 +104,7 @@ const AppSideNavItemGroup = ({
 export const AppSideNavItems = ({
   authUser,
   groups,
+  hasVirsh,
   isAdmin,
   isAuthenticated,
   logout,
@@ -113,6 +119,7 @@ export const AppSideNavItems = ({
           {groups.map((group, i) => (
             <AppSideNavItemGroup
               group={group}
+              hasVirsh={hasVirsh}
               isAdmin={isAdmin}
               key={`${i}-${group.groupTitle}`}
               path={path}

--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -15,7 +15,6 @@ import type { User } from "app/store/user/types";
 type Props = {
   authUser: User | null;
   groups: NavGroup[];
-  hasVirsh: boolean;
   isAdmin: boolean;
   isAuthenticated: boolean;
   logout: () => void;
@@ -29,10 +28,9 @@ const AppSideNavItemGroup = ({
   isAdmin,
   vaultIncomplete,
   path,
-  hasVirsh,
 }: { group: NavGroup } & Pick<
   Props,
-  "isAdmin" | "vaultIncomplete" | "path" | "hasVirsh"
+  "isAdmin" | "vaultIncomplete" | "path"
 >) => {
   const id = useId();
   const hasActiveChild = useMemo(() => {
@@ -43,6 +41,7 @@ const AppSideNavItemGroup = ({
     }
     return false;
   }, [group, path]);
+
   return (
     <>
       <li
@@ -74,9 +73,6 @@ const AppSideNavItemGroup = ({
         >
           {group.navLinks.map((navLink) => {
             if (!navLink.adminOnly || isAdmin) {
-              if (navLink.label === "Virsh" && !hasVirsh) {
-                return null;
-              }
               return (
                 <AppSideNavItem
                   icon={
@@ -104,7 +100,6 @@ const AppSideNavItemGroup = ({
 export const AppSideNavItems = ({
   authUser,
   groups,
-  hasVirsh,
   isAdmin,
   isAuthenticated,
   logout,
@@ -119,7 +114,6 @@ export const AppSideNavItems = ({
           {groups.map((group, i) => (
             <AppSideNavItemGroup
               group={group}
-              hasVirsh={hasVirsh}
               isAdmin={isAdmin}
               key={`${i}-${group.groupTitle}`}
               path={path}

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -16,6 +16,8 @@ import {
   configState as configStateFactory,
   controller as controllerFactory,
   controllerState as controllerStateFactory,
+  pod as podFactory,
+  podState as podStateFactory,
   rootState as rootStateFactory,
   user as userFactory,
   userState as userStateFactory,
@@ -56,6 +58,15 @@ describe("GlobalSideNav", () => {
       }),
       controller: controllerStateFactory({
         items: [controllerFactory()],
+        loaded: true,
+      }),
+      pod: podStateFactory({
+        loaded: true,
+        items: [
+          podFactory({
+            type: "virsh",
+          }),
+        ],
       }),
       user: userStateFactory({
         auth: authStateFactory({
@@ -339,5 +350,22 @@ describe("GlobalSideNav", () => {
     await waitFor(() =>
       expect(history.location.pathname).toBe(urls.intro.images)
     );
+  });
+
+  it("hides the 'Virsh' link if the user does not have any Virsh KVM hosts", () => {
+    const { rerender } = renderWithBrowserRouter(<AppSideNavigation />, {
+      route: "/machines",
+      state,
+    });
+
+    expect(screen.getByRole("link", { name: "Virsh" })).toBeInTheDocument();
+
+    state.pod.items = [];
+
+    rerender(<AppSideNavigation />);
+
+    expect(
+      screen.queryByRole("link", { name: "Virsh" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -23,6 +23,7 @@ import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
 import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
+import { actions as podActions } from "app/store/pod";
 import podSelectors from "app/store/pod/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as statusActions } from "app/store/status";
@@ -79,6 +80,10 @@ const AppSideNavigation = (): JSX.Element => {
 
   useEffect(() => {
     dispatch(controllerActions.fetch());
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch(podActions.fetch());
   }, [dispatch]);
 
   const virshKvms = useSelector(podSelectors.virsh);

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -88,7 +88,7 @@ const AppSideNavigation = (): JSX.Element => {
 
   const virshKvms = useSelector(podSelectors.virsh);
   const kvmsLoaded = useSelector(podSelectors.loaded);
-  const hasVirsh = virshKvms.length > 0;
+  const hideVirsh = kvmsLoaded && virshKvms.length < 1;
 
   const { unconfiguredControllers, configuredControllers } = useSelector(
     (state: RootState) =>
@@ -105,7 +105,7 @@ const AppSideNavigation = (): JSX.Element => {
   const themeColor = theme ? theme : maasTheme ? maasTheme : "default";
 
   const filteredGroups = useMemo(() => {
-    if (hasVirsh === false && kvmsLoaded) {
+    if (hideVirsh) {
       const kvmGroupIndex = navGroups.findIndex(
         (group) => group.groupTitle === "KVM"
       );
@@ -120,7 +120,7 @@ const AppSideNavigation = (): JSX.Element => {
     }
 
     return navGroups;
-  }, [hasVirsh]);
+  }, [hideVirsh]);
 
   return (
     <>

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -23,6 +23,7 @@ import authSelectors from "app/store/auth/selectors";
 import configSelectors from "app/store/config/selectors";
 import { actions as controllerActions } from "app/store/controller";
 import controllerSelectors from "app/store/controller/selectors";
+import podSelectors from "app/store/pod/selectors";
 import type { RootState } from "app/store/root/types";
 import { actions as statusActions } from "app/store/status";
 
@@ -79,6 +80,9 @@ const AppSideNavigation = (): JSX.Element => {
   useEffect(() => {
     dispatch(controllerActions.fetch());
   }, [dispatch]);
+
+  const virshKvms = useSelector(podSelectors.virsh);
+  const hasVirsh = virshKvms.length > 0;
 
   const { unconfiguredControllers, configuredControllers } = useSelector(
     (state: RootState) =>
@@ -138,6 +142,7 @@ const AppSideNavigation = (): JSX.Element => {
                 <AppSideNavItems
                   authUser={authUser}
                   groups={navGroups}
+                  hasVirsh={hasVirsh}
                   isAdmin={isAdmin}
                   isAuthenticated={isAuthenticated}
                   logout={logout}

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/no-multi-comp */
-import { useEffect, useContext, useState } from "react";
+import { useEffect, useContext, useState, useMemo } from "react";
 
 import { Button } from "@canonical/react-components";
 import classNames from "classnames";
@@ -87,6 +87,7 @@ const AppSideNavigation = (): JSX.Element => {
   }, [dispatch]);
 
   const virshKvms = useSelector(podSelectors.virsh);
+  const kvmsLoaded = useSelector(podSelectors.loaded);
   const hasVirsh = virshKvms.length > 0;
 
   const { unconfiguredControllers, configuredControllers } = useSelector(
@@ -102,6 +103,24 @@ const AppSideNavigation = (): JSX.Element => {
     setIsCollapsed(!isCollapsed);
   });
   const themeColor = theme ? theme : maasTheme ? maasTheme : "default";
+
+  const filteredGroups = useMemo(() => {
+    if (hasVirsh === false && kvmsLoaded) {
+      const kvmGroupIndex = navGroups.findIndex(
+        (group) => group.groupTitle === "KVM"
+      );
+
+      const virshItemIndex = navGroups[kvmGroupIndex].navLinks.findIndex(
+        (navLink) => navLink.label === "Virsh"
+      );
+
+      if (virshItemIndex > -1) {
+        navGroups[kvmGroupIndex].navLinks.splice(virshItemIndex, 1);
+      }
+    }
+
+    return navGroups;
+  }, [hasVirsh]);
 
   return (
     <>
@@ -146,8 +165,7 @@ const AppSideNavigation = (): JSX.Element => {
               <div className="p-side-navigation--icons is-dark">
                 <AppSideNavItems
                   authUser={authUser}
-                  groups={navGroups}
-                  hasVirsh={hasVirsh}
+                  groups={filteredGroups}
                   isAdmin={isAdmin}
                   isAuthenticated={isAuthenticated}
                   logout={logout}


### PR DESCRIPTION
## Done

- Hide "Virsh" in nav if user has no virsh kvms

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure you have mock data with Virsh KVM hosts
- Go to the UI
- Ensure the Virsh tab is shown in the nav and you can click it
- If you have multipass or LXD, set up a new instance with a clean install of the maas snap (no mock data)
- Go to the UI (and skip through the intro)
- Ensure the Virsh tab is ***not*** shown in the nav

## Fixes

Fixes [MAASENG-1334](https://warthogs.atlassian.net/browse/MAASENG-1334)


[MAASENG-1334]: https://warthogs.atlassian.net/browse/MAASENG-1334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ