### PR TITLE
refactor(machines): remove active row state

### DIFF
--- a/src/app/machines/hooks.tsx
+++ b/src/app/machines/hooks.tsx
@@ -18,12 +18,11 @@ import type { RootState } from "app/store/root/types";
  * @returns The toggle callback.
  */
 export const useToggleMenu = (
-  onToggleMenu: ((systemId: string, open: boolean) => void) | null,
-  systemId: string
+  onToggleMenu: ((open: boolean) => void) | null
 ): ((open: boolean) => void) => {
   return useCallback(
-    (open) => onToggleMenu && onToggleMenu(systemId, open),
-    [onToggleMenu, systemId]
+    (open) => onToggleMenu && onToggleMenu(open),
+    [onToggleMenu]
   );
 };
 

--- a/src/app/machines/types.ts
+++ b/src/app/machines/types.ts
@@ -40,3 +40,8 @@ export type MachineActionFormProps = Omit<
   "processingCount"
 > &
   MachineActionVariableProps;
+
+export type MachineMenuToggleHandler = (open: boolean) => void;
+export type GetMachineMenuToggleHandler = (
+  eventLabel: string
+) => MachineMenuToggleHandler;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -34,12 +34,9 @@ import TableHeader from "app/base/components/TableHeader";
 import { useSendAnalytics } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
 import { columnLabels, columns, MachineColumns } from "app/machines/constants";
+import type { GetMachineMenuToggleHandler } from "app/machines/types";
 import { actions as generalActions } from "app/store/general";
-import type {
-  Machine,
-  MachineMeta,
-  MachineStateListGroup,
-} from "app/store/machine/types";
+import type { Machine, MachineStateListGroup } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
@@ -79,14 +76,12 @@ type Props = {
 
 type TableColumn = MainTableCell & { key: string };
 
-type GetToggleHandler = (eventLabel: string) => (open: boolean) => void;
-
 type GenerateRowParams = {
   callId?: string | null;
   groupValue: MachineStateListGroup["value"];
   hiddenColumns: NonNullable<Props["hiddenColumns"]>;
   machines: Machine[];
-  getToggleHandler: GetToggleHandler;
+  getToggleHandler: GetMachineMenuToggleHandler;
   showActions: Props["showActions"];
   showMAC: boolean;
   showFullName: boolean;
@@ -313,7 +308,7 @@ const generateRows = ({
   showMAC,
   showFullName,
 }: GenerateRowParams) => {
-  const getMenuHandler: GetToggleHandler = (...args) =>
+  const getMenuHandler: GetMachineMenuToggleHandler = (...args) =>
     showActions ? getToggleHandler(...args) : () => undefined;
 
   return machines.map((row) => {

--- a/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/OwnerColumn/OwnerColumn.tsx
@@ -7,6 +7,7 @@ import DoubleRow from "app/base/components/DoubleRow";
 import { useMachineActions } from "app/base/hooks";
 import type { MachineMenuAction } from "app/base/hooks/node";
 import { useToggleMenu } from "app/machines/hooks";
+import type { MachineMenuToggleHandler } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
@@ -16,7 +17,7 @@ import { NodeActions } from "app/store/types/node";
 import userSelectors from "app/store/user/selectors";
 
 type Props = {
-  onToggleMenu?: (systemId: Machine[MachineMeta.PK], open: boolean) => void;
+  onToggleMenu?: MachineMenuToggleHandler;
   systemId: Machine[MachineMeta.PK];
   showFullName?: boolean;
 };
@@ -35,7 +36,7 @@ export const OwnerColumn = ({
   const machineTags = useSelector((state: RootState) =>
     tagSelectors.getByIDs(state, machine?.tags || null)
   );
-  const toggleMenu = useToggleMenu(onToggleMenu || null, systemId);
+  const toggleMenu = useToggleMenu(onToggleMenu || null);
   const user = useSelector((state: RootState) =>
     userSelectors.getByUsername(state, machine?.owner || "")
   );

--- a/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.tsx
@@ -7,6 +7,7 @@ import { Link } from "react-router-dom-v5-compat";
 import DoubleRow from "app/base/components/DoubleRow";
 import urls from "app/base/urls";
 import { useToggleMenu } from "app/machines/hooks";
+import type { MachineMenuToggleHandler } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
@@ -19,7 +20,7 @@ import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 
 type Props = {
-  onToggleMenu?: (systemId: Machine[MachineMeta.PK], open: boolean) => void;
+  onToggleMenu?: MachineMenuToggleHandler;
   systemId: Machine[MachineMeta.PK];
 };
 
@@ -35,7 +36,7 @@ export const PoolColumn = ({
     machineSelectors.getById(state, systemId)
   );
   const resourcePools = useSelector(resourcePoolSelectors.all);
-  const toggleMenu = useToggleMenu(onToggleMenu || null, systemId);
+  const toggleMenu = useToggleMenu(onToggleMenu || null);
 
   let poolLinks;
   const machinePools = resourcePools.filter(

--- a/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PowerColumn/PowerColumn.tsx
@@ -6,6 +6,7 @@ import { useDispatch, useSelector } from "react-redux";
 import DoubleRow from "app/base/components/DoubleRow";
 import PowerIcon from "app/base/components/PowerIcon";
 import { useToggleMenu } from "app/machines/hooks";
+import type { MachineMenuToggleHandler } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
@@ -15,7 +16,7 @@ import { NodeActions } from "app/store/types/node";
 import { breakLines } from "app/utils";
 
 type Props = {
-  onToggleMenu?: (systemId: Machine["system_id"], open: boolean) => void;
+  onToggleMenu?: MachineMenuToggleHandler;
   systemId: Machine["system_id"];
 };
 
@@ -28,7 +29,7 @@ export const PowerColumn = ({
   const machine = useSelector((state: RootState) =>
     machineSelectors.getById(state, systemId)
   );
-  const toggleMenu = useToggleMenu(onToggleMenu || null, systemId);
+  const toggleMenu = useToggleMenu(onToggleMenu || null);
   const powerState = machine?.power_state || PowerState.UNKNOWN;
 
   useEffect(() => {

--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -10,6 +10,7 @@ import TooltipButton from "app/base/components/TooltipButton";
 import { useMachineActions } from "app/base/hooks";
 import type { MachineMenuAction } from "app/base/hooks/node";
 import { useToggleMenu } from "app/machines/hooks";
+import type { MachineMenuToggleHandler } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { isTransientStatus, useFormattedOS } from "app/store/machine/utils";
@@ -60,7 +61,7 @@ const getStatusIcon = (machine: Machine | null) => {
 };
 
 type Props = {
-  onToggleMenu?: (systemId: string, open: boolean) => void;
+  onToggleMenu?: MachineMenuToggleHandler;
   systemId: string;
 };
 
@@ -114,7 +115,7 @@ export const StatusColumn = ({
     machineSelectors.getById(state, systemId)
   );
   const formattedOS = useFormattedOS(machine, true);
-  const toggleMenu = useToggleMenu(onToggleMenu || null, systemId);
+  const toggleMenu = useToggleMenu(onToggleMenu || null);
   const actionLinks = useMachineActions(systemId, actions);
   const statusText = getStatusText(machine, formattedOS);
   const seeLogs = React.useMemo(

--- a/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
@@ -7,6 +7,7 @@ import { Link } from "react-router-dom-v5-compat";
 import DoubleRow from "app/base/components/DoubleRow";
 import urls from "app/base/urls";
 import { useToggleMenu } from "app/machines/hooks";
+import type { MachineMenuToggleHandler } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineMeta } from "app/store/machine/types";
@@ -16,7 +17,7 @@ import zoneSelectors from "app/store/zone/selectors";
 import type { Zone, ZoneMeta } from "app/store/zone/types";
 
 type Props = {
-  onToggleMenu?: (systemId: Machine[MachineMeta.PK], open: boolean) => void;
+  onToggleMenu?: MachineMenuToggleHandler;
   systemId: Machine[MachineMeta.PK];
 };
 
@@ -46,7 +47,7 @@ export const ZoneColumn = ({
     machineSelectors.getById(state, systemId)
   );
   const zones = useSelector(zoneSelectors.all);
-  const toggleMenu = useToggleMenu(onToggleMenu || null, systemId);
+  const toggleMenu = useToggleMenu(onToggleMenu || null);
   let zoneLinks;
   const machineZones = zones.filter((zone) => zone.id !== machine?.zone.id);
   if (machine?.actions.includes(NodeActions.SET_ZONE)) {


### PR DESCRIPTION
## Done

- refactor(machines): remove active row state
(it was used to determine whether to apply an active row classname which is no longer used)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- perform an inline action on any of the listed machines
- verify the action has been performed correctly
- select a machine
- open bulk action menu (Take action)
- perform an action on the machine
- verify it's been performed on the selected machine

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

### Before

![Kapture 2023-03-10 at 10 30 31](https://user-images.githubusercontent.com/7452681/224278891-35999f22-7de1-4002-84c3-791ae1ddad4b.gif)

_entire table render tree re-rendered on open and close of an inline action menu_

### After
![Kapture 2023-03-10 at 10 26 30](https://user-images.githubusercontent.com/7452681/224279003-7ce377f3-dd33-4af4-bb1c-1b9b16944bd7.gif)

_only the menu element rendered on open and close of an inline action menu_
