### PR TITLE
test: Migrate 7 KVMHeaderForms to RTL MAASENG-1731

### DIFF
--- a/src/app/base/components/Stepper/Stepper.tsx
+++ b/src/app/base/components/Stepper/Stepper.tsx
@@ -1,10 +1,8 @@
-import type { ReactNode } from "react";
-
 import classNames from "classnames";
 
 type StepperItem = {
   step: string;
-  title: ReactNode;
+  title: string;
 };
 
 type Props = {
@@ -20,7 +18,7 @@ export const Stepper = ({ currentStep, items }: Props): JSX.Element => {
         const isComplete =
           items.findIndex(({ step }) => step === currentStep) > i;
         return (
-          <li className="stepper__item" key={item.step}>
+          <li aria-label={item.title} className="stepper__item" key={item.step}>
             <p
               aria-checked={isComplete}
               className={classNames("stepper__title", {

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
@@ -107,9 +107,25 @@ describe("AddLxd", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
-    expect(screen.getByText("Credentials")).not.toHaveClass("is-active");
-    expect(screen.getByText("Authentication")).toHaveClass("is-active");
-    expect(screen.getByText("Project selection")).not.toHaveClass("is-active");
+    expect(
+      screen.getByRole("listitem", { name: "Credentials" }).firstChild
+    ).not.toHaveClass("is-active");
+    expect(
+      screen.getByRole("listitem", { name: "Authentication" }).firstChild
+    ).toHaveClass("is-active");
+    expect(
+      screen.getByRole("listitem", { name: "Project selection" }).firstChild
+    ).not.toHaveClass("is-active");
+
+    expect(
+      screen.queryByRole("form", { name: "Credentials" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("form", { name: "Authentication" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("form", { name: "Project selection" })
+    ).not.toBeInTheDocument();
   });
 
   it("shows the project select form once authenticated", async () => {
@@ -141,9 +157,15 @@ describe("AddLxd", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
-    expect(screen.getByText("Credentials")).not.toHaveClass("is-active");
-    expect(screen.getByText("Authentication")).not.toHaveClass("is-active");
-    expect(screen.getByText("Project selection")).toHaveClass("is-active");
+    expect(
+      screen.getByRole("listitem", { name: "Credentials" }).firstChild
+    ).not.toHaveClass("is-active");
+    expect(
+      screen.getByRole("listitem", { name: "Authentication" }).firstChild
+    ).not.toHaveClass("is-active");
+    expect(
+      screen.getByRole("listitem", { name: "Project selection" }).firstChild
+    ).toHaveClass("is-active");
   });
 
   it("clears projects and runs cleanup on unmount", () => {

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/AuthenticationForm/AuthenticationForm.tsx
@@ -85,6 +85,7 @@ export const AuthenticationForm = ({
   return (
     <FormikForm<AuthenticationFormValues>
       allowAllEmpty
+      aria-label="Authentication"
       buttonsHelp={
         useCertificate && authenticating ? (
           <Spinner

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/CredentialsForm/CredentialsForm.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/CredentialsForm/CredentialsForm.tsx
@@ -110,6 +110,7 @@ export const CredentialsForm = ({
   return (
     <FormikForm<CredentialsFormValues>
       allowUnchanged={!!newPodValues.power_address}
+      aria-label="Credentials"
       cleanup={cleanup}
       enableReinitialize
       errors={errors}

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.tsx
@@ -98,6 +98,7 @@ export const SelectProjectForm = ({
 
   return (
     <FormikForm<SelectProjectFormValues>
+      aria-label="Project selection"
       initialValues={{
         existingProject: "",
         newProject: "",

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
@@ -1,9 +1,4 @@
-import { mount } from "enzyme";
 import { Formik } from "formik";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
 
 import type { NewPodValues } from "../../types";
 
@@ -19,9 +14,12 @@ import {
   podState as podStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { waitForComponentToPaint } from "testing/utils";
-
-const mockStore = configureStore();
+import {
+  renderWithBrowserRouter,
+  screen,
+  userEvent,
+  within,
+} from "testing/utils";
 
 describe("SelectProjectFormFields", () => {
   let state: RootState;
@@ -49,40 +47,25 @@ describe("SelectProjectFormFields", () => {
     state.pod.projects = {
       "192.168.1.1": [project],
     };
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <Formik
-              initialValues={{ existingProject: "", newProject: "" }}
-              onSubmit={jest.fn()}
-            >
-              <SelectProjectFormFields newPodValues={newPodValues} />
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik
+        initialValues={{ existingProject: "", newProject: "" }}
+        onSubmit={jest.fn()}
+      >
+        <SelectProjectFormFields newPodValues={newPodValues} />
+      </Formik>,
+      { route: "/kvm/add", state }
     );
 
-    // Check radio button for selecting existing project
-    wrapper.find("input[id='existing-project']").simulate("change", {
-      target: { name: "project-select", value: "checked" },
+    const radio = screen.getByRole("radio", {
+      name: "Select existing project",
     });
-    await waitForComponentToPaint(wrapper);
+    await userEvent.click(radio);
 
-    expect(
-      wrapper
-        .find("Notification[data-testid='existing-project-warning']")
-        .exists()
-    ).toBe(true);
-    expect(
-      wrapper
-        .find("Notification[data-testid='existing-project-warning']")
-        .text()
-    ).toBe("MAAS will recommission all VMs in the selected project.");
+    expect(screen.getByTestId("existing-project-warning")).toBeInTheDocument();
+    expect(screen.getByTestId("existing-project-warning")).toHaveTextContent(
+      "MAAS will recommission all VMs in the selected project."
+    );
   });
 
   it("selects the first available project when switching to existing projects", async () => {
@@ -104,45 +87,25 @@ describe("SelectProjectFormFields", () => {
         ],
       },
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <Formik
-              initialValues={{ existingProject: "", newProject: "" }}
-              onSubmit={jest.fn()}
-            >
-              <SelectProjectFormFields newPodValues={newPodValues} />
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+
+    renderWithBrowserRouter(
+      <Formik
+        initialValues={{ existingProject: "", newProject: "" }}
+        onSubmit={jest.fn()}
+      >
+        <SelectProjectFormFields newPodValues={newPodValues} />
+      </Formik>,
+      { route: "/kvm/add", state }
     );
 
-    // Check radio button for selecting existing project
-    wrapper.find("input[id='existing-project']").simulate("change", {
-      target: { name: "project-select", value: "checked" },
+    const radio = screen.getByRole("radio", {
+      name: "Select existing project",
     });
-    await waitForComponentToPaint(wrapper);
+    await userEvent.click(radio);
 
-    expect(
-      wrapper
-        .find("Input[name='existingProject'][value='default']")
-        .prop("disabled")
-    ).toBe(true);
-    expect(
-      wrapper
-        .find("Input[name='existingProject'][value='other']")
-        .prop("disabled")
-    ).toBe(false);
-    expect(
-      wrapper
-        .find("Input[name='existingProject'][value='other']")
-        .prop("checked")
-    ).toBe(true);
+    expect(screen.getByRole("radio", { name: "other" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "default" })).toBeDisabled();
+    expect(screen.getByRole("radio", { name: "other" })).toBeEnabled();
   });
 
   it("disables the existing project radio button if no existing projects are free", async () => {
@@ -171,27 +134,19 @@ describe("SelectProjectFormFields", () => {
         ],
       },
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <Formik
-              initialValues={{ existingProject: "", newProject: "" }}
-              onSubmit={jest.fn()}
-            >
-              <SelectProjectFormFields newPodValues={newPodValues} />
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik
+        initialValues={{ existingProject: "", newProject: "" }}
+        onSubmit={jest.fn()}
+      >
+        <SelectProjectFormFields newPodValues={newPodValues} />
+      </Formik>,
+      { route: "/kvm/add", state }
     );
 
-    expect(wrapper.find("input[id='existing-project']").prop("disabled")).toBe(
-      true
-    );
+    expect(
+      screen.getByRole("radio", { name: "Select existing project" })
+    ).toBeDisabled();
   });
 
   it("disables radio and shows a link to an existing LXD project", async () => {
@@ -212,33 +167,24 @@ describe("SelectProjectFormFields", () => {
         ],
       },
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/kvm/add", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <Formik
-              initialValues={{ existingProject: "", newProject: "" }}
-              onSubmit={jest.fn()}
-            >
-              <SelectProjectFormFields newPodValues={newPodValues} />
-            </Formik>
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <Formik
+        initialValues={{ existingProject: "", newProject: "" }}
+        onSubmit={jest.fn()}
+      >
+        <SelectProjectFormFields newPodValues={newPodValues} />
+      </Formik>,
+      { route: "/kvm/add", state }
     );
 
-    // Check radio button for selecting existing project
-    wrapper.find("input[id='existing-project']").simulate("change", {
-      target: { name: "project-select", value: "checked" },
+    const radio = screen.getByRole("radio", {
+      name: "Select existing project",
     });
-    await waitForComponentToPaint(wrapper);
+    await userEvent.click(radio);
 
-    expect(wrapper.find("[data-testid='existing-pod']").exists()).toBe(true);
-    expect(wrapper.find("[data-testid='existing-pod'] Link").prop("to")).toBe(
-      urls.kvm.lxd.single.index({ id: pod.id })
-    );
+    expect(screen.getByTestId("existing-pod")).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId("existing-pod")).getByRole("link")
+    ).toHaveAttribute("href", urls.kvm.lxd.single.index({ id: pod.id }));
   });
 });

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
@@ -78,6 +78,7 @@ export const SelectProjectFormFields = ({
           type="radio"
         />
         <FormikField
+          aria-label="New project name"
           disabled={!newProject}
           help={`A project name must be less than 63 characters and must not
                  contain spaces or special characters (i.e. / . ' " *)`}

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
@@ -1,14 +1,7 @@
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 import type { MockStore } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
 import ComposeForm from "../../ComposeForm";
-
-import type { MenuLink } from "./SubnetSelect";
 
 import type { Pod } from "app/store/pod/types";
 import type { RootState } from "app/store/root/types";
@@ -33,21 +26,19 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { waitForComponentToPaint } from "testing/utils";
+import {
+  renderWithBrowserRouter,
+  screen,
+  userEvent,
+  within,
+} from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
-const generateWrapper = (store: MockStore, pod: Pod) =>
-  mount(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: `/kvm/${pod.id}`, key: "testKey" }]}
-      >
-        <CompatRouter>
-          <ComposeForm clearSidePanelContent={jest.fn()} hostId={pod.id} />
-        </CompatRouter>
-      </MemoryRouter>
-    </Provider>
+const renderComposeForm = (store: MockStore, pod: Pod) =>
+  renderWithBrowserRouter(
+    <ComposeForm clearSidePanelContent={jest.fn()} hostId={pod.id} />,
+    { route: `/kvm/${pod.id}`, store }
   );
 
 describe("SubnetSelect", () => {
@@ -98,9 +89,9 @@ describe("SubnetSelect", () => {
       spaceFactory({ name: "Safe" }),
     ];
     const subnets = [
-      subnetFactory({ space: spaces[0].id, vlan: 1 }),
-      subnetFactory({ space: spaces[0].id, vlan: 1 }),
-      subnetFactory({ space: spaces[1].id, vlan: 1 }),
+      subnetFactory({ space: spaces[0].id, vlan: 1, name: "sub1" }),
+      subnetFactory({ space: spaces[1].id, vlan: 1, name: "sub2" }),
+      subnetFactory({ space: spaces[0].id, vlan: 1, name: "sub3" }),
     ];
     const pod = podDetailsFactory({
       attached_vlans: [1],
@@ -112,31 +103,35 @@ describe("SubnetSelect", () => {
     state.space.items = spaces;
     state.subnet.items = subnets;
     const store = mockStore(state);
-    const wrapper = generateWrapper(store, pod);
+    renderComposeForm(store, pod);
 
     // Click "Define" button
-    await act(async () => {
-      wrapper
-        .find("[data-testid='define-interfaces'] button")
-        .simulate("click");
-    });
-    wrapper.update();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Define (optional)" })
+    );
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Space" }),
+      ""
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Select subnet..." })
+    );
 
-    const links = wrapper
-      .find("SubnetSelect ContextualMenu")
-      .prop("links") as MenuLink[];
+    const spaceGroups = screen.getByLabelText("submenu").children;
 
-    // "Space: Outer" + outer subnets + "Space: Safe" + safe subnets
-    expect(links.length).toBe(5);
-    expect(links[0]).toBe("Space: Outer");
-    expect(links[3]).toBe("Space: Safe");
+    expect(spaceGroups).toHaveLength(5);
+    expect(spaceGroups[0]).toHaveTextContent("Space: Outer");
+    expect(spaceGroups[1]).toHaveTextContent("sub1");
+    expect(spaceGroups[2]).toHaveTextContent("sub3");
+    expect(spaceGroups[3]).toHaveTextContent("Space: Safe");
+    expect(spaceGroups[4]).toHaveTextContent("sub2");
   });
 
   it("filters subnets by selected space", async () => {
-    const space = spaceFactory();
+    const space = spaceFactory({ id: 0, name: "Outer" });
     const [subnetInSpace, subnetNotInSpace] = [
-      subnetFactory({ space: space.id, vlan: 1 }),
-      subnetFactory({ space: null, vlan: 1 }),
+      subnetFactory({ space: space.id, vlan: 1, name: "sub1" }),
+      subnetFactory({ space: null, vlan: 1, name: "sub2" }),
     ];
     const pod = podDetailsFactory({
       attached_vlans: [1],
@@ -148,49 +143,54 @@ describe("SubnetSelect", () => {
     state.space.items = [space];
     state.subnet.items = [subnetInSpace, subnetNotInSpace];
     const store = mockStore(state);
-    const wrapper = generateWrapper(store, pod);
-    let links = [];
-    let filteredLinks = [];
+    renderComposeForm(store, pod);
 
     // Click "Define" button
-    await act(async () => {
-      wrapper
-        .find("[data-testid='define-interfaces'] button")
-        .simulate("click");
-    });
-    wrapper.update();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Define (optional)" })
+    );
 
-    links = wrapper
-      .find("SubnetSelect ContextualMenu")
-      .prop("links") as MenuLink[];
-    filteredLinks = links.filter((link) => typeof link !== "string");
-    expect(filteredLinks.length).toBe(2);
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Space" }),
+      ""
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: "Select subnet..." })
+    );
+
+    let spaceGroups = screen.getByLabelText("submenu").children;
+
+    expect(spaceGroups[0]).toHaveTextContent("Space: Outer");
+    expect(spaceGroups[1]).toHaveTextContent("sub1");
+    expect(spaceGroups[2]).toHaveTextContent("No space");
+    expect(spaceGroups[3]).toHaveTextContent("sub2");
+    expect(spaceGroups).toHaveLength(4);
 
     // Choose the space in state from the dropdown
     // Only the subnet in the selected space should be available
-    await act(async () => {
-      wrapper
-        .find("FormikField select[name='interfaces[0].space']")
-        .simulate("change", {
-          target: {
-            name: "interfaces[0].space",
-            value: `${space.id}`,
-          },
-        });
-    });
-    wrapper.update();
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Space" }),
+      "0"
+    );
 
-    links = wrapper
-      .find("SubnetSelect ContextualMenu")
-      .prop("links") as MenuLink[];
-    filteredLinks = links.filter((link) => typeof link !== "string");
-    expect(filteredLinks.length).toBe(1);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Select subnet..." })
+    );
+
+    spaceGroups = screen.getByLabelText("submenu").children;
+
+    expect(spaceGroups).toHaveLength(1);
+    expect(spaceGroups[0]).toHaveTextContent("sub1");
   });
 
   it("shows an error if multiple interfaces defined without at least one PXE network", async () => {
     const fabric = fabricFactory();
     const space = spaceFactory();
-    const pxeVlan = vlanFactory({ fabric: fabric.id, id: 1 });
+    const pxeVlan = vlanFactory({
+      fabric: fabric.id,
+      id: 1,
+      name: "test-vlan-1",
+    });
     const nonPxeVlan = vlanFactory({ fabric: fabric.id, id: 2 });
     const pxeSubnet = subnetFactory({ name: "pxe", vlan: pxeVlan.id });
     const nonPxeSubnet = subnetFactory({
@@ -208,41 +208,60 @@ describe("SubnetSelect", () => {
     state.subnet.items = [pxeSubnet, nonPxeSubnet];
     state.vlan.items = [pxeVlan, nonPxeVlan];
     const store = mockStore(state);
-    const wrapper = generateWrapper(store, pod);
+    renderComposeForm(store, pod);
 
     // Click "Define" button
-    wrapper.find("[data-testid='define-interfaces'] button").simulate("click");
-    await waitForComponentToPaint(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Define (optional)" })
+    );
 
     // Add a second interface
-    wrapper.find("[data-testid='define-interfaces'] button").simulate("click");
-    await waitForComponentToPaint(wrapper);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add interface" })
+    );
 
     // Select non-PXE network for the first interface
-    wrapper.find("SubnetSelect button").at(0).simulate("click");
-    await waitForComponentToPaint(wrapper);
-    wrapper.find("ContextualMenuDropdown button").at(1).simulate("click");
-    await waitForComponentToPaint(wrapper);
+    await userEvent.selectOptions(
+      screen.getAllByRole("combobox", { name: "Space" })[0],
+      ""
+    );
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Select subnet..." })[0]
+    );
+    await userEvent.click(
+      within(screen.getByLabelText("submenu")).getByRole("button", {
+        name: /non-pxe/i,
+      })
+    );
 
     // Select non-PXE network for the second interface - error should be present.
-    wrapper.find("SubnetSelect button").at(1).simulate("click");
-    await waitForComponentToPaint(wrapper);
-    wrapper.find("ContextualMenuDropdown button").at(1).simulate("click");
-    await waitForComponentToPaint(wrapper);
-    expect(wrapper.find("[data-testid='no-pxe']").text()).toBe(
+    await userEvent.selectOptions(
+      screen.getAllByRole("combobox", { name: "Space" })[1],
+      ""
+    );
+    await userEvent.click(
+      screen.getAllByRole("button", { name: "Select subnet..." })[0]
+    );
+    await userEvent.click(
+      within(screen.getByLabelText("submenu")).getByRole("button", {
+        name: /non-pxe/i,
+      })
+    );
+    expect(screen.getByTestId("no-pxe")).toHaveTextContent(
       "Error: Select at least 1 PXE network when creating multiple interfaces."
     );
 
     // Select PXE network for the second interface - error should be removed.
-    wrapper.find("SubnetSelect button").at(1).simulate("click");
-    await waitForComponentToPaint(wrapper);
-    wrapper.find("ContextualMenuDropdown button").at(0).simulate("click");
-    await waitForComponentToPaint(wrapper);
-    expect(wrapper.find("[data-testid='no-pxe']").exists()).toBe(false);
+    await userEvent.click(screen.getAllByText("non-pxe")[1]);
+    await userEvent.click(
+      within(screen.getByLabelText("submenu")).getByRole("button", {
+        name: /pxe test-vlan-1/i,
+      })
+    );
+    expect(screen.queryByTestId("no-pxe")).not.toBeInTheDocument();
 
     // Remove second interface with PXE network - error should still not show.
-    wrapper.find("[data-testid='delete-interface']").at(1).simulate("click");
-    await waitForComponentToPaint(wrapper);
-    expect(wrapper.find("[data-testid='no-pxe']").exists()).toBe(false);
+    await userEvent.click(screen.getAllByTestId("delete-interface")[1]);
+    expect(screen.queryByTestId("no-pxe")).not.toBeInTheDocument();
   });
 });

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
@@ -26,7 +26,12 @@ import {
   zoneGenericActions as zoneGenericActionsFactory,
   zoneState as zoneStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
+import {
+  renderWithBrowserRouter,
+  screen,
+  userEvent,
+  within,
+} from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -148,12 +153,14 @@ describe("PoolSelect", () => {
 
     // defaultPool should be selected by default
     expect(
-      screen
-        .getByTestId("kvm-pool-select-default")
-        .querySelector(".p-icon--tick")
-    ).toBeInTheDocument();
+      within(screen.getByTestId("kvm-pool-select-default")).getByLabelText(
+        "selected"
+      )
+    ).toHaveClass("p-icon--tick");
     expect(
-      screen.getByTestId("kvm-pool-select-other").querySelector(".p-icon--tick")
+      within(screen.getByTestId("kvm-pool-select-other")).queryByLabelText(
+        "selected"
+      )
     ).not.toBeInTheDocument();
 
     // Select other pool

--- a/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.tsx
@@ -46,15 +46,18 @@ const generateDropdownContent = (
         <div className="u-align--right">Type</div>
         <ul className="p-inline-list u-default-text u-no-margin--bottom">
           <li className="p-inline-list__item">
-            <i className="p-circle--link is-inline"></i>
+            <i aria-label="Allocated" className="p-circle--link is-inline"></i>
             Allocated
           </li>
           <li className="p-inline-list__item">
-            <i className="p-circle--positive is-inline"></i>
+            <i
+              aria-label="Requested"
+              className="p-circle--positive is-inline"
+            ></i>
             Requested
           </li>
           <li className="p-inline-list__item">
-            <i className="p-circle--link-faded is-inline"></i>
+            <i aria-label="Free" className="p-circle--link-faded is-inline"></i>
             Free
           </li>
         </ul>
@@ -89,7 +92,11 @@ const generateDropdownContent = (
             type="button"
           >
             <div className="kvm-pool-select__row">
-              <div>{isSelected && <i className="p-icon--tick"></i>}</div>
+              <div>
+                {isSelected && (
+                  <i aria-label="selected" className="p-icon--tick"></i>
+                )}
+              </div>
               <div>
                 <strong data-testid="pool-name">
                   {isDefault ? `${name} (default)` : name}


### PR DESCRIPTION
## Done

Migrated the following tests to RTL:
```
8.0K	./src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
8.0K	./src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectForm.test.tsx
8.0K	./src/app/kvm/components/KVMHeaderForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.test.tsx
8.0K	./src/app/kvm/components/KVMHeaderForms/AddVirsh/AddVirsh.test.tsx
8.0K	./src/app/kvm/components/KVMHeaderForms/ComposeForm/InterfacesTable/SubnetSelect/SubnetSelect.test.tsx
8.0K	./src/app/kvm/components/KVMHeaderForms/ComposeForm/StorageTable/PoolSelect/PoolSelect.test.tsx
8.0K	./src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
```

## Fixes

Fixes [MAASENG-1731](https://warthogs.atlassian.net/browse/MAASENG-1731)



[MAASENG-1731]: https://warthogs.atlassian.net/browse/MAASENG-1731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ