### PR TITLE
test: migrate DiskTestStatus, NameColumn, NodeActionFormWrapper, VirshSettings, LXDHostToolbar to RTL

### DIFF
--- a/src/app/base/components/node/DiskTestStatus/DiskTestStatus.test.tsx
+++ b/src/app/base/components/node/DiskTestStatus/DiskTestStatus.test.tsx
@@ -1,63 +1,43 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 
+import "@testing-library/jest-dom/extend-expect";
 import DiskTestStatus from "./DiskTestStatus";
 
 import { ScriptResultStatus } from "app/store/scriptresult/types";
 
 describe("DiskTestStatus", () => {
   it("can show passed test status", () => {
-    const wrapper = mount(
-      <DiskTestStatus testStatus={ScriptResultStatus.PASSED} />
-    );
-
-    expect(wrapper.find(".p-icon--success").exists()).toBe(true);
+    render(<DiskTestStatus testStatus={ScriptResultStatus.PASSED} />);
+    expect(screen.getByLabelText(/ok/)).toBeInTheDocument();
   });
 
   it("can show running test status", () => {
-    const wrapper = mount(
-      <DiskTestStatus testStatus={ScriptResultStatus.RUNNING} />
-    );
-
-    expect(wrapper.find(".p-icon--running").exists()).toBe(true);
+    render(<DiskTestStatus testStatus={ScriptResultStatus.RUNNING} />);
+    expect(screen.getByLabelText(/running/i)).toBeInTheDocument();
   });
 
   it("can show pending test status", () => {
-    const wrapper = mount(
-      <DiskTestStatus testStatus={ScriptResultStatus.PENDING} />
-    );
-
-    expect(wrapper.find(".p-icon--pending").exists()).toBe(true);
+    render(<DiskTestStatus testStatus={ScriptResultStatus.PENDING} />);
+    expect(screen.getByLabelText(/pending/)).toBeInTheDocument();
   });
 
   it("can show error test status", () => {
-    const wrapper = mount(
-      <DiskTestStatus testStatus={ScriptResultStatus.FAILED} />
-    );
-
-    expect(wrapper.find(".p-icon--error").exists()).toBe(true);
+    render(<DiskTestStatus testStatus={ScriptResultStatus.FAILED} />);
+    expect(screen.getByLabelText(/error/)).toBeInTheDocument();
   });
 
   it("can show timed out test status", () => {
-    const wrapper = mount(
-      <DiskTestStatus testStatus={ScriptResultStatus.TIMEDOUT} />
-    );
-
-    expect(wrapper.find(".p-icon--timed-out").exists()).toBe(true);
+    render(<DiskTestStatus testStatus={ScriptResultStatus.TIMEDOUT} />);
+    expect(screen.getByLabelText(/timed out/)).toBeInTheDocument();
   });
 
   it("can show warning test status", () => {
-    const wrapper = mount(
-      <DiskTestStatus testStatus={ScriptResultStatus.SKIPPED} />
-    );
-
-    expect(wrapper.find(".p-icon--warning").exists()).toBe(true);
+    render(<DiskTestStatus testStatus={ScriptResultStatus.SKIPPED} />);
+    expect(screen.getByLabelText(/skipped/)).toBeInTheDocument();
   });
 
   it("can show unknown test status", () => {
-    const wrapper = mount(
-      <DiskTestStatus testStatus={ScriptResultStatus.NONE} />
-    );
-
-    expect(wrapper.find(".p-icon--power-unknown").exists()).toBe(true);
+    render(<DiskTestStatus testStatus={ScriptResultStatus.NONE} />);
+    expect(screen.getByLabelText(/unknown/)).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/node/DiskTestStatus/DiskTestStatus.test.tsx
+++ b/src/app/base/components/node/DiskTestStatus/DiskTestStatus.test.tsx
@@ -1,9 +1,8 @@
-import { render, screen } from "@testing-library/react";
-
 import "@testing-library/jest-dom/extend-expect";
 import DiskTestStatus from "./DiskTestStatus";
 
 import { ScriptResultStatus } from "app/store/scriptresult/types";
+import { render, screen } from "testing/utils";
 
 describe("DiskTestStatus", () => {
   it("can show passed test status", () => {

--- a/src/app/base/components/node/DiskTestStatus/DiskTestStatus.tsx
+++ b/src/app/base/components/node/DiskTestStatus/DiskTestStatus.tsx
@@ -6,15 +6,15 @@ type Props = { testStatus: Disk["test_status"] };
 const DiskTestStatus = ({ testStatus }: Props): JSX.Element => {
   switch (testStatus) {
     case ScriptResultStatus.PENDING:
-      return <i className="p-icon--pending"></i>;
+      return <i aria-label="pending" className="p-icon--pending"></i>;
     case ScriptResultStatus.RUNNING:
     case ScriptResultStatus.APPLYING_NETCONF:
     case ScriptResultStatus.INSTALLING:
-      return <i className="p-icon--running"></i>;
+      return <i aria-label="running" className="p-icon--running"></i>;
     case ScriptResultStatus.PASSED:
       return (
         <>
-          <i className="p-icon--success is-inline"></i>
+          <i aria-label="ok" className="p-icon--success is-inline"></i>
           <span>OK</span>
         </>
       );
@@ -25,28 +25,31 @@ const DiskTestStatus = ({ testStatus }: Props): JSX.Element => {
     case ScriptResultStatus.FAILED_INSTALLING:
       return (
         <>
-          <i className="p-icon--error is-inline"></i>
+          <i aria-label="error" className="p-icon--error is-inline"></i>
           <span>Error</span>
         </>
       );
     case ScriptResultStatus.TIMEDOUT:
       return (
         <>
-          <i className="p-icon--timed-out is-inline"></i>
+          <i aria-label="timed out" className="p-icon--timed-out is-inline"></i>
           <span>Timed out</span>
         </>
       );
     case ScriptResultStatus.SKIPPED:
       return (
         <>
-          <i className="p-icon--warning is-inline"></i>
+          <i aria-label="skipped" className="p-icon--warning is-inline"></i>
           <span>Skipped</span>
         </>
       );
     default:
       return (
         <>
-          <i className="p-icon--power-unknown is-inline"></i>
+          <i
+            aria-label="unknown"
+            className="p-icon--power-unknown is-inline"
+          ></i>
           <span>Unknown</span>
         </>
       );

--- a/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.test.tsx
+++ b/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import NodeActionFormWrapper from "./NodeActionFormWrapper";
@@ -7,6 +6,7 @@ import type { Node } from "app/store/types/node";
 import { NodeActions } from "app/store/types/node";
 import { machine as machineFactory } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
+import { render, screen, waitFor } from "testing/utils";
 
 describe("NodeActionFormWrapper", () => {
   afterEach(() => {

--- a/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.test.tsx
+++ b/src/app/base/components/node/NodeActionFormWrapper/NodeActionFormWrapper.test.tsx
@@ -1,4 +1,5 @@
-import { mount } from "enzyme";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import NodeActionFormWrapper from "./NodeActionFormWrapper";
 
@@ -17,7 +18,7 @@ describe("NodeActionFormWrapper", () => {
       machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
       machineFactory({ system_id: "def456", actions: [NodeActions.ABORT] }),
     ];
-    const wrapper = mount(
+    render(
       <NodeActionFormWrapper
         action={NodeActions.ABORT}
         clearSidePanelContent={jest.fn()}
@@ -31,10 +32,8 @@ describe("NodeActionFormWrapper", () => {
       </NodeActionFormWrapper>
     );
 
-    expect(wrapper.find("[data-testid='children']").exists()).toBe(true);
-    expect(wrapper.find("[data-testid='node-action-warning']").exists()).toBe(
-      false
-    );
+    expect(screen.getByTestId("children")).toBeInTheDocument();
+    expect(screen.queryByTestId("node-action-warning")).not.toBeInTheDocument();
   });
 
   it("displays a warning if not all selected nodes can perform selected action", () => {
@@ -42,7 +41,7 @@ describe("NodeActionFormWrapper", () => {
       machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
       machineFactory({ system_id: "def456", actions: [] }),
     ];
-    const wrapper = mount(
+    render(
       <NodeActionFormWrapper
         action={NodeActions.ABORT}
         clearSidePanelContent={jest.fn()}
@@ -56,10 +55,8 @@ describe("NodeActionFormWrapper", () => {
       </NodeActionFormWrapper>
     );
 
-    expect(wrapper.find("[data-testid='node-action-warning']").exists()).toBe(
-      true
-    );
-    expect(wrapper.find("[data-testid='children']").exists()).toBe(false);
+    expect(screen.getByTestId("node-action-warning")).toBeInTheDocument();
+    expect(screen.queryByTestId("children")).not.toBeInTheDocument();
   });
 
   it(`does not display a warning when action has started even if not all
@@ -70,7 +67,7 @@ describe("NodeActionFormWrapper", () => {
       machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
       machineFactory({ system_id: "def456", actions: [] }),
     ];
-    const wrapper = mount(
+    render(
       <NodeActionFormWrapper
         action={NodeActions.ABORT}
         clearSidePanelContent={jest.fn()}
@@ -84,19 +81,17 @@ describe("NodeActionFormWrapper", () => {
       </NodeActionFormWrapper>
     );
 
-    expect(wrapper.find("[data-testid='children']").exists()).toBe(true);
-    expect(wrapper.find("[data-testid='node-action-warning']").exists()).toBe(
-      false
-    );
+    expect(screen.getByTestId("children")).toBeInTheDocument();
+    expect(screen.queryByTestId("node-action-warning")).not.toBeInTheDocument();
   });
 
-  it("can run a function on actionable nodes if warning is shown", () => {
+  it("can run a function on actionable nodes if warning is shown", async () => {
     const onUpdateSelected = jest.fn();
     const nodes = [
       machineFactory({ system_id: "abc123", actions: [NodeActions.ABORT] }),
       machineFactory({ system_id: "def456", actions: [] }),
     ];
-    const wrapper = mount(
+    render(
       <NodeActionFormWrapper
         action={NodeActions.ABORT}
         clearSidePanelContent={jest.fn()}
@@ -110,12 +105,12 @@ describe("NodeActionFormWrapper", () => {
       </NodeActionFormWrapper>
     );
 
-    wrapper.find("button[data-testid='on-update-selected']").simulate("click");
+    await userEvent.click(screen.getByTestId("on-update-selected"));
 
     expect(onUpdateSelected).toHaveBeenCalledWith(["abc123"]);
   });
 
-  it("clears header content if no nodes are provided", () => {
+  it("clears header content if no nodes are provided", async () => {
     const clearSidePanelContent = jest.fn();
     const Proxy = ({ nodes }: { nodes: Node[] }) => (
       <NodeActionFormWrapper
@@ -130,15 +125,14 @@ describe("NodeActionFormWrapper", () => {
         Children
       </NodeActionFormWrapper>
     );
-    // Mount with one node selected.
-    const wrapper = mount(<Proxy nodes={[machineFactory()]} />);
+    // Render with one node selected.
+    const { rerender } = render(<Proxy nodes={[machineFactory()]} />);
 
     expect(clearSidePanelContent).not.toHaveBeenCalled();
 
     // Update with no nodes selected - clear header content should be called.
-    wrapper.setProps({ nodes: [] });
-    wrapper.update();
+    rerender(<Proxy nodes={[]} />);
 
-    expect(clearSidePanelContent).toHaveBeenCalled();
+    await waitFor(() => expect(clearSidePanelContent).toHaveBeenCalled());
   });
 });

--- a/src/app/base/components/node/networking/NameColumn/NameColumn.test.tsx
+++ b/src/app/base/components/node/networking/NameColumn/NameColumn.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -14,6 +13,7 @@ import {
   machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 

--- a/src/app/base/components/node/networking/NameColumn/NameColumn.test.tsx
+++ b/src/app/base/components/node/networking/NameColumn/NameColumn.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
@@ -43,7 +43,7 @@ describe("NameColumn", () => {
       }),
     ];
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <NameColumn
           handleRowCheckbox={jest.fn()}
@@ -54,7 +54,8 @@ describe("NameColumn", () => {
         />
       </Provider>
     );
-    expect(wrapper.find("RowCheckbox").prop("disabled")).toBe(true);
+    const checkbox = screen.getByRole("checkbox") as HTMLInputElement;
+    expect(checkbox.disabled).toBe(true);
   });
 
   it("can not show a checkbox", () => {
@@ -69,7 +70,7 @@ describe("NameColumn", () => {
       }),
     ];
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <NameColumn
           handleRowCheckbox={jest.fn()}
@@ -80,7 +81,7 @@ describe("NameColumn", () => {
         />
       </Provider>
     );
-    expect(wrapper.find("RowCheckbox").exists()).toBe(false);
-    expect(wrapper.find("span[data-testid='name']").exists()).toBe(true);
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(screen.getByTestId("name")).toBeInTheDocument();
   });
 });

--- a/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
@@ -1,4 +1,4 @@
-import { mount } from "enzyme";
+import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -39,7 +39,7 @@ describe("VirshSettings", () => {
 
   it("fetches the necessary data on load", () => {
     const store = mockStore(state);
-    mount(
+    render(
       <MemoryRouter>
         <Provider store={store}>
           <CompatRouter>
@@ -66,7 +66,7 @@ describe("VirshSettings", () => {
   it("displays a spinner if data has not loaded", () => {
     state.resourcepool.loaded = false;
     const store = mockStore(state);
-    const wrapper = mount(
+    render(
       <Provider store={store}>
         <MemoryRouter>
           <CompatRouter>
@@ -75,6 +75,6 @@ describe("VirshSettings", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(wrapper.find("Spinner").length).toBe(1);
+    expect(screen.getByText(/Loading/)).toBeInTheDocument();
   });
 });

--- a/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
@@ -1,4 +1,3 @@
-import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -15,6 +14,7 @@ import {
   tagState as tagStateFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 


### PR DESCRIPTION

## Done

- test: migrate DiskTestStatus, NameColumn to RTL
  - add accessible labels to icons

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
