### PR TITLE
test: update cypress tests #4779

### DIFF
--- a/cypress/e2e/with-users/base/navigation.spec.ts
+++ b/cypress/e2e/with-users/base/navigation.spec.ts
@@ -17,10 +17,6 @@ const expectExpandedNavigation = () => {
   );
 };
 
-const withinSideNavigtion = (fn: () => void) => {
-  cy.findByRole("navigation", { name: /main navigation/i }).within(fn);
-};
-
 context("Navigation - non-admin", () => {
   beforeEach(() => {
     cy.loginNonAdmin();
@@ -28,7 +24,7 @@ context("Navigation - non-admin", () => {
   });
 
   it("navigates to machines when clicking on the logo", () => {
-    withinSideNavigtion(() =>
+    cy.getMainNavigation().within(() =>
       cy.findByRole("link", { name: "Homepage" }).click()
     );
     cy.location("pathname").should("eq", generateMAASURL("/machines"));
@@ -92,9 +88,7 @@ context("Navigation - admin", () => {
     cy.viewport("macbook-13");
     cy.visit(generateMAASURL("/"));
     // set side navigation to expanded
-    cy.window().then((win) =>
-      win.localStorage.setItem("appSideNavIsCollapsed", "false")
-    );
+    cy.expandMainNavigation();
   });
 
   const expected = [
@@ -102,7 +96,6 @@ context("Navigation - admin", () => {
     { destinationUrl: "/devices", linkLabel: "Devices" },
     { destinationUrl: "/controllers", linkLabel: "Controllers" },
     { destinationUrl: "/kvm/lxd", linkLabel: "LXD" },
-    { destinationUrl: "/kvm/virsh", linkLabel: "Virsh" },
     { destinationUrl: "/images", linkLabel: "Images" },
     { destinationUrl: "/domains", linkLabel: "DNS" },
     { destinationUrl: "/networks", linkLabel: "Subnets" },
@@ -119,7 +112,7 @@ context("Navigation - admin", () => {
 
   it("navigates to /dashboard when clicking on the logo", () => {
     cy.waitForPageToLoad();
-    withinSideNavigtion(() =>
+    cy.getMainNavigation().within(() =>
       cy.findByRole("link", { name: "Homepage" }).click()
     );
     cy.location("pathname").should("eq", generateMAASURL("/dashboard"));
@@ -128,7 +121,7 @@ context("Navigation - admin", () => {
   expected.forEach(({ destinationUrl, linkLabel }) => {
     it(`navigates to ${destinationUrl} and highlights ${linkLabel} link`, () => {
       cy.waitForPageToLoad();
-      withinSideNavigtion(() =>
+      cy.getMainNavigation().within(() =>
         cy.findByRole("link", { name: linkLabel }).click()
       );
       cy.location("pathname").should("eq", generateMAASURL(destinationUrl));

--- a/cypress/e2e/with-users/kvm/list.spec.ts
+++ b/cypress/e2e/with-users/kvm/list.spec.ts
@@ -7,6 +7,6 @@ context("KVM listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-testid='section-header-title']").contains("KVM");
+    cy.get("[data-testid='section-header-title']").contains("LXD");
   });
 });

--- a/cypress/e2e/with-users/login/login.spec.ts
+++ b/cypress/e2e/with-users/login/login.spec.ts
@@ -3,6 +3,7 @@ import { generateMAASURL } from "../../utils";
 context("Login page", () => {
   beforeEach(() => {
     cy.visit(generateMAASURL("/"));
+    cy.expandMainNavigation();
   });
 
   it("is disabled by default", () => {
@@ -49,8 +50,9 @@ context("Login page", () => {
     cy.location("pathname").should("eq", generateMAASURL("/intro"));
 
     // Log out.
-    cy.get(".l-navigation__link:contains(Log out)").click();
-
+    cy.getMainNavigation().within(() =>
+      cy.findByRole("button", { name: /Log out/i }).click()
+    );
     // Set cookie to skip setup intro.
     cy.setCookie("skipsetupintro", "true");
 

--- a/cypress/e2e/with-users/machines/actions.spec.ts
+++ b/cypress/e2e/with-users/machines/actions.spec.ts
@@ -82,7 +82,13 @@ context("Machine listing - actions", () => {
 
   it("can create and set the zone of a machine", () => {
     const poolName = generateName("pool");
-    selectFirstMachine();
+    const machineName = generateName("machine");
+    cy.addMachine(machineName);
+    cy.findByRole("searchbox", { name: "Search" }).type(machineName);
+    // eslint-disable-next-line cypress/no-force
+    cy.findByRole("checkbox", { name: `${machineName}.maas` }).click({
+      force: true,
+    });
     openMachineActionForm("Set pool");
     cy.findByRole("complementary", { name: /Set pool/i }).should("exist");
     // eslint-disable-next-line cypress/no-force

--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -1,4 +1,4 @@
-import { generateMAASURL } from "../../utils";
+import { generateId, generateMAASURL, generateName } from "../../utils";
 
 context("Machine listing", () => {
   beforeEach(() => {
@@ -7,9 +7,9 @@ context("Machine listing", () => {
   });
 
   it("renders the correct heading", () => {
-    cy.get("[data-testid='section-header-title']").contains(
-      /machines in 1 pool/
-    );
+    cy.findByRole("heading", {
+      name: /[0-9]+ machine[s]? in [0-9]+ pool[s]?/i,
+    }).should("exist");
   });
 
   it("can group machines by all supported keys", () => {
@@ -38,8 +38,10 @@ context("Machine listing", () => {
   });
 
   it("displays machine counts with active filters", () => {
-    const searchFilter = "status:(=commissioning) hostname:(machine-)";
-    cy.addMachines(["machine-1", "machine-2"]);
+    const name = generateName();
+    const searchFilter = `status:(=commissioning) hostname:(${name})`;
+    const machines = [`${name}-1`, `${name}-2`];
+    cy.addMachines(machines);
     cy.findByRole("combobox", { name: "Group by" }).select("Group by status");
     cy.findByRole("searchbox").type(searchFilter);
     cy.findByText(/Showing 2 out of 2 machines/).should("exist");
@@ -80,11 +82,12 @@ context("Machine listing", () => {
   });
 
   it("can select a machine range", () => {
-    const searchFilter = "machi";
-    const newMachines = ["machine-a", "machine-b", "machine-c"];
+    const name = generateName();
+    const newMachines = [`${name}-a`, `${name}-b`, `${name}-c`];
     cy.addMachines(newMachines);
     cy.findByRole("combobox", { name: "Group by" }).select("No grouping");
-    cy.findByRole("searchbox", { name: "Search" }).type(searchFilter);
+    cy.findByRole("searchbox", { name: "Search" }).type(name);
+    cy.findByText(/Showing 3 out of 3 machines/).should("exist");
     // eslint-disable-next-line cypress/no-force
     cy.findByRole("checkbox", { name: `${newMachines[0]}.maas` }).click({
       force: true,
@@ -104,5 +107,6 @@ context("Machine listing", () => {
       cy.findAllByRole("button", { name: /Delete/i }).click();
     });
     cy.findByRole("button", { name: /Delete 3 machines/ }).click();
+    cy.findByText(/No machines match the search criteria./).should("exist");
   });
 });

--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -1,4 +1,4 @@
-import { generateId, generateMAASURL, generateName } from "../../utils";
+import { generateMAASURL, generateName } from "../../utils";
 
 context("Machine listing", () => {
   beforeEach(() => {

--- a/cypress/e2e/with-users/pools/list.spec.ts
+++ b/cypress/e2e/with-users/pools/list.spec.ts
@@ -7,7 +7,9 @@ context("Pools list", () => {
   });
 
   it("renders a heading", () => {
-    cy.contains(/machines in 1 pool/i);
+    cy.findByRole("heading", {
+      name: /[0-9]+ machine[s]? in [0-9]+ pool[s]?/i,
+    }).should("exist");
     cy.findByLabelText(/Pool list/i);
   });
 });

--- a/cypress/e2e/with-users/settings/configuration/general.spec.ts
+++ b/cypress/e2e/with-users/settings/configuration/general.spec.ts
@@ -18,7 +18,7 @@ context("Settings - General - Theme", () => {
 
   it("displays a live preview of a MAAS theme colour", () => {
     cy.findByRole("radio", { name: "Red" }).click();
-    cy.get(".l-navigation").should("have.class", "l-navigation--red");
+    cy.getMainNavigation().should("have.class", "is-maas-red");
   });
 
   it("persists the theme choice after saving and refreshing the page", () => {
@@ -29,7 +29,7 @@ context("Settings - General - Theme", () => {
 
     cy.reload(true);
 
-    cy.get(".l-navigation").should("have.class", "l-navigation--red");
+    cy.getMainNavigation().should("have.class", "is-maas-red");
   });
 
   it("persists the theme choice after saving and navigating away from page", () => {
@@ -40,28 +40,28 @@ context("Settings - General - Theme", () => {
 
     cy.findByRole("link", { name: "Deploy" }).click();
 
-    cy.get(".l-navigation").should("have.class", "l-navigation--red");
+    cy.getMainNavigation().should("have.class", "is-maas-red");
   });
 
   it("reverts the theme choice if not saved and page is refreshed", () => {
     cy.findByRole("radio", { name: "Red" }).click();
     cy.reload(true);
 
-    cy.get(".l-navigation").should("have.class", "is-maas-default");
+    cy.getMainNavigation().should("have.class", "is-maas-default");
   });
 
   it("reverts the theme choice if the user clicks cancel", () => {
     cy.findByRole("radio", { name: "Red" }).click();
     cy.findByRole("button", { name: "Cancel" }).click();
 
-    cy.get(".l-navigation").should("have.class", "is-maas-default");
+    cy.getMainNavigation().should("have.class", "is-maas-default");
   });
 
   it("reverts the theme choice if the user navigates to another page", () => {
     cy.findByRole("radio", { name: "Red" }).click();
     cy.findByRole("link", { name: "Deploy" }).click();
 
-    cy.get(".l-navigation").should("have.class", "is-maas-default");
+    cy.getMainNavigation().should("have.class", "is-maas-default");
   });
 });
 

--- a/cypress/e2e/with-users/settings/dhcp.spec.ts
+++ b/cypress/e2e/with-users/settings/dhcp.spec.ts
@@ -8,6 +8,7 @@ context("Settings - DHCP Snippets", () => {
     cy.visit(generateMAASURL("/settings/dhcp/add"));
   });
   afterEach(() => {
+    cy.login();
     cy.deleteMachine(machineName);
   });
 

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -54,7 +54,7 @@ Cypress.Commands.add("deleteMachine", (hostname: string) => {
   cy.visit(generateMAASURL("/machines"));
   cy.findByRole("combobox", { name: "Group by" }).select("No grouping");
   cy.findByRole("searchbox").type(hostname);
-  cy.findByText(/1 machine available/).should("exist");
+  cy.findByText(/Showing 1 out of 1 machines/).should("exist");
   cy.findByRole("grid", { name: "Machines" }).within(() =>
     // eslint-disable-next-line cypress/no-force
     cy
@@ -154,4 +154,14 @@ Cypress.Commands.add("waitForTableToLoad", ({ name } = { name: undefined }) => {
   cy.findByRole("grid", { name: /Loading/i }).should("exist");
   cy.findByRole("grid", { name: /Loading/i }).should("not.exist");
   return cy.findByRole("grid", { name }).should("exist");
+});
+
+Cypress.Commands.add("getMainNavigation", () => {
+  return cy.findByRole("navigation", { name: /main navigation/i });
+});
+
+Cypress.Commands.add("expandMainNavigation", () => {
+  return cy
+    .window()
+    .then((win) => win.localStorage.setItem("appSideNavIsCollapsed", "false"));
 });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -25,6 +25,8 @@ declare global {
       waitForTableToLoad(options?: {
         name?: string | RegExp;
       }): Cypress.Chainable<JQuery<HTMLElement>>;
+      getMainNavigation(): Cypress.Chainable<JQuery<HTMLElement>>;
+      expandMainNavigation(): void;
     }
   }
 }


### PR DESCRIPTION
## Done

- test: update cypress tests #4779
  - this fixes 11 out of 12 failing tests, most failures were related to MAAS New layout, fix for the dhcp form will come in a separate PR

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes: #4779

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
