### PR TITLE
WIP feat(settings): Add secondary navigation MAASENG-1364

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,11 +4,14 @@ import { useEffect, useState } from "react";
 import { Notification } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import * as Sentry from "@sentry/browser";
+import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
+import { matchPath, useLocation } from "react-router-dom-v5-compat";
 
 import packageInfo from "../../package.json";
 
 import NavigationBanner from "./base/components/AppSideNavigation/NavigationBanner";
+import SecondaryNavigation from "./base/components/SecondaryNavigation/SecondaryNavigation";
 import ThemePreviewContext from "./base/theme-preview-context";
 import { MAAS_UI_ID } from "./constants";
 import { formatErrors } from "./utils";
@@ -50,6 +53,8 @@ export const App = (): JSX.Element => {
   const configErrors = useSelector(configSelectors.errors);
   const [theme, setTheme] = useState(maasTheme ? maasTheme : "default");
   const previousAuthenticated = usePrevious(authenticated, false);
+  const { pathname } = useLocation();
+  const isSideNavVisible = matchPath("settings/*", pathname);
 
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());
@@ -154,9 +159,18 @@ export const App = (): JSX.Element => {
         )}
 
         <main className="l-main">
-          <div id="main-content">{content}</div>
-          <hr />
-          <Footer />
+          <div
+            className={classNames("l-main__nav", {
+              "is-open": isSideNavVisible,
+            })}
+          >
+            <SecondaryNavigation isOpen={!!isSideNavVisible} />
+          </div>
+          <div className="l-main__content" id="main-content">
+            {content}
+            <hr />
+            <Footer />
+          </div>
         </main>
         <aside className="l-status">
           <StatusBar />

--- a/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
@@ -27,6 +27,11 @@ export const AppSideNavItem = ({ navLink, icon, path }: Props): JSX.Element => {
         aria-current={isSelected(path, navLink) ? "page" : undefined}
         className="p-side-navigation__link"
         id={`${navLink.label}-${id}`}
+        onClick={(event) => {
+          // removing the focus from the link element after click
+          // this allows the side navigation to collapse on mouseleave
+          event.currentTarget.blur();
+        }}
         to={navLink.url}
       >
         {icon ? (

--- a/src/app/base/components/SecondaryNavigation/SecondaryNavigation.tsx
+++ b/src/app/base/components/SecondaryNavigation/SecondaryNavigation.tsx
@@ -1,0 +1,211 @@
+/* eslint-disable react/no-multi-comp */
+import classNames from "classnames";
+import type { Location } from "react-router-dom-v5-compat";
+import { Link, matchPath, useLocation } from "react-router-dom-v5-compat";
+
+import settingsURLs from "app/settings/urls";
+
+export type NavItem = {
+  label: string;
+  path?: string;
+  items?: NavItem[];
+};
+
+type ItemProps = { item: NavItem };
+
+const SideNavigationLink = ({ item }: ItemProps) => {
+  const location = useLocation();
+  const isActive = getIsActive({ item, location });
+  if (!item.path) {
+    return null;
+  }
+  return (
+    <Link
+      aria-current={isActive ? "page" : undefined}
+      className={classNames("p-side-navigation__link", {
+        "is-active": isActive,
+      })}
+      to={item.path}
+    >
+      {item.label}
+    </Link>
+  );
+};
+
+const SubNavItem = ({ item }: ItemProps) => {
+  return (
+    <li className="p-side-navigation__item" key={item.path}>
+      <SideNavigationLink item={item} />
+    </li>
+  );
+};
+
+const SubNavigation = ({ items }: { items: NavItem["items"] }) => {
+  if (!items || !items.length) return null;
+
+  return (
+    <ul className="p-side-navigation__list">
+      {items.map((item) => (
+        <SubNavItem item={item} key={item.path} />
+      ))}
+    </ul>
+  );
+};
+
+const getIsActive = ({
+  item,
+  location,
+}: ItemProps & { location: Location }) => {
+  const path = item.path;
+
+  if (!path) {
+    return false;
+  }
+
+  if (!item.items) {
+    return location.pathname.startsWith(path);
+  }
+
+  return matchPath(path, location.pathname);
+};
+
+const SideNavigationItem = ({ item }: ItemProps) => {
+  const location = useLocation();
+  const isActive = getIsActive({ item, location });
+  const itemClassName = classNames("p-side-navigation__item--title", {
+    "is-active": isActive,
+  });
+
+  return (
+    <li className={itemClassName} key={item.path || item.label}>
+      {item.path ? (
+        <SideNavigationLink item={item} />
+      ) : (
+        <span className="p-side-navigation__text p-side-navigation__item">
+          {item.label}
+        </span>
+      )}
+      {item.items ? <SubNavigation items={item.items} /> : null}
+    </li>
+  );
+};
+
+export const secondaryNavItems: NavItem[] = [
+  {
+    label: "Configuration",
+    items: [
+      { path: settingsURLs.configuration.general, label: "General" },
+      {
+        path: settingsURLs.configuration.commissioning,
+        label: "Commissioning",
+      },
+      { path: settingsURLs.configuration.deploy, label: "Deploy" },
+      {
+        path: settingsURLs.configuration.kernelParameters,
+        label: "Kernel parameters",
+      },
+    ],
+  },
+  {
+    label: "Security",
+    items: [
+      {
+        path: settingsURLs.security.securityProtocols,
+        label: "Security protocols",
+      },
+      {
+        path: settingsURLs.security.secretStorage,
+        label: "Secret storage",
+      },
+      {
+        path: settingsURLs.security.sessionTimeout,
+        label: "Session timeout",
+      },
+      {
+        path: settingsURLs.security.ipmiSettings,
+        label: "IPMI settings",
+      },
+    ],
+  },
+  {
+    path: settingsURLs.users.index,
+    label: "Users",
+  },
+  {
+    label: "Images",
+    items: [
+      { path: settingsURLs.images.ubuntu, label: "Ubuntu" },
+      { path: settingsURLs.images.windows, label: "Windows" },
+      { path: settingsURLs.images.vmware, label: "VMware" },
+    ],
+  },
+  {
+    path: settingsURLs.licenseKeys.index,
+    label: "License keys",
+  },
+  {
+    path: settingsURLs.storage,
+    label: "Storage",
+  },
+  {
+    label: "Network",
+    items: [
+      { path: settingsURLs.network.proxy, label: "Proxy" },
+      { path: settingsURLs.network.dns, label: "DNS" },
+      { path: settingsURLs.network.ntp, label: "NTP" },
+      { path: settingsURLs.network.syslog, label: "Syslog" },
+      {
+        path: settingsURLs.network.networkDiscovery,
+        label: "Network discovery",
+      },
+    ],
+  },
+  {
+    label: "Scripts",
+    items: [
+      {
+        path: settingsURLs.scripts.commissioning.index,
+        label: "Commissioning scripts",
+      },
+      {
+        path: settingsURLs.scripts.testing.index,
+        label: "Testing scripts",
+      },
+    ],
+  },
+  {
+    path: settingsURLs.dhcp.index,
+    label: "DHCP snippets",
+  },
+  {
+    path: settingsURLs.repositories.index,
+    label: "Package repos",
+  },
+];
+
+export const SecondaryNavigation = ({
+  isOpen,
+}: {
+  isOpen?: boolean;
+}): JSX.Element => {
+  return (
+    <div
+      className={classNames("p-side-navigation is-maas is-dark", {
+        "is-open": isOpen,
+      })}
+    >
+      <nav className="p-side-navigation__drawer u-padding-top--medium">
+        <h2 className="p-side-navigation__title p-heading--4 p-panel__logo-name">
+          Settings
+        </h2>
+        <ul className="p-side-navigation__list">
+          {secondaryNavItems.map((item) => (
+            <SideNavigationItem item={item} key={item.label} />
+          ))}
+        </ul>
+      </nav>
+    </div>
+  );
+};
+
+export default SecondaryNavigation;

--- a/src/app/base/components/SecondaryNavigation/_index.scss
+++ b/src/app/base/components/SecondaryNavigation/_index.scss
@@ -1,0 +1,45 @@
+@mixin SecondaryNavigation {
+  .p-side-navigation {
+    transition-duration: 0.165s;
+    transition-property: width, box-shadow, background;
+    transition-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+    width: 0;
+    visibility: hidden;
+    overflow-y: scroll;
+
+    &.is-open {
+      visibility: visible;
+      width: 100%;
+      @media (min-width: $breakpoint-small) {
+        width: $application-layout--side-nav-width-expanded;
+      }
+    }
+
+    &,
+    .p-side-navigation__drawer {
+      background: #444444 !important;
+      height: 100%;
+    }
+    .p-side-navigation__drawer {
+      transform: none;
+      position: static;
+      max-width: 100%;
+    }
+    .p-side-navigation__title {
+      @extend %vf-heading-4;
+      padding-left: 1.5rem;
+      margin-bottom: 2rem !important;
+    }
+
+    .p-side-navigation__text,
+    .p-side-navigation__item--title .p-side-navigation__item .p-side-navigation__link {
+      @media (min-width: $breakpoint-small) {
+        padding-left: 1.5rem;
+      }
+    }
+
+    .p-side-navigation__item .p-side-navigation__link {
+      padding-left: 3rem !important;
+    }
+  }
+}

--- a/src/app/base/components/SecondaryNavigation/index.ts
+++ b/src/app/base/components/SecondaryNavigation/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SecondaryNavigation";

--- a/src/app/settings/views/Configuration/General/General.tsx
+++ b/src/app/settings/views/Configuration/General/General.tsx
@@ -28,7 +28,7 @@ const General = (): JSX.Element => {
 
   return (
     <Row>
-      <Col size={9}>
+      <Col size={12}>
         {loading && <Spinner text={Labels.Loading} />}
         {loaded && <GeneralForm />}
       </Col>

--- a/src/app/settings/views/Security/SecretStorage/SecretStorage.tsx
+++ b/src/app/settings/views/Security/SecretStorage/SecretStorage.tsx
@@ -25,7 +25,7 @@ const SecretStorage = (): JSX.Element => {
   return (
     <>
       <Row>
-        <Col size={6}>
+        <Col size={12}>
           <VaultSettings />
         </Col>
       </Row>

--- a/src/app/settings/views/Settings.tsx
+++ b/src/app/settings/views/Settings.tsx
@@ -4,7 +4,6 @@ import { useDispatch, useSelector } from "react-redux";
 
 import MainContentSection from "app/base/components/MainContentSection";
 import SectionHeader from "app/base/components/SectionHeader";
-import SettingsNav from "app/settings/components/Nav";
 import Routes from "app/settings/components/Routes";
 import authSelectors from "app/store/auth/selectors";
 import { actions as configActions } from "app/store/config";
@@ -28,10 +27,7 @@ const Settings = (): JSX.Element => {
   }
 
   return (
-    <MainContentSection
-      header={<SectionHeader title="Settings" />}
-      sidebar={<SettingsNav />}
-    >
+    <MainContentSection>
       <Routes />
     </MainContentSection>
   );

--- a/src/scss/_patterns_application.scss
+++ b/src/scss/_patterns_application.scss
@@ -1,7 +1,24 @@
 @mixin maas-application {
   .l-main {
-    display: grid;
-    grid-template-rows: auto 1fr auto;
+    // display: grid;
+    // grid-template-rows: auto 1fr auto;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    @media (min-width: $breakpoint-small) {
+      flex-direction: row;
+    }
+    .l-main__nav {
+      flex-shrink: 0;
+
+      @media (min-width: $breakpoint-small) {
+        height: calc(100vh - 2.5rem);
+      }
+    }
+    .l-main__content {
+      width: 100%;
+      overflow-y: auto;
+    }
   }
   .l-aside {
     z-index: $side-panel-z-index;

--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -184,6 +184,10 @@
     margin-top: -$sp-x-small !important;
   }
 
+  .u-padding-top--medium {
+    padding-top: $spv--medium !important;
+  }
+
   .u-position--relative {
     position: relative !important;
   }

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -105,6 +105,7 @@
 @import "~app/base/components/NotificationGroup";
 @import "~app/base/components/Placeholder";
 @import "~app/base/components/Popover";
+@import "~app/base/components/SecondaryNavigation";
 @import "~app/base/components/SectionHeader";
 @import "~app/base/components/SelectButton";
 @import "~app/base/components/SSHKeyList";
@@ -141,6 +142,7 @@
 @include OverviewCard;
 @include Placeholder;
 @include Popover;
+@include SecondaryNavigation;
 @include SectionHeader;
 @include SelectButton;
 @include SSHKeyList;


### PR DESCRIPTION
## Done

- Itemised list of what was changed by this PR.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/settings`
- Ensure the secondary navigation is displayed correctly across all breakpoints https://zpl.io/1yvKk35
- Ensure page content is displayed correctly for each settings page

## Fixes

Fixes [MAASENG-1364](https://warthogs.atlassian.net/browse/MAASENG-1364)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

![image](https://user-images.githubusercontent.com/35104482/234253643-74203575-465c-4af8-af10-02170256c15d.png)
