### PR TITLE
create PageContent component MAASENG-1804

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -33,6 +33,7 @@ describe("App", () => {
   it("renders routes if logged in", () => {
     state.status.connected = true;
     state.status.authenticated = true;
+    state.user.auth.loaded = true;
     renderWithBrowserRouter(<App />, { route: "/settings", state });
     expect(window.location.pathname).toBe("/settings");
     expect(

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -4,26 +4,20 @@ import { useEffect, useState } from "react";
 import { Notification } from "@canonical/react-components";
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import * as Sentry from "@sentry/browser";
-import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
-import { matchPath, useLocation } from "react-router-dom-v5-compat";
 
 import packageInfo from "../../package.json";
 
 import NavigationBanner from "./base/components/AppSideNavigation/NavigationBanner";
-import SecondaryNavigation from "./base/components/SecondaryNavigation/SecondaryNavigation";
+import PageContent from "./base/components/PageContent/PageContent";
+import SectionHeader from "./base/components/SectionHeader";
 import ThemePreviewContext from "./base/theme-preview-context";
 import { MAAS_UI_ID } from "./constants";
-import { preferencesNavItems } from "./preferences/constants";
-import { settingsNavItems } from "./settings/constants";
 import { formatErrors } from "./utils";
 
 import Routes from "app/Routes";
 import AppSideNavigation from "app/base/components/AppSideNavigation";
-import Footer from "app/base/components/Footer";
 import Login from "app/base/components/Login";
-import MainContentSection from "app/base/components/MainContentSection";
-import SectionHeader from "app/base/components/SectionHeader";
 import StatusBar from "app/base/components/StatusBar";
 import FileContext, { fileContextStore } from "app/base/file-context";
 import { actions as authActions } from "app/store/auth";
@@ -55,10 +49,6 @@ export const App = (): JSX.Element => {
   const configErrors = useSelector(configSelectors.errors);
   const [theme, setTheme] = useState(maasTheme ? maasTheme : "default");
   const previousAuthenticated = usePrevious(authenticated, false);
-  const { pathname } = useLocation();
-  const isSettingsPage = matchPath("settings/*", pathname);
-  const isPreferencesPage = matchPath("account/prefs/*", pathname);
-  const isSideNavVisible = isSettingsPage || isPreferencesPage;
 
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());
@@ -100,10 +90,16 @@ export const App = (): JSX.Element => {
 
   let content: ReactNode = null;
   if (isLoading) {
-    content = <MainContentSection header={<SectionHeader loading />} />;
+    content = (
+      <PageContent
+        header={<SectionHeader loading />}
+        sidePanelContent={null}
+        sidePanelTitle={null}
+      />
+    );
   } else if (hasAuthError) {
     content = (
-      <MainContentSection>
+      <PageContent sidePanelContent={null} sidePanelTitle={null}>
         {authenticationError ? (
           authenticationError === "Session expired" ? (
             <Notification role="alert" severity="information">
@@ -117,11 +113,15 @@ export const App = (): JSX.Element => {
           )
         ) : null}
         <Login />
-      </MainContentSection>
+      </PageContent>
     );
   } else if (hasWebsocketError || hasVaultError) {
     content = (
-      <MainContentSection header={<SectionHeader title="Failed to connect" />}>
+      <PageContent
+        header={<SectionHeader title="Failed to connect" />}
+        sidePanelContent={null}
+        sidePanelTitle={null}
+      >
         <Notification severity="negative" title="Error:">
           The server connection failed
           {hasVaultError || connectionError
@@ -130,7 +130,7 @@ export const App = (): JSX.Element => {
               }"`
             : ""}
         </Notification>
-      </MainContentSection>
+      </PageContent>
     );
   } else if (isLoaded) {
     content = (
@@ -162,36 +162,7 @@ export const App = (): JSX.Element => {
           </header>
         )}
 
-        <main className="l-main">
-          {isSideNavVisible ? (
-            <div
-              className={classNames("l-main__nav", `is-maas-${theme}--accent`)}
-            >
-              <SecondaryNavigation
-                isOpen={!!isSideNavVisible}
-                items={
-                  isSettingsPage
-                    ? settingsNavItems
-                    : isPreferencesPage
-                    ? preferencesNavItems
-                    : []
-                }
-                title={
-                  isSettingsPage
-                    ? "Settings"
-                    : isPreferencesPage
-                    ? "My preferences"
-                    : ""
-                }
-              />
-            </div>
-          ) : null}
-          <div className="l-main__content" id="main-content">
-            {content}
-            <hr />
-            <Footer />
-          </div>
-        </main>
+        {content}
         <aside className="l-status">
           <StatusBar />
         </aside>

--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -1,6 +1,8 @@
 import { Redirect } from "react-router-dom";
 import { Route, Routes as ReactRouterRoutes } from "react-router-dom-v5-compat";
 
+import { LegacyPageContentWrapper } from "./base/components/PageContent/PageContent";
+
 import ErrorBoundary from "app/base/components/ErrorBoundary";
 import urls from "app/base/urls";
 import NotFound from "app/base/views/NotFound";
@@ -34,196 +36,200 @@ const Routes = (): JSX.Element => (
     <Route
       element={
         <ErrorBoundary>
-          <Intro />
-        </ErrorBoundary>
-      }
-      path={`${urls.intro.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <Preferences />
-        </ErrorBoundary>
-      }
-      path={`${urls.preferences.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <ControllerList />
-        </ErrorBoundary>
-      }
-      path={`${urls.controllers.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <ControllerDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.controllers.controller.index(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <DeviceList />
-        </ErrorBoundary>
-      }
-      path={`${urls.devices.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <DeviceDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.devices.device.index(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <DomainsList />
-        </ErrorBoundary>
-      }
-      path={`${urls.domains.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <DomainDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.domains.details(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <ImageList />
-        </ErrorBoundary>
-      }
-      path={`${urls.images.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <KVM />
-        </ErrorBoundary>
-      }
-      path={`${urls.kvm.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
           <Machines />
         </ErrorBoundary>
       }
       path={urls.machines.index}
     />
-    <Route
-      element={
-        <ErrorBoundary>
-          <MachineDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.machines.machine.index(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <Pools />
-        </ErrorBoundary>
-      }
-      path={`${urls.pools.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <Tags />
-        </ErrorBoundary>
-      }
-      path={`${urls.tags.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <Tags />
-        </ErrorBoundary>
-      }
-      path={`${urls.tags.tag.index(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <Settings />
-        </ErrorBoundary>
-      }
-      path={`${urls.settings.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <SubnetsList />
-        </ErrorBoundary>
-      }
-      path={`${urls.subnets.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <FabricDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.subnets.fabric.index(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <SpaceDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.subnets.space.index(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <SubnetDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.subnets.subnet.index(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <VLANDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.subnets.vlan.index(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <ZonesList />
-        </ErrorBoundary>
-      }
-      path={`${urls.zones.index}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <ZoneDetails />
-        </ErrorBoundary>
-      }
-      path={`${urls.zones.details(null)}/*`}
-    />
-    <Route
-      element={
-        <ErrorBoundary>
-          <Dashboard />
-        </ErrorBoundary>
-      }
-      path={`${urls.dashboard.index}/*`}
-    />
-    <Route element={<NotFound includeSection />} path="*" />
+    {/* TODO: Remove this wrapper route once all pages use the new page component wrapper */}
+    {/* https://warthogs.atlassian.net/browse/MAASENG-1832 */}
+    <Route element={<LegacyPageContentWrapper />}>
+      <Route
+        element={
+          <ErrorBoundary>
+            <Intro />
+          </ErrorBoundary>
+        }
+        path={`${urls.intro.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <Preferences />
+          </ErrorBoundary>
+        }
+        path={`${urls.preferences.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <ControllerList />
+          </ErrorBoundary>
+        }
+        path={`${urls.controllers.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <ControllerDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.controllers.controller.index(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <DeviceList />
+          </ErrorBoundary>
+        }
+        path={`${urls.devices.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <DeviceDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.devices.device.index(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <DomainsList />
+          </ErrorBoundary>
+        }
+        path={`${urls.domains.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <DomainDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.domains.details(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <ImageList />
+          </ErrorBoundary>
+        }
+        path={`${urls.images.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <KVM />
+          </ErrorBoundary>
+        }
+        path={`${urls.kvm.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <MachineDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.machines.machine.index(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <Pools />
+          </ErrorBoundary>
+        }
+        path={`${urls.pools.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <Tags />
+          </ErrorBoundary>
+        }
+        path={`${urls.tags.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <Tags />
+          </ErrorBoundary>
+        }
+        path={`${urls.tags.tag.index(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <Settings />
+          </ErrorBoundary>
+        }
+        path={`${urls.settings.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <SubnetsList />
+          </ErrorBoundary>
+        }
+        path={`${urls.subnets.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <FabricDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.subnets.fabric.index(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <SpaceDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.subnets.space.index(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <SubnetDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.subnets.subnet.index(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <VLANDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.subnets.vlan.index(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <ZonesList />
+          </ErrorBoundary>
+        }
+        path={`${urls.zones.index}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <ZoneDetails />
+          </ErrorBoundary>
+        }
+        path={`${urls.zones.details(null)}/*`}
+      />
+      <Route
+        element={
+          <ErrorBoundary>
+            <Dashboard />
+          </ErrorBoundary>
+        }
+        path={`${urls.dashboard.index}/*`}
+      />
+      <Route element={<NotFound includeSection />} path="*" />
+    </Route>
   </ReactRouterRoutes>
 );
 

--- a/src/app/base/components/AppSidePanel/AppSidePanel.tsx
+++ b/src/app/base/components/AppSidePanel/AppSidePanel.tsx
@@ -13,41 +13,57 @@ type Props = {
   content?: ReactNode;
 };
 
-const AppSidePanel = ({ title, size, content }: Props): JSX.Element => {
+const AppSidePanel = ({
+  title,
+  size,
+  content,
+}: Props & { title: string | null }): JSX.Element => {
   const { setSidePanelContent } = useSidePanel();
   useOnEscapePressed(() => setSidePanelContent(null));
+  return (
+    <aside
+      aria-label={title ?? undefined}
+      className={classNames("l-aside", {
+        "is-collapsed": !content,
+        "is-wide": size === "wide",
+        "is-narrow": size === "narrow",
+      })}
+      data-testid="section-header-content"
+      id="aside-panel"
+    >
+      <Row>
+        <Col size={12}>
+          {title ? (
+            <div className="row section-header">
+              <div className="col-12">
+                <h3 className="section-header__title u-flex--no-shrink p-heading--4">
+                  {title}
+                </h3>
+                <hr />
+              </div>
+            </div>
+          ) : null}
+          {content}
+        </Col>
+      </Row>
+    </aside>
+  );
+};
+
+// eslint-disable-next-line react/no-multi-comp
+const AppSidePanelLegacy = ({ title, size, content }: Props): JSX.Element => {
   return (
     // display the app side panel as a child of #maas-ui DOM node no matter where it's rendered
     // TODO: https://warthogs.atlassian.net/browse/MAASENG-1245 - move setSidePanelContent to the App component and remove this Portal workaround
     <Portal node={document && document.getElementById(MAAS_UI_ID)}>
-      <aside
-        aria-label={title ?? undefined}
-        className={classNames("l-aside", {
-          "is-collapsed": !content,
-          "is-wide": size === "wide",
-          "is-narrow": size === "narrow",
-        })}
-        data-testid="section-header-content"
-        id="aside-panel"
-      >
-        <Row>
-          <Col size={12}>
-            {title ? (
-              <div className="row section-header">
-                <div className="col-12">
-                  <h3 className="section-header__title u-flex--no-shrink p-heading--4">
-                    {title}
-                  </h3>
-                  <hr />
-                </div>
-              </div>
-            ) : null}
-            {content}
-          </Col>
-        </Row>
-      </aside>
+      <AppSidePanel
+        content={content}
+        size={size}
+        title={title ? title : null}
+      />
     </Portal>
   );
 };
 
 export default AppSidePanel;
+export { AppSidePanelLegacy };

--- a/src/app/base/components/AppSidePanel/index.ts
+++ b/src/app/base/components/AppSidePanel/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./AppSidePanel";
+export { default, AppSidePanelLegacy } from "./AppSidePanel";

--- a/src/app/base/components/NodeName/NodeName.test.tsx
+++ b/src/app/base/components/NodeName/NodeName.test.tsx
@@ -163,6 +163,7 @@ describe("NodeName", () => {
     );
 
     await userEvent.clear(screen.getByRole("textbox", { name: "Hostname" }));
+    await userEvent.tab();
     expect(
       screen.getByText("hostname is a required field")
     ).toBeInTheDocument();

--- a/src/app/base/components/PageContent/PageContent.test.tsx
+++ b/src/app/base/components/PageContent/PageContent.test.tsx
@@ -1,0 +1,31 @@
+import PageContent from "./PageContent";
+
+import { renderWithBrowserRouter, screen, within } from "testing/utils";
+
+it("displays sidebar with provided content", () => {
+  renderWithBrowserRouter(
+    <PageContent
+      header="Settings"
+      sidePanelContent={<div>Sidebar</div>}
+      sidePanelTitle={null}
+    >
+      content
+    </PageContent>
+  );
+  const aside = screen.getByRole("complementary");
+  expect(screen.getByRole("complementary")).not.toHaveClass("is-collapsed");
+  expect(within(aside).getByText("Sidebar"));
+});
+
+it("displays hidden sidebar when no content provided", () => {
+  renderWithBrowserRouter(
+    <PageContent
+      header="Settings"
+      sidePanelContent={null}
+      sidePanelTitle={null}
+    >
+      content
+    </PageContent>
+  );
+  expect(screen.queryByRole("complementary")).toHaveClass("is-collapsed");
+});

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -1,0 +1,132 @@
+import type { HTMLProps, ReactNode } from "react";
+
+import classNames from "classnames";
+import { useSelector } from "react-redux";
+import { Outlet, matchPath, useLocation } from "react-router-dom-v5-compat";
+
+import AppSidePanel from "../AppSidePanel";
+import Footer from "../Footer";
+import MainContentSection from "../MainContentSection";
+import SecondaryNavigation from "../SecondaryNavigation";
+
+import { preferencesNavItems } from "app/preferences/constants";
+import { settingsNavItems } from "app/settings/constants";
+import configSelectors from "app/store/config/selectors";
+
+export type Props = {
+  children?: ReactNode;
+  header?: ReactNode;
+  sidebar?: ReactNode;
+  isNotificationListHidden?: boolean;
+  sidePanelContent: React.ReactNode;
+  sidePanelSize?: "wide";
+  sidePanelTitle: string | null;
+} & HTMLProps<HTMLDivElement>;
+
+const PageContent = ({
+  children,
+  header,
+  sidebar,
+  isNotificationListHidden = false,
+  sidePanelContent,
+  sidePanelSize,
+  sidePanelTitle,
+  ...props
+}: Props): JSX.Element => {
+  const { pathname } = useLocation();
+  const isSettingsPage = matchPath("settings/*", pathname);
+  const isPreferencesPage = matchPath("account/prefs/*", pathname);
+  const isSideNavVisible = isSettingsPage || isPreferencesPage;
+  const maasTheme = useSelector(configSelectors.theme);
+
+  return (
+    <>
+      <main className="l-main">
+        {isSideNavVisible ? (
+          <div
+            className={classNames(
+              "l-main__nav",
+              `is-maas-${maasTheme}--accent`
+            )}
+          >
+            <SecondaryNavigation
+              isOpen={!!isSideNavVisible}
+              items={
+                isSettingsPage
+                  ? settingsNavItems
+                  : isPreferencesPage
+                  ? preferencesNavItems
+                  : []
+              }
+              title={
+                isSettingsPage
+                  ? "Settings"
+                  : isPreferencesPage
+                  ? "My preferences"
+                  : ""
+              }
+            />
+          </div>
+        ) : null}
+        <div className="l-main__content" id="main-content">
+          <MainContentSection
+            header={header}
+            isNotificationListHidden={isNotificationListHidden}
+            {...props}
+          >
+            {children}
+          </MainContentSection>
+          <hr />
+          <Footer />
+        </div>
+      </main>
+      <AppSidePanel
+        content={sidePanelContent}
+        size={sidePanelSize}
+        title={sidePanelTitle}
+      />
+    </>
+  );
+};
+
+// eslint-disable-next-line react/no-multi-comp
+export const LegacyPageContentWrapper = (): JSX.Element => {
+  const { pathname } = useLocation();
+  const isSettingsPage = matchPath("settings/*", pathname);
+  const isPreferencesPage = matchPath("account/prefs/*", pathname);
+  const isSideNavVisible = isSettingsPage || isPreferencesPage;
+  const theme = useSelector(configSelectors.theme);
+
+  return (
+    <main className="l-main">
+      {isSideNavVisible ? (
+        <div className={classNames("l-main__nav", `is-maas-${theme}--accent`)}>
+          <SecondaryNavigation
+            isOpen={!!isSideNavVisible}
+            items={
+              isSettingsPage
+                ? settingsNavItems
+                : isPreferencesPage
+                ? preferencesNavItems
+                : []
+            }
+            title={
+              isSettingsPage
+                ? "Settings"
+                : isPreferencesPage
+                ? "My preferences"
+                : ""
+            }
+          />
+        </div>
+      ) : null}
+      <div className="l-main__content" id="main-content">
+        <Outlet />
+        <hr />
+        <Footer />
+      </div>
+    </main>
+  );
+};
+
+export default PageContent;

--- a/src/app/base/components/PageContent/index.ts
+++ b/src/app/base/components/PageContent/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PageContent";

--- a/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -6,7 +6,7 @@ import type { TabLink } from "@canonical/react-components/dist/components/Tabs/T
 import classNames from "classnames";
 import type { LinkProps } from "react-router-dom";
 
-import AppSidePanel from "app/base/components/AppSidePanel";
+import { AppSidePanelLegacy } from "app/base/components/AppSidePanel";
 import type { DataTestElement } from "app/base/types";
 
 export type Props<P = LinkProps> = {
@@ -129,11 +129,13 @@ const SectionHeader = <P,>({
       {renderButtons && typeof renderButtons === "function"
         ? renderButtons()
         : null}
-      <AppSidePanel
-        content={sidePanelContent}
-        size={headerSize}
-        title={sidePanelTitle}
-      />
+      {sidePanelContent ? (
+        <AppSidePanelLegacy
+          content={sidePanelContent}
+          size={headerSize}
+          title={sidePanelTitle}
+        />
+      ) : null}
       {actionMenuGroup ? <>{actionMenuGroup}</> : null}
       {tabLinks?.length ? (
         <div className="section-header__tabs" data-testid="section-header-tabs">

--- a/src/app/base/components/node/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.test.tsx
+++ b/src/app/base/components/node/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 
 import NodeDevicesWarning from "./NodeDevicesWarning";
 
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import { NodeDeviceBus } from "app/store/nodedevice/types";
 import { NodeActions, NodeStatusCode } from "app/store/types/node";
 import {
@@ -36,7 +36,7 @@ describe("node is machine", () => {
     await userEvent.click(screen.getByTestId("commission-machine"));
 
     expect(setSidePanelContent).toHaveBeenCalledWith({
-      view: MachineHeaderViews.COMMISSION_MACHINE,
+      view: MachineSidePanelViews.COMMISSION_MACHINE,
     });
   });
 

--- a/src/app/base/components/node/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
+++ b/src/app/base/components/node/NodeDevices/NodeDevicesWarning/NodeDevicesWarning.tsx
@@ -1,6 +1,6 @@
 import { Button, Col, Icon, Row, Strip } from "@canonical/react-components";
 
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineSetSidePanelContent } from "app/machines/types";
 import type { ControllerDetails } from "app/store/controller/types";
 import type { MachineDetails } from "app/store/machine/types";
@@ -65,7 +65,7 @@ const NodeDevicesWarning = ({
             data-testid="commission-machine"
             onClick={() =>
               setSidePanelContent({
-                view: MachineHeaderViews.COMMISSION_MACHINE,
+                view: MachineSidePanelViews.COMMISSION_MACHINE,
               })
             }
           >

--- a/src/app/base/components/node/TestResults/TestResults.tsx
+++ b/src/app/base/components/node/TestResults/TestResults.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom-v5-compat";
 
 import { HardwareType } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineSetSidePanelContent } from "app/machines/types";
 import type { MachineDetails } from "app/store/machine/types";
 import type { TestStatus } from "app/store/types/node";
@@ -149,7 +149,7 @@ const TestResults = ({
                 disabled={!machine.actions.includes(NodeActions.TEST)}
                 onClick={() => {
                   setSidePanelContent({
-                    view: MachineHeaderViews.TEST_MACHINE,
+                    view: MachineSidePanelViews.TEST_MACHINE,
                     extras: { hardwareType: hardwareType },
                   });
                   sendAnalytics(

--- a/src/app/base/side-panel-context.tsx
+++ b/src/app/base/side-panel-context.tsx
@@ -34,8 +34,8 @@ export type SidePanelContent =
 
 export type SetSidePanelContent = (sidePanelContent: SidePanelContent) => void;
 
-export type SidePanelContextType = {
-  sidePanelContent: SidePanelContent;
+export type SidePanelContextType<T = SidePanelContent> = {
+  sidePanelContent: T;
   setSidePanelContent: SetSidePanelContent;
 };
 

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
@@ -1,7 +1,7 @@
 import KVMHeaderForms from "./KVMHeaderForms";
 
 import { KVMHeaderViews } from "app/kvm/constants";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import { PodType } from "app/store/pod/constants";
 import zoneSelectors from "app/store/zone/selectors";
 import {
@@ -256,7 +256,7 @@ describe("KVMHeaderForms", () => {
     renderWithBrowserRouter(
       <KVMHeaderForms
         setSidePanelContent={jest.fn()}
-        sidePanelContent={{ view: MachineHeaderViews.DELETE_MACHINE }}
+        sidePanelContent={{ view: MachineSidePanelViews.DELETE_MACHINE }}
       />,
       { state }
     );
@@ -273,7 +273,7 @@ describe("KVMHeaderForms", () => {
     renderWithBrowserRouter(
       <KVMHeaderForms
         setSidePanelContent={jest.fn()}
-        sidePanelContent={{ view: MachineHeaderViews.DELETE_MACHINE }}
+        sidePanelContent={{ view: MachineSidePanelViews.DELETE_MACHINE }}
       />,
       { state, route: "/kvm" }
     );

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.tsx
@@ -6,7 +6,7 @@ import { useSendAnalytics } from "app/base/hooks";
 import type { SetSearchFilter } from "app/base/types";
 import { VMS_PER_PAGE } from "app/kvm/components/LXDVMsTable";
 import type { KVMSetSidePanelContent } from "app/kvm/types";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import { useHasSelection } from "app/store/machine/utils/hooks";
 import { NodeActions } from "app/store/types/node";
 import { getNodeActionTitle } from "app/store/utils";
@@ -49,7 +49,7 @@ const VMsActionBar = ({
             menuPosition="left"
             nodeDisplay="VM"
             onActionClick={(action) => {
-              const view = Object.values(MachineHeaderViews).find(
+              const view = Object.values(MachineSidePanelViews).find(
                 ([, actionName]) => actionName === action
               );
               if (view) {
@@ -90,7 +90,9 @@ const VMsActionBar = ({
               disabled={vmActionsDisabled}
               hasIcon
               onClick={() =>
-                setSidePanelContent({ view: MachineHeaderViews.DELETE_MACHINE })
+                setSidePanelContent({
+                  view: MachineSidePanelViews.DELETE_MACHINE,
+                })
               }
             >
               <Icon name="delete" />

--- a/src/app/machines/components/MachineHeaderForms/MachineForms.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineForms.tsx
@@ -6,8 +6,9 @@ import AddChassisForm from "./AddChassis/AddChassisForm";
 import AddMachineForm from "./AddMachine/AddMachineForm";
 import MachineActionFormWrapper from "./MachineActionFormWrapper";
 
+import type { SidePanelContent } from "app/base/side-panel-context";
 import type { SetSearchFilter } from "app/base/types";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineActionHeaderViews } from "app/machines/constants";
 import type {
   MachineActionVariableProps,
@@ -16,13 +17,13 @@ import type {
 } from "app/machines/types";
 
 type Props = {
-  sidePanelContent: MachineSidePanelContent;
+  sidePanelContent: SidePanelContent;
   setSidePanelContent: MachineSetSidePanelContent;
   setSearchFilter?: SetSearchFilter;
   viewingDetails?: boolean;
 } & MachineActionVariableProps;
 
-export const MachineHeaderForms = ({
+export const MachineForms = ({
   sidePanelContent,
   machines,
   setSidePanelContent,
@@ -38,10 +39,14 @@ export const MachineHeaderForms = ({
     [setSidePanelContent]
   );
 
+  if (!sidePanelContent) {
+    return null;
+  }
+
   switch (sidePanelContent.view) {
-    case MachineHeaderViews.ADD_CHASSIS:
+    case MachineSidePanelViews.ADD_CHASSIS:
       return <AddChassisForm clearSidePanelContent={clearSidePanelContent} />;
-    case MachineHeaderViews.ADD_MACHINE:
+    case MachineSidePanelViews.ADD_MACHINE:
       return <AddMachineForm clearSidePanelContent={clearSidePanelContent} />;
     default:
       // We need to explicitly cast sidePanelContent.view here - TypeScript doesn't
@@ -75,4 +80,4 @@ export const MachineHeaderForms = ({
   }
 };
 
-export default MachineHeaderForms;
+export default MachineForms;

--- a/src/app/machines/components/MachineHeaderForms/index.ts
+++ b/src/app/machines/components/MachineHeaderForms/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./MachineHeaderForms";
+export { default } from "./MachineForms";

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -31,7 +31,7 @@ export const MachineNonActionHeaderViews = {
   ADD_MACHINE: ["machineNonActionForm", "addMachine"],
 } as const;
 
-export const MachineHeaderViews = {
+export const MachineSidePanelViews = {
   ...MachineActionHeaderViews,
   ...MachineNonActionHeaderViews,
 } as const;

--- a/src/app/machines/types.ts
+++ b/src/app/machines/types.ts
@@ -1,6 +1,6 @@
 import type { ValueOf } from "@canonical/react-components";
 
-import type { MachineHeaderViews } from "./constants";
+import type { MachineSidePanelViews } from "./constants";
 
 import type { HardwareType } from "app/base/enum";
 import type {
@@ -16,7 +16,7 @@ import type {
 import type { Script } from "app/store/script/types";
 
 export type MachineSidePanelContent = SidePanelContent<
-  ValueOf<typeof MachineHeaderViews>,
+  ValueOf<typeof MachineSidePanelViews>,
   {
     applyConfiguredNetworking?: Script["apply_configured_networking"];
     hardwareType?: HardwareType;

--- a/src/app/machines/utils.ts
+++ b/src/app/machines/utils.ts
@@ -1,6 +1,6 @@
-import { MachineHeaderViews } from "./constants";
-import type { MachineSidePanelContent } from "./types";
+import { MachineSidePanelViews } from "./constants";
 
+import type { SidePanelContent } from "app/base/side-panel-context";
 import { getNodeActionTitle } from "app/store/utils";
 
 /**
@@ -11,14 +11,14 @@ import { getNodeActionTitle } from "app/store/utils";
  */
 export const getHeaderTitle = (
   defaultTitle: string,
-  sidePanelContent: MachineSidePanelContent | null
+  sidePanelContent: SidePanelContent | null
 ): string => {
   if (sidePanelContent) {
     const [, name] = sidePanelContent.view;
     switch (name) {
-      case MachineHeaderViews.ADD_CHASSIS[1]:
+      case MachineSidePanelViews.ADD_CHASSIS[1]:
         return "Add chassis";
-      case MachineHeaderViews.ADD_MACHINE[1]:
+      case MachineSidePanelViews.ADD_MACHINE[1]:
         return "Add machine";
       default:
         return getNodeActionTitle(name);

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -2,7 +2,7 @@ import configureStore from "redux-mock-store";
 
 import MachineHeader from "./MachineHeader";
 
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { RootState } from "app/store/root/types";
 import { PowerState } from "app/store/types/enum";
 import {
@@ -75,7 +75,7 @@ describe("MachineHeader", () => {
     renderWithBrowserRouter(
       <MachineHeader
         setSidePanelContent={jest.fn()}
-        sidePanelContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
+        sidePanelContent={{ view: MachineSidePanelViews.DEPLOY_MACHINE }}
         systemId="abc123"
       />,
       { state, route: "/machine/abc123" }

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -15,7 +15,7 @@ import TableMenu from "app/base/components/TableMenu";
 import TooltipButton from "app/base/components/TooltipButton";
 import { useSendAnalytics } from "app/base/hooks";
 import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type {
   MachineSidePanelContent,
   MachineSetSidePanelContent,
@@ -131,7 +131,7 @@ const MachineHeader = ({
                     getNodeActionTitle(action),
                     "Open"
                   );
-                  const view = Object.values(MachineHeaderViews).find(
+                  const view = Object.values(MachineSidePanelViews).find(
                     ([, actionName]) => actionName === action
                   );
                   if (view) {
@@ -157,7 +157,7 @@ const MachineHeader = ({
                     getNodeActionTitle(action),
                     "Open"
                   );
-                  const view = Object.values(MachineHeaderViews).find(
+                  const view = Object.values(MachineSidePanelViews).find(
                     ([, actionName]) => actionName === action
                   );
                   if (view) {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.test.tsx
@@ -1,7 +1,7 @@
 import MachineNetworkActions from "./MachineNetworkActions";
 
 import { ExpandedState } from "app/base/components/NodeNetworkTab/NodeNetworkTab";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import { NodeStatus } from "app/store/types/node";
@@ -66,7 +66,7 @@ describe("MachineNetworkActions", () => {
         screen.getByRole("button", { name: /Validate network configuration/i })
       );
       expect(setSidePanelContent).toHaveBeenCalledWith({
-        view: MachineHeaderViews.TEST_MACHINE,
+        view: MachineSidePanelViews.TEST_MACHINE,
         extras: { applyConfiguredNetworking: true },
       });
     });

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetworkActions/MachineNetworkActions.tsx
@@ -10,7 +10,7 @@ import type {
 import { ExpandedState } from "app/base/components/NodeNetworkTab/NodeNetworkTab";
 import type { Selected } from "app/base/components/node/networking/types";
 import { useIsAllNetworkingDisabled, useSendAnalytics } from "app/base/hooks";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineSetSidePanelContent } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine, MachineDetails } from "app/store/machine/types";
@@ -146,7 +146,7 @@ const MachineNetworkActions = ({
           disabled={isAllNetworkingDisabled}
           onClick={() => {
             setSidePanelContent({
-              view: MachineHeaderViews.TEST_MACHINE,
+              view: MachineSidePanelViews.TEST_MACHINE,
               extras: { applyConfiguredNetworking: true },
             });
             sendAnalytics(

--- a/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -3,7 +3,7 @@ import { Link } from "react-router-dom-v5-compat";
 
 import { HardwareType } from "app/base/enum";
 import { useSendAnalytics } from "app/base/hooks";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineSetSidePanelContent } from "app/machines/types";
 import type { MachineDetails } from "app/store/machine/types";
 import type { TestStatus } from "app/store/types/node";
@@ -146,7 +146,7 @@ const TestResults = ({
                 disabled={!machine.actions.includes(NodeActions.TEST)}
                 onClick={() => {
                   setSidePanelContent({
-                    view: MachineHeaderViews.TEST_MACHINE,
+                    view: MachineSidePanelViews.TEST_MACHINE,
                     extras: { hardwareType: hardwareType },
                   });
                   sendAnalytics(

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -17,7 +17,7 @@ import NodeActionMenu from "app/base/components/NodeActionMenu";
 import NodeActionMenuGroup from "app/base/components/NodeActionMenuGroup";
 import { useSendAnalytics } from "app/base/hooks";
 import urls from "app/base/urls";
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineSetSidePanelContent } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import type { FetchGroupKey } from "app/store/machine/types";
@@ -134,7 +134,7 @@ const MachineListControls = ({
                     if (action === NodeActions.TAG && !tagsSeen) {
                       setTagsSeen(true);
                     }
-                    const view = Object.values(MachineHeaderViews).find(
+                    const view = Object.values(MachineSidePanelViews).find(
                       ([, actionName]) => actionName === action
                     );
                     if (view) {
@@ -160,7 +160,7 @@ const MachineListControls = ({
                     if (action === NodeActions.TAG && !tagsSeen) {
                       setTagsSeen(true);
                     }
-                    const view = Object.values(MachineHeaderViews).find(
+                    const view = Object.values(MachineSidePanelViews).find(
                       ([, actionName]) => actionName === action
                     );
                     if (view) {

--- a/src/app/machines/views/MachineList/MachineListHeader/AddHardwareMenu/AddHardwareMenu.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/AddHardwareMenu/AddHardwareMenu.tsx
@@ -1,6 +1,6 @@
 import { ContextualMenu } from "@canonical/react-components";
 
-import { MachineHeaderViews } from "app/machines/constants";
+import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineSetSidePanelContent } from "app/machines/types";
 
 type Props = {
@@ -21,12 +21,12 @@ export const AddHardwareMenu = ({
         {
           children: "Machine",
           onClick: () =>
-            setSidePanelContent({ view: MachineHeaderViews.ADD_MACHINE }),
+            setSidePanelContent({ view: MachineSidePanelViews.ADD_MACHINE }),
         },
         {
           children: "Chassis",
           onClick: () =>
-            setSidePanelContent({ view: MachineHeaderViews.ADD_CHASSIS }),
+            setSidePanelContent({ view: MachineSidePanelViews.ADD_CHASSIS }),
         },
       ]}
       position="right"

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -3,8 +3,6 @@ import reduxToolkit from "@reduxjs/toolkit";
 import MachineListHeader from "./MachineListHeader";
 
 import urls from "app/base/urls";
-import { MachineHeaderViews } from "app/machines/constants";
-import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
 import {
@@ -19,13 +17,7 @@ import {
   resourcePoolState as resourcePoolStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import {
-  screen,
-  waitFor,
-  renderWithBrowserRouter,
-  userEvent,
-  within,
-} from "testing/utils";
+import { screen, renderWithBrowserRouter, userEvent } from "testing/utils";
 
 describe("MachineListHeader", () => {
   let state: RootState;
@@ -67,30 +59,6 @@ describe("MachineListHeader", () => {
     jest.restoreAllMocks();
   });
 
-  it("displays a loader if machines have not loaded", () => {
-    state.machine.selectedMachines = {
-      groups: ["admin"],
-      grouping: FetchGroupKey.Owner,
-    };
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      loading: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        grouping={null}
-        searchFilter=""
-        setGrouping={jest.fn()}
-        setHiddenColumns={jest.fn()}
-        setHiddenGroups={jest.fn()}
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state, route: urls.machines.index }
-    );
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
-  });
-
   it("displays a machine count if machines have loaded", () => {
     state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
       count: 2,
@@ -105,62 +73,12 @@ describe("MachineListHeader", () => {
         setHiddenGroups={jest.fn()}
         setSearchFilter={jest.fn()}
         setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
       />,
       { state, route: urls.machines.index }
     );
     expect(screen.getByTestId("section-header-title")).toHaveTextContent(
       "2 machines in 1 pool"
     );
-  });
-
-  it("displays a spinner if the selected group count is loading", () => {
-    state.machine.selectedMachines = {
-      groups: ["admin"],
-      grouping: FetchGroupKey.Owner,
-    };
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      loading: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        grouping={null}
-        searchFilter=""
-        setGrouping={jest.fn()}
-        setHiddenColumns={jest.fn()}
-        setHiddenGroups={jest.fn()}
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
-  });
-
-  it("does not display a spinner if only machines are selected and the count is loading", () => {
-    state.machine.selectedMachines = { items: ["abc123"] };
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: 10,
-      loaded: true,
-    });
-    state.machine.counts["mocked-nanoid-3"] = machineStateCountFactory({
-      loading: true,
-    });
-    renderWithBrowserRouter(
-      <MachineListHeader
-        grouping={null}
-        searchFilter=""
-        setGrouping={jest.fn()}
-        setHiddenColumns={jest.fn()}
-        setHiddenGroups={jest.fn()}
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
-      />,
-      { state }
-    );
-    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
 
   it("hides the add hardware menu when machines are selected", () => {
@@ -174,7 +92,6 @@ describe("MachineListHeader", () => {
         setHiddenGroups={jest.fn()}
         setSearchFilter={jest.fn()}
         setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
       />,
       { state, route: urls.machines.index }
     );
@@ -191,77 +108,10 @@ describe("MachineListHeader", () => {
         setHiddenGroups={jest.fn()}
         setSearchFilter={jest.fn()}
         setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
       />,
       { state, route: urls.machines.index }
     );
     expect(screen.getByTestId("add-hardware-dropdown")).toBeInTheDocument();
-  });
-
-  it("closes action form when all machines are deselected", async () => {
-    state.machine.selectedMachines = { items: ["abc123"] };
-    const allMachinesCount = 10;
-    state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
-      count: allMachinesCount,
-      loaded: true,
-    });
-    const setSidePanelContent = jest.fn();
-    renderWithBrowserRouter(
-      <MachineListHeader
-        grouping={null}
-        searchFilter=""
-        setGrouping={jest.fn()}
-        setHiddenColumns={jest.fn()}
-        setHiddenGroups={jest.fn()}
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={setSidePanelContent}
-        sidePanelContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
-      />,
-      { state, route: urls.machines.index }
-    );
-    expect(setSidePanelContent).not.toHaveBeenCalled();
-    expect(screen.getByText("Deploy")).toBeInTheDocument();
-    state.machine.selectedMachines.items = [];
-    renderWithBrowserRouter(
-      <MachineListHeader
-        grouping={null}
-        searchFilter=""
-        setGrouping={jest.fn()}
-        setHiddenColumns={jest.fn()}
-        setHiddenGroups={jest.fn()}
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={setSidePanelContent}
-        sidePanelContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
-      />,
-      { state, route: urls.machines.index }
-    );
-    await waitFor(() => expect(setSidePanelContent).toHaveBeenCalledWith(null));
-  });
-
-  it("displays the action title if an action is selected", () => {
-    renderWithBrowserRouter(
-      <MachineListHeader
-        grouping={null}
-        searchFilter=""
-        setGrouping={jest.fn()}
-        setHiddenColumns={jest.fn()}
-        setHiddenGroups={jest.fn()}
-        setSearchFilter={jest.fn()}
-        setSidePanelContent={jest.fn()}
-        sidePanelContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
-      />,
-      { state, route: urls.machines.index }
-    );
-
-    expect(screen.getByTestId("section-header-title")).toHaveTextContent(
-      "0 machines in 1 pool"
-    );
-    expect(
-      within(screen.getByTestId("section-header-content")).getByRole(
-        "heading",
-        { level: 3 }
-      )
-    ).toHaveTextContent("Deploy");
   });
 
   it("displays a new label for the tag action", async () => {
@@ -322,7 +172,6 @@ describe("MachineListHeader", () => {
         setHiddenGroups={jest.fn()}
         setSearchFilter={jest.fn()}
         setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
       />,
       { state, route: urls.machines.index }
     );
@@ -346,7 +195,6 @@ describe("MachineListHeader", () => {
         setHiddenGroups={jest.fn()}
         setSearchFilter={jest.fn()}
         setSidePanelContent={jest.fn()}
-        sidePanelContent={null}
       />
     );
     // Open the take action menu.

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -1,27 +1,15 @@
 import { useCallback, useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { useMatch } from "react-router-dom-v5-compat";
 
 import MachineListControls from "../MachineListControls";
 
 import MachinesHeader from "app/base/components/node/MachinesHeader";
 import type { SetSearchFilter } from "app/base/types";
-import urls from "app/base/urls";
-import MachineHeaderForms from "app/machines/components/MachineHeaderForms";
-import type {
-  MachineSidePanelContent,
-  MachineSetSidePanelContent,
-} from "app/machines/types";
-import { getHeaderTitle } from "app/machines/utils";
+import type { MachineSetSidePanelContent } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
-import machineSelectors from "app/store/machine/selectors";
 import type { FetchGroupKey } from "app/store/machine/types";
-import { FilterMachines, selectedToFilters } from "app/store/machine/utils";
-import {
-  useFetchMachineCount,
-  useMachineSelectedCount,
-} from "app/store/machine/utils/hooks";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
 import { actions as resourcePoolActions } from "app/store/resourcepool";
 import resourcePoolSelectors from "app/store/resourcepool/selectors";
 
@@ -31,7 +19,6 @@ type Props = {
   setGrouping: (group: FetchGroupKey | null) => void;
   setHiddenGroups: (groups: string[]) => void;
   setHiddenColumns: React.Dispatch<React.SetStateAction<string[]>>;
-  sidePanelContent: MachineSidePanelContent | null;
   searchFilter: string;
   setSearchFilter: SetSearchFilter;
   setSidePanelContent: MachineSetSidePanelContent;
@@ -43,27 +30,13 @@ export const MachineListHeader = ({
   setGrouping,
   setHiddenGroups,
   setHiddenColumns,
-  sidePanelContent,
   searchFilter,
   setSearchFilter,
   setSidePanelContent,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const machinesPathMatch = useMatch(urls.machines.index);
-  const filter = FilterMachines.parseFetchFilters(searchFilter);
   // Get the count of all machines
   const { machineCount: allMachineCount } = useFetchMachineCount();
-  // Get the count of selected machines that match the current filter
-  const { selectedCount, selectedCountLoading } =
-    useMachineSelectedCount(filter);
-  const selectedMachines = useSelector(machineSelectors.selectedMachines);
-
-  // Clear the header when there are no selected machines
-  useEffect(() => {
-    if (!machinesPathMatch || selectedToFilters(selectedMachines) === null) {
-      setSidePanelContent(null);
-    }
-  }, [machinesPathMatch, selectedMachines, setSidePanelContent]);
 
   useEffect(() => {
     dispatch(resourcePoolActions.fetch());
@@ -100,21 +73,6 @@ export const MachineListHeader = ({
           setSidePanelContent={setSidePanelContent}
         />
       )}
-      sidePanelContent={
-        sidePanelContent && (
-          <MachineHeaderForms
-            searchFilter={searchFilter}
-            selectedCount={selectedCount}
-            selectedCountLoading={selectedCountLoading}
-            selectedMachines={selectedMachines}
-            setSearchFilter={setSearchFilter}
-            setSidePanelContent={setSidePanelContent}
-            sidePanelContent={sidePanelContent}
-          />
-        )
-      }
-      sidePanelTitle={getHeaderTitle("Machines", sidePanelContent)}
-      subtitleLoading={selectedCountLoading}
     />
   );
 };

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -4,6 +4,8 @@ import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
+import { MachineSidePanelViews } from "../constants";
+
 import {
   Label,
   Label as MachineListLabel,
@@ -438,5 +440,24 @@ describe("Machines", () => {
     expect(
       fetches2[fetches.length - 1].payload.params.group_collapsed
     ).toStrictEqual(["deployed"]);
+  });
+
+  it("displays the action title if an action is selected", () => {
+    state.machine.selectedMachines = { items: ["abc123"] };
+    renderWithBrowserRouter(<Machines />, {
+      state,
+      route: "/machines",
+      sidePanelContent: { view: MachineSidePanelViews.DEPLOY_MACHINE },
+    });
+
+    expect(screen.getByTestId("section-header-title")).toHaveTextContent(
+      "0 machines in 0 pools"
+    );
+    expect(
+      within(screen.getByTestId("section-header-content")).getByRole(
+        "heading",
+        { level: 3 }
+      )
+    ).toHaveTextContent("Deploy");
   });
 });

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -8,6 +8,7 @@ import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 import type { MockStoreEnhanced } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
+import type { SidePanelContent } from "app/base/side-panel-context";
 import SidePanelContextProvider from "app/base/side-panel-context";
 import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
@@ -93,12 +94,14 @@ type WrapperProps = {
   routePattern?: string;
   state?: RootState;
   store?: MockStoreEnhanced<RootState, {}>;
+  sidePanelContent?: SidePanelContent;
 };
 
 export const BrowserRouterWithProvider = ({
   children,
   parentRoute,
   routePattern,
+  sidePanelContent,
   state,
   store,
 }: WrapperProps & { children: React.ReactNode }): React.ReactElement => {
@@ -110,7 +113,7 @@ export const BrowserRouterWithProvider = ({
   const route = <Route element={children} path={routePattern} />;
   return (
     <Provider store={store ?? getMockStore(state || rootStateFactory())}>
-      <SidePanelContextProvider>
+      <SidePanelContextProvider value={sidePanelContent}>
         <BrowserRouter>
           <CompatRouter>
             {routePattern ? (


### PR DESCRIPTION
## Done

- create PageContent component 
- refactor MachineList to use PageComponent

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list and verify everything works as before including displayed machine count and filtering
- Select a machine and click an action in the header to open side panel
- Verify a side panel has opened correctly
- Go to controller list page
- Click a button in the header to open a side panel
- Verify a side panel has opened correctly
- Go to settings and verify the main route and all sub-routes are displayed correctly

## Fixes

Fixes: 
- https://warthogs.atlassian.net/browse/MAASENG-1804
- https://warthogs.atlassian.net/browse/MAASENG-1805 

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
