### PR TITLE
feat: improve popover a11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-router-dom-v5-compat": "6.8.1",
     "react-scripts": "5.0.1",
     "react-storage-hooks": "4.0.1",
+    "react-useportal": "1.0.18",
     "reconnecting-websocket": "4.4.0",
     "reduce-reducers": "1.0.4",
     "redux": "4.2.1",

--- a/src/app/base/components/Meter/Meter.test.tsx
+++ b/src/app/base/components/Meter/Meter.test.tsx
@@ -1,4 +1,4 @@
-import Meter, { DEFAULT_SEPARATOR_COLOR, TestIds } from "./Meter";
+import Meter, { defaultSeparatorColor, testIds } from "./Meter";
 
 import { render, screen } from "testing/utils";
 
@@ -31,19 +31,19 @@ describe("Meter", () => {
   it("can be made small", () => {
     render(<Meter data={[]} small />);
 
-    expect(screen.getByTestId(TestIds.Container)).toHaveClass("p-meter--small");
+    expect(screen.getByTestId(testIds.container)).toHaveClass("p-meter--small");
   });
 
   it("can be given a label", () => {
     render(<Meter data={[{ value: 1 }, { value: 3 }]} label="Meter label" />);
 
-    expect(screen.getByTestId(TestIds.Label).textContent).toBe("Meter label");
+    expect(screen.getByTestId(testIds.label).textContent).toBe("Meter label");
   });
 
   it("can be given a custom empty colour", () => {
     render(<Meter data={[]} emptyColor="#ABC" />);
 
-    expect(screen.getByTestId(TestIds.Bar)).toHaveStyle({
+    expect(screen.getByTestId(testIds.bar)).toHaveStyle({
       backgroundColor: "#ABC",
     });
   });
@@ -58,7 +58,7 @@ describe("Meter", () => {
         ]}
       />
     );
-    const segments = screen.getAllByTestId(TestIds.Filled);
+    const segments = screen.getAllByTestId(testIds.filled);
 
     expect(segments[0]).toHaveStyle({ backgroundColor: "#AAA" });
     expect(segments[1]).toHaveStyle({ backgroundColor: "#BBB" });
@@ -70,7 +70,7 @@ describe("Meter", () => {
       <Meter data={[{ color: "#ABC", value: 100 }]} max={10} overColor="#DEF" />
     );
 
-    expect(screen.getByTestId(TestIds.MeterOverflow)).toHaveStyle({
+    expect(screen.getByTestId(testIds.meteroverflow)).toHaveStyle({
       backgroundColor: "#DEF",
     });
   });
@@ -86,7 +86,7 @@ describe("Meter", () => {
         ]}
       />
     );
-    const segments = screen.getAllByTestId(TestIds.Filled);
+    const segments = screen.getAllByTestId(testIds.filled);
 
     expect(segments[0]).toHaveStyle({ width: "10%" });
     expect(segments[1]).toHaveStyle({ width: "20%" });
@@ -105,7 +105,7 @@ describe("Meter", () => {
         ]}
       />
     );
-    const segments = screen.getAllByTestId(TestIds.Filled);
+    const segments = screen.getAllByTestId(testIds.filled);
 
     expect(segments[0]).toHaveStyle({ left: "0%" });
     expect(segments[1]).toHaveStyle({ left: "10%" });
@@ -116,7 +116,7 @@ describe("Meter", () => {
   it("can be made segmented", () => {
     render(<Meter data={[{ value: 2 }]} max={10} segmented />);
 
-    expect(screen.getByTestId(TestIds.Segments)).toBeInTheDocument();
+    expect(screen.getByTestId(testIds.segments)).toBeInTheDocument();
   });
 
   it("can set the segment separator color", () => {
@@ -129,7 +129,7 @@ describe("Meter", () => {
       />
     );
 
-    expect(screen.getByTestId(TestIds.Segments)).toHaveStyle({
+    expect(screen.getByTestId(testIds.segments)).toHaveStyle({
       background: "rgb(171, 193, 35);",
     });
   });
@@ -141,8 +141,8 @@ describe("Meter", () => {
     });
     render(<Meter data={[{ value: 10 }]} max={100} segmented />);
 
-    expect(screen.getByTestId(TestIds.Segments)).toHaveStyle({
-      background: `repeating-linear-gradient(to right, transparent 0, transparent 1px, ${DEFAULT_SEPARATOR_COLOR} 1px, ${DEFAULT_SEPARATOR_COLOR} 2px );`,
+    expect(screen.getByTestId(testIds.segments)).toHaveStyle({
+      background: `repeating-linear-gradient(to right, transparent 0, transparent 1px, ${defaultSeparatorColor} 1px, ${defaultSeparatorColor} 2px );`,
     });
   });
 });

--- a/src/app/base/components/Meter/Meter.tsx
+++ b/src/app/base/components/Meter/Meter.tsx
@@ -1,33 +1,43 @@
+/* eslint-disable react/no-multi-comp */
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as React from "react";
 
-import { useListener } from "@canonical/react-components/dist/hooks";
+import { useListener } from "@canonical/react-components";
 import classNames from "classnames";
 
-import { COLOURS } from "app/base/constants";
+export const color = {
+  caution: "#F99B11",
+  light: "#F7F7F7",
+  linkFaded: "#D3E4ED",
+  link: "#0066CC",
+  negative: "#C7162B",
+  positiveFaded: "#B7CCB9",
+  positiveMid: "#4DAB4D",
+  positive: "#0E8420",
+} as const;
 
-export const DEFAULT_FILLED_COLORS = [
-  COLOURS.LINK,
-  COLOURS.POSITIVE,
-  COLOURS.NEGATIVE,
-  COLOURS.CAUTION,
+export const defaultFilledColors = [
+  color.link,
+  color.positive,
+  color.negative,
+  color.caution,
 ];
-export const DEFAULT_EMPTY_COLOR = COLOURS.LINK_FADED;
-export const DEFAULT_OVER_COLOR = COLOURS.CAUTION;
-export const DEFAULT_SEPARATOR_COLOR = COLOURS.LIGHT;
-const MINIMUM_SEGMENT_WIDTH = 2;
-const SEPARATOR_WIDTH = 1;
+export const defaultEmptyColor = color.linkFaded;
+export const defaultOverColor = color.caution;
+export const defaultSeparatorColor = color.light;
+const minimumSegmentWidth = 2;
+const separatorWidth = 1;
 
-const updateWidths = (
+const calculateWidths = (
   el: React.MutableRefObject<Element | null>,
   maximum: number,
   setSegmentWidth: (size: number) => void
 ) => {
   const boundingWidth = el?.current?.getBoundingClientRect()?.width || 0;
   const segmentWidth =
-    boundingWidth > maximum * MINIMUM_SEGMENT_WIDTH
+    boundingWidth > maximum * minimumSegmentWidth
       ? boundingWidth / maximum
-      : MINIMUM_SEGMENT_WIDTH;
+      : minimumSegmentWidth;
   setSegmentWidth(segmentWidth);
 };
 
@@ -49,25 +59,102 @@ type Props = {
   small?: boolean;
 };
 
-export enum TestIds {
-  Bar = "meter-bar",
-  Container = "meter-container",
-  Filled = "meter-filled",
-  Label = "meter-label",
-  MeterOverflow = "meter-overflow",
-  Segments = "meter-segments",
-}
+export const testIds = {
+  bar: "meter-bar",
+  container: "meter-container",
+  filled: "meter-filled",
+  label: "meter-label",
+  meteroverflow: "meter-overflow",
+  segments: "meter-segments",
+};
+
+const MeterSegment = ({
+  data,
+  datumWidths,
+  maximum,
+  overColor,
+  segmentWidth,
+  separatorColor,
+}: Props & {
+  datumWidths: number[];
+  maximum: number;
+  segmentWidth: number;
+}) => {
+  const isOverflowing = () =>
+    data.reduce((sum, datum) => sum + datum.value, 0) > maximum;
+
+  const filledStyle = (datum: MeterDatum, i: number) => ({
+    backgroundColor: datum.color,
+    left: `${datumWidths.reduce(
+      (leftPos, width, j) => (i > j ? leftPos + width : leftPos),
+      0
+    )}%`,
+    width: `${datumWidths[i]}%`,
+  });
+
+  const separatorStyle = () => ({
+    background: `repeating-linear-gradient(
+      to right,
+      transparent 0,
+      transparent ${segmentWidth - separatorWidth}px,
+      ${separatorColor} ${segmentWidth - separatorWidth}px,
+      ${separatorColor} ${segmentWidth}px
+    )`,
+  });
+
+  return (
+    <>
+      {isOverflowing() ? (
+        <div
+          className="p-meter__filled"
+          data-testid={testIds.meteroverflow}
+          style={{ backgroundColor: overColor, width: "100%" }}
+        ></div>
+      ) : (
+        data.map((datum, i) => (
+          <div
+            className="p-meter__filled"
+            data-testid={testIds.filled}
+            key={`meter-${i}`}
+            style={filledStyle(datum, i)}
+          ></div>
+        ))
+      )}
+      {segmentWidth > 0 && (
+        <div
+          className="p-meter__separators"
+          data-testid={testIds.segments}
+          style={separatorStyle()}
+        />
+      )}
+    </>
+  );
+};
+
+const MeterLabel = ({
+  labelClassName,
+  label,
+}: Pick<Props, "labelClassName" | "label">) => {
+  return (
+    <div
+      className={classNames("p-meter__label", labelClassName)}
+      data-testid={testIds.label}
+    >
+      {label}
+    </div>
+  );
+};
 
 const Meter = ({
   className,
   data,
-  emptyColor = DEFAULT_EMPTY_COLOR,
+  emptyColor = defaultEmptyColor,
   label,
   labelClassName,
   max,
-  overColor = DEFAULT_OVER_COLOR,
+  overColor = defaultOverColor,
   segmented = false,
-  separatorColor = DEFAULT_SEPARATOR_COLOR,
+  separatorColor = defaultSeparatorColor,
   small = false,
 }: Props): JSX.Element => {
   const el = useRef(null);
@@ -78,12 +165,12 @@ const Meter = ({
 
   useEffect(() => {
     if (segmented) {
-      updateWidths(el, maximum, setSegmentWidth);
+      calculateWidths(el, maximum, setSegmentWidth);
     }
   }, [maximum, segmented]);
 
   const onResize = useCallback(() => {
-    updateWidths(el, maximum, setSegmentWidth);
+    calculateWidths(el, maximum, setSegmentWidth);
   }, [el, maximum, setSegmentWidth]);
 
   useListener(window, onResize, "resize", true, segmented);
@@ -91,70 +178,24 @@ const Meter = ({
   return (
     <div
       className={classNames(small ? "p-meter--small" : "p-meter", className)}
-      data-testid={TestIds.Container}
+      data-testid={testIds.container}
       ref={el}
     >
       <div
         className="p-meter__bar"
-        data-testid={TestIds.Bar}
+        data-testid={testIds.bar}
         style={{ backgroundColor: emptyColor }}
       >
-        {valueSum > maximum ? (
-          <div
-            className="p-meter__filled"
-            data-testid={TestIds.MeterOverflow}
-            style={{
-              backgroundColor: overColor,
-              width: "100%",
-            }}
-          ></div>
-        ) : (
-          data.map((datum, i) => (
-            <div
-              className="p-meter__filled"
-              data-testid={TestIds.Filled}
-              key={`meter-${i}`}
-              style={{
-                backgroundColor:
-                  datum.color ||
-                  DEFAULT_FILLED_COLORS[i % DEFAULT_FILLED_COLORS.length],
-                borderRight:
-                  i + 1 < data.length
-                    ? `1px solid ${separatorColor}`
-                    : undefined,
-                left: `${datumWidths.reduce(
-                  (leftPos, width, j) => (i > j ? leftPos + width : leftPos),
-                  0
-                )}%`,
-                width: `${datumWidths[i]}%`,
-              }}
-            ></div>
-          ))
-        )}
-        {segmentWidth > 0 && (
-          <div
-            className="p-meter__separators"
-            data-testid={TestIds.Segments}
-            style={{
-              background: `repeating-linear-gradient(
-                to right,
-                transparent 0,
-                transparent ${segmentWidth - SEPARATOR_WIDTH}px,
-                ${separatorColor} ${segmentWidth - SEPARATOR_WIDTH}px,
-                ${separatorColor} ${segmentWidth}px
-              )`,
-            }}
-          />
-        )}
+        <MeterSegment
+          data={data}
+          datumWidths={datumWidths}
+          maximum={maximum}
+          overColor={overColor}
+          segmentWidth={segmentWidth}
+          separatorColor={separatorColor}
+        />
       </div>
-      {label && (
-        <div
-          className={classNames("p-meter__label", labelClassName)}
-          data-testid={TestIds.Label}
-        >
-          {label}
-        </div>
-      )}
+      {label && <MeterLabel label={label} labelClassName={labelClassName} />}
     </div>
   );
 };

--- a/src/app/base/components/Meter/_index.scss
+++ b/src/app/base/components/Meter/_index.scss
@@ -13,6 +13,7 @@
     overflow: hidden;
     position: relative;
     width: 100%;
+    border: 1px solid $color-mid;
   }
 
   .p-meter__label {

--- a/src/app/base/components/Meter/index.ts
+++ b/src/app/base/components/Meter/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./Meter";
+export { default, color } from "./Meter";

--- a/src/app/base/components/Popover/Popover.test.tsx
+++ b/src/app/base/components/Popover/Popover.test.tsx
@@ -1,21 +1,23 @@
-import { mount } from "enzyme";
-
 import Popover from "./Popover";
 
-describe("Popover", () => {
-  const body = document.querySelector("body");
-  const app = document.createElement("div");
-  if (body && app) {
-    app.setAttribute("id", "app");
-    body.appendChild(app);
-  }
+import { render, screen, userEvent } from "testing/utils";
 
-  it("renders popover content when focused", () => {
-    const wrapper = mount(
-      <Popover content={<span data-testid="test">Test</span>}>Child</Popover>
-    );
-    expect(wrapper.find("[data-testid='test']").exists()).toBe(false);
-    wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-testid='test']").exists()).toBe(true);
-  });
+it("renders popover content when focused", async () => {
+  render(<Popover content={<span>popover content</span>}>child text</Popover>);
+  expect(screen.queryByText("popover content")).not.toBeInTheDocument();
+  await userEvent.click(screen.getByText("child text"));
+  expect(screen.getByText("popover content")).toBeInTheDocument();
+});
+
+it("keeps popover content open on unhover if initiated by click", async () => {
+  render(<Popover content={<span>popover content</span>}>trigger</Popover>);
+  const button = screen.getByRole("button", { name: "trigger" });
+  await userEvent.hover(button);
+  expect(screen.getByText("popover content")).toBeInTheDocument();
+  await userEvent.unhover(button);
+  expect(screen.queryByText("popover content")).not.toBeInTheDocument();
+  await userEvent.click(button);
+  expect(screen.getByText("popover content")).toBeInTheDocument();
+  await userEvent.unhover(button);
+  expect(screen.getByText("popover content")).toBeInTheDocument();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -11139,6 +11139,13 @@ react-useportal@1.0.17:
   dependencies:
     use-ssr "^1.0.22"
 
+react-useportal@1.0.18:
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/react-useportal/-/react-useportal-1.0.18.tgz#b3baf14962f44402b2d0d6152acc2035c5342bd8"
+  integrity sha512-dGuT/yyE2T9RtUxRZJYkIX8tLHC7KxAxbMw/Ufjiwo8ixoDYzkk9LFKGnARtCtFz6Yd5AoP7fVymrN3eT04jiA==
+  dependencies:
+    use-ssr "^1.0.25"
+
 react@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
@@ -12917,6 +12924,11 @@ use-ssr@^1.0.22:
   version "1.0.24"
   resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.24.tgz#213a3df58f5ab9268e6fe1a57ad0a9de91e514d1"
   integrity sha512-0MFps7ezL57/3o0yl4CvrHLlp9z20n1rQZV/lSRz7if+TUoM6POU1XdOvEjIgjgKeIhTEye1U0khrIYWCTWw4g==
+
+use-ssr@^1.0.25:
+  version "1.0.25"
+  resolved "https://registry.yarnpkg.com/use-ssr/-/use-ssr-1.0.25.tgz#c7f54b59d6e52db26749b1d4115a650101a190bd"
+  integrity sha512-VYF8kJKI+X7+U4XgGoUER2BUl0vIr+8OhlIhyldgSGE0KHMoDRXPvWeHUUeUktq7ACEOVLzXGq1+QRxcvtwvyQ==
 
 use-sync-external-store@^1.0.0:
   version "1.2.0"


### PR DESCRIPTION
## Done
- improve popover a11y
- merge updates to Popover and Meter components from maas-site-manager
- add react-useportal as a dependency 

## Note
`react-useportal` adds 1.25KB to the JS bundle, but this will be followed up in https://warthogs.atlassian.net/browse/MAASENG-1599

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Fixes
https://warthogs.atlassian.net/browse/MAASENG-1600

### QA steps

- Go to `/MAAS/r/kvm/lxd` (you may need a test dataset for 1000 machines which contains LXD)
- Verify that popover and meter are displayed correctly on click and on hover

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

### After
<img width="1528" alt="CleanShot 2023-04-25 at 09 15 31@2x" src="https://user-images.githubusercontent.com/7452681/234202203-2fd63183-1510-4199-8bff-384ef543fa82.png">

