### PR TITLE
refactor: login errors mapping MAASENG-1489

### DIFF
--- a/cypress/e2e/with-users/login/login.spec.ts
+++ b/cypress/e2e/with-users/login/login.spec.ts
@@ -22,6 +22,16 @@ context("Login page", () => {
     cy.get(".p-form-validation__message").should("exist");
   });
 
+  it("displays an error message if submitted invalid login credentials", () => {
+    cy.findByRole("textbox", { name: /Username/ }).type("invalid-username");
+    cy.findByLabelText(/Password/)
+      .type("invalid-password")
+      .type("{enter}");
+    cy.findByRole("alert", {
+      name: /Please enter a correct username and password/i,
+    }).should("exist");
+  });
+
   it("enables the form if both fields have values", () => {
     cy.findByRole("button", { name: "Login" }).should("be.disabled");
     cy.get("input[name='username']").type("username");

--- a/src/app/base/components/Login/Login.tsx
+++ b/src/app/base/components/Login/Login.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   Code,
   Col,
-  Notification,
   Row,
   Strip,
 } from "@canonical/react-components";
@@ -49,7 +48,6 @@ export const Login = (): JSX.Element => {
   const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
   const externalLoginURL = useSelector(statusSelectors.externalLoginURL);
   const noUsers = useSelector(statusSelectors.noUsers);
-  const error = useSelector(statusSelectors.authenticationError);
 
   useWindowTitle("Login");
 
@@ -63,11 +61,6 @@ export const Login = (): JSX.Element => {
     <Strip>
       <Row>
         <Col emptyLarge={4} size={6}>
-          {externalAuthURL && error && (
-            <Notification severity="negative" title="Error:">
-              {error}
-            </Notification>
-          )}
           {noUsers && !externalAuthURL ? (
             <Card title={Labels.NoUsers}>
               <p>Use the following command to create one:</p>

--- a/src/app/utils/formatErrors.ts
+++ b/src/app/utils/formatErrors.ts
@@ -1,4 +1,7 @@
-const flattenErrors = (errors: unknown): string | null => {
+import type { APIError } from "app/base/types";
+import type { EventError } from "app/store/types/state";
+
+const flattenErrors = <E>(errors: E): string | null => {
   if (Array.isArray(errors)) {
     return errors.join(" ");
   }
@@ -14,9 +17,14 @@ const flattenErrors = (errors: unknown): string | null => {
  * @param errors - the errors string/array/object
  * @returns error message
  */
-export const formatErrors = <E>(
-  errors?: E,
-  errorKey?: keyof E
+
+export type ErrorType<E = null, I = any, K extends keyof I = any> =
+  | APIError<E>
+  | EventError<I, E, K>;
+
+export const formatErrors = <E, I, K extends keyof I>(
+  errors?: ErrorType<E, I, K>,
+  errorKey?: string
 ): string | null => {
   let errorMessage: string | null = null;
   if (errors) {
@@ -24,7 +32,7 @@ export const formatErrors = <E>(
       errorMessage = errors.join(" ");
     } else if (typeof errors === "object") {
       if (errorKey && errorKey in errors) {
-        errorMessage = flattenErrors(errors[errorKey]);
+        errorMessage = flattenErrors(errors[errorKey as keyof typeof errors]);
       } else {
         errorMessage = Object.entries(errors)
           .map(([key, value]) => `${key}: ${flattenErrors(value)}`)


### PR DESCRIPTION
## Done

- refactor: login errors mapping MAASENG-1489
  - reduce number of components and simplify logic
  - use formatErrors function to display errors
  - add e2e test for invalid credentials on login
  - update formatErrors types

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Ensure you can login and an error is still displayed when you enter invalid credentials.

## Fixes

Fixes: MAASENG-1489

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
