### PR TITLE
test: Migrate 2 small CPUColumn tests to RTL MAASENG-1741

### DIFF
--- a/src/app/kvm/components/CPUColumn/CPUColumn.test.tsx
+++ b/src/app/kvm/components/CPUColumn/CPUColumn.test.tsx
@@ -1,7 +1,3 @@
-import { mount } from "enzyme";
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
-
 import CPUColumn from "./CPUColumn";
 
 import type { Pod } from "app/store/pod/types";
@@ -14,8 +10,7 @@ import {
   rootState as rootStateFactory,
   vmClusterResource as vmClusterResourceFactory,
 } from "testing/factories";
-
-const mockStore = configureStore();
+import { renderWithMockStore, screen } from "testing/utils";
 
 describe("CPUColumn", () => {
   let state: RootState;
@@ -42,19 +37,15 @@ describe("CPUColumn", () => {
         free: 4,
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <CPUColumn
-          cores={pod.resources.cores}
-          overCommit={pod.cpu_over_commit_ratio}
-        />
-      </Provider>
+
+    renderWithMockStore(
+      <CPUColumn
+        cores={pod.resources.cores}
+        overCommit={pod.cpu_over_commit_ratio}
+      />,
+      { state }
     );
-    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "4 of 8 allocated"
-    );
-    expect(wrapper.find("Meter").prop("max")).toBe(8);
+    expect(screen.getByText(/4 of 8/i)).toBeInTheDocument();
   });
 
   it("can display correct cpu core information with overcommit", () => {
@@ -66,19 +57,15 @@ describe("CPUColumn", () => {
         free: 4,
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <CPUColumn
-          cores={pod.resources.cores}
-          overCommit={pod.cpu_over_commit_ratio}
-        />
-      </Provider>
+
+    renderWithMockStore(
+      <CPUColumn
+        cores={pod.resources.cores}
+        overCommit={pod.cpu_over_commit_ratio}
+      />,
+      { state }
     );
-    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "4 of 16 allocated"
-    );
-    expect(wrapper.find("Meter").prop("max")).toBe(16);
+    expect(screen.getByText(/4 of 16/i)).toBeInTheDocument();
   });
 
   it("can display when cpu has been overcommitted", () => {
@@ -90,20 +77,16 @@ describe("CPUColumn", () => {
         free: -1,
       }),
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <CPUColumn
-          cores={pod.resources.cores}
-          overCommit={pod.cpu_over_commit_ratio}
-        />
-      </Provider>
+
+    renderWithMockStore(
+      <CPUColumn
+        cores={pod.resources.cores}
+        overCommit={pod.cpu_over_commit_ratio}
+      />,
+      { state }
     );
-    expect(wrapper.find("[data-testid='meter-overflow']").exists()).toBe(true);
-    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "4 of 3 allocated"
-    );
-    expect(wrapper.find("Meter").prop("max")).toBe(3);
+    expect(screen.getByTestId("meter-overflow")).toBeInTheDocument();
+    expect(screen.getByText(/4 of 3/i)).toBeInTheDocument();
   });
 
   it("can display correct cpu core information for vmclusters", () => {
@@ -112,15 +95,10 @@ describe("CPUColumn", () => {
       allocated_tracked: 2,
       free: 3,
     });
-    const store = mockStore(state);
-    const wrapper = mount(
-      <Provider store={store}>
-        <CPUColumn cores={resources} />
-      </Provider>
-    );
-    expect(wrapper.find("Meter").find(".p-meter__label").text()).toBe(
-      "2 of 6 allocated"
-    );
-    expect(wrapper.find("Meter").prop("max")).toBe(6);
+
+    renderWithMockStore(<CPUColumn cores={resources} />, {
+      state,
+    });
+    expect(screen.getByText(/2 of 6/i)).toBeInTheDocument();
   });
 });

--- a/src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.test.tsx
+++ b/src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.test.tsx
@@ -1,15 +1,14 @@
-import { mount } from "enzyme";
-
 import CPUPopover from "./CPUPopover";
 
 import {
   podResource as podResourceFactory,
   vmClusterResource as vmClusterResourceFactory,
 } from "testing/factories";
+import { render, screen, userEvent } from "testing/utils";
 
 describe("CPUPopover", () => {
-  it("shows if cores are used by any other projects in the group", () => {
-    const wrapper = mount(
+  it("shows if cores are used by any other projects in the group", async () => {
+    render(
       <CPUPopover
         cores={podResourceFactory({
           allocated_other: 1,
@@ -19,12 +18,13 @@ describe("CPUPopover", () => {
         Child
       </CPUPopover>
     );
-    wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-testid='other']").exists()).toBe(true);
+
+    await userEvent.click(screen.getByRole("button", { name: "Child" }));
+    expect(screen.getByTestId("other")).toHaveTextContent("1");
   });
 
-  it("does not show other cores if no other projects in the group use them", () => {
-    const wrapper = mount(
+  it("does not show other cores if no other projects in the group use them", async () => {
+    render(
       <CPUPopover
         cores={podResourceFactory({
           allocated_other: 0,
@@ -34,12 +34,13 @@ describe("CPUPopover", () => {
         Child
       </CPUPopover>
     );
-    wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-testid='other']").exists()).toBe(false);
+
+    await userEvent.click(screen.getByRole("button", { name: "Child" }));
+    expect(screen.queryByTestId("other")).not.toBeInTheDocument();
   });
 
-  it("shows CPU over-commit ratio if it is not equal to 1", () => {
-    const wrapper = mount(
+  it("shows CPU over-commit ratio if it is not equal to 1", async () => {
+    render(
       <CPUPopover
         cores={podResourceFactory({
           allocated_other: 1,
@@ -49,12 +50,13 @@ describe("CPUPopover", () => {
         Child
       </CPUPopover>
     );
-    wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-testid='overcommit']").exists()).toBe(true);
+
+    await userEvent.click(screen.getByRole("button", { name: "Child" }));
+    expect(screen.getByTestId("overcommit")).toHaveTextContent("2");
   });
 
-  it("does not show CPU over-commit ratio if it is equal to 1", () => {
-    const wrapper = mount(
+  it("does not show CPU over-commit ratio if it is equal to 1", async () => {
+    render(
       <CPUPopover
         cores={podResourceFactory({
           allocated_other: 1,
@@ -64,12 +66,13 @@ describe("CPUPopover", () => {
         Child
       </CPUPopover>
     );
-    wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-testid='overcommit']").exists()).toBe(false);
+
+    await userEvent.click(screen.getByRole("button", { name: "Child" }));
+    expect(screen.queryByTestId("overcommit")).not.toBeInTheDocument();
   });
 
-  it("displays cores for a vmcluster", () => {
-    const wrapper = mount(
+  it("displays cores for a vmcluster", async () => {
+    render(
       <CPUPopover
         cores={vmClusterResourceFactory({
           allocated_other: 1,
@@ -81,10 +84,11 @@ describe("CPUPopover", () => {
         Child
       </CPUPopover>
     );
-    wrapper.find("Popover").simulate("focus");
-    expect(wrapper.find("[data-testid='other']").text()).toBe("1");
-    expect(wrapper.find("[data-testid='allocated']").text()).toBe("2");
-    expect(wrapper.find("[data-testid='free']").text()).toBe("3");
-    expect(wrapper.find("[data-testid='total']").text()).toBe("6");
+
+    await userEvent.click(screen.getByRole("button", { name: "Child" }));
+    expect(screen.getByTestId("other")).toHaveTextContent("1");
+    expect(screen.getByTestId("allocated")).toHaveTextContent("2");
+    expect(screen.getByTestId("free")).toHaveTextContent("3");
+    expect(screen.getByTestId("total")).toHaveTextContent("6");
   });
 });


### PR DESCRIPTION
## Done

Migrated the following tests to RTL:
```
4.0K	./src/app/kvm/components/CPUColumn/CPUColumn.test.tsx
4.0K	./src/app/kvm/components/CPUColumn/CPUPopover/CPUPopover.test.tsx
```

## Fixes

Fixes [MAASENG-1741](https://warthogs.atlassian.net/browse/MAASENG-1741)

