### PR TITLE
prepare 3.4 release

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,6 +14,7 @@ jobs:
         uses: canonical/setup-maas@main
         with:
           maas-url: ${{env.MAAS_URL}}/MAAS
+          channel: "3.4/edge"
       - name: Install Cypress
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,5 @@
 name: Playwright Tests
-on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
+on: [push]
 jobs:
   test:
     timeout-minutes: 15
@@ -23,6 +19,7 @@ jobs:
         uses: canonical/setup-maas@main
         with:
           maas-url: ${{env.MAAS_URL}}/MAAS
+          channel: "3.4/edge"
       - name: Create MAAS admin
         run: sudo maas createadmin --username=admin --password=test --email=fake@example.org
       - name: Wait for MAAS UI to be ready

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - "3.4"
   pull_request:
     branches:
-      - main
+      - "3.4"
 jobs:
   lint:
     name: Lint

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -37,14 +37,14 @@ branch. This might look something like the following:
 on:
   push:
     branches:
-      - 3.2
+      - 3.5
   pull_request:
     branches:
-      - 3.2
+      - 3.5
 ```
 
 Update the workflows to set the snap channel for the `maas` and
-`maas-test-db` snaps (e.g. `--channel=3.2/edge`).
+`maas-test-db` snaps (e.g. `--channel=3.5/edge`).
 
 Propose this against the appropriate version branch and merge once approved.
 


### PR DESCRIPTION

## Done
prepare 3.4 release
- update github actions to use 3.4
- update RELEASE.md

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
