### PR TITLE
test: Migrate 5 MachineHeaderForms tests to RTL MAASENG-1735

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
@@ -23,8 +23,8 @@ describe("CloneStorageTable", () => {
         selected={false}
       />
     );
-    const rows = screen.getAllByRole("row");
-    rows.shift();
+    const tableBody = screen.getAllByRole("rowgroup")[1];
+    const rows = within(tableBody).getAllByRole("row");
 
     rows.forEach((row) => {
       const placeholders = within(row).getAllByTestId("placeholder");
@@ -54,6 +54,9 @@ describe("CloneStorageTable", () => {
     });
     render(<CloneStorageTable machine={machine} selected={false} />);
     expect(screen.getByTestId("disk-available")).toHaveClass("p-icon--tick");
+    expect(screen.getByTestId("disk-available")).toHaveAccessibleName(
+      "available"
+    );
   });
 
   it("shows a cross for unavailable disks", () => {
@@ -62,6 +65,9 @@ describe("CloneStorageTable", () => {
     });
     render(<CloneStorageTable machine={machine} selected={false} />);
     expect(screen.getByTestId("disk-available")).toHaveClass("p-icon--close");
+    expect(screen.getByTestId("disk-available")).toHaveAccessibleName(
+      "not available"
+    );
   });
 
   it("shows a tick for available partitions", () => {
@@ -73,6 +79,9 @@ describe("CloneStorageTable", () => {
     render(<CloneStorageTable machine={machine} selected={false} />);
     expect(screen.getByTestId("partition-available")).toHaveClass(
       "p-icon--tick"
+    );
+    expect(screen.getByTestId("partition-available")).toHaveAccessibleName(
+      "available"
     );
   });
 
@@ -87,6 +96,9 @@ describe("CloneStorageTable", () => {
     render(<CloneStorageTable machine={machine} selected={false} />);
     expect(screen.getByTestId("partition-available")).toHaveClass(
       "p-icon--close"
+    );
+    expect(screen.getByTestId("partition-available")).toHaveAccessibleName(
+      "not available"
     );
   });
 });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.tsx
@@ -75,6 +75,7 @@ export const CloneStorageTable = ({
         columns: normaliseColumns({
           available: (
             <Icon
+              aria-label={diskAvailable(disk) ? "available" : "not available"}
               data-testid="disk-available"
               name={diskAvailable(disk) ? "tick" : "close"}
             />
@@ -105,6 +106,11 @@ export const CloneStorageTable = ({
             columns: normaliseColumns({
               available: (
                 <Icon
+                  aria-label={
+                    partitionAvailable(partition)
+                      ? "available"
+                      : "not available"
+                  }
                   data-testid="partition-available"
                   name={partitionAvailable(partition) ? "tick" : "close"}
                 />

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
@@ -1,10 +1,3 @@
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
-
 import CommissionForm from "../CommissionForm";
 
 import type { RootState } from "app/store/root/types";
@@ -17,8 +10,7 @@ import {
   scriptState as scriptStateFactory,
   script as scriptFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
 describe("CommissionForm", () => {
   let state: RootState;
@@ -69,40 +61,20 @@ describe("CommissionForm", () => {
   });
 
   it("displays a field for URL if a selected script has url parameter", async () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <CommissionForm
-              clearSidePanelContent={jest.fn()}
-              machines={[]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <CommissionForm
+        clearSidePanelContent={jest.fn()}
+        machines={[]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines/add", state }
     );
-    expect(wrapper.find("[data-testid='url-script-input']").exists()).toBe(
-      false
+    expect(screen.queryByTestId("url-script-input")).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("textbox", { name: "Testing scripts" })
     );
-    await act(async () => {
-      wrapper
-        .find(
-          "[data-testid='testing-scripts-selector'] Input .tag-selector__input"
-        )
-        .simulate("focus");
-    });
-    wrapper.update();
-    await act(async () => {
-      wrapper.find('[data-testid="existing-tag"]').at(0).simulate("click");
-    });
-    wrapper.update();
-    expect(wrapper.find("[data-testid='url-script-input']").exists()).toBe(
-      true
-    );
+    await userEvent.click(screen.getAllByTestId("existing-tag")[0]);
+    expect(screen.getByTestId("url-script-input")).toBeInTheDocument();
   });
 });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
@@ -48,8 +48,15 @@ describe("SetPoolFormFields", () => {
       />,
       { route, state }
     );
+
+    await userEvent.click(screen.getByLabelText("Create pool"));
+    expect(
+      screen.queryByRole("combobox", { name: "Resource pool" })
+    ).not.toBeInTheDocument();
     await userEvent.click(screen.getByLabelText("Select pool"));
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: "Resource pool" })
+    ).toBeInTheDocument();
   });
 
   it("shows inputs for creating a pool if create pool radio chosen", async () => {

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
@@ -1,10 +1,3 @@
-import { mount } from "enzyme";
-import { act } from "react-dom/test-utils";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
-
 import SetPoolForm from "../SetPoolForm";
 
 import type { RootState } from "app/store/root/types";
@@ -16,11 +9,11 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
 describe("SetPoolFormFields", () => {
   let state: RootState;
+  const route = "/machines";
   beforeEach(() => {
     state = rootStateFactory({
       machine: machineStateFactory({
@@ -46,57 +39,31 @@ describe("SetPoolFormFields", () => {
   });
 
   it("shows a select if select pool radio chosen", async () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <SetPoolForm
-              clearSidePanelContent={jest.fn()}
-              machines={[]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <SetPoolForm
+        clearSidePanelContent={jest.fn()}
+        machines={[]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route, state }
     );
-    await act(async () => {
-      wrapper.find("[data-testid='select-pool'] input").simulate("change", {
-        target: { name: "poolSelection", value: "select" },
-      });
-    });
-    wrapper.update();
-    expect(wrapper.find("Select").exists()).toBe(true);
+    await userEvent.click(screen.getByLabelText("Select pool"));
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
   it("shows inputs for creating a pool if create pool radio chosen", async () => {
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/machines", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <SetPoolForm
-              clearSidePanelContent={jest.fn()}
-              machines={[]}
-              processingCount={0}
-              viewingDetails={false}
-            />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
+    renderWithBrowserRouter(
+      <SetPoolForm
+        clearSidePanelContent={jest.fn()}
+        machines={[]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route, state }
     );
-    await act(async () => {
-      wrapper.find("[data-testid='create-pool'] input").simulate("change", {
-        target: { name: "poolSelection", value: "create" },
-      });
-    });
-    wrapper.update();
-    expect(wrapper.find("Input[name='name']").exists()).toBe(true);
-    expect(wrapper.find("Input[name='description']").exists()).toBe(true);
+    await userEvent.click(screen.getByLabelText("Create pool"));
+    expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    expect(screen.getByLabelText("Description")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done

Migrated the following tests to RTL:
```
4.0K	./src/app/machines/components/MachineHeaderForms/AddChassis/AddChassisFormFields/AddChassisFormFields.test.tsx
4.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneStorageTable/CloneStorageTable.test.tsx
4.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionFormFields/CommissionFormFields.test.tsx
4.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MarkBrokenForm/MarkBrokenForm.test.tsx
4.0K	./src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/SetPoolForm/SetPoolFormFields/SetPoolFormFields.test.tsx
```

## Fixes

Fixes [MAASENG-1735](https://warthogs.atlassian.net/browse/MAASENG-1735)


[MAASENG-1735]: https://warthogs.atlassian.net/browse/MAASENG-1735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ