### PR TITLE
fix(settings): Update MAAS name example emotes to not be misleading #4785

### DIFF
--- a/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -120,8 +120,9 @@ const GeneralForm = (): JSX.Element => {
             Use MAAS name and unicode emoji(s) to describe your MAAS instance.{" "}
             <br />
             <br />
-            Examples: <br />⛔ maas-prod <br />
-            my-maas ⚠️ no-deploys
+            Examples: <br />
+            US-west-2🇺🇸MAAS-prod <br />
+            my-maas❗no-deploys
           </>
         }
         label="MAAS name"

--- a/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -121,8 +121,8 @@ const GeneralForm = (): JSX.Element => {
             <br />
             <br />
             Examples: <br />
-            US-west-2🇺🇸MAAS-prod <br />
-            my-maas❗no-deploys
+            US-west-2 🇺🇸 MAAS-prod <br />
+            my-maas ❗ no-deploys
           </>
         }
         label="MAAS name"


### PR DESCRIPTION
## Done

- Updated MAAS name emoji examples in configuration to not be misleading

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/settings/configuration/general`
- Ensure emotes match the "after" screenshot below

## Fixes

Fixes #4785 

## Backports

Will be backported to 3.3 once merged

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/35104482/221563610-712a108f-5ed7-4866-9341-8f0cb210e318.png)

### After
![image](https://user-images.githubusercontent.com/35104482/221563672-8c3c5c6a-8fdc-4417-871c-8e33ac0a7e99.png)
