### PR TITLE
feat: display mac address in monospace font #4795

### DIFF
--- a/src/app/base/components/MacAddressDisplay/MacAddressDisplay.tsx
+++ b/src/app/base/components/MacAddressDisplay/MacAddressDisplay.tsx
@@ -1,0 +1,16 @@
+import classNames from "classnames";
+
+const MacAddressDisplay = ({
+  children,
+  className,
+  ...rest
+}: {
+  children: React.ReactNode;
+  className?: string;
+}): JSX.Element => (
+  <span {...rest} className={classNames("u-text--monospace", className)}>
+    {children}
+  </span>
+);
+
+export default MacAddressDisplay;

--- a/src/app/base/components/MacAddressDisplay/index.ts
+++ b/src/app/base/components/MacAddressDisplay/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MacAddressDisplay";

--- a/src/app/base/components/NodeSummaryNetworkCard/NetworkCardTable/NetworkCardTable.tsx
+++ b/src/app/base/components/NodeSummaryNetworkCard/NetworkCardTable/NetworkCardTable.tsx
@@ -7,6 +7,7 @@ import {
 } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
+import MacAddressDisplay from "app/base/components/MacAddressDisplay";
 import TooltipButton from "app/base/components/TooltipButton";
 import { useIsAllNetworkingDisabled } from "app/base/hooks";
 import type { Device } from "app/store/device/types";
@@ -86,7 +87,7 @@ const NetworkCardTable = ({ interfaces, node }: Props): JSX.Element => {
                 {iface.name}
                 <br />
                 <Tooltip message={iface.mac_address}>
-                  <small className="u-text--muted">{iface.mac_address}</small>
+                  <MacAddressDisplay>{iface.mac_address}</MacAddressDisplay>
                 </Tooltip>
               </TableCell>
               <TableCell className="ip" data-heading="IP address | Subnet">

--- a/src/app/base/components/node/networking/NameColumn/NameColumn.tsx
+++ b/src/app/base/components/node/networking/NameColumn/NameColumn.tsx
@@ -1,4 +1,5 @@
 import DoubleRow from "app/base/components/DoubleRow";
+import MacAddressDisplay from "app/base/components/MacAddressDisplay";
 import RowCheckbox from "app/base/components/RowCheckbox";
 import type { Selected } from "app/base/components/node/networking/types";
 import { useIsAllNetworkingDisabled } from "app/base/hooks";
@@ -56,7 +57,7 @@ const NameColumn = ({
         )
       }
       primaryClassName={checkboxSpace ? "u-nudge--primary-row" : null}
-      secondary={nic.mac_address}
+      secondary={<MacAddressDisplay>{nic.mac_address}</MacAddressDisplay>}
       secondaryClassName={
         checkboxSpace || showCheckbox ? "u-nudge--secondary-row" : null
       }

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
@@ -18,6 +18,7 @@ import DiscoveryAddForm from "../DiscoveryAddForm";
 import DiscoveriesFilterAccordion from "./DiscoveriesFilterAccordion";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import MacAddressDisplay from "app/base/components/MacAddressDisplay";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import TooltipButton from "app/base/components/TooltipButton";
 import { useWindowTitle } from "app/base/hooks";
@@ -114,7 +115,9 @@ const generateRows = (
         {
           content: (
             <DoubleRow
-              primary={discovery.mac_address}
+              primary={
+                <MacAddressDisplay>{discovery.mac_address}</MacAddressDisplay>
+              }
               secondary={discovery.mac_organization || "Unknown"}
             />
           ),

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 
 import RemoveInterface from "./RemoveInterface";
 
+import MacAddressDisplay from "app/base/components/MacAddressDisplay";
 import type {
   Expanded,
   SetExpanded,
@@ -104,7 +105,7 @@ const generateRow = (
     }),
     columns: [
       {
-        content: nic.mac_address,
+        content: <MacAddressDisplay>{nic.mac_address}</MacAddressDisplay>,
       },
       {
         content: <SubnetColumn link={link} nic={nic} node={device} />,

--- a/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
+++ b/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
@@ -5,6 +5,7 @@ import OwnerColumn from "./OwnerColumn";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import GroupCheckbox from "app/base/components/GroupCheckbox";
+import MacAddressDisplay from "app/base/components/MacAddressDisplay";
 import RowCheckbox from "app/base/components/RowCheckbox";
 import TableHeader from "app/base/components/TableHeader";
 import { useTableSort } from "app/base/hooks";
@@ -84,7 +85,11 @@ const generateRows = (
                 />
               }
               primaryTitle={fqdn}
-              secondary={<span data-testid="mac-display">{macDisplay}</span>}
+              secondary={
+                <MacAddressDisplay data-testid="mac-display">
+                  {macDisplay}
+                </MacAddressDisplay>
+              }
               secondaryClassName="u-nudge--secondary-row"
               secondaryTitle={[primary_mac, ...extra_macs].join(", ")}
             />

--- a/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
@@ -8,6 +8,7 @@ import { Link } from "react-router-dom-v5-compat";
 import MachineCheckbox from "../MachineCheckbox";
 
 import DoubleRow from "app/base/components/DoubleRow";
+import MacAddressDisplay from "app/base/components/MacAddressDisplay";
 import NonBreakingSpace from "app/base/components/NonBreakingSpace";
 import urls from "app/base/urls";
 import machineSelectors from "app/store/machine/selectors";
@@ -112,7 +113,7 @@ const generateMAC = (machine: Machine, machineURL: string) => {
   return (
     <>
       <Link title={machine.fqdn} to={machineURL}>
-        {machine.pxe_mac}
+        <MacAddressDisplay>{machine.pxe_mac}</MacAddressDisplay>
       </Link>
       {machine.extra_macs && machine.extra_macs.length > 0 ? (
         <Link to={machineURL}> (+{machine.extra_macs.length})</Link>

--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -65,7 +65,6 @@
     align-items: flex-end !important;
   }
 
-
   .u-flex--between {
     @extend %display-flex;
     justify-content: space-between !important;
@@ -203,6 +202,10 @@
 
   .u-upper-case--first:first-letter {
     text-transform: capitalize !important;
+  }
+
+  .u-text--monospace {
+    font-family: unquote($font-monospace) !important;
   }
 
   .u-no-line-height {


### PR DESCRIPTION
## Done

- display mac address in monospace font #4795

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: #4795

## Launchpad issue
https://bugs.launchpad.net/maas/+bug/1773671
`lp#1773671`

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/7452681/222484297-b4156904-b4e0-40f6-8888-7dad6000c17e.png)

### After
![image](https://user-images.githubusercontent.com/7452681/222484333-1e32942f-4088-4610-82e5-70d275461768.png)

### Before
<img width="1558" alt="Pasted Graphic 9" src="https://user-images.githubusercontent.com/7452681/222484433-64177be7-e485-47bf-aa47-cd10e9e88831.png">

### After
<img width="1560" alt="Pasted Graphic 8" src="https://user-images.githubusercontent.com/7452681/222484467-ef38512c-05eb-41af-b170-ce4196f4b98b.png">

### Before
<img width="1574" alt="Pasted Graphic 7" src="https://user-images.githubusercontent.com/7452681/222484505-63f67dd5-f231-4ead-83e9-bcd15ce01533.png">

### After
<img width="1569" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/7452681/222484536-80b4b41a-8d46-4005-aed5-67167ac889bd.png">
