### PR TITLE
fix(machines): Reset current page to first page on change of page size #4787

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -64,7 +64,6 @@ const MachineListPagination = ({
         <Input
           aria-label="page number"
           className="p-pagination__input"
-          defaultValue={props.currentPage}
           onChange={(e) => {
             setPageNumber(e.target.valueAsNumber);
             if (intervalRef.current) {

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -870,7 +870,11 @@ export const MachineListTable = ({
               paginate={setCurrentPage}
             />
             {setPageSize ? (
-              <PageSizeSelect pageSize={pageSize} setPageSize={setPageSize} />
+              <PageSizeSelect
+                pageSize={pageSize}
+                paginate={setCurrentPage}
+                setPageSize={setPageSize}
+              />
             ) : null}
           </span>
           <hr />

--- a/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.test.tsx
@@ -9,18 +9,27 @@ const DEFAULT_PAGE_SIZE = DEFAULTS.pageSize;
 describe("PageSizeSelect", () => {
   it("renders", () => {
     render(
-      <PageSizeSelect pageSize={DEFAULT_PAGE_SIZE} setPageSize={jest.fn()} />
+      <PageSizeSelect
+        pageSize={DEFAULT_PAGE_SIZE}
+        paginate={jest.fn()}
+        setPageSize={jest.fn()}
+      />
     );
     expect(
       screen.getByRole("combobox", { name: "Items per page" })
     ).toBeInTheDocument();
   });
 
-  it("calls a function to update the page size", async () => {
+  it("calls a function to update the page size and reset to the first page", async () => {
     const setPageSize = jest.fn();
+    const setCurrentPage = jest.fn();
 
     render(
-      <PageSizeSelect pageSize={DEFAULT_PAGE_SIZE} setPageSize={setPageSize} />
+      <PageSizeSelect
+        pageSize={DEFAULT_PAGE_SIZE}
+        paginate={setCurrentPage}
+        setPageSize={setPageSize}
+      />
     );
 
     const pageSizeSelect = screen.getByRole("combobox", {
@@ -29,5 +38,6 @@ describe("PageSizeSelect", () => {
     await userEvent.selectOptions(pageSizeSelect, "100");
 
     expect(setPageSize).toHaveBeenCalledWith(100);
+    expect(setCurrentPage).toHaveBeenCalledWith(1);
   });
 });

--- a/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PageSizeSelect/PageSizeSelect.tsx
@@ -1,7 +1,9 @@
 import { Select } from "@canonical/react-components";
+import type { PaginationProps } from "@canonical/react-components";
 
 type Props = {
   pageSize: number;
+  paginate: PaginationProps["paginate"];
   setPageSize: (pageSize: number) => void;
 };
 
@@ -27,13 +29,18 @@ const groupOptions = [
   },
 ];
 
-const PageSizeSelect = ({ pageSize, setPageSize }: Props): JSX.Element => {
+const PageSizeSelect = ({
+  pageSize,
+  paginate,
+  setPageSize,
+}: Props): JSX.Element => {
   return (
     <Select
       aria-label={Labels.ItemsPerPage}
       className="u-no-margin"
       defaultValue={pageSize}
       onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
+        paginate(1);
         setPageSize(parseInt(e.target.value));
       }}
       options={groupOptions}


### PR DESCRIPTION
## Done

- Page is set to `1` if page size is changed

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list (at least 100 machines in db)
- Set page size to 50
- Go to second page
- Set page size to 100
- Ensure you are returned to the first page

## Fixes

Fixes #4787