### PR TITLE
test: fix main Cypress run failed #4856

### DIFF
--- a/cypress/e2e/with-users/machines/actions.spec.ts
+++ b/cypress/e2e/with-users/machines/actions.spec.ts
@@ -45,9 +45,7 @@ const selectFirstMachine = () =>
   });
 
 const openMachineActionForm = (groupLabel: string, action: string) => {
-  cy.findByTestId("section-header-buttons").within(() => {
-    cy.findByRole("button", { name: groupLabel }).click();
-  });
+  cy.findByRole("button", { name: groupLabel }).click();
   cy.findByLabelText("submenu").within(() => {
     cy.findAllByRole("button", {
       name: new RegExp(`${action}...`),
@@ -72,9 +70,7 @@ context("Machine listing - actions", () => {
   it("displays the correct actions in the action menu", () => {
     selectFirstMachine();
     MACHINE_ACTIONS_GROUPS.forEach((actionGroup) => {
-      cy.findByTestId("section-header-buttons").within(() => {
-        cy.findByRole("button", { name: actionGroup.label }).click();
-      });
+      cy.findByRole("button", { name: actionGroup.label }).click();
       cy.findByLabelText("submenu").within(() => {
         cy.findAllByRole("button").should(
           "have.length",
@@ -83,10 +79,8 @@ context("Machine listing - actions", () => {
         cy.findAllByRole("button").should("be.enabled");
       });
     });
-    cy.findByTestId("section-header-buttons").within(() => {
-      cy.findByRole("button", { name: /Delete/i }).should("exist");
-      cy.findByRole("button", { name: /Delete/i }).should("be.enabled");
-    });
+    cy.findByRole("button", { name: /Delete/i }).should("exist");
+    cy.findByRole("button", { name: /Delete/i }).should("be.enabled");
   });
 
   MACHINE_ACTIONS_GROUPS.forEach((actionGroup) =>
@@ -107,10 +101,7 @@ context("Machine listing - actions", () => {
 
   it("loads machine Delete form", () => {
     selectFirstMachine();
-    cy.findByTestId("section-header-buttons").within(() => {
-      cy.findByRole("button", { name: /Delete/i }).click();
-    });
-
+    cy.findByRole("button", { name: /Delete/i }).click();
     cy.findByRole("complementary", { name: /Delete/i }).within(() => {
       cy.findAllByText(/Loading/).should("have.length", 0);
       cy.findByRole("heading", { name: /Delete/i });

--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -97,9 +97,7 @@ context("Machine listing", () => {
     cy.findByRole("checkbox", { name: `${newMachines[1]}.maas` }).should(
       "be.checked"
     );
-    cy.findByTestId("section-header-buttons").within(() =>
-      cy.findByRole("button", { name: /Delete/i }).click()
-    );
+    cy.findByRole("button", { name: /Delete/i }).click();
     cy.findByRole("button", { name: /Delete 3 machines/ }).click();
     cy.findByText(/No machines match the search criteria./).should("exist");
   });

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -61,9 +61,7 @@ Cypress.Commands.add("deleteMachine", (hostname: string) => {
       .findByRole("checkbox", { name: new RegExp(hostname) })
       .click({ force: true })
   );
-  cy.findByTestId("section-header-buttons").within(() =>
-    cy.findByRole("button", { name: /Delete/i }).click()
-  );
+  cy.findByRole("button", { name: /Delete/i }).click();
   cy.findByRole("button", { name: /Delete machine/ }).click();
   cy.findByRole("complementary", { name: /Delete/i }).should("not.exist");
   cy.findByText(/No machines match the search criteria/).should("exist");


### PR DESCRIPTION
## Done

- test: fix main Cypress run failed #4856

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes: #4856

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
