### PR TITLE
fix: update machine list pagination spacing

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/_index.scss
@@ -1,7 +1,5 @@
 @mixin MachineListPagination {
-
   .p-pagination--items {
-
     padding-bottom: $spv--small;
 
     .p-button {
@@ -33,9 +31,8 @@
       appearance: none;
     }
 
-    input[type=number] {
+    input[type="number"] {
       appearance: textfield;
     }
   }
-
 }

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -855,7 +855,7 @@ export const MachineListTable = ({
               />
             ) : null}
           </span>
-          <hr className="machine-list__divider" />
+          <hr />
         </div>
       ) : null}
       <MainTable

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -111,10 +111,6 @@
     justify-content: flex-end;
   }
 
-  .machine-list__divider {
-    margin-top: $spv--small;
-  }
-
   .p-tooltip__message .p-list::after {
     white-space: normal;
   }

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -112,7 +112,7 @@
   }
 
   .machine-list__divider {
-    margin-top: $spv--x-large;
+    margin-top: $spv--small;
   }
 
   .p-tooltip__message .p-list::after {


### PR DESCRIPTION
## Done

- update machine list pagination spacing to match designs

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- verify it's displayed with the correct margin in the pagination section across all breakpoints

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
Design reference: https://app.zeplin.io/project/63ca81b58cdf10309393a6cb/screen/63ce8acd84a530122c4806e6

### Before
<img width="1704" alt="CleanShot 2023-04-25 at 09 25 36@2x" src="https://user-images.githubusercontent.com/7452681/234204454-4b21372a-288d-46c2-85a8-4c27ec7c529d.png">

### After
<img width="1706" alt="CleanShot 2023-04-25 at 09 26 06@2x" src="https://user-images.githubusercontent.com/7452681/234204620-fdd36bfe-c9e9-4471-8d49-a2d391f3ff28.png">

