### PR TITLE
fix: round off values to 1 decimal place at most lp#2012466 (#4876)

### DIFF
--- a/src/app/kvm/components/KVMResourceMeter/KVMResourceMeter.tsx
+++ b/src/app/kvm/components/KVMResourceMeter/KVMResourceMeter.tsx
@@ -24,7 +24,7 @@ const KVMResourceMeter = ({
   const total = allocated + free + other;
   const { value: formattedTotal, unit: formattedUnit } = unit
     ? formatBytes(total, unit, { binary: binaryUnit, decimals: 1 })
-    : { value: total, unit: "" };
+    : { value: Number(total.toFixed(1)), unit: "" };
   const formatResource = (resource: number) =>
     unit
       ? formatBytes(resource, unit, {
@@ -32,7 +32,7 @@ const KVMResourceMeter = ({
           convertTo: formattedUnit,
           decimals: 1,
         }).value
-      : resource;
+      : Number(resource.toFixed(1));
   const formattedAllocated = formatResource(allocated);
   const formattedFree = formatResource(free);
   const formattedOther = formatResource(other);

--- a/src/app/store/pod/utils.ts
+++ b/src/app/store/pod/utils.ts
@@ -53,9 +53,9 @@ export const resourceWithOverCommit = (
   const total = totalAllocated + resource.free;
   const overCommitted = total * overCommit;
   return {
-    allocated_other: resource.allocated_other,
-    allocated_tracked: resource.allocated_tracked,
-    free: overCommitted - totalAllocated,
+    allocated_other: Number(resource.allocated_other.toFixed(1)),
+    allocated_tracked: Number(resource.allocated_tracked.toFixed(1)),
+    free: Number((overCommitted - totalAllocated).toFixed(1)),
   };
 };
 


### PR DESCRIPTION
## Done

- Round off CPU core values to 1 decimal place

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.
lp#2012466

## Backports
3.3

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
