### PR TITLE
test: Migrate 4 KVM/views tests to RTL MAASENG-1744

### DIFF
--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
@@ -1,14 +1,9 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import LXDClusterVMs from "./LXDClusterVMs";
 
 import urls from "app/base/urls";
-import LXDVMsTable from "app/kvm/components/LXDVMsTable";
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import {
@@ -22,66 +17,13 @@ import {
   machineStateListGroup as machineStateListGroupFactory,
   vmHost as vmHostFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter } from "testing/utils";
+import { renderWithBrowserRouter, screen } from "testing/utils";
 
 const mockStore = configureStore<RootState, {}>();
 
 describe("LXDClusterVMs", () => {
   beforeEach(() => {
     jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
-  });
-
-  it("can get resources for a cluster VM", () => {
-    const state = rootStateFactory({
-      vmcluster: vmClusterStateFactory({
-        items: [
-          vmClusterFactory({
-            id: 1,
-            virtual_machines: [
-              clusterVMFactory({
-                hugepages_backed: true,
-                pinned_cores: [2],
-                system_id: "abc123",
-                unpinned_cores: 3,
-              }),
-            ],
-          }),
-        ],
-        loaded: true,
-      }),
-    });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: urls.kvm.lxd.cluster.vms.index({ clusterId: 1 }),
-              key: "testKey",
-            },
-          ]}
-        >
-          <CompatRouter>
-            <LXDClusterVMs
-              clusterId={1}
-              searchFilter=""
-              setSearchFilter={jest.fn()}
-              setSidePanelContent={jest.fn()}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-
-    expect(
-      wrapper.find(LXDVMsTable).invoke("getResources")(
-        machineFactory({ system_id: "abc123" })
-      )
-    ).toStrictEqual({
-      hugepagesBacked: true,
-      pinnedCores: [2],
-      unpinnedCores: 3,
-    });
   });
 
   it("renders a link to a cluster's host's VM page", () => {
@@ -114,29 +56,17 @@ describe("LXDClusterVMs", () => {
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[
-            {
-              pathname: urls.kvm.lxd.cluster.vms.index({ clusterId: 1 }),
-              key: "testKey",
-            },
-          ]}
-        >
-          <CompatRouter>
-            <LXDClusterVMs
-              clusterId={1}
-              searchFilter=""
-              setSearchFilter={jest.fn()}
-              setSidePanelContent={jest.fn()}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <LXDClusterVMs
+        clusterId={1}
+        searchFilter=""
+        setSearchFilter={jest.fn()}
+        setSidePanelContent={jest.fn()}
+      />,
+      { route: urls.kvm.lxd.cluster.vms.index({ clusterId: 1 }), store }
     );
-
-    expect(wrapper.find("Link[data-testid='host-link']").prop("to")).toBe(
+    expect(screen.getByTestId("host-link")).toHaveAttribute(
+      "href",
       urls.kvm.lxd.cluster.vms.host({ clusterId: 1, hostId: 11 })
     );
   });
@@ -164,7 +94,7 @@ describe("LXDClusterVMs", () => {
         setSearchFilter={jest.fn()}
         setSidePanelContent={jest.fn()}
       />,
-      { store }
+      { route: urls.kvm.lxd.cluster.vms.index({ clusterId: 1 }), store }
     );
     const expected = machineActions.fetch("123456", {
       filter: { pod: ["host 1", "host 2"] },

--- a/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.test.tsx
@@ -1,9 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
-
 import VirshDetailsHeader from "./VirshDetailsHeader";
 
 import { PodType } from "app/store/pod/constants";
@@ -19,8 +13,7 @@ import {
   rootState as rootStateFactory,
   zone as zoneFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithBrowserRouter, screen } from "testing/utils";
 
 describe("VirshDetailsHeader", () => {
   let state: RootState;
@@ -48,46 +41,32 @@ describe("VirshDetailsHeader", () => {
     });
   });
 
-  it("displays a spinner if pod hasn't loaded", () => {
+  it("displays a spinner if pod has not loaded", () => {
     state.pod.items = [];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm/1", key: "testKey" }]}>
-          <CompatRouter>
-            <VirshDetailsHeader
-              id={1}
-              setSidePanelContent={jest.fn()}
-              sidePanelContent={null}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <VirshDetailsHeader
+        id={1}
+        setSidePanelContent={jest.fn()}
+        sidePanelContent={null}
+      />,
+      { route: "/kvm/1", state }
     );
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
   });
 
   it("displays the virsh power address", () => {
     state.pod.items[0].power_parameters = powerParametersFactory({
       power_address: "qemu+ssh://ubuntu@192.168.1.1/system",
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <VirshDetailsHeader
-              id={1}
-              setSidePanelContent={jest.fn()}
-              sidePanelContent={null}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <VirshDetailsHeader
+        id={1}
+        setSidePanelContent={jest.fn()}
+        sidePanelContent={null}
+      />,
+      { route: "/kvm/1/resources", state }
     );
-    expect(wrapper.find("[data-testid='block-subtitle']").at(0).text()).toBe(
+    expect(screen.getAllByTestId("block-subtitle")[0]).toHaveTextContent(
       "qemu+ssh://ubuntu@192.168.1.1/system"
     );
   });
@@ -96,47 +75,31 @@ describe("VirshDetailsHeader", () => {
     state.pod.items[0].resources = podResourcesFactory({
       vm_count: podVmCountFactory({ tracked: 5 }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <VirshDetailsHeader
-              id={1}
-              setSidePanelContent={jest.fn()}
-              sidePanelContent={null}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <VirshDetailsHeader
+        id={1}
+        setSidePanelContent={jest.fn()}
+        sidePanelContent={null}
+      />,
+      { route: "/kvm/1/resources", state }
     );
-    expect(wrapper.find("[data-testid='block-subtitle']").at(1).text()).toBe(
+    expect(screen.getAllByTestId("block-subtitle")[1]).toHaveTextContent(
       "5 available"
     );
   });
 
-  it("displays the pod's zone's name", () => {
+  it("displays the pod zone name", () => {
     state.zone.items = [zoneFactory({ id: 101, name: "danger" })];
     state.pod.items[0].zone = 101;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/1/resources", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <VirshDetailsHeader
-              id={1}
-              setSidePanelContent={jest.fn()}
-              sidePanelContent={null}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <VirshDetailsHeader
+        id={1}
+        setSidePanelContent={jest.fn()}
+        sidePanelContent={null}
+      />,
+      { route: "/kvm/1/resources", state }
     );
-    expect(wrapper.find("[data-testid='block-subtitle']").at(2).text()).toBe(
+    expect(screen.getAllByTestId("block-subtitle")[2]).toHaveTextContent(
       "danger"
     );
   });


### PR DESCRIPTION
## Done

Migrated the following tests to RTL:
```
8.0K	./src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.test.tsx
8.0K	./src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
8.0K	./src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/AuthenticationCard/UpdateCertificate/UpdateCertificate.test.tsx
8.0K	./src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.test.tsx
```

## Fixes

Fixes [MAASENG-1744](https://warthogs.atlassian.net/browse/MAASENG-1744)


[MAASENG-1744]: https://warthogs.atlassian.net/browse/MAASENG-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ