### PR TITLE
fix: upload-assets should check the response status

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -43,9 +43,6 @@ jobs:
           python-version: "3.10"
       - name: Install deps
         run: pip install requests
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
       - name: Upload to assets server
         run: python scripts/upload-assets.py
         env:

--- a/scripts/upload-assets.py
+++ b/scripts/upload-assets.py
@@ -22,4 +22,5 @@ response = requests.post(
         'token': api_token
     }
 )
+response.raise_for_status()
 print(response.text)


### PR DESCRIPTION
## Done

- Make the home-grown upload-assets script a bit more reliable see #4853 

## QA

### MAAS deployment
N/A

### Running the branch

N/A

### QA steps

- Run the action, watch it fail

## Fixes


## Launchpad issue

N/A

