### PR TITLE
test(machines): use correct no results found role

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -872,7 +872,11 @@ export const MachineListTable = ({
           "machine-list--grouped": grouping,
           "machine-list--loading": machinesLoading,
         })}
-        emptyStateMsg={!machinesLoading && filter ? Label.NoResults : null}
+        emptyStateMsg={
+          !machinesLoading && filter ? (
+            <div role="status">{Label.NoResults}</div>
+          ) : null
+        }
         headers={filterColumns(headers, hiddenColumns, showActions)}
         rows={machinesLoading ? skeletonRows : rows}
         {...props}

--- a/tests/machines.spec.ts
+++ b/tests/machines.spec.ts
@@ -44,7 +44,9 @@ test("machines list loads", async ({ page }) => {
   await page.getByLabel("Search").type("doesnotexist");
   await expect(page.getByRole("grid", { name: /Loading/i })).not.toBeVisible();
   await expect(
-    page.getByText(/No machines match the search criteria/)
+    page.getByRole("status", {
+      name: /No machines match the search criteria/i,
+    })
   ).toBeVisible();
   // expect an additional single machine.list request
   await expect(machineListRequests.length).toBe(2);


### PR DESCRIPTION
## Done

- test: use correct role for no results found 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
