### PR TITLE
ci: move docs checker to separate workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -54,26 +54,3 @@ jobs:
         with:
           filename: .github/ISSUE_TEMPLATE/cypress-failure.md
           update_existing: true
-  docs:
-    name: maas.io/docs links
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@main
-      - name: Get branch name
-        uses: nelonoel/branch-name@v1.0.1
-      - name: Run Cypress docs tests
-        uses: cypress-io/github-action@v4
-        with:
-          browser: chrome
-          config: baseUrl=http://maas.io/docs
-          spec: "cypress/e2e/docs-links/**/*.spec.ts"
-      - name: Create issue on failure
-        if: failure()
-        uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-        with:
-          filename: .github/ISSUE_TEMPLATE/maas-io-docs-failed.md
-          update_existing: true

--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -1,0 +1,28 @@
+name: MAAS Docs link checker
+on:
+  schedule:
+    - cron: "0 14 * * 1-5" # At 14:00 every day-of-week from Monday through Friday.
+jobs:
+  docs:
+    name: maas.io/docs links
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@main
+      - name: Get branch name
+        uses: nelonoel/branch-name@v1.0.1
+      - name: Run Cypress docs tests
+        uses: cypress-io/github-action@v4
+        with:
+          browser: chrome
+          config: baseUrl=http://maas.io/docs
+          spec: "cypress/e2e/docs-links/**/*.spec.ts"
+      - name: Create issue on failure
+        if: failure()
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/maas-io-docs-failed.md
+          update_existing: true

--- a/src/app/base/docsUrls.ts
+++ b/src/app/base/docsUrls.ts
@@ -29,7 +29,7 @@ const docsUrls = {
     "https://maas.io/docs/how-to-tag-machines#heading--kernel-options",
   tagsXpathExpressions:
     "https://maas.io/docs/how-to-tag-machines#heading--xpath-expressions",
-  vaultIntegration: "https://maas.io/docs/how-to-enable-vault",
+  vaultIntegration: "https://maas.io/docs/how-to-use-hashicorp-vault-with-maas",
 } as const;
 
 export default docsUrls;


### PR DESCRIPTION
## Done

- Move docs checker to separate workflow
  - set to run on cron schedule  `0 14 * * 1-5` (At 14:00 every day-of-week from Monday through Friday)
  - docs links tests are most often broken by changes to the docs themselves rather than any specific change to the maas-ui codebase therefore it makes sense for them to be run periodically

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
