### PR TITLE
test: update navigation cypress tests

### DIFF
--- a/cypress/e2e/with-users/base/navigation.spec.ts
+++ b/cypress/e2e/with-users/base/navigation.spec.ts
@@ -17,6 +17,10 @@ const expectExpandedNavigation = () => {
   );
 };
 
+const withinSideNavigtion = (fn: () => void) => {
+  cy.findByRole("navigation", { name: /main navigation/i }).within(fn);
+};
+
 context("Navigation - non-admin", () => {
   beforeEach(() => {
     cy.loginNonAdmin();
@@ -24,13 +28,15 @@ context("Navigation - non-admin", () => {
   });
 
   it("navigates to machines when clicking on the logo", () => {
-    cy.findByRole("link", { name: "Homepage" }).click();
+    withinSideNavigtion(() =>
+      cy.findByRole("link", { name: "Homepage" }).click()
+    );
     cy.location("pathname").should("eq", generateMAASURL("/machines"));
     cy.get(".p-side-navigation__item.is-selected a").contains("Machines");
   });
 });
 
-context("Navigation - admin", () => {
+context("Navigation - admin - collapse", () => {
   beforeEach(() => {
     cy.login();
     // Need the window to be wide enough so that menu items aren't hidden under
@@ -59,89 +65,6 @@ context("Navigation - admin", () => {
     expectCollapsedNavigation();
   });
 
-  it("navigates to dashboard when clicking on the logo", () => {
-    cy.waitForPageToLoad();
-    cy.findByRole("link", { name: "Homepage" }).click();
-    cy.location("pathname").should("eq", generateMAASURL("/dashboard"));
-    cy.findByRole("link", { current: "page", name: "Homepage" }).should(
-      "exist"
-    );
-  });
-
-  it("navigates to machines", () => {
-    cy.get(".p-side-navigation__link:contains(Machines)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/machines"));
-    cy.get(".p-side-navigation__item.is-selected a").contains("Machines");
-  });
-
-  it("navigates to devices", () => {
-    cy.get(".p-side-navigation__link:contains(Devices)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/devices"));
-  });
-
-  it("navigates to controllers", () => {
-    cy.get(".p-side-navigation__link:contains(Controllers)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/controllers"));
-    cy.get(".p-side-navigation__item.is-selected a").contains("Controllers");
-  });
-
-  it("navigates to lxd kvm list", () => {
-    cy.get(".p-side-navigation__link:contains(LXD)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/kvm/lxd"));
-    cy.get(".p-side-navigation__item.is-selected a").contains("LXD");
-  });
-
-  it("navigates to virsh kvm list", () => {
-    cy.get(".p-side-navigation__link:contains(Virsh)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/kvm/virsh"));
-    cy.get(".p-side-navigation__item.is-selected a").contains("Virsh");
-  });
-
-  it("navigates to images", () => {
-    cy.get(".p-side-navigation__link:contains(Images)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/images"));
-    cy.get(".p-side-navigation__item.is-selected a").contains("Images");
-  });
-
-  it("navigates to domains", () => {
-    cy.get(".p-side-navigation__link:contains(DNS)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/domains"));
-    cy.get(".p-side-navigation__item.is-selected a").contains("DNS");
-  });
-
-  it("navigates to zones", () => {
-    cy.get(".p-side-navigation__link:contains(AZs)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/zones"));
-    cy.get(".p-side-navigation__item.is-selected a").contains("AZs");
-  });
-
-  it("navigates to subnets", () => {
-    cy.get(".p-side-navigation__link:contains(Subnets)").click();
-    cy.location("pathname").should("eq", generateMAASURL("/networks"));
-    cy.location("search").should("eq", "?by=fabric&q=");
-    cy.get(".p-side-navigation__item.is-selected a").contains("Subnets");
-  });
-
-  it("navigates to settings", () => {
-    cy.get(".p-side-navigation__link:contains(Settings)").click();
-    cy.location("pathname").should(
-      "eq",
-      generateMAASURL("/settings/configuration/general")
-    );
-    cy.get(".p-side-navigation__item.is-selected a").contains("Settings");
-  });
-
-  it("navigates to preferences", () => {
-    cy.get(`.l-navigation__link:contains(${Cypress.env("username")})`).click();
-    cy.location("pathname").should(
-      "eq",
-      generateMAASURL("/account/prefs/details")
-    );
-    cy.get(".p-side-navigation__item.is-selected a").contains(
-      Cypress.env("username")
-    );
-  });
-
   it("opens and closes the menu on mobile", () => {
     cy.viewport("iphone-8");
     const getMainNavigation = () =>
@@ -154,7 +77,63 @@ context("Navigation - admin", () => {
     );
     getMainNavigation()
       .should("be.visible")
-      .within(() => cy.findByRole("button", { name: /Close/ }).click());
+      .within(() =>
+        cy.findByRole("button", { name: /collapse main navigation/ }).click()
+      );
     getMainNavigation().should("not.be.visible");
+  });
+});
+
+context("Navigation - admin", () => {
+  beforeEach(() => {
+    cy.login();
+    // Need the window to be wide enough so that menu items aren't hidden under
+    // the hardware menu.
+    cy.viewport("macbook-13");
+    cy.visit(generateMAASURL("/"));
+    // set side navigation to expanded
+    cy.window().then((win) =>
+      win.localStorage.setItem("appSideNavIsCollapsed", "false")
+    );
+  });
+
+  const expected = [
+    { destinationUrl: "/machines", linkLabel: "Machines" },
+    { destinationUrl: "/devices", linkLabel: "Devices" },
+    { destinationUrl: "/controllers", linkLabel: "Controllers" },
+    { destinationUrl: "/kvm/lxd", linkLabel: "LXD" },
+    { destinationUrl: "/kvm/virsh", linkLabel: "Virsh" },
+    { destinationUrl: "/images", linkLabel: "Images" },
+    { destinationUrl: "/domains", linkLabel: "DNS" },
+    { destinationUrl: "/networks", linkLabel: "Subnets" },
+    {
+      destinationUrl: "/settings/configuration/general",
+      linkLabel: "Settings",
+    },
+    {
+      destinationUrl: "/account/prefs/details",
+      linkLabel: Cypress.env("username"),
+    },
+    { destinationUrl: "/zones", linkLabel: "AZs" },
+  ];
+
+  it("navigates to /dashboard when clicking on the logo", () => {
+    cy.waitForPageToLoad();
+    withinSideNavigtion(() =>
+      cy.findByRole("link", { name: "Homepage" }).click()
+    );
+    cy.location("pathname").should("eq", generateMAASURL("/dashboard"));
+  });
+
+  expected.forEach(({ destinationUrl, linkLabel }) => {
+    it(`navigates to ${destinationUrl} and highlights ${linkLabel} link`, () => {
+      cy.waitForPageToLoad();
+      withinSideNavigtion(() =>
+        cy.findByRole("link", { name: linkLabel }).click()
+      );
+      cy.location("pathname").should("eq", generateMAASURL(destinationUrl));
+      cy.get(".p-side-navigation__item.is-selected a").contains(linkLabel);
+      cy.findByRole("link", { current: "page" }).should("have.text", linkLabel);
+    });
   });
 });

--- a/cypress/e2e/with-users/controllers/list.spec.ts
+++ b/cypress/e2e/with-users/controllers/list.spec.ts
@@ -9,12 +9,4 @@ context("Controller listing", () => {
   it("renders the correct heading", () => {
     cy.get("[data-testid='section-header-title']").contains("Controllers");
   });
-
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/controllers")
-    );
-  });
 });

--- a/cypress/e2e/with-users/devices/list.spec.ts
+++ b/cypress/e2e/with-users/devices/list.spec.ts
@@ -10,14 +10,6 @@ context("Device listing", () => {
     cy.get("[data-testid='section-header-title']").contains("Devices");
   });
 
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/devices")
-    );
-  });
-
   it("can add a tag to the device", () => {
     // can add a device
     cy.findByRole("button", { name: /Add device/ }).click();

--- a/cypress/e2e/with-users/domains/list.spec.ts
+++ b/cypress/e2e/with-users/domains/list.spec.ts
@@ -9,12 +9,4 @@ context("DNS", () => {
   it("renders the correct heading", () => {
     cy.get("[data-testid='section-header-title']").contains("DNS");
   });
-
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/domains")
-    );
-  });
 });

--- a/cypress/e2e/with-users/images/list.spec.ts
+++ b/cypress/e2e/with-users/images/list.spec.ts
@@ -9,12 +9,4 @@ context("Images list", () => {
   it("renders the correct heading", () => {
     cy.get("[data-testid='section-header-title']").contains("Images");
   });
-
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/images")
-    );
-  });
 });

--- a/cypress/e2e/with-users/kvm/list.spec.ts
+++ b/cypress/e2e/with-users/kvm/list.spec.ts
@@ -9,12 +9,4 @@ context("KVM listing", () => {
   it("renders the correct heading", () => {
     cy.get("[data-testid='section-header-title']").contains("KVM");
   });
-
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/kvm/lxd")
-    );
-  });
 });

--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -12,14 +12,6 @@ context("Machine listing", () => {
     );
   });
 
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/machines")
-    );
-  });
-
   it("can group machines by all supported keys", () => {
     const GROUP_BY_OPTIONS = [
       "No grouping",

--- a/cypress/e2e/with-users/preferences/base.spec.ts
+++ b/cypress/e2e/with-users/preferences/base.spec.ts
@@ -9,12 +9,4 @@ context("User preferences", () => {
   it("renders the correct heading", () => {
     cy.get("[data-testid='section-header-title']").contains("My preferences");
   });
-
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/account/prefs")
-    );
-  });
 });

--- a/cypress/e2e/with-users/settings/base.spec.ts
+++ b/cypress/e2e/with-users/settings/base.spec.ts
@@ -9,12 +9,4 @@ context("Settings", () => {
   it("renders the correct heading", () => {
     cy.get("[data-testid='section-header-title']").contains("Settings");
   });
-
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/settings")
-    );
-  });
 });

--- a/cypress/e2e/with-users/settings/configuration/general.spec.ts
+++ b/cypress/e2e/with-users/settings/configuration/general.spec.ts
@@ -47,21 +47,21 @@ context("Settings - General - Theme", () => {
     cy.findByRole("radio", { name: "Red" }).click();
     cy.reload(true);
 
-    cy.get(".l-navigation").should("have.class", "l-navigation--default");
+    cy.get(".l-navigation").should("have.class", "is-maas-default");
   });
 
   it("reverts the theme choice if the user clicks cancel", () => {
     cy.findByRole("radio", { name: "Red" }).click();
     cy.findByRole("button", { name: "Cancel" }).click();
 
-    cy.get(".l-navigation").should("have.class", "l-navigation--default");
+    cy.get(".l-navigation").should("have.class", "is-maas-default");
   });
 
   it("reverts the theme choice if the user navigates to another page", () => {
     cy.findByRole("radio", { name: "Red" }).click();
     cy.findByRole("link", { name: "Deploy" }).click();
 
-    cy.get(".l-navigation").should("have.class", "l-navigation--default");
+    cy.get(".l-navigation").should("have.class", "is-maas-default");
   });
 });
 

--- a/cypress/e2e/with-users/subnets/subnets.spec.ts
+++ b/cypress/e2e/with-users/subnets/subnets.spec.ts
@@ -11,20 +11,6 @@ context("Subnets", () => {
     cy.findByRole("heading", { level: 1 }).contains("Subnets");
   });
 
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/networks")
-    );
-    cy.get(".l-navigation").within(() => {
-      cy.findByRole("link", { current: "page" }).should(
-        "have.attr",
-        "href",
-        generateMAASURL("/networks")
-      );
-    });
-  });
   it("displays the main networking view correctly", () => {
     const expectedHeaders = [
       "Fabric",

--- a/cypress/e2e/with-users/zones/list.spec.ts
+++ b/cypress/e2e/with-users/zones/list.spec.ts
@@ -11,12 +11,4 @@ context("Zones", () => {
       "Availability zones"
     );
   });
-
-  it("highlights the correct navigation link", () => {
-    cy.findByRole("link", { current: "page" }).should(
-      "have.attr",
-      "href",
-      generateMAASURL("/zones")
-    );
-  });
 });


### PR DESCRIPTION
## Done

- fix cypress tests related to navigation
- move navigation related assertions to `navigation.spec.ts`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4748

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
