### PR TITLE
round off values to 2 decimal places at most

### DIFF
--- a/src/app/kvm/components/KVMResourceMeter/KVMResourceMeter.tsx
+++ b/src/app/kvm/components/KVMResourceMeter/KVMResourceMeter.tsx
@@ -24,7 +24,7 @@ const KVMResourceMeter = ({
   const total = allocated + free + other;
   const { value: formattedTotal, unit: formattedUnit } = unit
     ? formatBytes(total, unit, { binary: binaryUnit, decimals: 1 })
-    : { value: Number(total.toFixed(2)), unit: "" };
+    : { value: Number(total.toFixed(1)), unit: "" };
   const formatResource = (resource: number) =>
     unit
       ? formatBytes(resource, unit, {
@@ -32,7 +32,7 @@ const KVMResourceMeter = ({
           convertTo: formattedUnit,
           decimals: 1,
         }).value
-      : Number(resource.toFixed(2));
+      : Number(resource.toFixed(1));
   const formattedAllocated = formatResource(allocated);
   const formattedFree = formatResource(free);
   const formattedOther = formatResource(other);

--- a/src/app/kvm/components/KVMResourceMeter/KVMResourceMeter.tsx
+++ b/src/app/kvm/components/KVMResourceMeter/KVMResourceMeter.tsx
@@ -24,7 +24,7 @@ const KVMResourceMeter = ({
   const total = allocated + free + other;
   const { value: formattedTotal, unit: formattedUnit } = unit
     ? formatBytes(total, unit, { binary: binaryUnit, decimals: 1 })
-    : { value: total, unit: "" };
+    : { value: Number(total.toFixed(2)), unit: "" };
   const formatResource = (resource: number) =>
     unit
       ? formatBytes(resource, unit, {
@@ -32,7 +32,7 @@ const KVMResourceMeter = ({
           convertTo: formattedUnit,
           decimals: 1,
         }).value
-      : resource;
+      : Number(resource.toFixed(2));
   const formattedAllocated = formatResource(allocated);
   const formattedFree = formatResource(free);
   const formattedOther = formatResource(other);

--- a/src/app/store/pod/utils.ts
+++ b/src/app/store/pod/utils.ts
@@ -53,9 +53,9 @@ export const resourceWithOverCommit = (
   const total = totalAllocated + resource.free;
   const overCommitted = total * overCommit;
   return {
-    allocated_other: resource.allocated_other,
-    allocated_tracked: resource.allocated_tracked,
-    free: overCommitted - totalAllocated,
+    allocated_other: Number(resource.allocated_other.toFixed(2)),
+    allocated_tracked: Number(resource.allocated_tracked.toFixed(2)),
+    free: Number((overCommitted - totalAllocated).toFixed(2)),
   };
 };
 

--- a/src/app/store/pod/utils.ts
+++ b/src/app/store/pod/utils.ts
@@ -53,9 +53,9 @@ export const resourceWithOverCommit = (
   const total = totalAllocated + resource.free;
   const overCommitted = total * overCommit;
   return {
-    allocated_other: Number(resource.allocated_other.toFixed(2)),
-    allocated_tracked: Number(resource.allocated_tracked.toFixed(2)),
-    free: Number((overCommitted - totalAllocated).toFixed(2)),
+    allocated_other: Number(resource.allocated_other.toFixed(1)),
+    allocated_tracked: Number(resource.allocated_tracked.toFixed(1)),
+    free: Number((overCommitted - totalAllocated).toFixed(1)),
   };
 };
 


### PR DESCRIPTION
## Done

- Round off values of free and total CPU cores to (at most) 2 decimal places

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- register LXD VM host
- set an overcommit ratio with a fractional value to have a factional value for available CPU cores
- goto /MAAS/r/kvm/lxd
- Hover over the CPU cores for that host and ensure the values are at most 2 decimal places

## Fixes

Fixes: # .

## Launchpad issue
https://bugs.launchpad.net/maas/+bug/2012466

Related Launchpad maas issue in the form `lp#number`.
lp#2012466

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
<img width="599" alt="image" src="https://user-images.githubusercontent.com/47540149/234317253-b88b8e34-9c25-4d01-908b-625f2be6f8c3.png">

