### PR TITLE
ci: fix main build upload failed #4853

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -10,6 +10,9 @@ jobs:
     env:
       PACKAGE_NAME: maas-ui-${{ github.sha }}.tar.gz
       REACT_APP_GIT_SHA: ${{ github.sha }}
+    strategy:
+      matrix:
+        node-version: [16.x]
     steps:
       - uses: actions/checkout@v3
       - name: Get branch name
@@ -19,22 +22,37 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "**/node_modules"
-          key: ${{ runner.os }}-modules-v1-${{ hashFiles('**/yarn.lock') }}
-      - name: Install dotrun
-        uses: canonical/install-dotrun@main
-      - name: Install dependencies
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install
         if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: dotrun --env CYPRESS_INSTALL_BINARY=0 install
-      - name: Build assets
-        run: dotrun --env CI=false --env REACT_APP_GIT_SHA=${{env.REACT_APP_GIT_SHA}} build
+        run: CYPRESS_INSTALL_BINARY=0 yarn install
+      - name: Build
+        run: REACT_APP_GIT_SHA=${{env.REACT_APP_GIT_SHA}} yarn build
+        env:
+          CI: false
       - name: Compress
         run: cd build && tar -czf ../${{env.PACKAGE_NAME}} ./ && ls -hs ../${{env.PACKAGE_NAME}}
-      - name: Install upload-assets snap
-        run: sudo snap install upload-assets
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - name: Install deps
+        run: pip install requests
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
       - name: Upload to assets server
-        run: upload-assets --url-path ${{env.PACKAGE_NAME}} ${{env.PACKAGE_NAME}}
+        run: python scripts/upload-assets.py
         env:
           UPLOAD_ASSETS_API_TOKEN: ${{secrets.UPLOAD_ASSETS_API_TOKEN}}
+          ASSET_FILE_PATH: ${{env.PACKAGE_NAME}}
+          ASSET_URL_PATH: ${{env.PACKAGE_NAME}}
+          ASSET_TAGS: "auto-upload"
       - name: Create issue on failure
         if: failure()
         uses: JasonEtco/create-an-issue@v2

--- a/scripts/upload-assets.py
+++ b/scripts/upload-assets.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import os
+import requests
+import base64
+api_token = os.getenv('UPLOAD_ASSETS_API_TOKEN')
+file_path = os.getenv('ASSET_FILE_PATH')
+url_path = os.getenv('ASSET_URL_PATH')
+tags = os.getenv('ASSET_TAGS')
+print(file_path)
+filename = os.path.basename(file_path)
+api_url = "https://assets.ubuntu.com/v1"
+content = open(file_path, 'rb').read()
+response = requests.post(
+    api_url,
+    data={
+        'asset': base64.b64encode(content),
+        'friendly-name': filename.replace(' ', '+'),
+        'url-path': url_path,
+        'tags': tags,
+        'type': 'base64',
+        'token': api_token
+    }
+)
+print(response.text)


### PR DESCRIPTION

## Done

- ci: fix main build upload failed #4853
  - use python script for asset uploading

This fixes upload failure due to error in upload-assets snap https://snapcraft.io/upload-assets - more on this in the linked issue #4853

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes: #4853

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
