### PR TITLE
ci: use dotrun for build upload

### DIFF
--- a/.github/ISSUE_TEMPLATE/upload-failure.md
+++ b/.github/ISSUE_TEMPLATE/upload-failure.md
@@ -6,6 +6,4 @@ assignees: ''
 
 ---
 
-Uploading the build to the assets server has failed for the {{ env.BRANCH_NAME }} branch:
-
-<https://github.com/>{{ env.REPO }}/actions/runs/{{ env.RUN_ID }}
+Uploading the build to the assets server has [failed](https://github.com/{{ env.REPO }}/actions/runs/{{ env.RUN_ID }}) for the {{ env.BRANCH_NAME }} branch.

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -10,9 +10,6 @@ jobs:
     env:
       PACKAGE_NAME: maas-ui-${{ github.sha }}.tar.gz
       REACT_APP_GIT_SHA: ${{ github.sha }}
-    strategy:
-      matrix:
-        node-version: [16.x]
     steps:
       - uses: actions/checkout@v3
       - name: Get branch name
@@ -23,17 +20,13 @@ jobs:
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Install
+      - name: Install dotrun
+        uses: canonical/install-dotrun@main
+      - name: Install dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: CYPRESS_INSTALL_BINARY=0 yarn install
-      - name: Build
-        run: REACT_APP_GIT_SHA=${{env.REACT_APP_GIT_SHA}} yarn build
-        env:
-          CI: false
+        run: dotrun --env CYPRESS_INSTALL_BINARY=0 install
+      - name: Build assets
+        run: dotrun --env CI=false --env REACT_APP_GIT_SHA=${{env.REACT_APP_GIT_SHA}} build
       - name: Compress
         run: cd build && tar -czf ../${{env.PACKAGE_NAME}} ./ && ls -hs ../${{env.PACKAGE_NAME}}
       - name: Install upload-assets snap

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-modules-v1-${{ hashFiles('**/yarn.lock') }}
       - name: Install dotrun
         uses: canonical/install-dotrun@main
       - name: Install dependencies


### PR DESCRIPTION
## Done

- ci: use dotrun for build upload
  - fix upload failure issue link

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/4781

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
