### PR TITLE
test: fix long-running tests MAASENG-1712

### DIFF
--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -236,7 +236,6 @@ export const NodeActionMenuGroup = ({
         <span className="p-action-button--wrapper" key={i}>
           {menu}
         </span>
-        // <>{menu}</>
       ))}
       {singleNode &&
         nodes &&

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -32,12 +32,11 @@ import { screen, renderWithBrowserRouter, fireEvent } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 
-jest.useFakeTimers();
-
 describe("MachineList", () => {
   let state: RootState;
 
   beforeEach(() => {
+    jest.useFakeTimers();
     jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
     const machines = [
       machineFactory({
@@ -220,6 +219,7 @@ describe("MachineList", () => {
   afterEach(() => {
     localStorage.clear();
     jest.restoreAllMocks();
+    jest.useRealTimers();
   });
 
   it("can display an error", () => {
@@ -429,7 +429,6 @@ describe("MachineList", () => {
     );
     // Using fireEvent instead of userEvent here,
     // since using the latter seems to break every other test in this file
-
     // eslint-disable-next-line testing-library/prefer-user-event
     fireEvent.click(screen.getByRole("button", { name: "Next page" }));
     const expected = machineActions.fetch("123456", {


### PR DESCRIPTION


## Done

- test: fix long-running tests MAASENG-1712
  - remove leftover comment

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
