### PR TITLE
Fix: remove lock and unlock dialog on machine details page

### DIFF
--- a/src/app/base/components/NodeName/NodeName.test.tsx
+++ b/src/app/base/components/NodeName/NodeName.test.tsx
@@ -163,6 +163,7 @@ describe("NodeName", () => {
     );
 
     await userEvent.clear(screen.getByRole("textbox", { name: "Hostname" }));
+    await userEvent.tab();
     expect(
       screen.getByText("hostname is a required field")
     ).toBeInTheDocument();

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -1,8 +1,10 @@
+import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import MachineHeader from "./MachineHeader";
 
 import { MachineHeaderViews } from "app/machines/constants";
+import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import { PowerState } from "app/store/types/enum";
 import { NodeActions } from "app/store/types/node";
@@ -25,6 +27,7 @@ const mockStore = configureStore<RootState>();
 describe("MachineHeader", () => {
   let state: RootState;
   beforeEach(() => {
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
     state = rootStateFactory({
       machine: machineStateFactory({
         loaded: true,
@@ -36,6 +39,10 @@ describe("MachineHeader", () => {
         }),
       }),
     });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("displays a spinner when loading", () => {
@@ -245,8 +252,15 @@ describe("MachineHeader", () => {
         name: /lock/i,
       })
     ).not.toBeInTheDocument();
+    const expectedAction = machineActions.lock(
+      {
+        filter: { id: [state.machine.items[0].system_id] },
+      },
+      "123456"
+    );
+
     expect(
-      store.getActions().some((action) => action.type === "machine/lock")
-    ).toBe(true);
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
   });
 });

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -5,6 +5,7 @@ import MachineHeader from "./MachineHeader";
 import { MachineHeaderViews } from "app/machines/constants";
 import type { RootState } from "app/store/root/types";
 import { PowerState } from "app/store/types/enum";
+import { NodeActions } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -221,5 +222,31 @@ describe("MachineHeader", () => {
     expect(
       screen.queryByTestId("section-header-subtitle")
     ).not.toBeInTheDocument();
+  });
+
+  it("shouldn't need confirmation before locking a machine", async () => {
+    state.machine.items[0].actions = [NodeActions.LOCK];
+    state.machine.items[0].permissions = ["edit", "delete"];
+    const store = mockStore(state);
+
+    renderWithBrowserRouter(
+      <MachineHeader
+        setSidePanelContent={jest.fn()}
+        sidePanelContent={null}
+        systemId="abc123"
+      />,
+      { store, route: "/machine/abc123" }
+    );
+
+    await userEvent.click(screen.getByRole("switch", { name: /lock/i }));
+
+    expect(
+      screen.queryByRole("complementary", {
+        name: /lock/i,
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      store.getActions().some((action) => action.type === "machine/lock")
+    ).toBe(true);
   });
 });

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -25,7 +25,10 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
-import { useFetchMachine } from "app/store/machine/utils/hooks";
+import {
+  useFetchMachine,
+  useSelectedMachinesActionsDispatch,
+} from "app/store/machine/utils/hooks";
 import type { RootState } from "app/store/root/types";
 import { ScriptResultStatus } from "app/store/scriptresult/types";
 import { NodeActions } from "app/store/types/node";
@@ -52,6 +55,10 @@ const MachineHeader = ({
   const statuses = useSelector((state: RootState) =>
     machineSelectors.getStatuses(state, systemId)
   );
+  const { dispatch: dispatchForSelectedMachines } =
+    useSelectedMachinesActionsDispatch({
+      selectedMachines: { items: [systemId] },
+    });
   const powerMenuRef = useRef<HTMLSpanElement>(null);
   const isDetails = isMachineDetails(machine);
   useFetchMachine(systemId);
@@ -134,6 +141,18 @@ const MachineHeader = ({
                   const view = Object.values(MachineHeaderViews).find(
                     ([, actionName]) => actionName === action
                   );
+                  const [, actionFunction] =
+                    Object.entries(machineActions).find(
+                      ([key]) => key === action
+                    ) || [];
+                  if (
+                    (action === NodeActions.LOCK ||
+                      action === NodeActions.UNLOCK) &&
+                    actionFunction
+                  ) {
+                    dispatchForSelectedMachines(actionFunction);
+                    return;
+                  }
                   if (view) {
                     setSidePanelContent({ view });
                   }

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -138,21 +138,18 @@ const MachineHeader = ({
                     getNodeActionTitle(action),
                     "Open"
                   );
+                  if (action === NodeActions.LOCK) {
+                    dispatchForSelectedMachines(machineActions.lock);
+                    return;
+                  }
+                  if (action === NodeActions.UNLOCK) {
+                    dispatchForSelectedMachines(machineActions.unlock);
+                    return;
+                  }
                   const view = Object.values(MachineHeaderViews).find(
                     ([, actionName]) => actionName === action
                   );
-                  const [, actionFunction] =
-                    Object.entries(machineActions).find(
-                      ([key]) => key === action
-                    ) || [];
-                  if (
-                    (action === NodeActions.LOCK ||
-                      action === NodeActions.UNLOCK) &&
-                    actionFunction
-                  ) {
-                    dispatchForSelectedMachines(actionFunction);
-                    return;
-                  }
+
                   if (view) {
                     setSidePanelContent({ view });
                   }

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -63,6 +63,28 @@ const MachineHeader = ({
   const isDetails = isMachineDetails(machine);
   useFetchMachine(systemId);
 
+  const handleActionClick = (action: NodeActions) => {
+    sendAnalytics(
+      "Machine details action form",
+      getNodeActionTitle(action),
+      "Open"
+    );
+
+    const isImmediateAction =
+      action === NodeActions.LOCK || action === NodeActions.UNLOCK;
+
+    if (isImmediateAction) {
+      dispatchForSelectedMachines(machineActions[action]);
+    } else {
+      const view = Object.values(MachineHeaderViews).find(
+        ([, actionName]) => actionName === action
+      );
+      if (view) {
+        setSidePanelContent({ view });
+      }
+    }
+  };
+
   if (!machine || !isDetails) {
     return <SectionHeader loading />;
   }
@@ -132,28 +154,7 @@ const MachineHeader = ({
                 isNodeLocked={machine.locked}
                 nodeDisplay="machine"
                 nodes={[machine]}
-                onActionClick={(action) => {
-                  sendAnalytics(
-                    "Machine details action form",
-                    getNodeActionTitle(action),
-                    "Open"
-                  );
-                  if (action === NodeActions.LOCK) {
-                    dispatchForSelectedMachines(machineActions.lock);
-                    return;
-                  }
-                  if (action === NodeActions.UNLOCK) {
-                    dispatchForSelectedMachines(machineActions.unlock);
-                    return;
-                  }
-                  const view = Object.values(MachineHeaderViews).find(
-                    ([, actionName]) => actionName === action
-                  );
-
-                  if (view) {
-                    setSidePanelContent({ view });
-                  }
-                }}
+                onActionClick={handleActionClick}
                 singleNode
               />
             </div>
@@ -167,19 +168,7 @@ const MachineHeader = ({
                 key="action-dropdown"
                 nodeDisplay="machine"
                 nodes={[machine]}
-                onActionClick={(action) => {
-                  sendAnalytics(
-                    "Machine details action form",
-                    getNodeActionTitle(action),
-                    "Open"
-                  );
-                  const view = Object.values(MachineHeaderViews).find(
-                    ([, actionName]) => actionName === action
-                  );
-                  if (view) {
-                    setSidePanelContent({ view });
-                  }
-                }}
+                onActionClick={handleActionClick}
                 toggleAppearance=""
                 toggleClassName="p-action-menu u-no-margin--bottom"
                 toggleLabel="Menu"


### PR DESCRIPTION
## Done

- Remove dialog when locking/unlocking a machine on details page

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Proceed to the details page of any machine that's eligible for locking/unlocking
- Click on the Lock/Unlock button
- ENsure that the machine is locked / unlocked without any dialog being shown.

## Fixes
[MAASENG-1610](https://warthogs.atlassian.net/browse/MAASENG-1610)

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
BEFORE:
<img width="993" alt="image" src="https://github.com/canonical/maas-ui/assets/47540149/a77f9560-03a1-4605-933f-2710b97ab1ce">

AFTER:
<img width="582" alt="image" src="https://github.com/canonical/maas-ui/assets/47540149/f4ef56aa-27a4-46ce-889a-56442e3deeab">



[MAASENG-1610]: https://warthogs.atlassian.net/browse/MAASENG-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ