### PR TITLE
migrate 3 kvm tests to RTL MAASENG-1738

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -378,7 +378,7 @@ describe("GlobalSideNav", () => {
     expect(screen.getByRole("navigation")).toHaveClass("is-collapsed");
   });
 
-  it("persists collapsed state", () => {
+  it("persists collapsed state", async () => {
     state.user.auth.user = null;
     const { rerender } = renderWithBrowserRouter(<AppSideNavigation />, {
       route: "/",
@@ -386,7 +386,9 @@ describe("GlobalSideNav", () => {
     });
 
     const primaryNavigation = screen.getByRole("navigation");
-    screen.getByRole("button", { name: "expand main navigation" }).click();
+    await userEvent.click(
+      screen.getByRole("button", { name: "expand main navigation" })
+    );
     expect(primaryNavigation).toHaveClass("is-pinned");
     rerender(<AppSideNavigation />);
     expect(primaryNavigation).toHaveClass("is-pinned");

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -214,7 +214,9 @@ describe("DhcpFormFields", () => {
     await waitFor(() =>
       expect(screen.getByRole("grid")).toHaveAttribute("aria-busy", "false")
     );
-    within(screen.getByRole("grid")).getByText(machine.hostname).click();
+    await userEvent.click(
+      within(screen.getByRole("grid")).getByText(machine.hostname)
+    );
     expect(
       screen.getByRole("button", { name: new RegExp(machine.hostname, "i") })
     ).toHaveAccessibleDescription(Labels.AppliesTo);

--- a/src/app/base/components/SegmentedControl/SegmentedControl.test.tsx
+++ b/src/app/base/components/SegmentedControl/SegmentedControl.test.tsx
@@ -1,6 +1,6 @@
 import SegmentedControl from "./SegmentedControl";
 
-import { render, screen } from "testing/utils";
+import { render, screen, userEvent } from "testing/utils";
 
 const options = [
   {
@@ -44,7 +44,7 @@ it("selects the active option", () => {
   );
 });
 
-it("calls the callback when clicking a button", () => {
+it("calls the callback when clicking a button", async () => {
   const onSelect = jest.fn();
   render(
     <SegmentedControl
@@ -53,6 +53,6 @@ it("calls the callback when clicking a button", () => {
       selected="#00FF00"
     />
   );
-  screen.getByRole("tab", { name: "Blue" }).click();
+  await userEvent.click(screen.getByRole("tab", { name: "Blue" }));
   expect(onSelect).toHaveBeenCalledWith("#0000FF");
 });

--- a/src/app/base/components/TableActionsDropdown/TableActionsDropdown.test.tsx
+++ b/src/app/base/components/TableActionsDropdown/TableActionsDropdown.test.tsx
@@ -1,6 +1,6 @@
 import TableActionsDropdown from "./TableActionsDropdown";
 
-import { render, screen } from "testing/utils";
+import { render, screen, userEvent } from "testing/utils";
 
 describe("TableActionsDropdown", () => {
   it("can be explicitly disabled", () => {
@@ -23,7 +23,7 @@ describe("TableActionsDropdown", () => {
     expect(screen.getByRole("button")).toBeDisabled();
   });
 
-  it("can conditionally show actions", () => {
+  it("can conditionally show actions", async () => {
     render(
       <TableActionsDropdown
         actions={[
@@ -35,8 +35,7 @@ describe("TableActionsDropdown", () => {
       />
     );
     // Open menu
-    const button = screen.getByRole("button");
-    button.click();
+    await userEvent.click(screen.getByRole("button"));
 
     expect(
       screen.getByRole("button", { name: "Action 1" })
@@ -49,7 +48,7 @@ describe("TableActionsDropdown", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("runs click function with action type as argument", () => {
+  it("runs click function with action type as argument", async () => {
     const onActionClick = jest.fn();
     render(
       <TableActionsDropdown
@@ -58,11 +57,8 @@ describe("TableActionsDropdown", () => {
       />
     );
     // Open menu and click the actions
-    const button = screen.getByRole("button");
-    button.click();
-    const actionButton = screen.getByRole("button", { name: "Action 1" });
-    actionButton.click();
-
+    await userEvent.click(screen.getByRole("button"));
+    await userEvent.click(screen.getByRole("button", { name: "Action 1" }));
     expect(onActionClick).toHaveBeenCalledWith("action-1");
   });
 });

--- a/src/app/base/components/TableHeader/TableHeader.test.tsx
+++ b/src/app/base/components/TableHeader/TableHeader.test.tsx
@@ -4,7 +4,7 @@
 import TableHeader from "./TableHeader";
 
 import { SortDirection } from "app/base/types";
-import { render, screen } from "testing/utils";
+import { render, screen, userEvent } from "testing/utils";
 
 describe("TableHeader ", () => {
   it("renders a div if no onClick prop is present", () => {
@@ -13,12 +13,12 @@ describe("TableHeader ", () => {
     expect(container.querySelector("div")).toBeInTheDocument();
   });
 
-  it("renders a Button if onClick prop is present", () => {
+  it("renders a Button if onClick prop is present", async () => {
     const mockFn = jest.fn();
     render(<TableHeader onClick={mockFn}>Text</TableHeader>);
     expect(screen.getByRole("button")).toBeInTheDocument();
 
-    screen.getByRole("button").click();
+    await userEvent.click(screen.getByRole("button"));
     expect(mockFn).toHaveBeenCalled();
   });
 

--- a/src/app/base/components/TableHeader/TableHeader.tsx
+++ b/src/app/base/components/TableHeader/TableHeader.tsx
@@ -34,6 +34,7 @@ const TableHeader = ({
       <span>{children}</span>
       {currentSort && currentSort.key === sortKey && (
         <Icon
+          aria-label={`(${currentSort.direction})`}
           name={
             currentSort.direction === "ascending"
               ? "chevron-up"

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
@@ -620,7 +620,7 @@ describe("NetworkTable", () => {
       await userEvent.click(
         within(
           screen.getByRole("columnheader", { name: Label.Name })
-        ).getByRole("button", { name: Label.Name })
+        ).getByRole("button", { name: `${Label.Name} (descending)` })
       );
       const names = screen
         .getAllByRole("row")

--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.test.tsx
@@ -75,7 +75,9 @@ describe("ControllerListTable", () => {
       expect(rows[3]).toStrictEqual(screen.getByTestId("controller-c"));
 
       // Change sort to ascending FQDN
-      await userEvent.click(screen.getByRole("button", { name: "Name" }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Name (descending)" })
+      );
       rows = screen.getAllByRole("row");
       expect(rows[1]).toStrictEqual(screen.getByTestId("controller-c"));
       expect(rows[2]).toStrictEqual(screen.getByTestId("controller-b"));
@@ -115,7 +117,9 @@ describe("ControllerListTable", () => {
       expect(rows[3]).toStrictEqual(screen.getByTestId("controller-c"));
 
       // Change sort to ascending version
-      await userEvent.click(screen.getByRole("button", { name: "Version" }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Version (descending)" })
+      );
 
       rows = screen.getAllByRole("row");
       expect(rows[1]).toStrictEqual(screen.getByTestId("controller-c"));

--- a/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.test.tsx
+++ b/src/app/devices/views/DeviceList/DeviceListHeader/DeviceListHeader.test.tsx
@@ -9,7 +9,7 @@ import {
   deviceState as deviceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, screen } from "testing/utils";
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
 describe("DeviceListHeader", () => {
   let state: RootState;
@@ -67,7 +67,7 @@ describe("DeviceListHeader", () => {
     expect(screen.getByTestId("add-device-button")).toBeDisabled();
   });
 
-  it("can open the add device form", () => {
+  it("can open the add device form", async () => {
     const setSidePanelContent = jest.fn();
     renderWithBrowserRouter(
       <MemoryRouter>
@@ -79,7 +79,7 @@ describe("DeviceListHeader", () => {
       </MemoryRouter>,
       { state }
     );
-    screen.getByTestId("add-device-button").click();
+    await userEvent.click(screen.getByTestId("add-device-button"));
     expect(setSidePanelContent).toHaveBeenCalledWith({
       view: DeviceHeaderViews.ADD_DEVICE,
     });

--- a/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.test.tsx
+++ b/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.test.tsx
@@ -109,7 +109,9 @@ describe("DeviceListTable", () => {
       expect(getRowTestId(3)).toBe("device-c");
 
       // Change sort to ascending FQDN
-      await userEvent.click(screen.getByRole("button", { name: "FQDN" }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "FQDN (descending)" })
+      );
       expect(getRowTestId(1)).toBe("device-c");
       expect(getRowTestId(2)).toBe("device-b");
       expect(getRowTestId(3)).toBe("device-a");
@@ -149,7 +151,7 @@ describe("DeviceListTable", () => {
 
       // Change sort to ascending IP assignment
       await userEvent.click(
-        screen.getByRole("button", { name: "IP assignment" })
+        screen.getByRole("button", { name: "IP assignment (descending)" })
       );
       expect(getRowTestId(1)).toBe("device-c");
       expect(getRowTestId(2)).toBe("device-b");
@@ -178,7 +180,9 @@ describe("DeviceListTable", () => {
       expect(getRowTestId(3)).toBe("device-c");
 
       // Change sort to ascending zone name
-      await userEvent.click(screen.getByRole("button", { name: "Zone" }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Zone (descending)" })
+      );
       expect(getRowTestId(1)).toBe("device-c");
       expect(getRowTestId(2)).toBe("device-b");
       expect(getRowTestId(3)).toBe("device-a");
@@ -206,7 +210,9 @@ describe("DeviceListTable", () => {
       expect(getRowTestId(3)).toBe("device-c");
 
       // Change sort to ascending owner
-      await userEvent.click(screen.getByRole("button", { name: "Owner" }));
+      await userEvent.click(
+        screen.getByRole("button", { name: "Owner (descending)" })
+      );
       expect(getRowTestId(1)).toBe("device-c");
       expect(getRowTestId(2)).toBe("device-b");
       expect(getRowTestId(3)).toBe("device-a");

--- a/src/app/kvm/views/KVMList/KVMList.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMList.test.tsx
@@ -96,6 +96,7 @@ describe("KVMList", () => {
     });
 
     expect(document.title).toEqual(expect.stringContaining("LXD"));
+    expect(window.location.pathname).toEqual(urls.kvm.lxd.index);
   });
 
   it("displays a message if there are no LXD KVMs", () => {

--- a/src/app/kvm/views/KVMList/KVMList.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMList.test.tsx
@@ -1,14 +1,10 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { Router } from "react-router";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import KVMList from "./KVMList";
 
 import urls from "app/base/urls";
 import { PodType } from "app/store/pod/constants";
+import type { RootState } from "app/store/root/types";
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -16,22 +12,18 @@ import {
   vmCluster as vmClusterFactory,
   vmClusterState as vmClusterStateFactory,
 } from "testing/factories";
+import { renderWithBrowserRouter, screen } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("KVMList", () => {
   it("correctly fetches the necessary data", () => {
     const state = rootStateFactory();
     const store = mockStore(state);
-    mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <CompatRouter>
-            <KVMList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<KVMList />, {
+      route: "/kvm",
+      store,
+    });
     const expectedActions = [
       "pod/fetch",
       "resourcepool/fetch",
@@ -53,19 +45,12 @@ describe("KVMList", () => {
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.lxd.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<KVMList />, {
+      route: urls.kvm.lxd.index,
+      store,
+    });
 
-    expect(wrapper.find("[data-testid='lxd-table']").exists()).toBe(true);
+    expect(screen.getByTestId("lxd-table")).toBeInTheDocument();
   });
 
   it("shows a LXD table when viewing the LXD tab and there are clusters", () => {
@@ -75,18 +60,12 @@ describe("KVMList", () => {
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.lxd.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("[data-testid='lxd-table']").exists()).toBe(true);
+    renderWithBrowserRouter(<KVMList />, {
+      route: urls.kvm.lxd.index,
+      store,
+    });
+
+    expect(screen.getByTestId("lxd-table")).toBeInTheDocument();
   });
 
   it("shows a virsh table when viewing the Virsh tab", () => {
@@ -96,42 +75,27 @@ describe("KVMList", () => {
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.virsh.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<KVMList />, {
+      route: urls.kvm.virsh.index,
+      store,
+    });
 
-    expect(wrapper.find("[data-testid='virsh-table']").exists()).toBe(true);
+    expect(screen.getByTestId("virsh-table")).toBeInTheDocument();
   });
 
-  it("redirects to the LXD tab if not already on a tab", () => {
+  it("redirects to the LXD tab if not already on a tab", async () => {
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [podFactory({ type: PodType.LXD })],
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
-      urls.kvm.lxd.index
-    );
+    renderWithBrowserRouter(<KVMList />, {
+      route: urls.kvm.index,
+      store,
+    });
+
+    expect(document.title).toEqual(expect.stringContaining("LXD"));
   });
 
   it("displays a message if there are no LXD KVMs", () => {
@@ -141,27 +105,23 @@ describe("KVMList", () => {
       }),
     });
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.lxd.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
-      urls.kvm.lxd.index
-    );
-    expect(wrapper.find("[data-testid='no-hosts']").exists()).toBe(true);
+    renderWithBrowserRouter(<KVMList />, {
+      route: urls.kvm.lxd.index,
+      store,
+    });
+
+    expect(document.title).toEqual(expect.stringContaining("LXD"));
+    expect(screen.getByTestId("no-hosts")).toBeInTheDocument();
     expect(
-      wrapper.find("[data-testid='no-hosts'] h4").text().includes("LXD")
-    ).toBe(true);
+      screen.getByRole("heading", {
+        name: /No LXD hosts available/i,
+      })
+    ).toBeInTheDocument();
     expect(
-      wrapper.find("[data-testid='no-hosts'] p").text().includes("LXD")
-    ).toBe(true);
+      screen.getByText(
+        /Select the Add LXD host button and add the LXD host to see hosts on this page./i
+      )
+    ).toBeInTheDocument();
   });
 
   it("displays a message if there are no Virsh KVMs", () => {
@@ -170,28 +130,23 @@ describe("KVMList", () => {
         items: [],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.virsh.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
-      urls.kvm.virsh.index
-    );
-    expect(wrapper.find("[data-testid='no-hosts']").exists()).toBe(true);
+    renderWithBrowserRouter(<KVMList />, {
+      route: urls.kvm.virsh.index,
+      state,
+    });
+
+    expect(document.title).toEqual(expect.stringContaining("Virsh"));
+    expect(screen.getByTestId("no-hosts")).toBeInTheDocument();
     expect(
-      wrapper.find("[data-testid='no-hosts'] h4").text().includes("Virsh")
-    ).toBe(true);
+      screen.getByRole("heading", {
+        name: /No Virsh hosts available/i,
+      })
+    ).toBeInTheDocument();
     expect(
-      wrapper.find("[data-testid='no-hosts'] p").text().includes("Virsh")
-    ).toBe(true);
+      screen.getByText(
+        /Select the Add Virsh host button and add the Virsh host to see hosts on this page./i
+      )
+    ).toBeInTheDocument();
   });
 
   it("displays a spinner when loading pods", () => {
@@ -200,22 +155,18 @@ describe("KVMList", () => {
         loading: true,
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: urls.kvm.index, key: "testKey" }]}
-        >
-          <CompatRouter>
-            <KVMList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find(Router).prop("history").location.pathname).toBe(
-      urls.kvm.lxd.index
-    );
-    expect(wrapper.find("[data-testid='no-hosts']").exists()).toBe(false);
-    expect(wrapper.find("Spinner").exists()).toBe(true);
+    renderWithBrowserRouter(<KVMList />, {
+      route: urls.kvm.index,
+      state,
+    });
+
+    expect(screen.queryByTestId("no-hosts")).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Loading.../i)).toHaveLength(2);
+    expect(
+      screen.queryByText(/No LXD hosts available/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/No Virsh hosts available/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -73,7 +74,7 @@ describe("KVMListHeader", () => {
     );
   });
 
-  it("can open the add LXD form at the LXD URL", () => {
+  it("can open the add LXD form at the LXD URL", async () => {
     const setSidePanelContent = jest.fn();
     const store = mockStore(state);
     render(
@@ -92,13 +93,13 @@ describe("KVMListHeader", () => {
       </Provider>
     );
     expect(screen.getByTestId("add-kvm")).toHaveTextContent("Add LXD host");
-    screen.getByTestId("add-kvm").click();
+    await userEvent.click(screen.getByTestId("add-kvm"));
     expect(setSidePanelContent).toHaveBeenCalledWith({
       view: KVMHeaderViews.ADD_LXD_HOST,
     });
   });
 
-  it("can open the add Virsh form at the Virsh URL", () => {
+  it("can open the add Virsh form at the Virsh URL", async () => {
     const setSidePanelContent = jest.fn();
     const store = mockStore(state);
     render(
@@ -117,7 +118,7 @@ describe("KVMListHeader", () => {
       </Provider>
     );
     expect(screen.getByTestId("add-kvm")).toHaveTextContent("Add Virsh host");
-    screen.getByTestId("add-kvm").click();
+    await userEvent.click(screen.getByTestId("add-kvm"));
     expect(setSidePanelContent).toHaveBeenCalledWith({
       view: KVMHeaderViews.ADD_VIRSH_HOST,
     });

--- a/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.test.tsx
+++ b/src/app/kvm/views/KVMList/LxdTable/LxdKVMHostTable/LxdKVMHostTable.test.tsx
@@ -1,9 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
-
 import { generateClusterRows, generateSingleHostRows } from "../LxdTable";
 
 import LxdKVMHostTable from "./LxdKVMHostTable";
@@ -19,11 +13,10 @@ import {
   vmHost as vmHostFactory,
   vmClusterState as vmClusterStateFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
 describe("LxdKVMHostTable", () => {
-  it("can update the LXD hosts sort order", () => {
+  it("can update the LXD hosts sort order", async () => {
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [
@@ -51,47 +44,38 @@ describe("LxdKVMHostTable", () => {
         ],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <CompatRouter>
-            <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />,
+      { route: "/kvm", state }
     );
     const getLxdVms = (rowNumber: number) =>
-      wrapper
-        .find("tbody TableRow")
-        .at(rowNumber)
-        .find("[data-testid='machines-count']");
+      screen.getAllByTestId("machines-count")[rowNumber];
 
     // Sorted ascending by name by default
-    expect(getLxdVms(0).text()).toBe("2");
-    expect(getLxdVms(1).text()).toBe("3");
-    expect(getLxdVms(2).text()).toBe("1");
+    expect(getLxdVms(0).textContent).toBe("2");
+    expect(getLxdVms(1).textContent).toBe("3");
+    expect(getLxdVms(2).textContent).toBe("1");
 
     // Change to sort ascending vms
-    wrapper.find("[data-testid='vms-header'] button").simulate("click");
-    expect(getLxdVms(0).text()).toBe("1");
-    expect(getLxdVms(1).text()).toBe("2");
-    expect(getLxdVms(2).text()).toBe("3");
+    await userEvent.click(screen.getByRole("button", { name: /VM s/i }));
+    expect(getLxdVms(0).textContent).toBe("1");
+    expect(getLxdVms(1).textContent).toBe("2");
+    expect(getLxdVms(2).textContent).toBe("3");
 
     // Change to descending vms
-    wrapper.find("[data-testid='vms-header'] button").simulate("click");
-    expect(getLxdVms(0).text()).toBe("3");
-    expect(getLxdVms(1).text()).toBe("2");
-    expect(getLxdVms(2).text()).toBe("1");
+    await userEvent.click(screen.getByRole("button", { name: /VM s/i }));
+    expect(getLxdVms(0).textContent).toBe("3");
+    expect(getLxdVms(1).textContent).toBe("2");
+    expect(getLxdVms(2).textContent).toBe("1");
 
     // Change to no sort
-    wrapper.find("[data-testid='vms-header'] button").simulate("click");
-    expect(getLxdVms(0).text()).toBe("3");
-    expect(getLxdVms(1).text()).toBe("1");
-    expect(getLxdVms(2).text()).toBe("2");
+    await userEvent.click(screen.getByRole("button", { name: /VM s/i }));
+    expect(getLxdVms(0).textContent).toBe("3");
+    expect(getLxdVms(1).textContent).toBe("1");
+    expect(getLxdVms(2).textContent).toBe("2");
   });
 
-  it("can update the LXD project sort order", () => {
+  it("can update the LXD project sort order", async () => {
     const state = rootStateFactory({
       pod: podStateFactory({
         items: [
@@ -114,39 +98,33 @@ describe("LxdKVMHostTable", () => {
         ],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <CompatRouter>
-            <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />,
+      { route: "/kvm", state }
     );
     const getLxdName = (rowNumber: number) =>
-      wrapper.find("tbody TableRow").at(rowNumber).find("[data-testid='name']");
+      screen.getAllByTestId("name")[rowNumber];
 
     // Sorted ascending by name by default
-    expect(getLxdName(0).text()).toBe("pod-1");
-    expect(getLxdName(1).text()).toBe("pod-2");
-    expect(getLxdName(2).text()).toBe("pod-3");
-    expect(getLxdName(3).text()).toBe("pod-4");
+    expect(getLxdName(0).textContent).toBe("pod-1");
+    expect(getLxdName(1).textContent).toBe("pod-2");
+    expect(getLxdName(2).textContent).toBe("pod-3");
+    expect(getLxdName(3).textContent).toBe("pod-4");
 
     // Change to sort descending by name. Groups themselves are not sorted so
     // only the LXD pods in each group should be sorted.
-    wrapper.find("[data-testid='name-header'] button").simulate("click");
-    expect(getLxdName(0).text()).toBe("pod-4");
-    expect(getLxdName(1).text()).toBe("pod-3");
-    expect(getLxdName(2).text()).toBe("pod-2");
-    expect(getLxdName(3).text()).toBe("pod-1");
+    await userEvent.click(screen.getByRole("button", { name: /Name/i }));
+    expect(getLxdName(0).textContent).toBe("pod-4");
+    expect(getLxdName(1).textContent).toBe("pod-3");
+    expect(getLxdName(2).textContent).toBe("pod-2");
+    expect(getLxdName(3).textContent).toBe("pod-1");
 
     // Change to no sort
-    wrapper.find("[data-testid='name-header'] button").simulate("click");
-    expect(getLxdName(0).text()).toBe("pod-2");
-    expect(getLxdName(1).text()).toBe("pod-1");
-    expect(getLxdName(2).text()).toBe("pod-3");
-    expect(getLxdName(3).text()).toBe("pod-4");
+    await userEvent.click(screen.getByRole("button", { name: /Name/i }));
+    expect(getLxdName(0).textContent).toBe("pod-2");
+    expect(getLxdName(1).textContent).toBe("pod-1");
+    expect(getLxdName(2).textContent).toBe("pod-3");
+    expect(getLxdName(3).textContent).toBe("pod-4");
   });
 
   it("can display a single host type", () => {
@@ -155,20 +133,12 @@ describe("LxdKVMHostTable", () => {
         items: [podFactory()],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <CompatRouter>
-            <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <LxdKVMHostTable rows={generateSingleHostRows(state.pod.items)} />,
+      { route: "/kvm", state }
     );
-    expect(wrapper.find("[data-testid='host-type']").text()).toBe(
-      "Single host"
-    );
-    expect(wrapper.find("[data-testid='hosts-count']").exists()).toBe(false);
+    expect(screen.getByTestId("host-type")).toHaveTextContent("Single host");
+    expect(screen.queryByTestId("hosts-count")).toBeNull();
   });
 
   it("can display a cluster host type", () => {
@@ -181,22 +151,11 @@ describe("LxdKVMHostTable", () => {
         ],
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={[{ pathname: "/kvm", key: "testKey" }]}>
-          <CompatRouter>
-            <LxdKVMHostTable
-              rows={generateClusterRows(state.vmcluster.items)}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <LxdKVMHostTable rows={generateClusterRows(state.vmcluster.items)} />,
+      { route: "/kvm", state }
     );
-    expect(wrapper.find("[data-testid='host-type']").text()).toBe("Cluster");
-    expect(wrapper.find("[data-testid='hosts-count']").exists()).toBe(true);
-    expect(wrapper.find("[data-testid='hosts-count']").text()).toBe(
-      "2 KVM hosts"
-    );
+    expect(screen.getByTestId("host-type")).toHaveTextContent("Cluster");
+    expect(screen.getByTestId("hosts-count")).toHaveTextContent("2 KVM hosts");
   });
 });

--- a/src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx
+++ b/src/app/kvm/views/KVMList/VirshTable/VirshTable.test.tsx
@@ -1,5 +1,3 @@
-import configureStore from "redux-mock-store";
-
 import VirshTable from "./VirshTable";
 
 import type { RootState } from "app/store/root/types";
@@ -13,8 +11,6 @@ import {
   zoneState as zoneStateFactory,
 } from "testing/factories";
 import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
-
-const mockStore = configureStore();
 
 describe("VirshTable", () => {
   let state: RootState;

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -213,7 +214,7 @@ describe("CloneResults", () => {
     expect(screen.getAllByTestId("error-row").length).toBe(2);
   });
 
-  it("can filter machines by error type", () => {
+  it("can filter machines by error type", async () => {
     const setSearchFilter = jest.fn();
     state.machine.eventErrors = [
       eventErrorFactory({
@@ -251,7 +252,7 @@ describe("CloneResults", () => {
         </MemoryRouter>
       </Provider>
     );
-    screen.getByTestId("error-filter-link").click();
+    await userEvent.click(screen.getByTestId("error-filter-link"));
     expect(setSearchFilter).toHaveBeenCalledWith("system_id:(def456,ghi789)");
   });
 

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
@@ -18,7 +18,7 @@ import {
   vlan as vlanFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen, within, waitFor } from "testing/utils";
+import { render, screen, within, waitFor, userEvent } from "testing/utils";
 
 const subnetId = 1;
 const getRootState = () => {
@@ -182,15 +182,13 @@ it("dispatches a delete action on submit", async () => {
   expect(
     screen.getByText(/Are you sure you want to delete this subnet?/)
   ).toBeInTheDocument();
-  screen.getByRole("button", { name: /Delete/i }).click();
+  await userEvent.click(screen.getByRole("button", { name: /Delete/i }));
 
-  await waitFor(() => {
-    const expectedAction = subnetActions.delete(subnetId);
-    const actualAction = store
-      .getActions()
-      .find((actualAction) => actualAction.type === expectedAction.type);
-    expect(actualAction).toStrictEqual(expectedAction);
-  });
+  const expectedAction = subnetActions.delete(subnetId);
+  const actualAction = store
+    .getActions()
+    .find((actualAction) => actualAction.type === expectedAction.type);
+  expect(actualAction).toStrictEqual(expectedAction);
 });
 
 it("redirects on save", async () => {

--- a/src/app/tags/views/TagList/TagListControls/TagListControls.test.tsx
+++ b/src/app/tags/views/TagList/TagListControls/TagListControls.test.tsx
@@ -11,7 +11,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { render, screen, userEvent } from "testing/utils";
 
 const mockStore = configureStore();
 let state: RootState;
@@ -31,7 +31,7 @@ beforeEach(() => {
   });
 });
 
-it("can update the filter", () => {
+it("can update the filter", async () => {
   const setFilter = jest.fn();
   const store = mockStore(state);
   render(
@@ -49,6 +49,6 @@ it("can update the filter", () => {
       </MemoryRouter>
     </Provider>
   );
-  screen.getByRole("tab", { name: Label.Manual }).click();
+  await userEvent.click(screen.getByRole("tab", { name: Label.Manual }));
   expect(setFilter).toHaveBeenCalledWith(TagSearchFilter.Manual);
 });

--- a/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -101,7 +101,7 @@ it("displays the tags in order", () => {
   expect(names[1].textContent).toBe("rad");
 });
 
-it("can change the sort order", () => {
+it("can change the sort order", async () => {
   const store = mockStore(state);
   render(
     <Provider store={store}>
@@ -124,7 +124,9 @@ it("can change the sort order", () => {
   });
   expect(names[0].textContent).toBe("cool");
   expect(names[1].textContent).toBe("rad");
-  screen.getByRole("button", { name: Label.Name }).click();
+  await userEvent.click(
+    screen.getByRole("button", { name: `${Label.Name} (descending)` })
+  );
   names = screen.queryAllByRole("gridcell", {
     name: Label.Name,
   });


### PR DESCRIPTION
## Done

- migrate 3 kvm tests to RTL MAASENG-1738
- replace `.click()` calls with `userEvent.click()`
- add aria-label to table header sort direction indicator

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1738

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
