### PR TITLE
fix(MachineList): Update pagination behaviour MAASENG-1490

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
@@ -4,45 +4,33 @@ import type { Props as MachineListPaginationProps } from "./MachineListPaginatio
 import { fireEvent, render, screen, userEvent } from "testing/utils";
 
 describe("MachineListPagination - display", () => {
-  it("displays pagination if there are machines", () => {
-    render(
-      <MachineListPagination
-        currentPage={1}
-        itemsPerPage={20}
-        machineCount={100}
-        machinesLoading={false}
-        paginate={jest.fn()}
-      />
-    );
-    expect(
-      screen.getByRole("navigation", { name: Label.Pagination })
-    ).toBeInTheDocument();
-  });
-
-  it("does not display pagination if there are no machines", () => {
-    render(
-      <MachineListPagination
-        currentPage={1}
-        itemsPerPage={20}
-        machineCount={0}
-        machinesLoading={false}
-        paginate={jest.fn()}
-      />
-    );
-    expect(
-      screen.queryByRole("navigation", { name: Label.Pagination })
-    ).not.toBeInTheDocument();
-  });
-
-  it("displays pagination while refetching machines", () => {
-    // Set up shared props to make it clear what's changing on rerenders.
-    const props = {
+  let props: MachineListPaginationProps;
+  beforeEach(() => {
+    props = {
       currentPage: 1,
       itemsPerPage: 20,
       machineCount: 100,
       machinesLoading: false,
       paginate: jest.fn(),
     };
+  });
+
+  it("displays pagination if there are machines", () => {
+    render(<MachineListPagination {...props} />);
+    expect(
+      screen.getByRole("navigation", { name: Label.Pagination })
+    ).toBeInTheDocument();
+  });
+
+  it("does not display pagination if there are no machines", () => {
+    props.machineCount = 0;
+    render(<MachineListPagination {...props} />);
+    expect(
+      screen.queryByRole("navigation", { name: Label.Pagination })
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays pagination while refetching machines", () => {
     const { rerender } = render(<MachineListPagination {...props} />);
     expect(
       screen.getByRole("navigation", { name: Label.Pagination })
@@ -54,29 +42,18 @@ describe("MachineListPagination - display", () => {
   });
 
   it("hides pagination if there are no refetched machines", () => {
-    // Set up shared props to make it clear what's changing on rerenders.
-    const props = {
-      currentPage: 1,
-      itemsPerPage: 20,
-      machineCount: 100,
-      machinesLoading: false,
-      paginate: jest.fn(),
-    };
     const { rerender } = render(<MachineListPagination {...props} />);
     expect(
       screen.getByRole("navigation", { name: Label.Pagination })
     ).toBeInTheDocument();
-    rerender(<MachineListPagination {...props} machinesLoading={true} />);
+    props.machinesLoading = true;
+    rerender(<MachineListPagination {...props} />);
     expect(
       screen.getByRole("navigation", { name: Label.Pagination })
     ).toBeInTheDocument();
-    rerender(
-      <MachineListPagination
-        {...props}
-        machineCount={0}
-        machinesLoading={false}
-      />
-    );
+    props.machinesLoading = false;
+    props.machineCount = 0;
+    rerender(<MachineListPagination {...props} />);
     expect(
       screen.queryByRole("navigation", { name: Label.Pagination })
     ).not.toBeInTheDocument();

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
@@ -1,81 +1,147 @@
 import MachineListPagination, { Label } from "./MachineListPagination";
+import type { Props as MachineListPaginationProps } from "./MachineListPagination";
 
-import { render, screen } from "testing/utils";
+import { fireEvent, render, screen, userEvent } from "testing/utils";
 
-it("displays pagination if there are machines", () => {
-  render(
-    <MachineListPagination
-      currentPage={1}
-      itemsPerPage={20}
-      machineCount={100}
-      machinesLoading={false}
-      paginate={jest.fn()}
-    />
-  );
-  expect(
-    screen.getByRole("navigation", { name: Label.Pagination })
-  ).toBeInTheDocument();
+describe("MachineListPagination - display", () => {
+  it("displays pagination if there are machines", () => {
+    render(
+      <MachineListPagination
+        currentPage={1}
+        itemsPerPage={20}
+        machineCount={100}
+        machinesLoading={false}
+        paginate={jest.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("navigation", { name: Label.Pagination })
+    ).toBeInTheDocument();
+  });
+
+  it("does not display pagination if there are no machines", () => {
+    render(
+      <MachineListPagination
+        currentPage={1}
+        itemsPerPage={20}
+        machineCount={0}
+        machinesLoading={false}
+        paginate={jest.fn()}
+      />
+    );
+    expect(
+      screen.queryByRole("navigation", { name: Label.Pagination })
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays pagination while refetching machines", () => {
+    // Set up shared props to make it clear what's changing on rerenders.
+    const props = {
+      currentPage: 1,
+      itemsPerPage: 20,
+      machineCount: 100,
+      machinesLoading: false,
+      paginate: jest.fn(),
+    };
+    const { rerender } = render(<MachineListPagination {...props} />);
+    expect(
+      screen.getByRole("navigation", { name: Label.Pagination })
+    ).toBeInTheDocument();
+    rerender(<MachineListPagination {...props} machinesLoading={true} />);
+    expect(
+      screen.getByRole("navigation", { name: Label.Pagination })
+    ).toBeInTheDocument();
+  });
+
+  it("hides pagination if there are no refetched machines", () => {
+    // Set up shared props to make it clear what's changing on rerenders.
+    const props = {
+      currentPage: 1,
+      itemsPerPage: 20,
+      machineCount: 100,
+      machinesLoading: false,
+      paginate: jest.fn(),
+    };
+    const { rerender } = render(<MachineListPagination {...props} />);
+    expect(
+      screen.getByRole("navigation", { name: Label.Pagination })
+    ).toBeInTheDocument();
+    rerender(<MachineListPagination {...props} machinesLoading={true} />);
+    expect(
+      screen.getByRole("navigation", { name: Label.Pagination })
+    ).toBeInTheDocument();
+    rerender(
+      <MachineListPagination
+        {...props}
+        machineCount={0}
+        machinesLoading={false}
+      />
+    );
+    expect(
+      screen.queryByRole("navigation", { name: Label.Pagination })
+    ).not.toBeInTheDocument();
+  });
 });
 
-it("does not display pagination if there are no machines", () => {
-  render(
-    <MachineListPagination
-      currentPage={1}
-      itemsPerPage={20}
-      machineCount={0}
-      machinesLoading={false}
-      paginate={jest.fn()}
-    />
-  );
-  expect(
-    screen.queryByRole("navigation", { name: Label.Pagination })
-  ).not.toBeInTheDocument();
-});
+describe("MachineListPagination - interaction", () => {
+  let props: MachineListPaginationProps;
+  beforeEach(() => {
+    props = {
+      currentPage: 1,
+      itemsPerPage: 20,
+      machineCount: 100,
+      machinesLoading: false,
+      paginate: jest.fn(),
+    };
+  });
 
-it("displays pagination while refetching machines", () => {
-  // Set up shared props to make it clear what's changing on rerenders.
-  const props = {
-    currentPage: 1,
-    itemsPerPage: 20,
-    machineCount: 100,
-    machinesLoading: false,
-    paginate: jest.fn(),
-  };
-  const { rerender } = render(<MachineListPagination {...props} />);
-  expect(
-    screen.getByRole("navigation", { name: Label.Pagination })
-  ).toBeInTheDocument();
-  rerender(<MachineListPagination {...props} machinesLoading={true} />);
-  expect(
-    screen.getByRole("navigation", { name: Label.Pagination })
-  ).toBeInTheDocument();
-});
+  it("calls a function to go to the next page when the 'Next page' button is clicked", async () => {
+    render(<MachineListPagination {...props} />);
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    expect(props.paginate).toHaveBeenCalledWith(2);
+  });
 
-it("hides pagination if there are no refetched machines", () => {
-  // Set up shared props to make it clear what's changing on rerenders.
-  const props = {
-    currentPage: 1,
-    itemsPerPage: 20,
-    machineCount: 100,
-    machinesLoading: false,
-    paginate: jest.fn(),
-  };
-  const { rerender } = render(<MachineListPagination {...props} />);
-  expect(
-    screen.getByRole("navigation", { name: Label.Pagination })
-  ).toBeInTheDocument();
-  rerender(<MachineListPagination {...props} machinesLoading={true} />);
-  expect(
-    screen.getByRole("navigation", { name: Label.Pagination })
-  ).toBeInTheDocument();
-  rerender(
-    <MachineListPagination
-      {...props}
-      machineCount={0}
-      machinesLoading={false}
-    />
-  );
-  expect(
-    screen.queryByRole("navigation", { name: Label.Pagination })
-  ).not.toBeInTheDocument();
+  it("calls a function to go to the previous page when the 'Previous page' button is clicked", async () => {
+    props.currentPage = 2;
+
+    render(<MachineListPagination {...props} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous page" })
+    );
+    expect(props.paginate).toHaveBeenCalledWith(1);
+  });
+
+  it("takes an input for page number and calls a function to paginate when Enter is pressed", async () => {
+    render(<MachineListPagination {...props} />);
+
+    const pageInput = screen.getByRole("spinbutton", { name: "page number" });
+
+    // Using userEvent to clear this first doesn't work, so we have to use fireEvent instead.
+    fireEvent.change(pageInput, { target: { value: "4" } });
+    await userEvent.click(pageInput);
+    await userEvent.keyboard("{Enter}");
+
+    expect(props.paginate).toHaveBeenCalledWith(4);
+  });
+
+  it("displays an error if no value is present in the page number input", async () => {
+    render(<MachineListPagination {...props} />);
+
+    const pageInput = screen.getByRole("spinbutton", { name: "page number" });
+
+    await userEvent.clear(pageInput);
+    expect(screen.getByText(/Enter a page number/i)).toBeInTheDocument();
+  });
+
+  it("displays an error if an invalid page number is entered", async () => {
+    render(<MachineListPagination {...props} />);
+
+    const pageInput = screen.getByRole("spinbutton", { name: "page number" });
+
+    // Using userEvent to clear this first doesn't work, so we have to use fireEvent instead.
+    fireEvent.change(pageInput, { target: { value: "69" } });
+    expect(
+      screen.getByText(/"69" is not a valid page number/i)
+    ).toBeInTheDocument();
+  });
 });

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 
 import type {
   PaginationProps,
@@ -32,10 +32,21 @@ const MachineListPagination = ({
   machinesLoading,
   ...props
 }: Props): JSX.Element | null => {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [pageNumber, setPageNumber] = useState<number | undefined>(
     props.currentPage
   );
   const [error, setError] = useState("");
+
+  // Clear the timeout when the component is unmounted.
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        clearTimeout(intervalRef.current);
+      }
+    };
+  }, []);
 
   const count = useFetchedCount(machineCount, machinesLoading);
   const totalPages = machineCount
@@ -58,27 +69,32 @@ const MachineListPagination = ({
           aria-label="page number"
           className="p-pagination__input"
           error={error}
+          onBlur={() => {
+            setPageNumber(props.currentPage);
+            setError("");
+          }}
           onChange={(e) => {
             if (e.target.value) {
               setPageNumber(e.target.valueAsNumber);
-              if (
-                e.target.valueAsNumber > totalPages ||
-                e.target.valueAsNumber < 1
-              ) {
-                setError(
-                  `"${e.target.valueAsNumber}" is not a valid page number.`
-                );
-              } else {
-                setError("");
+              if (intervalRef.current) {
+                clearTimeout(intervalRef.current);
               }
+              intervalRef.current = setTimeout(() => {
+                if (
+                  e.target.valueAsNumber > totalPages ||
+                  e.target.valueAsNumber < 1
+                ) {
+                  setError(
+                    `"${e.target.valueAsNumber}" is not a valid page number.`
+                  );
+                } else {
+                  setError("");
+                  props.paginate(e.target.valueAsNumber);
+                }
+              }, DEFAULT_DEBOUNCE_INTERVAL);
             } else {
               setPageNumber(undefined);
               setError("Enter a page number.");
-            }
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !error) {
-              props.paginate(e.currentTarget.valueAsNumber);
             }
           }}
           required

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -42,7 +42,6 @@ const MachineListPagination = ({
   useEffect(() => {
     return () => {
       if (intervalRef.current) {
-        // eslint-disable-next-line react-hooks/exhaustive-deps
         clearTimeout(intervalRef.current);
       }
     };

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -42,8 +42,6 @@ const MachineListPagination = ({
     ? Math.ceil(machineCount / props.itemsPerPage)
     : 1;
 
-  // TODO: add top margin to hr beneath pagination and shit
-
   return count > 0 ? (
     <nav aria-label={Label.Pagination} className="p-pagination">
       <span className="u-flex--align-baseline p-pagination--items">

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
@@ -23,7 +23,8 @@
 
     .p-form-validation__message {
       position: absolute;
-      margin-top: 0;
+      margin-top: $spv--small;
+      margin-left: $spv--small;
     }
 
     // required to get rid of buttons/arrows while keeping number-only input

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
@@ -21,6 +21,11 @@
       text-align: center;
     }
 
+    .p-form-validation__message {
+      position: absolute;
+      margin-top: 0;
+    }
+
     // required to get rid of buttons/arrows while keeping number-only input
     input::-webkit-outer-spin-button,
     input::-webkit-inner-spin-button {

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -832,7 +832,7 @@ export const MachineListTable = ({
   return (
     <>
       {machineCount ? (
-        <div className="u-flex--between u-flex--align-end u-flex--wrap">
+        <div className="u-flex--between u-flex--align-baseline u-flex--wrap">
           <hr />
           <MachineListDisplayCount
             currentPage={currentPage}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -855,7 +855,7 @@ export const MachineListTable = ({
               />
             ) : null}
           </span>
-          <hr />
+          <hr className="machine-list__divider" />
         </div>
       ) : null}
       <MainTable

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -111,6 +111,10 @@
     justify-content: flex-end;
   }
 
+  .machine-list__divider {
+    margin-top: $spv--large;
+  }
+
   .p-tooltip__message .p-list::after {
     white-space: normal;
   }

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -112,7 +112,7 @@
   }
 
   .machine-list__divider {
-    margin-top: $spv--large;
+    margin-top: $spv--x-large;
   }
 
   .p-tooltip__message .p-list::after {


### PR DESCRIPTION
## Done

- Error messages are displayed for invalid values
- Error messages are cleared on blur and value is reset to current page
- Adjusted styling of error message (approved by @amylily1011)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

**Make sure you have enough machines (and a small enough page size) to need multiple pages.**

1. Go to machine list
2. Change the page number to a different valid page using the input
3. Ensure the page changes
4. Clear the value
5. Ensure an error message displays
6. Enter an invalid page number (e.g. if you have 5 pages, enter something > 5)
7. Ensure an error message displays
8. Click away from the input
9. Ensure the error message is cleared and the value is reset

## Fixes

Fixes [MAASENG-1490](https://warthogs.atlassian.net/browse/MAASENG-1490)


[MAASENG-1490]: https://warthogs.atlassian.net/browse/MAASENG-1490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ