### PR TITLE
test: Migrate four base components to RTL

### DIFF
--- a/src/app/base/components/node/ActionConfirm/ActionConfirm.test.tsx
+++ b/src/app/base/components/node/ActionConfirm/ActionConfirm.test.tsx
@@ -1,11 +1,10 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import ActionConfirm from "./ActionConfirm";
 
 import * as maasUiHooks from "app/base/hooks/analytics";
+import type { RootState } from "app/store/root/types";
 import {
   machineDetails as machineDetailsFactory,
   machineEventError as machineEventErrorFactory,
@@ -14,8 +13,9 @@ import {
   machineStatuses as machineStatusesFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { renderWithMockStore, screen } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
   usePrevious: jest.fn(),
@@ -32,26 +32,29 @@ describe("ActionConfirm", () => {
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <ActionConfirm
-          closeExpanded={jest.fn()}
-          confirmLabel="Confirm"
-          eventName="deleteFilesystem"
-          message={<span>Are you sure you want to do that?</span>}
-          onConfirm={jest.fn()}
-          onSaveAnalytics={{
-            action: "Action",
-            category: "Category",
-            label: "Label",
-          }}
-          statusKey="deletingFilesystem"
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <ActionConfirm
+        closeExpanded={jest.fn()}
+        confirmLabel="Confirm"
+        eventName="deleteFilesystem"
+        message={<span>Are you sure you want to do that?</span>}
+        onConfirm={jest.fn()}
+        onSaveAnalytics={{
+          action: "Action",
+          category: "Category",
+          label: "Label",
+        }}
+        statusKey="deletingFilesystem"
+        systemId="abc123"
+      />,
+      { store }
     );
 
-    expect(wrapper.find("ActionButton").prop("loading")).toBe(true);
+    const actionButton = screen.getByRole("button", {
+      name: "Waiting for action to complete",
+    });
+    expect(actionButton).toBeInTheDocument();
+    expect(actionButton).toHaveClass("is-processing");
   });
 
   it("can show errors", () => {
@@ -72,25 +75,24 @@ describe("ActionConfirm", () => {
     });
     const store = mockStore(state);
     const closeExpanded = jest.fn();
-    const wrapper = mount(
-      <Provider store={store}>
-        <ActionConfirm
-          closeExpanded={closeExpanded}
-          confirmLabel="Confirm"
-          message="Are you sure you want to do that?"
-          onConfirm={jest.fn()}
-          onSaveAnalytics={{
-            action: "Action",
-            category: "Category",
-            label: "Label",
-          }}
-          statusKey="deletingFilesystem"
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <ActionConfirm
+        closeExpanded={closeExpanded}
+        confirmLabel="Confirm"
+        message="Are you sure you want to do that?"
+        onConfirm={jest.fn()}
+        onSaveAnalytics={{
+          action: "Action",
+          category: "Category",
+          label: "Label",
+        }}
+        statusKey="deletingFilesystem"
+        systemId="abc123"
+      />,
+      { store }
     );
 
-    expect(wrapper.find("[data-testid='error-message']").text()).toBe("uh oh");
+    expect(screen.getByTestId("error-message")).toHaveTextContent("uh oh");
   });
 
   it("can change the submit appearance", () => {
@@ -104,26 +106,27 @@ describe("ActionConfirm", () => {
     });
     const store = mockStore(state);
     const closeExpanded = jest.fn();
-    const wrapper = mount(
-      <Provider store={store}>
-        <ActionConfirm
-          closeExpanded={closeExpanded}
-          confirmLabel="Confirm"
-          message="Are you sure you want to do that?"
-          onConfirm={jest.fn()}
-          onSaveAnalytics={{
-            action: "Action",
-            category: "Category",
-            label: "Label",
-          }}
-          statusKey="creatingCacheSet"
-          submitAppearance="positive"
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <ActionConfirm
+        closeExpanded={closeExpanded}
+        confirmLabel="Confirm"
+        message="Are you sure you want to do that?"
+        onConfirm={jest.fn()}
+        onSaveAnalytics={{
+          action: "Action",
+          category: "Category",
+          label: "Label",
+        }}
+        statusKey="creatingCacheSet"
+        submitAppearance="positive"
+        systemId="abc123"
+      />,
+      { store }
     );
 
-    expect(wrapper.find("ActionButton").prop("appearance")).toBe("positive");
+    expect(screen.getByRole("button", { name: "Confirm" })).toHaveClass(
+      "p-button--positive"
+    );
   });
 
   it("sends an analytics event when saved", () => {
@@ -147,19 +150,18 @@ describe("ActionConfirm", () => {
     });
     const store = mockStore(state);
     const closeExpanded = jest.fn();
-    mount(
-      <Provider store={store}>
-        <ActionConfirm
-          closeExpanded={closeExpanded}
-          confirmLabel="Confirm"
-          eventName="deleteFilesystem"
-          message="Are you sure you want to do that?"
-          onConfirm={jest.fn()}
-          onSaveAnalytics={analyticsEvent}
-          statusKey="deletingFilesystem"
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <ActionConfirm
+        closeExpanded={closeExpanded}
+        confirmLabel="Confirm"
+        eventName="deleteFilesystem"
+        message="Are you sure you want to do that?"
+        onConfirm={jest.fn()}
+        onSaveAnalytics={analyticsEvent}
+        statusKey="deletingFilesystem"
+        systemId="abc123"
+      />,
+      { store }
     );
 
     expect(useSendMock).toHaveBeenCalled();
@@ -187,23 +189,22 @@ describe("ActionConfirm", () => {
     });
     const store = mockStore(state);
     const closeExpanded = jest.fn();
-    mount(
-      <Provider store={store}>
-        <ActionConfirm
-          closeExpanded={closeExpanded}
-          confirmLabel="Confirm"
-          eventName="deleteFilesystem"
-          message="Are you sure you want to do that?"
-          onConfirm={jest.fn()}
-          onSaveAnalytics={{
-            action: "Action",
-            category: "Category",
-            label: "Label",
-          }}
-          statusKey="deletingFilesystem"
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <ActionConfirm
+        closeExpanded={closeExpanded}
+        confirmLabel="Confirm"
+        eventName="deleteFilesystem"
+        message="Are you sure you want to do that?"
+        onConfirm={jest.fn()}
+        onSaveAnalytics={{
+          action: "Action",
+          category: "Category",
+          label: "Label",
+        }}
+        statusKey="deletingFilesystem"
+        systemId="abc123"
+      />,
+      { store }
     );
 
     expect(closeExpanded).toHaveBeenCalled();

--- a/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
+++ b/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
@@ -3,13 +3,11 @@ import configureStore from "redux-mock-store";
 import DeleteForm from "./DeleteForm";
 
 import type { RootState } from "app/store/root/types";
-import { machine as machineFactory } from "testing/factories";
 import {
-  getTestState,
-  renderWithBrowserRouter,
-  screen,
-  userEvent,
-} from "testing/utils";
+  machine as machineFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 
@@ -17,7 +15,7 @@ describe("DeleteForm", () => {
   let state: RootState;
 
   beforeEach(() => {
-    state = getTestState();
+    state = rootStateFactory();
   });
 
   it("correctly runs function to delete given nodes", async () => {

--- a/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
+++ b/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
@@ -1,7 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DeleteForm from "./DeleteForm";
@@ -11,9 +7,9 @@ import {
   machine as machineFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { submitFormikForm } from "testing/utils";
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("DeleteForm", () => {
   let state: RootState;
@@ -22,32 +18,29 @@ describe("DeleteForm", () => {
     state = rootStateFactory();
   });
 
-  it("correctly runs function to delete given nodes", () => {
+  it("correctly runs function to delete given nodes", async () => {
     const onSubmit = jest.fn();
     const nodes = [
       machineFactory({ system_id: "abc123" }),
       machineFactory({ system_id: "def456" }),
     ];
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <DeleteForm
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={nodes}
-              onSubmit={onSubmit}
-              processingCount={0}
-              redirectURL="/redirect"
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <DeleteForm
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={nodes}
+        onSubmit={onSubmit}
+        processingCount={0}
+        redirectURL="/redirect"
+        viewingDetails={false}
+      />,
+      { store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete 2 machines" })
+    );
     expect(onSubmit).toHaveBeenCalledWith(
       {},
       expect.objectContaining({ resetForm: expect.any(Function) })
@@ -58,29 +51,24 @@ describe("DeleteForm", () => {
     const nodes = [machineFactory({ system_id: "abc123" })];
     const store = mockStore(state);
     const Proxy = ({ processingCount }: { processingCount: number }) => (
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <DeleteForm
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={nodes}
-              onSubmit={jest.fn()}
-              processingCount={processingCount}
-              redirectURL="/redirect"
-              viewingDetails
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+      <DeleteForm
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={nodes}
+        onSubmit={jest.fn()}
+        processingCount={processingCount}
+        redirectURL="/redirect"
+        viewingDetails
+      />
     );
-    const wrapper = mount(<Proxy processingCount={1} />);
+    const { rerender } = renderWithBrowserRouter(
+      <Proxy processingCount={1} />,
+      { route: "/", store }
+    );
 
-    wrapper.setProps({ processingCount: 0 });
-    wrapper.update();
-    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
-      "/redirect"
-    );
+    rerender(<Proxy processingCount={0} />);
+
+    expect(window.location.pathname).toBe("/redirect");
   });
 
   it("does not redirect from details view if there are errors", () => {
@@ -93,27 +81,23 @@ describe("DeleteForm", () => {
       errors: string | null;
       processingCount: number;
     }) => (
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
-          <CompatRouter>
-            <DeleteForm
-              clearSidePanelContent={jest.fn()}
-              errors={errors}
-              modelName="machine"
-              nodes={nodes}
-              onSubmit={jest.fn()}
-              processingCount={processingCount}
-              redirectURL="/redirect"
-              viewingDetails
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+      <DeleteForm
+        clearSidePanelContent={jest.fn()}
+        errors={errors}
+        modelName="machine"
+        nodes={nodes}
+        onSubmit={jest.fn()}
+        processingCount={processingCount}
+        redirectURL="/redirect"
+        viewingDetails
+      />
     );
-    const wrapper = mount(<Proxy errors={null} processingCount={1} />);
+    const { rerender } = renderWithBrowserRouter(
+      <Proxy errors={null} processingCount={1} />,
+      { route: "/", store }
+    );
 
-    wrapper.setProps({ errors: "It didn't work", processingCount: 0 });
-    wrapper.update();
-    expect(wrapper.find(Router).prop("history").location.pathname).toBe("/");
+    rerender(<Proxy errors={"It didn't work"} processingCount={0} />);
+    expect(window.location.pathname).toBe("/");
   });
 });

--- a/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
+++ b/src/app/base/components/node/DeleteForm/DeleteForm.test.tsx
@@ -3,11 +3,13 @@ import configureStore from "redux-mock-store";
 import DeleteForm from "./DeleteForm";
 
 import type { RootState } from "app/store/root/types";
+import { machine as machineFactory } from "testing/factories";
 import {
-  machine as machineFactory,
-  rootState as rootStateFactory,
-} from "testing/factories";
-import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
+  getTestState,
+  renderWithBrowserRouter,
+  screen,
+  userEvent,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 
@@ -15,7 +17,7 @@ describe("DeleteForm", () => {
   let state: RootState;
 
   beforeEach(() => {
-    state = rootStateFactory();
+    state = getTestState();
   });
 
   it("correctly runs function to delete given nodes", async () => {

--- a/src/app/base/components/node/DiskBootStatus/DiskBootStatus.test.tsx
+++ b/src/app/base/components/node/DiskBootStatus/DiskBootStatus.test.tsx
@@ -1,29 +1,30 @@
-import { mount } from "enzyme";
-
 import DiskBootStatus from "./DiskBootStatus";
 
 import { DiskTypes } from "app/store/types/enum";
 import { nodeDisk as diskFactory } from "testing/factories";
+import { render, screen } from "testing/utils";
 
 describe("DiskBootStatus", () => {
   it("shows boot status for boot disks", () => {
     const disk = diskFactory({ is_boot: true, type: DiskTypes.PHYSICAL });
-    const wrapper = mount(<DiskBootStatus disk={disk} />);
+    render(<DiskBootStatus disk={disk} />);
 
-    expect(wrapper.find("Icon").prop("name")).toBe("tick");
+    const icon = screen.getByLabelText("Boot disk");
+    expect(icon).toHaveClass("p-icon--tick");
   });
 
   it("shows boot status for non-boot disks", () => {
     const disk = diskFactory({ is_boot: false, type: DiskTypes.PHYSICAL });
-    const wrapper = mount(<DiskBootStatus disk={disk} />);
+    render(<DiskBootStatus disk={disk} />);
 
-    expect(wrapper.find("Icon").prop("name")).toBe("close");
+    const icon = screen.getByLabelText("Non-boot disk");
+    expect(icon).toHaveClass("p-icon--close");
   });
 
   it("shows boot status for non-physical disks", () => {
     const disk = diskFactory({ is_boot: false, type: DiskTypes.VIRTUAL });
-    const wrapper = mount(<DiskBootStatus disk={disk} />);
+    render(<DiskBootStatus disk={disk} />);
 
-    expect(wrapper.find("span").text()).toBe("—");
+    expect(screen.getByText("—")).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/node/DiskBootStatus/DiskBootStatus.tsx
+++ b/src/app/base/components/node/DiskBootStatus/DiskBootStatus.tsx
@@ -7,7 +7,11 @@ type Props = { disk: Disk };
 
 const DiskBootStatus = ({ disk }: Props): JSX.Element => {
   if (disk.type === DiskTypes.PHYSICAL) {
-    return disk.is_boot ? <Icon name="tick" /> : <Icon name="close" />;
+    return disk.is_boot ? (
+      <Icon aria-label="Boot disk" name="tick" />
+    ) : (
+      <Icon aria-label="Non-boot disk" name="close" />
+    );
   }
   return <span>—</span>;
 };

--- a/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
+++ b/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
@@ -1,7 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FieldlessForm from "./FieldlessForm";
@@ -15,13 +11,13 @@ import {
   machineStatus as machineStatusFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { submitFormikForm } from "testing/utils";
+import { screen, renderWithBrowserRouter, userEvent } from "testing/utils";
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
   usePrevious: jest.fn(),
 }));
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("FieldlessForm", () => {
   let state: RootState;
@@ -51,58 +47,46 @@ describe("FieldlessForm", () => {
     jest.restoreAllMocks();
   });
 
-  it("can unset the selected action", () => {
+  it("can unset the selected action", async () => {
     const store = mockStore(state);
     const clearSidePanelContent = jest.fn();
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.ON}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={clearSidePanelContent}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.ON}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={clearSidePanelContent}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
-    wrapper.find('[data-testid="cancel-action"] button').simulate("click");
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(clearSidePanelContent).toHaveBeenCalled();
   });
 
-  it("can dispatch abort action on given machines", () => {
+  it("can dispatch abort action on given machines", async () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.ABORT}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.ABORT}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Abort actions for machine" })
+    );
     expect(
       store.getActions().filter(({ type }) => type === "machine/abort")
     ).toStrictEqual([
@@ -123,30 +107,25 @@ describe("FieldlessForm", () => {
     ]);
   });
 
-  it("can dispatch acquire action on given machines", () => {
+  it("can dispatch acquire action on given machines", async () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.ACQUIRE}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.ACQUIRE}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Allocate machine" })
+    );
     expect(
       store.getActions().filter(({ type }) => type === "machine/acquire")
     ).toStrictEqual([
@@ -167,30 +146,25 @@ describe("FieldlessForm", () => {
     ]);
   });
 
-  it("can dispatch exit rescue mode action on given machines", () => {
+  it("can dispatch exit rescue mode action on given machines", async () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.EXIT_RESCUE_MODE}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.EXIT_RESCUE_MODE}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Exit rescue mode for machine" })
+    );
     expect(
       store.getActions().filter(({ type }) => type === "machine/exitRescueMode")
     ).toStrictEqual([
@@ -211,30 +185,23 @@ describe("FieldlessForm", () => {
     ]);
   });
 
-  it("can dispatch lock action on given machines", () => {
+  it("can dispatch lock action on given machines", async () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.LOCK}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.LOCK}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(screen.getByRole("button", { name: "Lock machine" }));
     expect(
       store.getActions().filter(({ type }) => type === "machine/lock")
     ).toStrictEqual([
@@ -255,30 +222,25 @@ describe("FieldlessForm", () => {
     ]);
   });
 
-  it("can dispatch mark fixed action on given machines", () => {
+  it("can dispatch mark fixed action on given machines", async () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.MARK_FIXED}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.MARK_FIXED}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Mark machine fixed" })
+    );
     expect(
       store.getActions().filter(({ type }) => type === "machine/markFixed")
     ).toStrictEqual([
@@ -299,30 +261,25 @@ describe("FieldlessForm", () => {
     ]);
   });
 
-  it("can dispatch power off action on given machines", () => {
+  it("can dispatch power off action on given machines", async () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.OFF}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.OFF}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machine", store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Power off machine" })
+    );
     expect(
       store.getActions().filter(({ type }) => type === "machine/off")
     ).toStrictEqual([
@@ -343,30 +300,25 @@ describe("FieldlessForm", () => {
     ]);
   });
 
-  it("can dispatch power on action on given machines", () => {
+  it("can dispatch power on action on given machines", async () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.ON}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.ON}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Power on machine" })
+    );
     expect(
       store.getActions().filter(({ type }) => type === "machine/on")
     ).toStrictEqual([
@@ -387,30 +339,25 @@ describe("FieldlessForm", () => {
     ]);
   });
 
-  it("can dispatch unlock action on given machines", () => {
+  it("can dispatch unlock action on given machines", async () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <FieldlessForm
-              action={NodeActions.UNLOCK}
-              actions={machineActions}
-              cleanup={machineActions.cleanup}
-              clearSidePanelContent={jest.fn()}
-              modelName="machine"
-              nodes={[state.machine.items[0]]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <FieldlessForm
+        action={NodeActions.UNLOCK}
+        actions={machineActions}
+        cleanup={machineActions.cleanup}
+        clearSidePanelContent={jest.fn()}
+        modelName="machine"
+        nodes={[state.machine.items[0]]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
 
-    submitFormikForm(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Unlock machine" })
+    );
     expect(
       store.getActions().filter(({ type }) => type === "machine/unlock")
     ).toStrictEqual([

--- a/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
+++ b/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
@@ -6,11 +6,12 @@ import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
-  screen,
-  renderWithBrowserRouter,
-  userEvent,
-  getTestState,
-} from "testing/utils";
+  machine as machineFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  rootState as rootStateFactory,
+} from "testing/factories";
+import { screen, renderWithBrowserRouter, userEvent } from "testing/utils";
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
   usePrevious: jest.fn(),
@@ -22,7 +23,20 @@ describe("FieldlessForm", () => {
   let state: RootState;
 
   beforeEach(() => {
-    state = getTestState();
+    state = rootStateFactory({
+      machine: machineStateFactory({
+        loaded: true,
+        items: [
+          machineFactory({
+            system_id: "abc123",
+          }),
+        ],
+        selected: [],
+        statuses: {
+          abc123: machineStatusFactory(),
+        },
+      }),
+    });
   });
 
   afterEach(() => {

--- a/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
+++ b/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
@@ -6,12 +6,11 @@ import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
-  machine as machineFactory,
-  machineState as machineStateFactory,
-  machineStatus as machineStatusFactory,
-  rootState as rootStateFactory,
-} from "testing/factories";
-import { screen, renderWithBrowserRouter, userEvent } from "testing/utils";
+  screen,
+  renderWithBrowserRouter,
+  userEvent,
+  getTestState,
+} from "testing/utils";
 
 jest.mock("@canonical/react-components/dist/hooks", () => ({
   usePrevious: jest.fn(),
@@ -23,20 +22,7 @@ describe("FieldlessForm", () => {
   let state: RootState;
 
   beforeEach(() => {
-    state = rootStateFactory({
-      machine: machineStateFactory({
-        loaded: true,
-        items: [
-          machineFactory({
-            system_id: "abc123",
-          }),
-        ],
-        selected: [],
-        statuses: {
-          abc123: machineStatusFactory(),
-        },
-      }),
-    });
+    state = getTestState();
   });
 
   afterEach(() => {

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -23,9 +23,6 @@ import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
   generalState as generalStateFactory,
-  machineState as machineStateFactory,
-  machineStatus as machineStatusFactory,
-  machine as machineFactory,
   podDetails as podDetailsFactory,
   podState as podStateFactory,
   podStatus as podStatusFactory,
@@ -255,18 +252,6 @@ export const getTestState = (): RootState => {
         data: [powerTypeFactory()],
         loaded: true,
       }),
-    }),
-    machine: machineStateFactory({
-      loaded: true,
-      items: [
-        machineFactory({
-          system_id: "abc123",
-        }),
-      ],
-      selected: [],
-      statuses: {
-        abc123: machineStatusFactory(),
-      },
     }),
     pod: podStateFactory({
       items: [pod],

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -23,6 +23,9 @@ import {
   fabric as fabricFactory,
   fabricState as fabricStateFactory,
   generalState as generalStateFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machine as machineFactory,
   podDetails as podDetailsFactory,
   podState as podStateFactory,
   podStatus as podStatusFactory,
@@ -252,6 +255,18 @@ export const getTestState = (): RootState => {
         data: [powerTypeFactory()],
         loaded: true,
       }),
+    }),
+    machine: machineStateFactory({
+      loaded: true,
+      items: [
+        machineFactory({
+          system_id: "abc123",
+        }),
+      ],
+      selected: [],
+      statuses: {
+        abc123: machineStatusFactory(),
+      },
     }),
     pod: podStateFactory({
       items: [pod],


### PR DESCRIPTION
## Done

Migrated the following tests to RTL:
- src/app/base/components/node/ActionConfirm
- src/app/base/components/node/DeleteForm
- src/app/base/components/node/DiskBootStatus
- src/app/base/components/node/FieldlessForm