### PR TITLE
migrate machineNetworkActions tests to RTL

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx
@@ -42,7 +42,7 @@ describe("MachineNetworkActions", () => {
         />,
         { state, route: "/machine/abc123" }
       );
-      // expect(wrapper.find("Button").last().prop("disabled")).toBe(true);
+
       expect(
         screen.getByRole("button", { name: /Validate network configuration/i })
       ).toBeDisabled();

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx
@@ -1,8 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import configureStore from "redux-mock-store";
-
 import MachineNetworkActions from "./MachineNetworkActions";
 
 import { ExpandedState } from "app/base/components/NodeNetworkTab/NodeNetworkTab";
@@ -17,8 +12,7 @@ import {
   networkLink as networkLinkFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
 describe("MachineNetworkActions", () => {
   let state: RootState;
@@ -37,44 +31,40 @@ describe("MachineNetworkActions", () => {
   describe("validate network", () => {
     it("disables the button when networking is disabled", () => {
       state.machine.items[0].status = NodeStatus.DEPLOYED;
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
-      expect(wrapper.find("Button").last().prop("disabled")).toBe(true);
+      // expect(wrapper.find("Button").last().prop("disabled")).toBe(true);
+      expect(
+        screen.getByRole("button", { name: /Validate network configuration/i })
+      ).toBeDisabled();
     });
 
-    it("shows the test form when clicking the button", () => {
-      const store = mockStore(state);
+    it("shows the test form when clicking the button", async () => {
       const setSidePanelContent = jest.fn();
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={setSidePanelContent}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={setSidePanelContent}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
-      wrapper.find("Button").last().simulate("click");
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /Validate network configuration/i })
+      );
       expect(setSidePanelContent).toHaveBeenCalledWith({
         view: MachineHeaderViews.TEST_MACHINE,
         extras: { applyConfiguredNetworking: true },
@@ -83,7 +73,7 @@ describe("MachineNetworkActions", () => {
   });
 
   describe("create bond", () => {
-    it("sets the state to show the form when clicking the button", () => {
+    it("sets the state to show the form when clicking the button", async () => {
       state.machine.items = [
         machineDetailsFactory({
           interfaces: [
@@ -101,24 +91,23 @@ describe("MachineNetworkActions", () => {
           system_id: "abc123",
         }),
       ];
-      const store = mockStore(state);
       const setExpanded = jest.fn();
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[{ nicId: 1 }, { nicId: 2 }]}
-              setExpanded={setExpanded}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[{ nicId: 1 }, { nicId: 2 }]}
+          setExpanded={setExpanded}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
-      wrapper.find("Button[data-testid='addBond']").simulate("click");
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /Create bond/i })
+      );
+
       expect(setExpanded).toHaveBeenCalledWith({
         content: ExpandedState.ADD_BOND,
       });
@@ -126,56 +115,43 @@ describe("MachineNetworkActions", () => {
 
     it("disables the button when networking is disabled", () => {
       state.machine.items[0].status = NodeStatus.DEPLOYED;
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
       expect(
-        wrapper.find("Button[data-testid='addBond']").prop("disabled")
-      ).toBe(true);
-      expect(
-        wrapper.find("Tooltip[data-testid='addBond-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("button", { name: /Create bond/i })
+      ).toBeDisabled();
     });
 
     it("disables the button when no interfaces are selected", () => {
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
+
       expect(
-        wrapper.find("Button[data-testid='addBond']").prop("disabled")
-      ).toBe(true);
-      expect(
-        wrapper.find("Tooltip[data-testid='addBond-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("button", { name: /Create bond/i })
+      ).toBeDisabled();
+      screen
+        .getAllByRole("tooltip", { name: /no interfaces are selected/i })
+        .forEach((tooltip) => expect(tooltip).toBeInTheDocument());
     });
 
-    it("disables the button when only 1 interface is selected", () => {
+    it("disables the create bond button when only 1 interface is selected", () => {
       state.machine.items = [
         machineDetailsFactory({
           interfaces: [
@@ -191,28 +167,26 @@ describe("MachineNetworkActions", () => {
           system_id: "abc123",
         }),
       ];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[{ nicId: 1 }]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[{ nicId: 1 }]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
+
       expect(
-        wrapper.find("Button[data-testid='addBond']").prop("disabled")
-      ).toBe(true);
+        screen.getByRole("button", { name: /Create bond/i })
+      ).toBeDisabled();
       expect(
-        wrapper.find("Tooltip[data-testid='addBond-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("tooltip", {
+          name: /A bond must include more than one interface/i,
+        })
+      ).toBeInTheDocument();
     });
 
     it("disables the button when some selected interfaces are not physical", () => {
@@ -237,28 +211,26 @@ describe("MachineNetworkActions", () => {
           system_id: "abc123",
         }),
       ];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[{ nicId: 1, linkId: 2 }, { nicId: 2 }]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[{ nicId: 1, linkId: 2 }, { nicId: 2 }]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
+
       expect(
-        wrapper.find("Button[data-testid='addBond']").prop("disabled")
-      ).toBe(true);
+        screen.getByRole("button", { name: /Create bond/i })
+      ).toBeDisabled();
       expect(
-        wrapper.find("Tooltip[data-testid='addBond-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("tooltip", {
+          name: /A bond can only include physical interfaces/i,
+        })
+      ).toBeInTheDocument();
     });
 
     it("disables the button when selected interfaces have different VLANS", () => {
@@ -279,33 +251,31 @@ describe("MachineNetworkActions", () => {
           system_id: "abc123",
         }),
       ];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[{ nicId: 1, linkId: 2 }, { nicId: 2 }]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[{ nicId: 1, linkId: 2 }, { nicId: 2 }]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
+
       expect(
-        wrapper.find("Button[data-testid='addBond']").prop("disabled")
-      ).toBe(true);
+        screen.getByRole("button", { name: /Create bond/i })
+      ).toBeDisabled();
       expect(
-        wrapper.find("Tooltip[data-testid='addBond-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("tooltip", {
+          name: /All selected interfaces must be on the same VLAN/i,
+        })
+      ).toBeInTheDocument();
     });
   });
 
   describe("create bridge", () => {
-    it("sets the state to show the form when clicking the button", () => {
+    it("sets the state to show the form when clicking the button", async () => {
       state.machine.items = [
         machineDetailsFactory({
           interfaces: [
@@ -317,24 +287,22 @@ describe("MachineNetworkActions", () => {
           system_id: "abc123",
         }),
       ];
-      const store = mockStore(state);
       const setExpanded = jest.fn();
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[{ nicId: 1 }]}
-              setExpanded={setExpanded}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[{ nicId: 1 }]}
+          setExpanded={setExpanded}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
-      wrapper.find("Button[data-testid='addBridge']").simulate("click");
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /create bridge/i })
+      );
       expect(setExpanded).toHaveBeenCalledWith({
         content: ExpandedState.ADD_BRIDGE,
       });
@@ -342,53 +310,42 @@ describe("MachineNetworkActions", () => {
 
     it("disables the button when networking is disabled", () => {
       state.machine.items[0].status = NodeStatus.DEPLOYED;
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
       expect(
-        wrapper.find("Button[data-testid='addBridge']").prop("disabled")
-      ).toBe(true);
-      expect(
-        wrapper.find("Tooltip[data-testid='addBridge-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("button", { name: /create bridge/i })
+      ).toBeDisabled();
+      screen
+        .getAllByRole("tooltip", {
+          name: new RegExp("Network can't be modified for this machine.", "i"),
+        })
+        .forEach((tooltip) => expect(tooltip).toBeInTheDocument());
     });
 
     it("disables the button when no interfaces are selected", () => {
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
+
       expect(
-        wrapper.find("Button[data-testid='addBridge']").prop("disabled")
-      ).toBe(true);
-      expect(
-        wrapper.find("Tooltip[data-testid='addBridge-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("button", { name: /create bridge/i })
+      ).toBeDisabled();
     });
 
     it("disables the button when more than 1 interface is selected", () => {
@@ -407,28 +364,26 @@ describe("MachineNetworkActions", () => {
           system_id: "abc123",
         }),
       ];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[{ nicId: 1 }, { nicId: 2 }]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[{ nicId: 1 }, { nicId: 2 }]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
+
       expect(
-        wrapper.find("Button[data-testid='addBridge']").prop("disabled")
-      ).toBe(true);
+        screen.getByRole("button", { name: /create bridge/i })
+      ).toBeDisabled();
       expect(
-        wrapper.find("Tooltip[data-testid='addBridge-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("tooltip", {
+          name: /A bridge can only be created from one interface/i,
+        })
+      ).toBeInTheDocument();
     });
 
     it("disables the button when an alias is selected", () => {
@@ -453,28 +408,26 @@ describe("MachineNetworkActions", () => {
           system_id: "abc123",
         }),
       ];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[{ nicId: 1, linkId: 2 }]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[{ nicId: 1, linkId: 2 }]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
+
       expect(
-        wrapper.find("Button[data-testid='addBridge']").prop("disabled")
-      ).toBe(true);
+        screen.getByRole("button", { name: /create bridge/i })
+      ).toBeDisabled();
       expect(
-        wrapper.find("Tooltip[data-testid='addBridge-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("tooltip", {
+          name: /A bridge can not be created from an alias/i,
+        })
+      ).toBeInTheDocument();
     });
 
     it("disables the button when a bridge is selected", () => {
@@ -493,28 +446,26 @@ describe("MachineNetworkActions", () => {
           system_id: "abc123",
         }),
       ];
-      const store = mockStore(state);
-      const wrapper = mount(
-        <Provider store={store}>
-          <MemoryRouter
-            initialEntries={[{ pathname: "/machine/abc123", key: "testKey" }]}
-          >
-            <MachineNetworkActions
-              expanded={null}
-              selected={[{ nicId: 1 }, { nicId: 2 }]}
-              setExpanded={jest.fn()}
-              setSidePanelContent={jest.fn()}
-              systemId="abc123"
-            />
-          </MemoryRouter>
-        </Provider>
+
+      renderWithBrowserRouter(
+        <MachineNetworkActions
+          expanded={null}
+          selected={[{ nicId: 1 }, { nicId: 2 }]}
+          setExpanded={jest.fn()}
+          setSidePanelContent={jest.fn()}
+          systemId="abc123"
+        />,
+        { state, route: "/machine/abc123" }
       );
+
       expect(
-        wrapper.find("Button[data-testid='addBridge']").prop("disabled")
-      ).toBe(true);
+        screen.getByRole("button", { name: /create bridge/i })
+      ).toBeDisabled();
       expect(
-        wrapper.find("Tooltip[data-testid='addBridge-tooltip']").exists()
-      ).toBe(true);
+        screen.getByRole("tooltip", {
+          name: /A bridge can only be created from one interface/i,
+        })
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Done

- Migrated MachineNetworkActions tests to RTL

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- `yarn test src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx`

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
