### PR TITLE
test: Migrate 8 MachineHeaderForms test to RTL MAASENG-1730

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
@@ -83,26 +83,23 @@ describe("AddMachineFormFields", () => {
     );
 
     expect(
-      (
-        screen.getByRole("option", {
-          name: "bionic (ga-18.04)",
-        }) as HTMLOptionElement
-      ).selected
-    ).toBe(true);
+      screen.getByRole("option", {
+        name: "bionic (ga-18.04)",
+        selected: true,
+      })
+    ).toBeInTheDocument();
     expect(
-      (
-        screen.getByRole("option", {
-          name: "xenial (ga-16.04)",
-        }) as HTMLOptionElement
-      ).selected
-    ).toBe(false);
+      screen.getByRole("option", {
+        name: "xenial (ga-16.04)",
+        selected: false,
+      })
+    ).toBeInTheDocument();
     expect(
-      (
-        screen.getByRole("option", {
-          name: "No minimum kernel",
-        }) as HTMLOptionElement
-      ).selected
-    ).toBe(false);
+      screen.getByRole("option", {
+        name: "No minimum kernel",
+        selected: false,
+      })
+    ).toBeInTheDocument();
   });
 
   it("can add extra mac address fields", async () => {

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -94,7 +94,7 @@ describe("CloneForm", () => {
     ).toBeDisabled();
     expect(
       screen.getByRole("checkbox", { name: "Clone network configuration" })
-    ).not.toBeDisabled();
+    ).toBeEnabled();
 
     // Select config to clone - submit should be re-disabled.
     await userEvent.click(
@@ -103,10 +103,10 @@ describe("CloneForm", () => {
 
     expect(
       screen.getByRole("checkbox", { name: "Clone network configuration" })
-    ).not.toBeDisabled();
+    ).toBeEnabled();
     expect(
       screen.getByRole("button", { name: "Clone to machine" })
-    ).not.toBeDisabled();
+    ).toBeEnabled();
   });
 
   it("shows cloning results when the form is successfully submitted", async () => {

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -1,15 +1,10 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import CloneForm from "./CloneForm";
 
-import ActionForm from "app/base/components/ActionForm";
 import { actions as machineActions } from "app/store/machine";
+import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
@@ -22,12 +17,20 @@ import {
   nodeDisk as diskFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { submitFormikForm, waitForComponentToPaint } from "testing/utils";
+import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("CloneForm", () => {
-  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+  beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it("should be submittable only when a machine and cloning config are selected", async () => {
     const machines = [
       machineFactory({ system_id: "abc123" }),
@@ -63,86 +66,134 @@ describe("CloneForm", () => {
     state.fabric.loaded = true;
     state.subnet.loaded = true;
     state.vlan.loaded = true;
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <CloneForm
-              clearSidePanelContent={jest.fn()}
-              machines={[]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CloneForm
+        clearSidePanelContent={jest.fn()}
+        machines={[]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", state }
     );
-    const isCheckboxDisabled = () =>
-      wrapper.find("input[name='interfaces']").prop("disabled") === true;
-    const isSubmitDisabled = () =>
-      wrapper.find(".p-button--positive[type='submit']").prop("disabled") ===
-      true;
 
     // Checkboxes and submit should be disabled at first.
-    expect(isCheckboxDisabled()).toBe(true);
-    expect(isSubmitDisabled()).toBe(true);
+    expect(
+      screen.getByRole("button", { name: "Clone to machine" })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("checkbox", { name: "Clone network configuration" })
+    ).toBeDisabled();
 
-    // Select a source machine - checkbox should be enabled.
-    wrapper.find("[data-testid='machine-select-row']").at(0).simulate("click");
-    await waitForComponentToPaint(wrapper);
-    expect(isCheckboxDisabled()).toBe(false);
-    expect(isSubmitDisabled()).toBe(true);
+    // Select a source machine - form should update
+    await userEvent.click(
+      screen.getByRole("row", { name: machines[1].hostname })
+    );
 
-    // Select config to clone - submit should be enabled.
-    wrapper.find("input[name='interfaces']").simulate("change", {
-      target: { name: "interfaces", value: true },
-    });
-    await waitForComponentToPaint(wrapper);
-    expect(isCheckboxDisabled()).toBe(false);
-    expect(isSubmitDisabled()).toBe(false);
+    expect(
+      screen.getByRole("button", { name: "Clone to machine" })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("checkbox", { name: "Clone network configuration" })
+    ).not.toBeDisabled();
+
+    // Select config to clone - submit should be re-disabled.
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Clone network configuration" })
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: "Clone network configuration" })
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Clone to machine" })
+    ).not.toBeDisabled();
   });
 
-  it("shows cloning results when the form is successfully submitted", () => {
+  it("shows cloning results when the form is successfully submitted", async () => {
+    const machines = [
+      machineFactory({ system_id: "abc123", hostname: "a-machine-name" }),
+      machineDetailsFactory({
+        disks: [diskFactory()],
+        interfaces: [nicFactory()],
+        system_id: "def456",
+        hostname: "another-machine",
+      }),
+    ];
     const state = rootStateFactory({
       machine: machineStateFactory({
+        active: null,
+        items: machines,
         loaded: true,
+        selected: ["abc123"],
+
+        lists: {
+          "123456": machineStateList({
+            groups: [
+              machineStateListGroup({
+                items: [machines[1].system_id],
+              }),
+            ],
+            loaded: true,
+          }),
+        },
+        statuses: machineStatusesFactory({
+          abc123: machineStatusFactory(),
+          def456: machineStatusFactory(),
+        }),
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <CloneForm
-              clearSidePanelContent={jest.fn()}
-              machines={[]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    expect(wrapper.find("CloneResults").exists()).toBe(false);
+    state.fabric.loaded = true;
+    state.subnet.loaded = true;
+    state.vlan.loaded = true;
 
-    act(() => {
-      const onSuccess = wrapper.find(ActionForm).prop("onSuccess");
-      onSuccess && onSuccess({});
-    });
-    wrapper.update();
-    expect(wrapper.find("CloneResults").exists()).toBe(true);
+    const store = mockStore(state);
+
+    const { rerender } = renderWithBrowserRouter(
+      <CloneForm
+        clearSidePanelContent={jest.fn()}
+        machines={[]}
+        processingCount={0}
+        selectedMachines={{ items: [machines[1].system_id] }}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
+    );
+
+    await userEvent.click(
+      screen.getByRole("row", { name: machines[1].hostname })
+    );
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Clone network configuration" })
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Clone to machine" })
+    );
+
+    mockFormikFormSaved();
+    rerender(
+      <CloneForm
+        clearSidePanelContent={jest.fn()}
+        machines={[]}
+        processingCount={0}
+        viewingDetails={false}
+      />
+    );
+
+    expect(screen.getByText("Cloning complete")).toBeInTheDocument();
   });
 
-  it("can dispatch an action to clone to the given machines", () => {
+  it("can dispatch an action to clone to the given machines", async () => {
     const machines = [
       machineFactory({ system_id: "abc123" }),
       machineFactory({ system_id: "def456" }),
-      machineFactory({ system_id: "ghi789" }),
+      machineDetailsFactory({
+        disks: [diskFactory()],
+        interfaces: [nicFactory()],
+        system_id: "ghi789",
+        hostname: "another-machine",
+      }),
     ];
     const state = rootStateFactory({
       machine: machineStateFactory({
@@ -150,6 +201,17 @@ describe("CloneForm", () => {
         items: machines,
         loaded: true,
         selected: ["abc123", "def456"],
+
+        lists: {
+          "123456": machineStateList({
+            groups: [
+              machineStateListGroup({
+                items: [machines[2].system_id],
+              }),
+            ],
+            loaded: true,
+          }),
+        },
         statuses: machineStatusesFactory({
           abc123: machineStatusFactory(),
           def456: machineStatusFactory(),
@@ -157,30 +219,34 @@ describe("CloneForm", () => {
         }),
       }),
     });
+    state.fabric.loaded = true;
+    state.subnet.loaded = true;
+    state.vlan.loaded = true;
+
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <CloneForm
-              clearSidePanelContent={jest.fn()}
-              selectedMachines={{
-                items: [machines[0].system_id, machines[1].system_id],
-              }}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CloneForm
+        clearSidePanelContent={jest.fn()}
+        machines={state.machine.items}
+        selectedMachines={{
+          items: [machines[0].system_id, machines[1].system_id],
+        }}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
     );
 
-    submitFormikForm(wrapper, {
-      interfaces: true,
-      source: "ghi789",
-      storage: false,
-    });
+    await userEvent.click(
+      screen.getByRole("row", { name: machines[2].hostname })
+    );
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Clone network configuration" })
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Clone to machine" })
+    );
 
     const expectedAction = machineActions.clone(
       {

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -1,7 +1,5 @@
 import reduxToolkit from "@reduxjs/toolkit";
-import { mount } from "enzyme";
 import { Formik } from "formik";
-import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 
 import CloneFormFields from "./CloneFormFields";
@@ -10,7 +8,7 @@ import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import {
   fabricState as fabricStateFactory,
-  machine as machineFactory,
+  machineDetails as machineDetailsFactory,
   machineState as machineStateFactory,
   machineStateList as machineStateListFactory,
   machineStateListGroup as machineStateListGroupFactory,
@@ -18,13 +16,13 @@ import {
   subnetState as subnetStateFactory,
   vlanState as vlanStateFactory,
 } from "testing/factories";
-import { waitForComponentToPaint } from "testing/utils";
+import { renderWithMockStore, screen, userEvent } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("CloneFormFields", () => {
   let state: RootState;
-  const machine = machineFactory({
+  const machine = machineDetailsFactory({
     pod: { id: 11, name: "podrick" },
     system_id: "abc123",
   });
@@ -58,18 +56,17 @@ describe("CloneFormFields", () => {
 
   it("dispatches action to fetch data on load", () => {
     const store = mockStore(state);
-    mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{ interfaces: false, source: "", storage: false }}
-          onSubmit={jest.fn()}
-        >
-          <CloneFormFields
-            selectedMachine={null}
-            setSelectedMachine={jest.fn()}
-          />
-        </Formik>
-      </Provider>
+    renderWithMockStore(
+      <Formik
+        initialValues={{ interfaces: false, source: "", storage: false }}
+        onSubmit={jest.fn()}
+      >
+        <CloneFormFields
+          selectedMachine={null}
+          setSelectedMachine={jest.fn()}
+        />
+      </Formik>,
+      { store }
     );
 
     const expectedActions = [
@@ -87,25 +84,22 @@ describe("CloneFormFields", () => {
   });
 
   it("dispatches action to get full machine details on machine click", async () => {
-    const machine = machineFactory({ system_id: "abc123" });
+    const machine = machineDetailsFactory({ system_id: "abc123" });
     state.machine.items = [machine];
     const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{ interfaces: false, source: "", storage: false }}
-          onSubmit={jest.fn()}
-        >
-          <CloneFormFields
-            selectedMachine={null}
-            setSelectedMachine={jest.fn()}
-          />
-        </Formik>
-      </Provider>
+    renderWithMockStore(
+      <Formik
+        initialValues={{ interfaces: false, source: "", storage: false }}
+        onSubmit={jest.fn()}
+      >
+        <CloneFormFields
+          selectedMachine={null}
+          setSelectedMachine={jest.fn()}
+        />
+      </Formik>,
+      { store }
     );
-    wrapper.find("[data-testid='machine-select-row']").at(0).simulate("click");
-    await waitForComponentToPaint(wrapper);
-
+    await userEvent.click(screen.getAllByTestId("machine-select-row")[0]);
     const expectedAction = machineActions.get(
       machine.system_id,
       "mocked-nanoid"
@@ -117,35 +111,30 @@ describe("CloneFormFields", () => {
   });
 
   it("applies different styling depending on clone selection state", async () => {
-    const machine = machineFactory({ system_id: "abc123" });
+    const machine = machineDetailsFactory({ system_id: "abc123" });
     state.machine.items = [machine];
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <Formik
-          initialValues={{ interfaces: false, source: "", storage: false }}
-          onSubmit={jest.fn()}
-        >
-          <CloneFormFields
-            selectedMachine={null}
-            setSelectedMachine={jest.fn()}
-          />
-        </Formik>
-      </Provider>
+    renderWithMockStore(
+      <Formik
+        initialValues={{ interfaces: false, source: "", storage: false }}
+        onSubmit={jest.fn()}
+      >
+        <CloneFormFields
+          selectedMachine={machine}
+          setSelectedMachine={jest.fn()}
+        />
+      </Formik>,
+      { state }
     );
-    const getTableClass = () =>
-      wrapper.find("MainTable.clone-table--network").prop("className");
+    let table = screen.getAllByRole("grid")[0];
     // Table has unselected styling by default
-    expect(getTableClass()?.includes("not-selected")).toBe(true);
+    expect(table).toHaveClass("not-selected");
 
     // Check the checkbox for the table.
-    wrapper
-      .find("input[name='interfaces']")
-      .at(0)
-      .simulate("change", { target: { name: "interfaces", value: true } });
-    await waitForComponentToPaint(wrapper);
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Clone network configuration" })
+    );
 
-    // Table should not have unselected styling.
-    expect(getTableClass()?.includes("not-selected")).toBe(false);
+    table = screen.getAllByRole("grid")[0];
+    expect(table).not.toHaveClass("not-selected");
   });
 });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -125,7 +125,7 @@ describe("CloneFormFields", () => {
       </Formik>,
       { state }
     );
-    let table = screen.getAllByRole("grid")[0];
+    let table = screen.getByRole("grid", { name: "Clone network" });
     // Table has unselected styling by default
     expect(table).toHaveClass("not-selected");
 
@@ -134,7 +134,7 @@ describe("CloneFormFields", () => {
       screen.getByRole("checkbox", { name: "Clone network configuration" })
     );
 
-    table = screen.getAllByRole("grid")[0];
+    table = screen.getByRole("grid", { name: "Clone network" });
     expect(table).not.toHaveClass("not-selected");
   });
 });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.test.tsx
@@ -46,8 +46,7 @@ describe("CloneNetworkTable", () => {
       state,
     });
     expect(screen.getAllByRole("row")).toHaveLength(1);
-    // expect(wrapper.find("MainTable").prop("rows")).toStrictEqual([]);
-    // expect(wrapper.find("Placeholder").exists()).toBe(false);
+    expect(screen.queryByTestId("placeholder")).not.toBeInTheDocument();
   });
 
   it("renders placeholder content while details are loading", () => {
@@ -61,8 +60,8 @@ describe("CloneNetworkTable", () => {
         state,
       }
     );
-    const rows = screen.getAllByRole("row");
-    rows.shift(); // Remove the table header row
+    const table = screen.getAllByRole("rowgroup")[1];
+    const rows = within(table).getAllByRole("row");
     rows.forEach((row) => {
       const placeholders = within(row).getAllByTestId("placeholder");
       expect(placeholders[0]).toHaveTextContent("Name");

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.tsx
@@ -203,6 +203,7 @@ export const CloneNetworkTable = ({
 
   return (
     <MainTable
+      aria-label="Clone network"
       className={classNames("clone-table--network", {
         "not-selected": !selected,
       })}

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.tsx
@@ -80,6 +80,7 @@ export const CommissionFormFields = ({
         />
         {urlScriptsSelected.map((script) => (
           <FormikField
+            aria-label={`URL(s) to use for ${script.name} script`}
             data-testid="url-script-input"
             help={getObjectString(script.parameters.url, "description")}
             key={script.name}


### PR DESCRIPTION
## Done

Migrated the following files to RTL:
```
8.0K	./src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisForm/AddChassisForm.test.tsx
8.0K	./src/app/machines/components/MachineHeaderForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
8.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
8.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
8.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.test.tsx
8.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionForm.test.tsx
8.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
8.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolForm.test.tsx
```

## Fixes

Fixes [MAASENG-1730](https://warthogs.atlassian.net/browse/MAASENG-1730)


[MAASENG-1730]: https://warthogs.atlassian.net/browse/MAASENG-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ