### PR TITLE
refactor(machines): use machineActions property accessor

### DIFF
--- a/src/app/base/hooks/node.ts
+++ b/src/app/base/hooks/node.ts
@@ -61,10 +61,7 @@ export const useMachineActions = (
             onClick: () => {
               const actionMethod = kebabToCamelCase(action);
               // Find the method for the function.
-              const [, actionFunction] =
-                Object.entries(machineActions).find(
-                  ([key]) => key === actionMethod
-                ) || [];
+              const actionFunction = machineActions[actionMethod];
               if (actionFunction) {
                 dispatch(actionFunction({ system_id: systemId }));
               }


### PR DESCRIPTION
## Done

- refactor: replace machineActions Object entries method lookup with property accessor (TS Object.entries has weak typing by default for Object keys and uses a generic string)
  - fixes maas upload failed #4807

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes: #4807

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
