### PR TITLE
migrate CreteRaidFields to RTL MAASENG-1626

### DIFF
--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.test.tsx
@@ -1,14 +1,6 @@
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
-
 import CreateRaid from "../CreateRaid";
 
 import type { RootState } from "app/store/root/types";
-import { DiskTypes } from "app/store/types/enum";
 import {
   machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
@@ -18,8 +10,12 @@ import {
   nodePartition as partitionFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import {
+  renderWithBrowserRouter,
+  screen,
+  userEvent,
+  within,
+} from "testing/utils";
 
 describe("CreateRaidFields", () => {
   let state: RootState;
@@ -42,35 +38,20 @@ describe("CreateRaidFields", () => {
       disks,
       system_id: "abc123",
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <CreateRaid
-              closeForm={jest.fn()}
-              selected={disks}
-              systemId="abc123"
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />,
+      { state }
     );
 
-    // Select RAID 0
-    await act(async () => {
-      wrapper.find("FormikField[name='level'] select").simulate("change", {
-        target: { name: "level", value: DiskTypes.RAID_0 },
-      });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 0"
+    );
 
     // RAID 0s should not allow spare devices
-    expect(wrapper.find("[data-testid='max-spares']").exists()).toBe(false);
+    expect(screen.queryByTestId("max-spares")).not.toBeInTheDocument();
     // RAID 0 size is calculated as (minSize * numActive) = 1GB * 2 disks
-    expect(wrapper.find("Input[data-testid='raid-size']").prop("value")).toBe(
-      "2 GB"
-    );
+    expect(screen.getByTestId("raid-size")).toHaveValue("2 GB");
   });
 
   it("can handle RAID 1 devices", async () => {
@@ -83,37 +64,47 @@ describe("CreateRaidFields", () => {
       disks,
       system_id: "abc123",
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <CreateRaid
-              closeForm={jest.fn()}
-              selected={disks}
-              systemId="abc123"
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />,
+      { state }
     );
 
-    // Select RAID 1
-    await act(async () => {
-      wrapper.find("FormikField[name='level'] select").simulate("change", {
-        target: { name: "level", value: DiskTypes.RAID_1 },
-      });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 1"
+    );
 
     // RAID 1s allow spare devices, with a minimum of 2 active
-    expect(wrapper.find("[data-testid='max-spares']").text()).toBe(
+    expect(screen.getByTestId("max-spares").textContent).toBe("Spare (max 1)");
+    // RAID 1 size is calculated as (minSize) = 1GB
+    expect(screen.getByTestId("raid-size")).toHaveValue("1 GB");
+  });
+
+  it("can handle RAID 1 devices", async () => {
+    const disks = [
+      diskFactory({ available_size: 1000000000 }), // 1GB
+      diskFactory({ available_size: 1500000000 }), // 1.5GB
+      diskFactory({ available_size: 2000000000 }), // 2GB
+    ];
+    state.machine.items[0] = machineDetailsFactory({
+      disks,
+      system_id: "abc123",
+    });
+    renderWithBrowserRouter(
+      <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />,
+      { state }
+    );
+
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 1"
+    );
+    // RAID 1s allow spare devices, with a minimum of 2 active
+    expect(screen.queryByTestId("max-spares")).toHaveTextContent(
       "Spare (max 1)"
     );
     // RAID 1 size is calculated as (minSize) = 1GB
-    expect(wrapper.find("Input[data-testid='raid-size']").prop("value")).toBe(
-      "1 GB"
-    );
+    expect(screen.getByTestId("raid-size")).toHaveValue("1 GB");
   });
 
   it("can handle RAID 5 devices", async () => {
@@ -127,37 +118,22 @@ describe("CreateRaidFields", () => {
       disks,
       system_id: "abc123",
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <CreateRaid
-              closeForm={jest.fn()}
-              selected={disks}
-              systemId="abc123"
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />,
+      { state }
     );
 
-    // Select RAID 5
-    await act(async () => {
-      wrapper.find("FormikField[name='level'] select").simulate("change", {
-        target: { name: "level", value: DiskTypes.RAID_5 },
-      });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 5"
+    );
 
     // RAID 5s allow spare devices, with a minimum of 3 active
-    expect(wrapper.find("[data-testid='max-spares']").text()).toBe(
+    expect(screen.queryByTestId("max-spares")).toHaveTextContent(
       "Spare (max 1)"
     );
     // RAID 5 size is calculated as minSize * (numActive - 1) = 1GB * (4 - 1)
-    expect(wrapper.find("Input[data-testid='raid-size']").prop("value")).toBe(
-      "3 GB"
-    );
+    expect(screen.getByTestId("raid-size")).toHaveValue("3 GB");
   });
 
   it("can handle RAID 6 devices", async () => {
@@ -172,37 +148,22 @@ describe("CreateRaidFields", () => {
       disks,
       system_id: "abc123",
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <CreateRaid
-              closeForm={jest.fn()}
-              selected={disks}
-              systemId="abc123"
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />,
+      { state }
     );
 
-    // Select RAID 6
-    await act(async () => {
-      wrapper.find("FormikField[name='level'] select").simulate("change", {
-        target: { name: "level", value: DiskTypes.RAID_6 },
-      });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 6"
+    );
 
     // RAID 6s allow spare devices, with a minimum of 4 active
-    expect(wrapper.find("[data-testid='max-spares']").text()).toBe(
+    expect(screen.queryByTestId("max-spares")).toHaveTextContent(
       "Spare (max 1)"
     );
     // RAID 6 size is calculated as minSize * (numActive - 2) = 1GB * (5 - 2)
-    expect(wrapper.find("Input[data-testid='raid-size']").prop("value")).toBe(
-      "3 GB"
-    );
+    expect(screen.getByTestId("raid-size")).toHaveValue("3 GB");
   });
 
   it("can handle RAID 10 devices", async () => {
@@ -216,37 +177,22 @@ describe("CreateRaidFields", () => {
       disks,
       system_id: "abc123",
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <CreateRaid
-              closeForm={jest.fn()}
-              selected={disks}
-              systemId="abc123"
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CreateRaid closeForm={jest.fn()} selected={disks} systemId="abc123" />,
+      { state }
     );
 
-    // Select RAID 10
-    await act(async () => {
-      wrapper.find("FormikField[name='level'] select").simulate("change", {
-        target: { name: "level", value: DiskTypes.RAID_10 },
-      });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 10"
+    );
 
     // RAID 10s allow spare devices, with a minimum of 3 active
-    expect(wrapper.find("[data-testid='max-spares']").text()).toBe(
+    expect(screen.queryByTestId("max-spares")).toHaveTextContent(
       "Spare (max 1)"
     );
     // RAID 10 size is calculated as (minSize * numActive) / 2 = (1.5GB * 4) / 2
-    expect(wrapper.find("Input[data-testid='raid-size']").prop("value")).toBe(
-      "3 GB"
-    );
+    expect(screen.getByTestId("raid-size")).toHaveValue("3 GB");
   });
 
   it("can handle setting spare disks and partitions", async () => {
@@ -263,83 +209,56 @@ describe("CreateRaidFields", () => {
       disks,
       system_id: "abc123",
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <CreateRaid
-              closeForm={jest.fn()}
-              selected={[disks[0], disks[1], ...partitions]}
-              systemId="abc123"
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CreateRaid
+        closeForm={jest.fn()}
+        selected={[disks[0], disks[1], ...partitions]}
+        systemId="abc123"
+      />,
+      { state }
     );
     const isActive = (i: number) =>
-      wrapper
-        .find("[data-testid='active-status']")
-        .at(i)
-        .find("[data-testid='is-active']")
-        .exists();
-    const isDisabled = (i: number) =>
-      wrapper
-        .find("[data-testid='spare-storage-device'] input")
-        .at(i)
-        .prop("disabled");
+      within(screen.getAllByTestId("active-status")[i]).queryByTestId(
+        "is-active"
+      );
+    const getCheckbox = (i: number) =>
+      screen.getAllByTestId("spare-storage-device")[i].querySelector("input");
 
-    // Select RAID 1
-    await act(async () => {
-      wrapper.find("FormikField[name='level'] select").simulate("change", {
-        target: { name: "level", value: DiskTypes.RAID_1 },
-      });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 1"
+    );
 
     // RAID 1s allow spare devices, with a minimum of 2 active
-    expect(wrapper.find("[data-testid='max-spares']").text()).toBe(
+    expect(screen.queryByTestId("max-spares")).toHaveTextContent(
       "Spare (max 2)"
     );
 
     // None of the spare checkboxes should be disabled.
-    expect(isDisabled(0)).toBe(false);
-    expect(isDisabled(1)).toBe(false);
-    expect(isDisabled(2)).toBe(false);
-    expect(isDisabled(3)).toBe(false);
+    expect(getCheckbox(0)).not.toBeDisabled();
+    expect(getCheckbox(1)).not.toBeDisabled();
+    expect(getCheckbox(2)).not.toBeDisabled();
+    expect(getCheckbox(3)).not.toBeDisabled();
 
     // Check the spare checkboxes for the first disk and first partition
-    await act(async () => {
-      const diskId = `raid-${disks[0].type}-${disks[0].id}`;
-      const partitionId = `raid-${partitions[0].type}-${partitions[0].id}`;
-      wrapper.find(`Input[id='${diskId}'] input`).simulate("change", {
-        target: {
-          id: diskId,
-          value: "checked",
-        },
-      });
-      wrapper.find(`Input[id='${partitionId}'] input`).simulate("change", {
-        target: {
-          id: partitionId,
-          value: "checked",
-        },
-      });
-    });
-    wrapper.update();
+    const diskId = `raid-${disks[0].type}-${disks[0].id}`;
+    const partitionId = `raid-${partitions[0].type}-${partitions[0].id}`;
+    await userEvent.click(screen.getByTestId(diskId));
+    await userEvent.click(screen.getByTestId(partitionId));
 
     // First disk and partition should be spare, second disk and partition
     // should be active.
-    expect(isActive(0)).toBe(false);
-    expect(isActive(1)).toBe(true);
-    expect(isActive(2)).toBe(false);
-    expect(isActive(3)).toBe(true);
+    expect(isActive(0)).not.toBeInTheDocument();
+    expect(isActive(1)).toBeInTheDocument();
+    expect(isActive(2)).not.toBeInTheDocument();
+    expect(isActive(3)).toBeInTheDocument();
 
     // Should not be able to select any more spare devices, but should still
     // be able to unselect existing spares.
-    expect(isDisabled(0)).toBe(false);
-    expect(isDisabled(1)).toBe(true);
-    expect(isDisabled(2)).toBe(false);
-    expect(isDisabled(3)).toBe(true);
+    expect(getCheckbox(0)).not.toBeDisabled();
+    expect(getCheckbox(1)).toBeDisabled();
+    expect(getCheckbox(2)).not.toBeDisabled();
+    expect(getCheckbox(3)).toBeDisabled();
   });
 
   it("resets block/partition and spare block/partition values on RAID level change", async () => {
@@ -356,73 +275,47 @@ describe("CreateRaidFields", () => {
       disks,
       system_id: "abc123",
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter>
-          <CompatRouter>
-            <CreateRaid
-              closeForm={jest.fn()}
-              selected={[disks[0], disks[1], ...partitions]}
-              systemId="abc123"
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CreateRaid
+        closeForm={jest.fn()}
+        selected={[disks[0], disks[1], ...partitions]}
+        systemId="abc123"
+      />,
+      { state }
     );
     const isActive = (i: number) =>
-      wrapper
-        .find("[data-testid='active-status']")
-        .at(i)
-        .find("[data-testid='is-active']")
-        .exists();
+      within(screen.getAllByTestId("active-status")[i]).queryByTestId(
+        "is-active"
+      );
 
-    // Select RAID 1
-    await act(async () => {
-      wrapper.find("FormikField[name='level'] select").simulate("change", {
-        target: { name: "level", value: DiskTypes.RAID_1 },
-      });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 1"
+    );
 
     // Check the spare checkboxes for the first disk and first partition
-    await act(async () => {
-      const diskId = `raid-${disks[0].type}-${disks[0].id}`;
-      const partitionId = `raid-${partitions[0].type}-${partitions[0].id}`;
-      wrapper.find(`Input[id='${diskId}'] input`).simulate("change", {
-        target: {
-          id: diskId,
-          value: "checked",
-        },
-      });
-      wrapper.find(`Input[id='${partitionId}'] input`).simulate("change", {
-        target: {
-          id: partitionId,
-          value: "checked",
-        },
-      });
-    });
-    wrapper.update();
+    const diskId = `raid-${disks[0].type}-${disks[0].id}`;
+    const partitionId = `raid-${partitions[0].type}-${partitions[0].id}`;
+    await userEvent.click(screen.getByTestId(diskId));
+    await userEvent.click(screen.getByTestId(partitionId));
 
     // First disk and partition should be spare, second disk and partition
     // should be active
-    expect(isActive(0)).toBe(false);
-    expect(isActive(1)).toBe(true);
-    expect(isActive(2)).toBe(false);
-    expect(isActive(3)).toBe(true);
+    expect(isActive(0)).not.toBeInTheDocument();
+    expect(isActive(1)).toBeInTheDocument();
+    expect(isActive(2)).not.toBeInTheDocument();
+    expect(isActive(3)).toBeInTheDocument();
 
     // Change to RAID 5
-    await act(async () => {
-      wrapper.find("FormikField[name='level'] select").simulate("change", {
-        target: { name: "level", value: DiskTypes.RAID_5 },
-      });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByLabelText("RAID level"),
+      "RAID 5"
+    );
 
     // All should be reset to active.
-    expect(isActive(0)).toBe(true);
-    expect(isActive(1)).toBe(true);
-    expect(isActive(2)).toBe(true);
-    expect(isActive(3)).toBe(true);
+    expect(isActive(0)).toBeInTheDocument();
+    expect(isActive(1)).toBeInTheDocument();
+    expect(isActive(2)).toBeInTheDocument();
+    expect(isActive(3)).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateRaid/CreateRaidFields/CreateRaidFields.tsx
@@ -205,6 +205,7 @@ export const CreateRaidFields = ({
                         <td data-testid="spare-storage-device">
                           <Input
                             checked={isSpareDevice}
+                            data-testid={id}
                             disabled={!isSpareDevice && numSpare >= maxSpares}
                             id={id}
                             label=" "


### PR DESCRIPTION
## Done

- migrate CreteRaidFields to RTL MAASENG-1626

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: MAASENG-1626

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
