### PR TITLE
test: Migrate NetworkTableActions.test to RTL MAASENG-1619

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -1,5 +1,3 @@
-import configureStore from "redux-mock-store";
-
 import NetworkTableActions from "./NetworkTableActions";
 
 import { ExpandedState } from "app/base/components/NodeNetworkTab/NodeNetworkTab";
@@ -18,8 +16,6 @@ import {
   vlan as vlanFactory,
 } from "testing/factories";
 import { renderWithMockStore, screen, userEvent } from "testing/utils";
-
-const mockStore = configureStore<RootState>();
 
 const openMenu = async () => {
   await userEvent.click(screen.getByRole("button", { name: "Take action:" }));
@@ -44,14 +40,13 @@ describe("NetworkTableActions", () => {
   });
 
   it("can display the menu", () => {
-    const store = mockStore(state);
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     expect(
       screen.getByRole("button", { name: "Take action:" })
@@ -62,14 +57,14 @@ describe("NetworkTableActions", () => {
     state.machine.items[0].permissions = [];
     state.machine.items[0].status = NodeStatus.NEW;
     nic.type = NetworkInterfaceTypes.VLAN;
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     expect(screen.getByRole("button", { name: "Take action:" })).toBeDisabled();
   });
@@ -77,14 +72,14 @@ describe("NetworkTableActions", () => {
   it("can display an item to mark an interface as connected", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.link_connected = false;
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -97,14 +92,14 @@ describe("NetworkTableActions", () => {
   it("can display an item to mark an interface as disconnected", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.link_connected = true;
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -119,7 +114,7 @@ describe("NetworkTableActions", () => {
     nic.link_connected = false;
     const link = networkLinkFactory();
     nic.links = [networkLinkFactory(), link];
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         link={link}
@@ -127,7 +122,7 @@ describe("NetworkTableActions", () => {
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -141,7 +136,7 @@ describe("NetworkTableActions", () => {
     nic.link_connected = true;
     const link = networkLinkFactory();
     nic.links = [networkLinkFactory(), link];
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         link={link}
@@ -149,7 +144,7 @@ describe("NetworkTableActions", () => {
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -160,14 +155,14 @@ describe("NetworkTableActions", () => {
 
   it("can display an item to remove the interface", async () => {
     nic.type = NetworkInterfaceTypes.BOND;
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -179,14 +174,14 @@ describe("NetworkTableActions", () => {
   it("can display an item to edit the interface", async () => {
     nic.type = NetworkInterfaceTypes.BOND;
     const setExpanded = jest.fn();
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={setExpanded}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -205,14 +200,14 @@ describe("NetworkTableActions", () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.link_connected = false;
     const setExpanded = jest.fn();
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={setExpanded}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -230,14 +225,14 @@ describe("NetworkTableActions", () => {
   it("can display an action to add an alias", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.links = [networkLinkFactory()];
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -256,14 +251,14 @@ describe("NetworkTableActions", () => {
   it("can display a disabled action to add an alias", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.links = [networkLinkFactory({ mode: NetworkLinkMode.LINK_UP })];
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -286,14 +281,14 @@ describe("NetworkTableActions", () => {
     const vlan = vlanFactory({ fabric: fabric.id });
     state.vlan.items = [vlan];
     nic.vlan_id = vlan.id;
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -310,14 +305,14 @@ describe("NetworkTableActions", () => {
   it("can display a disabled action to add a VLAN", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     state.vlan.items = [];
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();
@@ -334,14 +329,14 @@ describe("NetworkTableActions", () => {
   it("can not display an action to add an alias or vlan", async () => {
     state.machine.items[0].permissions = [];
     state.machine.items[0].status = NodeStatus.NEW;
-    const store = mockStore(state);
+
     renderWithMockStore(
       <NetworkTableActions
         nic={nic}
         setExpanded={jest.fn()}
         systemId="abc123"
       />,
-      { store }
+      { state }
     );
     // Open the menu:
     await openMenu();

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx
@@ -1,5 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import NetworkTableActions from "./NetworkTableActions";
@@ -19,8 +17,13 @@ import {
   rootState as rootStateFactory,
   vlan as vlanFactory,
 } from "testing/factories";
+import { renderWithMockStore, screen, userEvent } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
+
+const openMenu = async () => {
+  await userEvent.click(screen.getByRole("button", { name: "Take action:" }));
+};
 
 describe("NetworkTableActions", () => {
   let nic: NetworkInterface;
@@ -42,17 +45,17 @@ describe("NetworkTableActions", () => {
 
   it("can display the menu", () => {
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
-    expect(wrapper.find("TableMenu").exists()).toBe(true);
-    expect(wrapper.find("TableMenu").prop("disabled")).toBe(false);
+    expect(
+      screen.getByRole("button", { name: "Take action:" })
+    ).toBeInTheDocument();
   });
 
   it("disables menu when networking is disabled and limited editing is not allowed", () => {
@@ -60,279 +63,223 @@ describe("NetworkTableActions", () => {
     state.machine.items[0].status = NodeStatus.NEW;
     nic.type = NetworkInterfaceTypes.VLAN;
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
-    expect(wrapper.find("TableMenu").prop("disabled")).toBe(true);
+    expect(screen.getByRole("button", { name: "Take action:" })).toBeDisabled();
   });
 
-  it("can display an item to mark an interface as connected", () => {
+  it("can display an item to mark an interface as connected", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.link_connected = false;
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
+    await openMenu();
+
     expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Mark as connected"
-        )
-        .exists()
-    ).toBe(true);
+      screen.getByRole("button", { name: "Mark as connected" })
+    ).toBeInTheDocument();
   });
 
-  it("can display an item to mark an interface as disconnected", () => {
+  it("can display an item to mark an interface as disconnected", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.link_connected = true;
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
+    await openMenu();
+
     expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Mark as disconnected"
-        )
-        .exists()
-    ).toBe(true);
+      screen.getByRole("button", { name: "Mark as disconnected" })
+    ).toBeInTheDocument();
   });
 
-  it("does not display an item to mark an alias as connected", () => {
+  it("does not display an item to mark an alias as connected", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.link_connected = false;
     const link = networkLinkFactory();
     nic.links = [networkLinkFactory(), link];
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          link={link}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        link={link}
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
+    await openMenu();
     expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Mark as connected"
-        )
-        .exists()
-    ).toBe(false);
+      screen.queryByRole("button", { name: "Mark as connected" })
+    ).not.toBeInTheDocument();
   });
 
-  it("does not display an item to mark an alias as disconnected", () => {
+  it("does not display an item to mark an alias as disconnected", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.link_connected = true;
     const link = networkLinkFactory();
     nic.links = [networkLinkFactory(), link];
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          link={link}
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        link={link}
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
+    await openMenu();
     expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Mark as disconnected"
-        )
-        .exists()
-    ).toBe(false);
+      screen.queryByRole("button", { name: "Mark as disconnected" })
+    ).not.toBeInTheDocument();
   });
 
-  it("can display an item to remove the interface", () => {
+  it("can display an item to remove the interface", async () => {
     nic.type = NetworkInterfaceTypes.BOND;
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
+    await openMenu();
     expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Remove Bond..."
-        )
-        .exists()
-    ).toBe(true);
+      screen.getByRole("button", { name: "Remove Bond..." })
+    ).toBeInTheDocument();
   });
 
-  it("can display an item to edit the interface", () => {
+  it("can display an item to edit the interface", async () => {
     nic.type = NetworkInterfaceTypes.BOND;
     const setExpanded = jest.fn();
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={setExpanded}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={setExpanded}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
-    const item = wrapper.findWhere(
-      (n) =>
-        n.type() === "button" &&
-        n.hasClass("p-contextual-menu__link") &&
-        n.text() === "Edit Bond"
-    );
-    expect(item.exists()).toBe(true);
-    item.simulate("click");
+    await openMenu();
+    const editBondButton = screen.getByRole("button", {
+      name: "Edit Bond",
+    });
+    expect(editBondButton).toBeInTheDocument();
+    await userEvent.click(editBondButton);
     expect(setExpanded).toHaveBeenCalledWith({
       content: ExpandedState.EDIT,
       nicId: nic.id,
     });
   });
 
-  it("can display a warning when trying to edit a disconnected interface", () => {
+  it("can display a warning when trying to edit a disconnected interface", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.link_connected = false;
     const setExpanded = jest.fn();
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={setExpanded}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={setExpanded}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
-    const item = wrapper.findWhere(
-      (n) =>
-        n.type() === "button" &&
-        n.hasClass("p-contextual-menu__link") &&
-        n.text() === "Edit Physical"
-    );
-    expect(item.exists()).toBe(true);
-    item.simulate("click");
+    await openMenu();
+    const editPhysicalButton = screen.getByRole("button", {
+      name: "Edit Physical",
+    });
+    expect(editPhysicalButton).toBeInTheDocument();
+    await userEvent.click(editPhysicalButton);
     expect(setExpanded).toHaveBeenCalledWith({
       content: ExpandedState.DISCONNECTED_WARNING,
       nicId: nic.id,
     });
   });
 
-  it("can display an action to add an alias", () => {
+  it("can display an action to add an alias", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.links = [networkLinkFactory()];
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
-    const addAlias = wrapper.findWhere(
-      (n) =>
-        n.type() === "button" &&
-        n.hasClass("p-contextual-menu__link") &&
-        n.text() === "Add alias"
-    );
-    expect(addAlias.exists()).toBe(true);
-    expect(addAlias.prop("disabled")).toBe(false);
-    expect(addAlias.find("Tooltip").exists()).toBe(false);
+    await openMenu();
+    const addAlias = screen.getByRole("button", {
+      name: "Add alias",
+    });
+    expect(addAlias).toBeInTheDocument();
+    expect(addAlias).not.toBeDisabled();
+    expect(
+      screen.queryByRole("tooltip", {
+        name: "IP mode needs to be configured for this interface.",
+      })
+    ).not.toBeInTheDocument();
   });
 
-  it("can display a disabled action to add an alias", () => {
+  it("can display a disabled action to add an alias", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     nic.links = [networkLinkFactory({ mode: NetworkLinkMode.LINK_UP })];
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
-    const addAlias = wrapper.findWhere(
-      (n) =>
-        n.type() === "button" &&
-        n.hasClass("p-contextual-menu__link") &&
-        n.text() === "Add alias"
-    );
-    expect(addAlias.exists()).toBe(true);
-    expect(addAlias.prop("disabled")).toBe(true);
-    expect(addAlias.find("Tooltip").exists()).toBe(true);
+    await openMenu();
+    const addAlias = screen.getByRole("button", {
+      name: "Add alias",
+    });
+    expect(addAlias).toBeInTheDocument();
+    expect(addAlias).toBeDisabled();
+    expect(
+      screen.getByRole("tooltip", {
+        name: "IP mode needs to be configured for this interface.",
+      })
+    ).toBeInTheDocument();
   });
 
-  it("can display an action to add a VLAN", () => {
+  it("can display an action to add a VLAN", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     const fabric = fabricFactory();
     state.fabric.items = [fabric];
@@ -340,91 +287,69 @@ describe("NetworkTableActions", () => {
     state.vlan.items = [vlan];
     nic.vlan_id = vlan.id;
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
-    const addVLAN = wrapper.findWhere(
-      (n) =>
-        n.type() === "button" &&
-        n.hasClass("p-contextual-menu__link") &&
-        n.text() === "Add VLAN"
-    );
-    expect(addVLAN.exists()).toBe(true);
-    expect(addVLAN.prop("disabled")).toBe(false);
-    expect(addVLAN.find("Tooltip").exists()).toBe(false);
+    await openMenu();
+    const addVLAN = screen.getByRole("button", { name: "Add VLAN" });
+    expect(addVLAN).toBeInTheDocument();
+    expect(addVLAN).not.toBeDisabled();
+    expect(
+      screen.queryByRole("tooltip", {
+        name: "There are no unused VLANS for this interface.",
+      })
+    ).not.toBeInTheDocument();
   });
 
-  it("can display a disabled action to add a VLAN", () => {
+  it("can display a disabled action to add a VLAN", async () => {
     nic.type = NetworkInterfaceTypes.PHYSICAL;
     state.vlan.items = [];
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
-    const addVLAN = wrapper.findWhere(
-      (n) =>
-        n.type() === "button" &&
-        n.hasClass("p-contextual-menu__link") &&
-        n.text() === "Add VLAN"
-    );
-    expect(addVLAN.exists()).toBe(true);
-    expect(addVLAN.prop("disabled")).toBe(true);
-    expect(addVLAN.find("Tooltip").exists()).toBe(true);
+    await openMenu();
+    const addVLAN = screen.getByRole("button", { name: "Add VLAN" });
+    expect(addVLAN).toBeInTheDocument();
+    expect(addVLAN).toBeDisabled();
+    expect(
+      screen.getByRole("tooltip", {
+        name: "There are no unused VLANS for this interface.",
+      })
+    ).toBeInTheDocument();
   });
 
-  it("can not display an action to add an alias or vlan", () => {
+  it("can not display an action to add an alias or vlan", async () => {
     state.machine.items[0].permissions = [];
     state.machine.items[0].status = NodeStatus.NEW;
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <NetworkTableActions
-          nic={nic}
-          setExpanded={jest.fn()}
-          systemId="abc123"
-        />
-      </Provider>
+    renderWithMockStore(
+      <NetworkTableActions
+        nic={nic}
+        setExpanded={jest.fn()}
+        systemId="abc123"
+      />,
+      { store }
     );
     // Open the menu:
-    wrapper.find("Button.p-contextual-menu__toggle").simulate("click");
-    wrapper.update();
+    await openMenu();
     expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Add alias"
-        )
-        .exists()
-    ).toBe(false);
+      screen.queryByRole("button", { name: "Add alias" })
+    ).not.toBeInTheDocument();
     expect(
-      wrapper
-        .findWhere(
-          (n) =>
-            n.type() === "button" &&
-            n.hasClass("p-contextual-menu__link") &&
-            n.text() === "Add VLAN"
-        )
-        .exists()
-    ).toBe(false);
+      screen.queryByRole("button", { name: "Add VLAN" })
+    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done

- Migrated src/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions.test.tsx to RTL

## Fixes

Fixes [MAASENG-1619](https://warthogs.atlassian.net/browse/MAASENG-1619)


[MAASENG-1619]: https://warthogs.atlassian.net/browse/MAASENG-1619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ