### PR TITLE
fix: check filter groups loaded MAASENG-1522

### DIFF
--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.test.tsx
@@ -1,5 +1,8 @@
+import configureStore from "redux-mock-store";
+
 import MachinesFilterAccordion, { Label } from "./MachinesFilterAccordion";
 
+import { actions as machineActions } from "app/store/machine";
 import { FilterGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import {
@@ -7,7 +10,9 @@ import {
   rootState as rootStateFactory,
   machineFilterGroup as machineFilterGroupFactory,
 } from "testing/factories";
-import { userEvent, screen, renderWithMockStore } from "testing/utils";
+import { userEvent, screen, renderWithMockStore, waitFor } from "testing/utils";
+
+const mockStore = configureStore<RootState>();
 
 describe("MachinesFilterAccordion", () => {
   let state: RootState;
@@ -27,6 +32,30 @@ describe("MachinesFilterAccordion", () => {
       { state }
     );
     expect(screen.getByRole("button", { name: Label.Toggle })).toBeDisabled();
+  });
+
+  it("does not fetch filters if filters have been loaded", async () => {
+    state.machine.filtersLoaded = true;
+    const store = mockStore(state);
+    renderWithMockStore(
+      <MachinesFilterAccordion searchText="" setSearchText={jest.fn()} />,
+      { store }
+    );
+    expect(store.getActions()).toEqual(
+      expect.not.arrayContaining([machineActions.filterGroups()])
+    );
+  });
+
+  it("fetches filters if filters have not been loaded", async () => {
+    state.machine.filtersLoaded = false;
+    const store = mockStore(state);
+    renderWithMockStore(
+      <MachinesFilterAccordion searchText="" setSearchText={jest.fn()} />,
+      { store }
+    );
+    await waitFor(() =>
+      expect(store.getActions()).toEqual([machineActions.filterGroups()])
+    );
   });
 
   it("can display options", async () => {

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
@@ -84,8 +84,10 @@ const MachinesFilterAccordion = ({
   });
 
   useEffect(() => {
-    dispatch(machineActions.filterGroups());
-  }, [dispatch]);
+    if (!filtersLoaded) {
+      dispatch(machineActions.filterGroups());
+    }
+  }, [dispatch, filtersLoaded]);
 
   return (
     <ContextualMenu


### PR DESCRIPTION
## Done

- fix: check filter groups loaded 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Verify that filter groups are loaded correctly

## Fixes

Fixes: MAASENG-1522

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
