### PR TITLE
test: update sitespeed.io workflow

### DIFF
--- a/sitespeed.io/login.js
+++ b/sitespeed.io/login.js
@@ -22,5 +22,5 @@ module.exports = async function (context, commands) {
     "[data-testid='section-header-title-spinner']",
     TIMEOUT
   );
-  await commands.wait.byXpath("//header//a[text()='admin']");
+  await commands.wait.byXpath("//a//span[text()='admin']");
 };

--- a/sitespeed.io/scripts/machines.js
+++ b/sitespeed.io/scripts/machines.js
@@ -1,12 +1,13 @@
 const { constructURL } = require("../utils");
 
 const TIMEOUT = 120000;
+const allMachinesLoaded = "//h1[text()[normalize-space() = '1000']]";
 
 const coldCache = async (context, commands) => {
   await commands.cache.clearKeepCookies();
   await commands.measure.start("Machine list - cold cache");
   await commands.navigate(constructURL(context, "/machines"));
-  await commands.wait.byXpath("//*[text()='1000 Machines']", TIMEOUT);
+  await commands.wait.byXpath(allMachinesLoaded, TIMEOUT);
   return commands.measure.stop();
 };
 
@@ -14,7 +15,7 @@ const warmCache = async (context, commands) => {
   await commands.navigate(constructURL(context, "/machines"));
   await commands.measure.start("Machine list - warm cache");
   await commands.navigate(constructURL(context, "/machines"));
-  await commands.wait.byXpath("//*[text()='1000 Machines']", TIMEOUT);
+  await commands.wait.byXpath(allMachinesLoaded, TIMEOUT);
   return commands.measure.stop();
 };
 


### PR DESCRIPTION
## Done

- fix sitespeed.io workflow
  - update xpath selector

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Verify the fix has worked by checking workflow output from `test-sitespeed.io-fix` branch: https://github.com/canonical/maas-ui/actions/runs/5156251350


## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
