### PR TITLE
migrate StatusColumn test to RTL MAASENG-1708

### DIFF
--- a/src/app/base/components/PowerIcon/PowerIcon.tsx
+++ b/src/app/base/components/PowerIcon/PowerIcon.tsx
@@ -44,7 +44,11 @@ const PowerIcon = ({
 
   return (
     <span>
-      <Icon className={iconClass} name={iconName} />
+      <Icon
+        aria-label={showSpinner ? "loading" : powerState}
+        className={iconClass}
+        name={iconName}
+      />
       {children}
     </span>
   );

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/StatusColumn/StatusColumn.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/StatusColumn/StatusColumn.test.tsx
@@ -1,8 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import configureStore from "redux-mock-store";
-
 import StatusColumn from "./StatusColumn";
 
 import { PowerState } from "app/store/types/enum";
@@ -15,28 +10,18 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+import { renderWithMockStore, screen } from "testing/utils";
 
-const mockStore = configureStore();
-
-describe("NameColumn", () => {
+describe("StatusColumn", () => {
   it("shows a spinner if the machine is still loading", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
-        >
-          <StatusColumn systemId="abc123" />
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithMockStore(<StatusColumn systemId="abc123" />, { state });
 
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
   });
 
   it("shows a spinner if the VM is in a transient state", () => {
@@ -50,18 +35,11 @@ describe("NameColumn", () => {
         ],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
-        >
-          <StatusColumn systemId="abc123" />
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithMockStore(<StatusColumn systemId="abc123" />, { state });
 
-    expect(wrapper.find("Icon").prop("name")).toBe("spinner");
+    const loadingIcon = screen.getByLabelText(/Loading/i);
+    expect(loadingIcon).toBeInTheDocument();
+    expect(loadingIcon).toHaveClass("u-animation--spin");
   });
 
   it("shows a power icon if the VM is not in a transient state", () => {
@@ -76,18 +54,11 @@ describe("NameColumn", () => {
         ],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
-        >
-          <StatusColumn systemId="abc123" />
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithMockStore(<StatusColumn systemId="abc123" />, { state });
 
-    expect(wrapper.find("Icon").prop("name")).toBe("power-off");
+    const offIcon = screen.getByLabelText(/off/i);
+    expect(offIcon).toBeInTheDocument();
+    expect(offIcon).toHaveClass("p-icon--power-off");
   });
 
   it("can show a VM's OS info", () => {
@@ -110,18 +81,9 @@ describe("NameColumn", () => {
         ],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/project", key: "testKey" }]}
-        >
-          <StatusColumn systemId="abc123" />
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithMockStore(<StatusColumn systemId="abc123" />, { state });
 
-    expect(wrapper.find("DoubleRow").prop("secondary")).toBe(
+    expect(screen.getByTestId("secondary").textContent).toBe(
       "Ubuntu 20.04 LTS"
     );
   });

--- a/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.tsx.snap
+++ b/src/app/machines/views/MachineList/MachineListTable/PowerColumn/__snapshots__/PowerColumn.test.tsx.snap
@@ -70,10 +70,12 @@ exports[`PowerColumn renders 1`] = `
             >
               <span>
                 <Icon
+                  aria-label="on"
                   className=""
                   name="power-on"
                 >
                   <i
+                    aria-label="on"
                     className="p-icon--power-on"
                   />
                 </Icon>


### PR DESCRIPTION
## Done

- migrate StatusColumn test to RTL MAASENG-1708

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1708

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
