### PR TITLE
ci: upload build artifact to GitHub

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -2,9 +2,11 @@ name: Upload
 on:
   pull_request_target:
     types: [closed]
+  pull_request:
+    branches:
+      - main
 jobs:
   upload-build:
-    if: github.event.pull_request.merged == true
     name: Upload build artifacts
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -36,7 +36,10 @@ jobs:
           CI: false
       - name: Compress
         run: cd build && tar -czf ../${{env.PACKAGE_NAME}} ./ && ls -hs ../${{env.PACKAGE_NAME}}
-
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{env.PACKAGE_NAME}}
+          path: ${{env.PACKAGE_NAME}}
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
## Done

- upload build artifact to GitHub

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
