### PR TITLE
test: add eslint-plugin-unused-imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  plugins: ["prettier"],
+  plugins: ["unused-imports", "prettier"],
   extends: [
     "react-app", // Use the recommended rules from CRA.
     "plugin:prettier/recommended", // Ensure this is last in the list.
@@ -42,11 +42,16 @@ module.exports = {
       },
       rules: {
         "prettier/prettier": "error",
-        "@typescript-eslint/no-unused-vars": [
-          "error",
+        "@typescript-eslint/no-unused-vars": "off",
+        "unused-imports/no-unused-imports": "error",
+        "unused-imports/no-unused-vars": [
+          "warn",
           {
-            args: "none",
+            vars: "all",
+            varsIgnorePattern: "^_",
+            args: "after-used",
             ignoreRestSiblings: true,
+            argsIgnorePattern: "^_",
           },
         ],
         "@typescript-eslint/consistent-type-imports": 2,

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "eslint-plugin-cypress": "2.12.1",
     "eslint-plugin-no-only-tests": "3.1.0",
     "eslint-plugin-prettier": "4.2.1",
+    "eslint-plugin-unused-imports": "2.0.0",
     "formik-devtools-extension": "0.1.8",
     "http-proxy-middleware": "2.0.6",
     "jest-fetch-mock": "3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6448,6 +6448,18 @@ eslint-plugin-testing-library@^5.0.1:
   dependencies:
     "@typescript-eslint/utils" "^5.13.0"
 
+eslint-plugin-unused-imports@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@5.1.1, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
## Done

- add eslint-plugin-unused-imports

## What this does

This will automatically remove unused imports on save or when running eslint with `--fix`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Checkout this branch locally
- Go to `App.tsx`
- Add `import { actions } from "app/store/user";` at the top of the file
- If you have autofix enabled on save in your code editor:
  - save the file and the import should be removed
- If you do not have autofix enabled in your code editor:
  - Run `yarn lint --fix` and once done the import should be removed

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
