### PR TITLE
feat(machines): New pagination and page size dropdown MAASENG-1369

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -712,7 +712,7 @@ describe("MachineList", () => {
         </MemoryRouter>
       </Provider>
     );
-    wrapper.find(".p-pagination__link--next").simulate("click");
+    wrapper.find("Button.p-pagination__link--next").simulate("click");
     const expected = machineActions.fetch("123456", {
       page_number: 2,
     });

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -80,7 +80,7 @@ const MachineList = ({
     "hiddenGroups",
     []
   );
-  const [storedPageSize] = useStorageState<number>(
+  const [storedPageSize, setStoredPageSize] = useStorageState<number>(
     localStorage,
     "machineListPageSize",
     DEFAULT_PAGE_SIZE
@@ -150,6 +150,7 @@ const MachineList = ({
         pageSize={pageSize}
         setCurrentPage={setCurrentPage}
         setHiddenGroups={setHiddenGroups}
+        setPageSize={setStoredPageSize}
         setSortDirection={setSortDirection}
         setSortKey={setSortKey}
         sortDirection={sortDirection}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/MachineListDisplayCount.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/MachineListDisplayCount.tsx
@@ -22,12 +22,10 @@ export const MachineListDisplayCount = ({
   };
 
   return (
-    <>
-      <strong>
-        Showing {getCurrentPageDisplayedMachineCount()} out of {machineCount}{" "}
-        machines
-      </strong>
-    </>
+    <strong className="machine-list--display-count">
+      Showing {getCurrentPageDisplayedMachineCount()} out of {machineCount}{" "}
+      machines
+    </strong>
   );
 };
 

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/_index.scss
@@ -1,0 +1,5 @@
+@mixin MachineListDisplayCount {
+  .machine-list--display-count {
+    padding-bottom: $spv--small;
+  }
+}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -2,7 +2,7 @@ import type {
   PaginationProps,
   PropsWithSpread,
 } from "@canonical/react-components";
-import { Pagination } from "@canonical/react-components";
+import { Button, Icon, Input } from "@canonical/react-components";
 
 import { useFetchedCount } from "app/store/machine/utils";
 
@@ -27,14 +27,39 @@ const MachineListPagination = ({
   ...props
 }: Props): JSX.Element | null => {
   const count = useFetchedCount(machineCount, machinesLoading);
+  const totalPages = machineCount
+    ? Math.ceil(machineCount / props.itemsPerPage)
+    : 1;
 
   return count > 0 ? (
-    <Pagination
-      aria-label={Label.Pagination}
-      className="u-nudge-down"
-      totalItems={count}
-      {...props}
-    />
+    <span className="u-flex--align-baseline p-pagination--items">
+      <Button
+        className="p-pagination__link--previous"
+        disabled={props.currentPage === 1}
+        onClick={() => props.paginate(props.currentPage - 1)}
+      >
+        <Icon name="chevron-down" />
+      </Button>
+      <strong>Page </strong>{" "}
+      <Input
+        className="p-pagination__input"
+        defaultValue={props.currentPage}
+        onChange={(e) =>
+          e.target.valueAsNumber > 0 && e.target.valueAsNumber <= totalPages
+            ? props.paginate(e.target.valueAsNumber)
+            : {}
+        }
+        type="number"
+      />{" "}
+      <strong> of {totalPages}</strong>
+      <Button
+        className="p-pagination__link--next"
+        disabled={props.currentPage === totalPages}
+        onClick={() => props.paginate(props.currentPage + 1)}
+      >
+        <Icon name="chevron-down" />
+      </Button>
+    </span>
   ) : null;
 };
 

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -62,6 +62,7 @@ const MachineListPagination = ({
         </Button>
         <strong>Page </strong>{" "}
         <Input
+          aria-label="page number"
           className="p-pagination__input"
           defaultValue={props.currentPage}
           onChange={(e) => {

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -32,34 +32,36 @@ const MachineListPagination = ({
     : 1;
 
   return count > 0 ? (
-    <span className="u-flex--align-baseline p-pagination--items">
-      <Button
-        className="p-pagination__link--previous"
-        disabled={props.currentPage === 1}
-        onClick={() => props.paginate(props.currentPage - 1)}
-      >
-        <Icon name="chevron-down" />
-      </Button>
-      <strong>Page </strong>{" "}
-      <Input
-        className="p-pagination__input"
-        defaultValue={props.currentPage}
-        onChange={(e) =>
-          e.target.valueAsNumber > 0 && e.target.valueAsNumber <= totalPages
-            ? props.paginate(e.target.valueAsNumber)
-            : {}
-        }
-        type="number"
-      />{" "}
-      <strong> of {totalPages}</strong>
-      <Button
-        className="p-pagination__link--next"
-        disabled={props.currentPage === totalPages}
-        onClick={() => props.paginate(props.currentPage + 1)}
-      >
-        <Icon name="chevron-down" />
-      </Button>
-    </span>
+    <nav aria-label={Label.Pagination} className="p-pagination">
+      <span className="u-flex--align-baseline p-pagination--items">
+        <Button
+          className="p-pagination__link--previous"
+          disabled={props.currentPage === 1}
+          onClick={() => props.paginate(props.currentPage - 1)}
+        >
+          <Icon name="chevron-down" />
+        </Button>
+        <strong>Page </strong>{" "}
+        <Input
+          className="p-pagination__input"
+          defaultValue={props.currentPage}
+          onChange={(e) =>
+            e.target.valueAsNumber > 0 && e.target.valueAsNumber <= totalPages
+              ? props.paginate(e.target.valueAsNumber)
+              : {}
+          }
+          type="number"
+        />{" "}
+        <strong> of {totalPages}</strong>
+        <Button
+          className="p-pagination__link--next"
+          disabled={props.currentPage === totalPages}
+          onClick={() => props.paginate(props.currentPage + 1)}
+        >
+          <Icon name="chevron-down" />
+        </Button>
+      </span>
+    </nav>
   ) : null;
 };
 

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -35,6 +35,7 @@ const MachineListPagination = ({
     <nav aria-label={Label.Pagination} className="p-pagination">
       <span className="u-flex--align-baseline p-pagination--items">
         <Button
+          aria-label="Previous page"
           className="p-pagination__link--previous"
           disabled={props.currentPage === 1}
           onClick={() => props.paginate(props.currentPage - 1)}
@@ -54,6 +55,7 @@ const MachineListPagination = ({
         />{" "}
         <strong className="u-no-wrap"> of {totalPages}</strong>
         <Button
+          aria-label="Next page"
           className="p-pagination__link--next"
           disabled={props.currentPage === totalPages}
           onClick={() => props.paginate(props.currentPage + 1)}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -52,7 +52,7 @@ const MachineListPagination = ({
           }
           type="number"
         />{" "}
-        <strong> of {totalPages}</strong>
+        <strong className="u-no-wrap"> of {totalPages}</strong>
         <Button
           className="p-pagination__link--next"
           disabled={props.currentPage === totalPages}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
@@ -14,8 +14,9 @@
     .p-pagination__input {
       margin: 0 $spv--small;
       appearance: none;
-      width: 1.625rem;
+      width: 3rem;
       min-width: 0;
+      text-align: center;
     }
 
     // required to get rid of buttons/arrows while keeping number-only input

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
@@ -1,0 +1,24 @@
+@mixin MachineListPagination {
+
+  .p-pagination--items {
+
+    .p-button {
+      margin: 0;
+      border: 0;
+    }
+
+    .p-pagination__input {
+      margin: 0 $spv--small;
+      appearance: none;
+      width: 1.625rem;
+      min-width: 0;
+    }
+
+    // required to get rid of buttons/arrows while keeping number-only input
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+      appearance: none;
+    }
+  }
+
+}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
@@ -2,6 +2,8 @@
 
   .p-pagination--items {
 
+    padding-bottom: $spv--small;
+
     .p-button {
       margin: 0;
       border: 0;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
@@ -24,6 +24,10 @@
     input::-webkit-inner-spin-button {
       appearance: none;
     }
+
+    input[type=number] {
+      appearance: textfield;
+    }
   }
 
 }

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
@@ -7,6 +7,10 @@
       border: 0;
     }
 
+    .p-pagination__link--next {
+      margin-right: $spv--large * 2;
+    }
+
     .p-pagination__input {
       margin: 0 $spv--small;
       appearance: none;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -854,7 +854,8 @@ export const MachineListTable = ({
   return (
     <>
       {machineCount ? (
-        <div className="u-flex--between u-flex--align-center u-flex--wrap">
+        <div className="u-flex--between u-flex--align-end u-flex--wrap">
+          <hr />
           <MachineListDisplayCount
             currentPage={currentPage}
             machineCount={machineCount}
@@ -872,6 +873,7 @@ export const MachineListTable = ({
               <PageSizeSelect pageSize={pageSize} setPageSize={setPageSize} />
             ) : null}
           </span>
+          <hr />
         </div>
       ) : null}
       <MainTable

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -853,7 +853,7 @@ export const MachineListTable = ({
   return (
     <>
       {machineCount ? (
-        <div className="u-flex--between u-flex--align-center">
+        <div className="u-flex--between u-flex--align-center u-flex--wrap">
           <MachineListDisplayCount
             currentPage={currentPage}
             machineCount={machineCount}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -20,6 +20,7 @@ import MachineListDisplayCount from "./MachineListDisplayCount";
 import MachineListPagination from "./MachineListPagination";
 import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
+import PageSizeSelect from "./PageSizeSelect";
 import PoolColumn from "./PoolColumn";
 import PowerColumn from "./PowerColumn";
 import RamColumn from "./RamColumn";
@@ -68,6 +69,7 @@ type Props = {
   pageSize: number;
   setCurrentPage: (currentPage: number) => void;
   setHiddenGroups?: (hiddenGroups: (string | null)[]) => void;
+  setPageSize?: (pageSize: number) => void;
   showActions?: boolean;
   sortDirection: ValueOf<typeof SortDirection>;
   sortKey: FetchGroupKey | null;
@@ -520,6 +522,7 @@ export const MachineListTable = ({
   pageSize,
   setCurrentPage,
   setHiddenGroups,
+  setPageSize,
   showActions = true,
   sortDirection,
   sortKey,
@@ -863,6 +866,9 @@ export const MachineListTable = ({
             machinesLoading={machinesLoading}
             paginate={setCurrentPage}
           />
+          {setPageSize ? (
+            <PageSizeSelect pageSize={pageSize} setPageSize={setPageSize} />
+          ) : null}
         </div>
       ) : null}
       <MainTable

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -859,16 +859,18 @@ export const MachineListTable = ({
             machineCount={machineCount}
             pageSize={pageSize}
           />
-          <MachineListPagination
-            currentPage={currentPage}
-            itemsPerPage={pageSize}
-            machineCount={machineCount}
-            machinesLoading={machinesLoading}
-            paginate={setCurrentPage}
-          />
-          {setPageSize ? (
-            <PageSizeSelect pageSize={pageSize} setPageSize={setPageSize} />
-          ) : null}
+          <span className="u-flex--end">
+            <MachineListPagination
+              currentPage={currentPage}
+              itemsPerPage={pageSize}
+              machineCount={machineCount}
+              machinesLoading={machinesLoading}
+              paginate={setCurrentPage}
+            />
+            {setPageSize ? (
+              <PageSizeSelect pageSize={pageSize} setPageSize={setPageSize} />
+            ) : null}
+          </span>
         </div>
       ) : null}
       <MainTable

--- a/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.test.tsx
@@ -1,0 +1,33 @@
+import { DEFAULTS } from "../constants";
+
+import PageSizeSelect from "./PageSizeSelect";
+
+import { render, screen, userEvent } from "testing/utils";
+
+const DEFAULT_PAGE_SIZE = DEFAULTS.pageSize;
+
+describe("PageSizeSelect", () => {
+  it("renders", () => {
+    render(
+      <PageSizeSelect pageSize={DEFAULT_PAGE_SIZE} setPageSize={jest.fn()} />
+    );
+    expect(
+      screen.getByRole("combobox", { name: "Items per page" })
+    ).toBeInTheDocument();
+  });
+
+  it("calls a function to update the page size", async () => {
+    const setPageSize = jest.fn();
+
+    render(
+      <PageSizeSelect pageSize={DEFAULT_PAGE_SIZE} setPageSize={setPageSize} />
+    );
+
+    const pageSizeSelect = screen.getByRole("combobox", {
+      name: "Items per page",
+    });
+    await userEvent.selectOptions(pageSizeSelect, "100");
+
+    expect(setPageSize).toHaveBeenCalledWith(100);
+  });
+});

--- a/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.tsx
@@ -1,0 +1,43 @@
+import { Select } from "@canonical/react-components";
+
+type Props = {
+  pageSize: number;
+  setPageSize: (pageSize: number) => void;
+};
+
+export enum Labels {
+  ItemsPerPage = "Items per page",
+  Fifty = "50/page",
+  OneHundred = "100/page",
+  TwoHundred = "200/page",
+}
+
+const groupOptions = [
+  {
+    value: 50,
+    label: Labels.Fifty,
+  },
+  {
+    value: 100,
+    label: Labels.OneHundred,
+  },
+  {
+    value: 200,
+    label: Labels.TwoHundred,
+  },
+];
+
+const PageSizeSelect = ({ pageSize, setPageSize }: Props): JSX.Element => {
+  return (
+    <Select
+      aria-label={Labels.ItemsPerPage}
+      defaultValue={pageSize}
+      onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+        setPageSize(parseInt(e.target.value));
+      }}
+      options={groupOptions}
+    />
+  );
+};
+
+export default PageSizeSelect;

--- a/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.tsx
@@ -31,6 +31,7 @@ const PageSizeSelect = ({ pageSize, setPageSize }: Props): JSX.Element => {
   return (
     <Select
       aria-label={Labels.ItemsPerPage}
+      className="u-no-margin"
       defaultValue={pageSize}
       onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
         setPageSize(parseInt(e.target.value));

--- a/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/index.ts
+++ b/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PageSizeSelect";

--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -60,6 +60,12 @@
     align-items: center !important;
   }
 
+  .u-flex--align-end {
+    @extend %display-flex;
+    align-items: flex-end !important;
+  }
+
+
   .u-flex--between {
     @extend %display-flex;
     justify-content: space-between !important;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -243,10 +243,12 @@
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
 @import "~app/machines/views/MachineList";
-@import "~app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss";
+@import "~app/machines/views/MachineList/MachineListTable/MachineListDisplayCount";
+@import "~app/machines/views/MachineList/MachineListTable/MachineListPagination";
 @include CloneFormFields;
 @include CloneResults;
 @include MachineList;
+@include MachineListDisplayCount;
 @include MachineListPagination;
 @include MachineHeader;
 @include MachineSummary;

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -243,9 +243,11 @@
 @import "~app/machines/views/MachineDetails/MachineSummary";
 @import "~app/machines/views/MachineDetails/MachineSummary/NumaCard";
 @import "~app/machines/views/MachineList";
+@import "~app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss";
 @include CloneFormFields;
 @include CloneResults;
 @include MachineList;
+@include MachineListPagination;
 @include MachineHeader;
 @include MachineSummary;
 @include MarkBrokenFormFields;


### PR DESCRIPTION
## Done

- Updated machine list pagination component to allow input for page number
- Added select for page size

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list (ensure you have at least 100 machines)
- Ensure only 50 machines per page are displayed by default
- Click on the page counter and type a number between 1 and your page count (inclusive)
- Ensure the page updates
- Enter a number outside this range
- Ensure nothing happens
- Click the buttons to navigate between pages
- Ensure the page updates
- Click the dropdown and select "100/page"
- Ensure 100 machines are displayed
- Click the dropdown and select "200/page"
- Ensure the correct number of machines are displayed

## Fixes

Fixes https://warthogs.atlassian.net/browse/MAASENG-1369
Fixes https://warthogs.atlassian.net/browse/MAASENG-1366

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/220656296-cbba50c6-cf8a-46dd-8d3f-f348166aaace.png)

### After
![image](https://user-images.githubusercontent.com/35104482/220656469-5b1bc579-d0be-4efc-b389-84d40d8d9752.png)

