### PR TITLE
feat(machines): Add notification to show number of selected machines MAASENG-1355

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/MachineListDisplayCount.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListDisplayCount/MachineListDisplayCount.tsx
@@ -1,3 +1,21 @@
+export const getCurrentPageDisplayedMachineCount = (
+  machineCount: number | null,
+  pageSize: number,
+  currentPage: number
+): number => {
+  if (!machineCount) {
+    return 0;
+  }
+
+  const totalPages = Math.ceil(machineCount / pageSize);
+
+  if (currentPage === totalPages) {
+    return pageSize - (totalPages * pageSize - machineCount);
+  } else {
+    return pageSize;
+  }
+};
+
 export const MachineListDisplayCount = ({
   machineCount,
   pageSize,
@@ -7,24 +25,11 @@ export const MachineListDisplayCount = ({
   pageSize: number;
   currentPage: number;
 }): JSX.Element => {
-  const getCurrentPageDisplayedMachineCount = () => {
-    if (!machineCount) {
-      return null;
-    }
-
-    const totalPages = Math.ceil(machineCount / pageSize);
-
-    if (currentPage === totalPages) {
-      return pageSize - (totalPages * pageSize - machineCount);
-    } else {
-      return pageSize;
-    }
-  };
-
   return (
     <strong className="machine-list--display-count">
-      Showing {getCurrentPageDisplayedMachineCount()} out of {machineCount}{" "}
-      machines
+      Showing{" "}
+      {getCurrentPageDisplayedMachineCount(machineCount, pageSize, currentPage)}{" "}
+      out of {machineCount} machines
     </strong>
   );
 };

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/MachineListSelectedCount.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/MachineListSelectedCount.test.tsx
@@ -1,0 +1,146 @@
+import configureStore from "redux-mock-store";
+
+import MachineListSelectedCount from "./MachineListSelectedCount";
+
+import { actions as machineActions } from "app/store/machine";
+import type { RootState } from "app/store/root/types";
+import {
+  screen,
+  renderWithMockStore,
+  getTestState,
+  userEvent,
+} from "testing/utils";
+
+const mockStore = configureStore<RootState>();
+
+describe("MachineListSelectedCount", () => {
+  let state: RootState;
+  beforeEach(() => {
+    state = getTestState();
+  });
+
+  it("displays the number of selected machines", () => {
+    renderWithMockStore(
+      <MachineListSelectedCount
+        filter={""}
+        machineCount={20}
+        selectedCount={10}
+      />,
+      { state }
+    );
+
+    expect(screen.getByText(/10 machines selected/i)).toBeInTheDocument();
+  });
+
+  it("displays a button to select all machines", () => {
+    renderWithMockStore(
+      <MachineListSelectedCount
+        filter={""}
+        machineCount={20}
+        selectedCount={10}
+      />,
+      { state }
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Select all 20 machines"
+    );
+  });
+
+  it("displays a button to select all filtered machines", () => {
+    renderWithMockStore(
+      <MachineListSelectedCount
+        filter={"filter"}
+        machineCount={20}
+        selectedCount={10}
+      />,
+      { state }
+    );
+
+    expect(screen.getByRole("button")).toHaveTextContent(
+      "Select all 20 filtered machines"
+    );
+  });
+
+  it("displays a button to clear selection if all machines are selected", () => {
+    renderWithMockStore(
+      <MachineListSelectedCount
+        filter={""}
+        machineCount={20}
+        selectedCount={20}
+      />,
+      { state }
+    );
+
+    expect(screen.getByText(/Selected all 20 machines/i)).toBeInTheDocument();
+    expect(screen.getByRole("button")).toHaveTextContent("Clear selection");
+  });
+
+  it("dispatches an action to select all machines", async () => {
+    const store = mockStore(state);
+    renderWithMockStore(
+      <MachineListSelectedCount
+        filter={""}
+        machineCount={20}
+        selectedCount={10}
+      />,
+      { store }
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Select all 20 machines" })
+    );
+
+    const expectedAction = machineActions.setSelectedMachines({ filter: {} });
+
+    expect(
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+
+  it("dispatches an action to select all filtered machines", async () => {
+    const store = mockStore(state);
+    renderWithMockStore(
+      <MachineListSelectedCount
+        filter={"this-is-a-filter"}
+        machineCount={20}
+        selectedCount={10}
+      />,
+      { store }
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Select all 20 filtered machines" })
+    );
+
+    const expectedAction = machineActions.setSelectedMachines({
+      filter: { free_text: ["this-is-a-filter"] },
+    });
+
+    expect(
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+
+  it("dispatches an action to clear the selection", async () => {
+    const store = mockStore(state);
+    renderWithMockStore(
+      <MachineListSelectedCount
+        filter={""}
+        machineCount={20}
+        selectedCount={20}
+      />,
+      { store }
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Clear selection" })
+    );
+
+    const expectedAction = machineActions.setSelectedMachines(null);
+
+    expect(
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/MachineListSelectedCount.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/MachineListSelectedCount.tsx
@@ -1,0 +1,59 @@
+import { Notification, Button } from "@canonical/react-components";
+import pluralize from "pluralize";
+import { useDispatch } from "react-redux";
+
+import { actions as machineActions } from "app/store/machine";
+import { FilterMachines } from "app/store/machine/utils";
+
+type Props = {
+  filter: string;
+  machineCount: number | null;
+  selectedCount: number;
+};
+
+export const MachineListSelectedCount = ({
+  filter,
+  machineCount,
+  selectedCount,
+}: Props): JSX.Element => {
+  const dispatch = useDispatch();
+
+  return (
+    <Notification borderless className="u-no-margin--bottom" title="Selection">
+      {machineCount && selectedCount < machineCount ? (
+        <>
+          {selectedCount} {pluralize("machine", selectedCount)} selected.{" "}
+          <Button
+            appearance="link"
+            onClick={() => {
+              dispatch(
+                machineActions.setSelectedMachines({
+                  filter: FilterMachines.parseFetchFilters(filter),
+                })
+              );
+            }}
+          >
+            {filter
+              ? `Select all ${machineCount} filtered machines`
+              : `Select all ${machineCount} machines`}
+          </Button>
+        </>
+      ) : (
+        <>
+          Selected all {machineCount}
+          {filter ? " filtered" : ""} machines.{" "}
+          <Button
+            appearance="link"
+            onClick={() => {
+              dispatch(machineActions.setSelectedMachines(null));
+            }}
+          >
+            Clear selection
+          </Button>
+        </>
+      )}
+    </Notification>
+  );
+};
+
+export default MachineListSelectedCount;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/index.ts
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineListSelectedCount";

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -838,14 +838,18 @@ export const MachineListTable = ({
           {
             className: "select-notification",
             key: "select-info",
-            expanded: true,
-            expandedContent: (
-              <MachineListSelectedCount
-                filter={filter}
-                machineCount={machineCount}
-                selectedCount={selectedCount}
-              />
-            ),
+            columns: [
+              {
+                colSpan: columns.length - hiddenColumns.length,
+                content: (
+                  <MachineListSelectedCount
+                    filter={filter}
+                    machineCount={machineCount}
+                    selectedCount={selectedCount}
+                  />
+                ),
+              },
+            ],
           },
         ]
       : [];
@@ -886,7 +890,6 @@ export const MachineListTable = ({
           "machine-list--loading": machinesLoading,
         })}
         emptyStateMsg={!machinesLoading && filter ? Label.NoResults : null}
-        expanding={true}
         headers={filterColumns(headers, hiddenColumns, showActions)}
         rows={machinesLoading ? skeletonRows : [...selectionState, ...rows]}
         {...props}

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -832,27 +832,35 @@ export const MachineListTable = ({
     [hiddenColumns, showActions]
   );
 
-  const selectionState =
-    selectedCount > 0
-      ? [
-          {
-            className: "select-notification",
-            key: "select-info",
-            columns: [
-              {
-                colSpan: columns.length - hiddenColumns.length,
-                content: (
-                  <MachineListSelectedCount
-                    filter={filter}
-                    machineCount={machineCount}
-                    selectedCount={selectedCount}
-                  />
-                ),
-              },
-            ],
-          },
-        ]
-      : [];
+  const selectionState = useMemo(() => {
+    if (selectedCount > 0) {
+      return [
+        {
+          className: "select-notification",
+          key: "select-info",
+          columns: [
+            {
+              colSpan: columns.length - hiddenColumns.length,
+              content: (
+                <MachineListSelectedCount
+                  filter={filter}
+                  machineCount={machineCount}
+                  selectedCount={selectedCount}
+                />
+              ),
+            },
+          ],
+        },
+      ];
+    } else {
+      return [];
+    }
+  }, [filter, hiddenColumns.length, machineCount, selectedCount]);
+
+  const renderRows = useMemo(
+    () => [...selectionState, ...rows],
+    [rows, selectionState]
+  );
 
   return (
     <>
@@ -891,7 +899,7 @@ export const MachineListTable = ({
         })}
         emptyStateMsg={!machinesLoading && filter ? Label.NoResults : null}
         headers={filterColumns(headers, hiddenColumns, showActions)}
-        rows={machinesLoading ? skeletonRows : [...selectionState, ...rows]}
+        rows={machinesLoading ? skeletonRows : renderRows}
         {...props}
       />
     </>

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -857,7 +857,7 @@ export const MachineListTable = ({
     }
   }, [filter, hiddenColumns.length, machineCount, selectedCount]);
 
-  const renderRows = useMemo(
+  const machineRows = useMemo(
     () => [...selectionState, ...rows],
     [rows, selectionState]
   );
@@ -899,7 +899,7 @@ export const MachineListTable = ({
         })}
         emptyStateMsg={!machinesLoading && filter ? Label.NoResults : null}
         headers={filterColumns(headers, hiddenColumns, showActions)}
-        rows={machinesLoading ? skeletonRows : renderRows}
+        rows={machinesLoading ? skeletonRows : machineRows}
         {...props}
       />
     </>

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useMemo, memo, useCallback, useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
-import { Notification, Button, MainTable } from "@canonical/react-components";
+import { Button, MainTable } from "@canonical/react-components";
 import type {
   MainTableCell,
   MainTableRow,
@@ -18,6 +18,7 @@ import FabricColumn from "./FabricColumn";
 import GroupCheckbox from "./GroupCheckbox";
 import MachineListDisplayCount from "./MachineListDisplayCount";
 import MachineListPagination from "./MachineListPagination";
+import MachineListSelectedCount from "./MachineListSelectedCount/MachineListSelectedCount";
 import NameColumn from "./NameColumn";
 import OwnerColumn from "./OwnerColumn";
 import PageSizeSelect from "./PageSizeSelect";
@@ -839,14 +840,11 @@ export const MachineListTable = ({
             key: "select-info",
             expanded: true,
             expandedContent: (
-              <Notification
-                borderless
-                className="u-no-margin--bottom"
-                title="Selection"
-              >
-                Selected {selectedCount} {pluralize("machine", selectedCount)}{" "}
-                on this page.
-              </Notification>
+              <MachineListSelectedCount
+                filter={filter}
+                machineCount={machineCount}
+                selectedCount={selectedCount}
+              />
             ),
           },
         ]

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useMemo, memo, useCallback, useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
-import { Button, MainTable } from "@canonical/react-components";
+import { Notification, Button, MainTable } from "@canonical/react-components";
 import type {
   MainTableCell,
   MainTableRow,
@@ -39,6 +39,7 @@ import { actions as generalActions } from "app/store/general";
 import type { Machine, MachineStateListGroup } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
+import { useMachineSelectedCount } from "app/store/machine/utils/hooks";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import { actions as tagActions } from "app/store/tag";
 import { actions as userActions } from "app/store/user";
@@ -519,6 +520,7 @@ export const MachineListTable = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
   const sendAnalytics = useSendAnalytics();
+  const { selectedCount } = useMachineSelectedCount();
 
   const currentSort = {
     direction: sortDirection,
@@ -829,6 +831,27 @@ export const MachineListTable = ({
     [hiddenColumns, showActions]
   );
 
+  const selectionState =
+    selectedCount > 0
+      ? [
+          {
+            className: "select-notification",
+            key: "select-info",
+            expanded: true,
+            expandedContent: (
+              <Notification
+                borderless
+                className="u-no-margin--bottom"
+                title="Selection"
+              >
+                Selected {selectedCount} {pluralize("machine", selectedCount)}{" "}
+                on this page.
+              </Notification>
+            ),
+          },
+        ]
+      : [];
+
   return (
     <>
       {machineCount ? (
@@ -865,8 +888,9 @@ export const MachineListTable = ({
           "machine-list--loading": machinesLoading,
         })}
         emptyStateMsg={!machinesLoading && filter ? Label.NoResults : null}
+        expanding={true}
         headers={filterColumns(headers, hiddenColumns, showActions)}
-        rows={machinesLoading ? skeletonRows : rows}
+        rows={machinesLoading ? skeletonRows : [...selectionState, ...rows]}
         {...props}
       />
     </>

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -174,10 +174,4 @@
       margin-right: $spv--x-small;
     }
   }
-
-  // .select-notification {
-  //   td.p-table__expanding-panel {
-  //     border: 0;
-  //   }
-  // }
 }

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -175,9 +175,9 @@
     }
   }
 
-  .select-notification {
-    td.p-table__expanding-panel {
-      border: 0;
-    }
-  }
+  // .select-notification {
+  //   td.p-table__expanding-panel {
+  //     border: 0;
+  //   }
+  // }
 }

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -174,4 +174,10 @@
       margin-right: $spv--x-small;
     }
   }
+
+  .select-notification {
+    td.p-table__expanding-panel {
+      border: 0;
+    }
+  }
 }


### PR DESCRIPTION
## Done

- Added a notification to show the number of machines currently selected
- Created MachineListSelectedCount component
- Exported `getCurrentPageDisplayedMachineCount` function from `MachineListDisplayCount` to assist with [MAASENG-1688](https://warthogs.atlassian.net/browse/MAASENG-1688)

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Select a few machines
- Ensure a notification is displayed with the correct number of machines selected
- Click "Select all X machines"
- Ensure all machines are selected
- Click "Clear selection"
- Ensure selection is cleared
- Enter a filter into the searchbox and repeat the above steps, ensuring that "filtered" is correctly shown in the notificaiton

## Fixes

Fixes [MAASENG-1355](https://warthogs.atlassian.net/browse/MAASENG-1355)

## Screenshots

### Some selected

![image](https://github.com/canonical/maas-ui/assets/35104482/0839c413-4693-4107-9d6b-0da6d5fc5cf5)

### All selected

![image](https://github.com/canonical/maas-ui/assets/35104482/48c22f5b-9290-4a66-aa74-db62b0d2f2be)

### Filtered selected

![image](https://github.com/canonical/maas-ui/assets/35104482/58d33102-1508-4d08-bdd3-f86ea8963e2a)

### All filtered selected

![image](https://github.com/canonical/maas-ui/assets/35104482/8b53d399-7ec1-4d3c-825b-76784565852e)


[MAASENG-1688]: https://warthogs.atlassian.net/browse/MAASENG-1688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAASENG-1355]: https://warthogs.atlassian.net/browse/MAASENG-1355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ