### PR TITLE
fix: buttons remain visible on side panel open #MAASENG-1803

### DIFF
--- a/src/app/base/components/SectionHeader/SectionHeader.test.tsx
+++ b/src/app/base/components/SectionHeader/SectionHeader.test.tsx
@@ -92,7 +92,7 @@ describe("SectionHeader", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not render buttons if header content is present", () => {
+  it("buttons remain visible if header content is present", () => {
     const { rerender } = renderWithBrowserRouter(
       <SectionHeader
         buttons={[<button key="button">Click me</button>]}
@@ -111,9 +111,7 @@ describe("SectionHeader", () => {
         title="Title"
       />
     );
-    expect(
-      screen.queryByTestId("section-header-buttons")
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("section-header-buttons")).toBeInTheDocument();
     expect(screen.getByTestId("section-header-subtitle")).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -114,7 +114,7 @@ const SectionHeader = <P,>({
           subtitleLoading,
           loading
         )}
-        {buttons?.length && !sidePanelContent ? (
+        {buttons?.length ? (
           <List
             className="section-header__buttons u-flex--between"
             data-testid="section-header-buttons"

--- a/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
@@ -9,7 +9,7 @@ import {
   discoveryState as discoveryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { userEvent, screen, renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("DashboardHeader", () => {
   let state: RootState;
@@ -52,19 +52,5 @@ describe("DashboardHeader", () => {
     expect(
       screen.getByRole("button", { name: DashboardHeaderLabels.ClearAll })
     ).toBeInTheDocument();
-  });
-
-  it("hides the clear-all button when the form is visible", async () => {
-    renderWithBrowserRouter(<DashboardHeader />, {
-      route: "/dashboard",
-      state,
-    });
-
-    const clearAllButton = screen.getByRole("button", {
-      name: DashboardHeaderLabels.ClearAll,
-    });
-
-    await userEvent.click(clearAllButton);
-    expect(clearAllButton).not.toBeInTheDocument();
   });
 });

--- a/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
@@ -13,7 +13,7 @@ import {
   spaceState as spaceStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { userEvent, render, screen, waitFor } from "testing/utils";
+import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
 const renderTestCase = (
   space = spaceFactory({
@@ -72,7 +72,11 @@ it("displays a delete confirmation before delete", async () => {
     screen.getByText("Are you sure you want to delete this space?")
   ).toBeInTheDocument();
 
-  await userEvent.click(screen.getByRole("button", { name: "Delete space" }));
+  await userEvent.click(
+    within(screen.getByRole("complementary")).getByRole("button", {
+      name: "Delete space",
+    })
+  );
 
   const expectedActions = [spaceActions.cleanup(), spaceActions.delete(1)];
 

--- a/src/app/tags/views/Tags.test.tsx
+++ b/src/app/tags/views/Tags.test.tsx
@@ -13,12 +13,7 @@ import {
   tag as tagFactory,
   tagState as tagStateFactory,
 } from "testing/factories";
-import {
-  userEvent,
-  screen,
-  within,
-  renderWithBrowserRouter,
-} from "testing/utils";
+import { screen, within, renderWithBrowserRouter } from "testing/utils";
 
 describe("Tags", () => {
   let scrollToSpy: jest.Mock;
@@ -89,82 +84,5 @@ describe("Tags", () => {
     expect(
       within(details).getByRole("link", { name: TagDetailsLabel.EditButton })
     ).toBeInTheDocument();
-  });
-
-  it("hides buttons when deleting tags", async () => {
-    renderWithBrowserRouter(<Tags />, {
-      routePattern: `${urls.tags.tag.index(null)}/*`,
-      state,
-      route: urls.tags.tag.index({ id: 1 }),
-    });
-    const header = screen.getByLabelText(TagsHeaderLabel.Header);
-    const details = screen.getByLabelText(TagDetailsLabel.Title);
-    await userEvent.click(
-      within(details).getByRole("button", {
-        name: TagDetailsLabel.DeleteButton,
-      })
-    );
-    expect(
-      within(header).queryByRole("button", {
-        name: TagsHeaderLabel.CreateButton,
-      })
-    ).not.toBeInTheDocument();
-    expect(
-      within(details).queryByRole("button", {
-        name: TagDetailsLabel.DeleteButton,
-      })
-    ).not.toBeInTheDocument();
-    expect(
-      within(details).queryByRole("link", { name: TagDetailsLabel.EditButton })
-    ).not.toBeInTheDocument();
-  });
-
-  it("hides buttons when updating tags", () => {
-    renderWithBrowserRouter(<Tags />, {
-      routePattern: `${urls.tags.tag.index(null)}/*`,
-      state,
-      route: urls.tags.tag.update({ id: 1 }),
-    });
-    const header = screen.getByLabelText(TagsHeaderLabel.Header);
-    const details = screen.getByLabelText(TagUpdateLabel.Form);
-    expect(
-      within(header).queryByRole("button", {
-        name: TagsHeaderLabel.CreateButton,
-      })
-    ).not.toBeInTheDocument();
-    expect(
-      within(details).queryByRole("button", {
-        name: TagDetailsLabel.DeleteButton,
-      })
-    ).not.toBeInTheDocument();
-    expect(
-      within(details).queryByRole("link", { name: TagDetailsLabel.EditButton })
-    ).not.toBeInTheDocument();
-  });
-
-  it("hides buttons when creating tags", async () => {
-    renderWithBrowserRouter(<Tags />, {
-      routePattern: `${urls.tags.tag.index(null)}/*`,
-      state,
-      route: urls.tags.tag.index({ id: 1 }),
-    });
-    const header = screen.getByLabelText(TagsHeaderLabel.Header);
-    const details = screen.getByLabelText(TagDetailsLabel.Title);
-    await userEvent.click(
-      within(header).getByRole("button", { name: TagsHeaderLabel.CreateButton })
-    );
-    expect(
-      within(header).queryByRole("button", {
-        name: TagsHeaderLabel.CreateButton,
-      })
-    ).not.toBeInTheDocument();
-    expect(
-      within(details).queryByRole("button", {
-        name: TagDetailsLabel.DeleteButton,
-      })
-    ).not.toBeInTheDocument();
-    expect(
-      within(details).queryByRole("link", { name: TagDetailsLabel.EditButton })
-    ).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Done

- fix: buttons should remain visible on side panel open

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1803

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
