### PR TITLE
fix: tests tab not updating scripresults on mount

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -1,5 +1,4 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
-import { mount } from "enzyme";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -22,6 +21,7 @@ import {
   testStatus as testStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { renderWithMockStore, screen } from "testing/utils";
 
 jest.mock("@canonical/react-components/dist/hooks", () => {
   const hooks = jest.requireActual("@canonical/react-components/dist/hooks");
@@ -31,7 +31,7 @@ jest.mock("@canonical/react-components/dist/hooks", () => {
   };
 });
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("MachineTests", () => {
   let state: RootState;
@@ -44,6 +44,9 @@ describe("MachineTests", () => {
             locked: false,
             permissions: ["edit"],
             system_id: "abc123",
+            testing_status: testStatusFactory({
+              status: TestStatusStatus.RUNNING,
+            }),
           }),
         ],
       }),
@@ -74,7 +77,7 @@ describe("MachineTests", () => {
     ];
     const store = mockStore(state);
 
-    const wrapper = mount(
+    renderWithMockStore(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -85,18 +88,19 @@ describe("MachineTests", () => {
             </Routes>
           </CompatRouter>
         </MemoryRouter>
-      </Provider>
+      </Provider>,
+      { store }
     );
 
-    expect(
-      wrapper.find("[data-testid='hardware-heading']").at(0).text()
-    ).toEqual("CPU");
-    expect(
-      wrapper.find("[data-testid='hardware-heading']").at(1).text()
-    ).toEqual("Network");
-    expect(
-      wrapper.find("[data-testid='hardware-heading']").at(2).text()
-    ).toEqual("Other Results");
+    expect(screen.getAllByTestId("hardware-heading")[0]).toHaveTextContent(
+      "CPU"
+    );
+    expect(screen.getAllByTestId("hardware-heading")[1]).toHaveTextContent(
+      "Network"
+    );
+    expect(screen.getAllByTestId("hardware-heading")[2]).toHaveTextContent(
+      "Other Results"
+    );
   });
 
   it("renders headings for each block device", () => {
@@ -124,7 +128,7 @@ describe("MachineTests", () => {
     ];
     const store = mockStore(state);
 
-    const wrapper = mount(
+    renderWithMockStore(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -135,11 +139,12 @@ describe("MachineTests", () => {
             </Routes>
           </CompatRouter>
         </MemoryRouter>
-      </Provider>
+      </Provider>,
+      { store }
     );
-    expect(
-      wrapper.find("[data-testid='storage-heading']").first().text()
-    ).toEqual("/dev/sda (model: QEMU HARDDISK, serial: lxd_root)");
+    expect(screen.getByTestId("storage-heading")).toHaveTextContent(
+      "/dev/sda (model: QEMU HARDDISK, serial: lxd_root)"
+    );
   });
 
   it("shows a heading for a block device without a model and serial", () => {
@@ -166,7 +171,7 @@ describe("MachineTests", () => {
       }),
     ];
     const store = mockStore(state);
-    const wrapper = mount(
+    renderWithMockStore(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -177,11 +182,10 @@ describe("MachineTests", () => {
             </Routes>
           </CompatRouter>
         </MemoryRouter>
-      </Provider>
+      </Provider>,
+      { store }
     );
-    expect(
-      wrapper.find("[data-testid='storage-heading']").first().text()
-    ).toEqual("/dev/sda");
+    expect(screen.getByTestId("storage-heading")).toHaveTextContent("/dev/sda");
   });
 
   it("shows a heading for a network interface", () => {
@@ -206,7 +210,7 @@ describe("MachineTests", () => {
       }),
     ];
     const store = mockStore(state);
-    const wrapper = mount(
+    renderWithMockStore(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -217,18 +221,19 @@ describe("MachineTests", () => {
             </Routes>
           </CompatRouter>
         </MemoryRouter>
-      </Provider>
+      </Provider>,
+      { store }
     );
-    expect(
-      wrapper.find("[data-testid='hardware-device-heading']").first().text()
-    ).toEqual("ens4 (52:54:00:57:e9:ac)");
+    expect(screen.getByTestId("hardware-device-heading")).toHaveTextContent(
+      "ens4 (52:54:00:57:e9:ac)"
+    );
   });
 
   it("fetches script results if they haven't been fetched", () => {
     state.nodescriptresult.items = { abc123: [] };
     state.scriptresult.items = [];
     const store = mockStore(state);
-    mount(
+    renderWithMockStore(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -239,7 +244,8 @@ describe("MachineTests", () => {
             </Routes>
           </CompatRouter>
         </MemoryRouter>
-      </Provider>
+      </Provider>,
+      { store }
     );
     expect(
       store
@@ -248,11 +254,11 @@ describe("MachineTests", () => {
     ).toBe(true);
   });
 
-  it("does not fetch script results if they have already been loaded", () => {
+  it("fetches script results on mount if they have already been loaded", () => {
     state.nodescriptresult.items = { abc123: [] };
-    state.scriptresult.items = [];
+    state.scriptresult.items = [scriptResultFactory()];
     const store = mockStore(state);
-    const wrapper = mount(
+    renderWithMockStore(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -263,14 +269,9 @@ describe("MachineTests", () => {
             </Routes>
           </CompatRouter>
         </MemoryRouter>
-      </Provider>
+      </Provider>,
+      { store }
     );
-    expect(
-      store
-        .getActions()
-        .filter((action) => action.type === "scriptresult/getByNodeId").length
-    ).toBe(1);
-    wrapper.setProps({});
     expect(
       store
         .getActions()
@@ -304,7 +305,7 @@ describe("MachineTests", () => {
       }),
     ];
     const store = mockStore(state);
-    mount(
+    renderWithMockStore(
       <Provider store={store}>
         <MemoryRouter
           initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
@@ -315,12 +316,13 @@ describe("MachineTests", () => {
             </Routes>
           </CompatRouter>
         </MemoryRouter>
-      </Provider>
+      </Provider>,
+      { store }
     );
     expect(
       store
         .getActions()
         .filter((action) => action.type === "scriptresult/getByNodeId").length
-    ).toBe(1);
+    ).toBe(2);
   });
 });

--- a/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
+++ b/src/app/machines/views/MachineDetails/MachineTests/MachineTests.tsx
@@ -57,20 +57,26 @@ const MachineTests = (): JSX.Element => {
   useWindowTitle(`${machine?.fqdn || "Machine"} tests`);
   const isDetails = isMachineDetails(machine);
 
+  // load script results on mount
+  useEffect(() => {
+    if (isId(id)) {
+      dispatch(scriptResultActions.getByNodeId(id));
+    }
+  }, [dispatch, id]);
+
   useEffect(() => {
     if (
       isId(id) &&
       !loading &&
-      (!scriptResults?.length ||
-        // Refetch the script results when the testing status changes to
-        // pending, otherwise the new script results won't be associated with
-        // the machine.
-        (machine?.testing_status.status === TestStatusStatus.PENDING &&
-          previousTestingStatus !== machine?.testing_status.status))
+      // Refetch the script results when the testing status changes to
+      // pending, otherwise the new script results won't be associated with
+      // the machine.
+      machine?.testing_status.status === TestStatusStatus.PENDING &&
+      previousTestingStatus !== machine?.testing_status.status
     ) {
       dispatch(scriptResultActions.getByNodeId(id));
     }
-  }, [dispatch, previousTestingStatus, scriptResults, loading, machine, id]);
+  }, [dispatch, previousTestingStatus, loading, machine, id]);
 
   if (isId(id) && isDetails && scriptResults?.length) {
     return (


### PR DESCRIPTION
## Done

- fix: tests tab not updating scripresults on mount
- refactor `MachineTests.test.tsx` to RTL

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine details page
- Go to Network tab
- Click "Validate network configuration" and submit the form
- Go to the Tests tab
- Verify that new tests are displayed

## Fixes

Fixes: https://bugs.launchpad.net/maas-ui/+bug/2017977

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
