### PR TITLE
test: migrate kvm tests to RTL MAASENG-1742

### DIFF
--- a/src/app/kvm/components/StorageResources/StorageResources.tsx
+++ b/src/app/kvm/components/StorageResources/StorageResources.tsx
@@ -29,6 +29,7 @@ const StorageResources = ({
   return (
     <div
       className={classNames("storage-resources", { "single-pool": singlePool })}
+      data-testid="lxd-cluster-storage"
     >
       <div className="storage-resources__header">
         <h4 className="p-text--x-small-capitalised">Storage</h4>

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
@@ -24,10 +24,9 @@ describe("LXDClusterSummaryCard", () => {
         items: [vmClusterFactory({ id: 1 })],
       }),
     });
-    renderWithMockStore(
-      <LXDClusterSummaryCard clusterId={1} showStorage />,
-      { state }
-    );
+    renderWithMockStore(<LXDClusterSummaryCard clusterId={1} showStorage />, {
+      state,
+    });
 
     expect(screen.getByTestId("lxd-cluster-storage")).toBeInTheDocument();
   });
@@ -38,10 +37,9 @@ describe("LXDClusterSummaryCard", () => {
         loading: true,
       }),
     });
-    renderWithMockStore(
-      <LXDClusterSummaryCard clusterId={1} showStorage />,
-      { state }
-    );
+    renderWithMockStore(<LXDClusterSummaryCard clusterId={1} showStorage />, {
+      state,
+    });
 
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
   });

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
@@ -12,7 +12,7 @@ import {
   vmClusterState as vmClusterStateFactory,
   vmHost as vmHostFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, screen, within } from "testing/utils";
+import { renderWithMockStore, screen, within } from "testing/utils";
 
 describe("LXDClusterSummaryCard", () => {
   it("can show the section for storage", () => {

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.test.tsx
@@ -24,7 +24,7 @@ describe("LXDClusterSummaryCard", () => {
         items: [vmClusterFactory({ id: 1 })],
       }),
     });
-    renderWithBrowserRouter(
+    renderWithMockStore(
       <LXDClusterSummaryCard clusterId={1} showStorage />,
       { state }
     );
@@ -38,7 +38,7 @@ describe("LXDClusterSummaryCard", () => {
         loading: true,
       }),
     });
-    renderWithBrowserRouter(
+    renderWithMockStore(
       <LXDClusterSummaryCard clusterId={1} showStorage />,
       { state }
     );
@@ -55,7 +55,7 @@ describe("LXDClusterSummaryCard", () => {
         items: [vmClusterFactory({ id: 1 })],
       }),
     });
-    renderWithBrowserRouter(
+    renderWithMockStore(
       <LXDClusterSummaryCard clusterId={1} showStorage={false} />,
       { state }
     );
@@ -111,7 +111,7 @@ describe("LXDClusterSummaryCard", () => {
         ],
       }),
     });
-    renderWithBrowserRouter(<LXDClusterSummaryCard clusterId={1} />, { state });
+    renderWithMockStore(<LXDClusterSummaryCard clusterId={1} />, { state });
 
     const ifaceMeter = screen.getByTestId("iface-meter");
     expect(ifaceMeter).toBeInTheDocument();

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterSummaryCard/LXDClusterSummaryCard.tsx
@@ -81,7 +81,6 @@ const LXDClusterSummaryCard = ({
       {showStorage && (
         <StorageResources
           allocated={storage.allocated_tracked}
-          data-testid="lxd-cluster-storage"
           free={storage.free}
           other={storage.allocated_other}
           pools={storage_pools}

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.test.tsx
@@ -35,7 +35,7 @@ describe("AuthenticationCard", () => {
   it("shows a spinner if pod is not PodDetails type", () => {
     state.pod.items[0] = podFactory({ id: 1 });
     renderWithBrowserRouter(<AuthenticationCard hostId={pod.id} />, {
-      route: "/machines",
+      route: "/kvm/1/edit",
       state,
     });
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
@@ -43,7 +43,7 @@ describe("AuthenticationCard", () => {
 
   it("can open the update certificate form", async () => {
     renderWithBrowserRouter(<AuthenticationCard hostId={pod.id} />, {
-      route: "/machines",
+      route: "/kvm/1/edit",
       state,
     });
     expect(screen.queryByText("Update Certificate")).not.toBeInTheDocument();
@@ -63,7 +63,7 @@ describe("AuthenticationCard", () => {
     power_parameters.certificate = undefined;
     power_parameters.key = undefined;
     renderWithBrowserRouter(<AuthenticationCard hostId={pod.id} />, {
-      route: "/machines",
+      route: "/kvm/1/edit",
       state,
     });
 

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/AuthenticationCard.test.tsx
@@ -1,9 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
-
 import AuthenticationCard from "./AuthenticationCard";
 
 import { PodType } from "app/store/pod/constants";
@@ -17,7 +11,7 @@ import {
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-const mockStore = configureStore();
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
 describe("AuthenticationCard", () => {
   let state: RootState;
@@ -40,40 +34,27 @@ describe("AuthenticationCard", () => {
 
   it("shows a spinner if pod is not PodDetails type", () => {
     state.pod.items[0] = podFactory({ id: 1 });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <AuthenticationCard hostId={pod.id} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    renderWithBrowserRouter(<AuthenticationCard hostId={pod.id} />, {
+      route: "/machines",
+      state,
+    });
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
 
-  it("can open the update certificate form", () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <AuthenticationCard hostId={pod.id} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("UpdateCertificate").exists()).toBe(false);
+  it("can open the update certificate form", async () => {
+    renderWithBrowserRouter(<AuthenticationCard hostId={pod.id} />, {
+      route: "/machines",
+      state,
+    });
+    expect(screen.queryByText("Update Certificate")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("form", { name: "Update certificate" })
+    ).not.toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("show-update-certificate"));
 
-    wrapper
-      .find("Button[data-testid='show-update-certificate']")
-      .simulate("click");
-    expect(wrapper.find("UpdateCertificate").exists()).toBe(true);
+    expect(
+      screen.getByRole("form", { name: "Update certificate" })
+    ).toBeInTheDocument();
   });
 
   it("opens the update certificate form automatically if pod has no certificate", () => {
@@ -81,18 +62,13 @@ describe("AuthenticationCard", () => {
     const power_parameters = pod.power_parameters as PodPowerParameters;
     power_parameters.certificate = undefined;
     power_parameters.key = undefined;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/edit", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <AuthenticationCard hostId={pod.id} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("UpdateCertificate").exists()).toBe(true);
+    renderWithBrowserRouter(<AuthenticationCard hostId={pod.id} />, {
+      route: "/machines",
+      state,
+    });
+
+    expect(
+      screen.getByRole("form", { name: "Update certificate" })
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.tsx
@@ -78,6 +78,7 @@ const UpdateCertificate = ({
     <FormikForm<UpdateCertificateValues>
       allowAllEmpty={shouldGenerateCert}
       allowUnchanged={shouldGenerateCert}
+      aria-label="Update certificate"
       errors={podErrors}
       initialValues={{ certificate: "", key: "", password: "" }}
       onCancel={onCancel}


### PR DESCRIPTION
## Done

- test: migrate kvm tests to RTL MAASENG-1742

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1742

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
