### PR TITLE
refactor: rename selected state MAASENG-1837

### DIFF
--- a/src/__snapshots__/root-reducer.test.ts.snap
+++ b/src/__snapshots__/root-reducer.test.ts.snap
@@ -222,8 +222,7 @@ Object {
     "loading": false,
     "saved": false,
     "saving": false,
-    "selected": Array [],
-    "selectedMachines": null,
+    "selected": null,
     "statuses": Object {},
   },
   "message": Object {

--- a/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
+++ b/src/app/base/components/node/FieldlessForm/FieldlessForm.test.tsx
@@ -31,7 +31,7 @@ describe("FieldlessForm", () => {
             system_id: "abc123",
           }),
         ],
-        selected: [],
+        selected: null,
         statuses: {
           abc123: machineStatusFactory(),
         },

--- a/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/AddLxd/AddLxd.test.tsx
@@ -164,9 +164,11 @@ describe("AddLxd", () => {
     );
     await userEvent.click(screen.getByRole("button", { name: "Next" }));
 
-    expect(
-      screen.getByRole("listitem", { name: "Credentials" }).firstChild
-    ).not.toHaveClass("is-active");
+    await waitFor(() =>
+      expect(
+        screen.getByRole("listitem", { name: "Credentials" }).firstChild
+      ).not.toHaveClass("is-active")
+    );
     expect(
       screen.getByRole("listitem", { name: "Authentication" }).firstChild
     ).not.toHaveClass("is-active");

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.test.tsx
@@ -252,7 +252,7 @@ describe("KVMHeaderForms", () => {
   });
 
   it("renders machine action forms if a machine action is selected", () => {
-    state.machine.selectedMachines = { items: ["abc123"] };
+    state.machine.selected = { items: ["abc123"] };
     renderWithBrowserRouter(
       <KVMHeaderForms
         setSidePanelContent={jest.fn()}
@@ -269,7 +269,7 @@ describe("KVMHeaderForms", () => {
   });
 
   it("renders machine action forms with selected machine count", () => {
-    state.machine.selectedMachines = { items: ["abc123", "def456"] };
+    state.machine.selected = { items: ["abc123", "def456"] };
     renderWithBrowserRouter(
       <KVMHeaderForms
         setSidePanelContent={jest.fn()}

--- a/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
+++ b/src/app/kvm/components/KVMHeaderForms/KVMHeaderForms.tsx
@@ -127,7 +127,7 @@ const KVMHeaderForms = ({
   searchFilter,
   setSearchFilter,
 }: Props): JSX.Element | null => {
-  const selectedMachines = useSelector(machineSelectors.selectedMachines);
+  const selectedMachines = useSelector(machineSelectors.selected);
   const { selectedCount } = useMachineSelectedCount();
   const onRenderRef = useScrollOnRender<HTMLDivElement>();
   const clearSidePanelContent = useCallback(

--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
@@ -75,7 +75,7 @@ describe("LXDVMsTable", () => {
 
     unmount();
 
-    const expectedAction = machineActions.setSelectedMachines(null);
+    const expectedAction = machineActions.setSelected(null);
     expect(
       store.getActions().find((action) => action.type === expectedAction.type)
     ).toStrictEqual(expectedAction);

--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.tsx
@@ -71,14 +71,14 @@ const LXDVMsTable = ({
     // Clear machine selection and close the action form on filters change
     if (searchFilter !== previousSearchFilter) {
       setSidePanelContent(null);
-      dispatch(machineActions.setSelectedMachines(null));
+      dispatch(machineActions.setSelected(null));
     }
   }, [searchFilter, previousSearchFilter, setSidePanelContent, dispatch]);
 
   useEffect(
     () => () => {
       // Clear machine selected state when unmounting.
-      dispatch(machineActions.setSelectedMachines(null));
+      dispatch(machineActions.setSelected(null));
     },
     [dispatch]
   );

--- a/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsActionBar/VMsActionBar.test.tsx
@@ -40,7 +40,7 @@ describe("VMsActionBar", () => {
   it("disables VM actions if none are selected", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
-        selectedMachines: null,
+        selected: null,
       }),
     });
     const store = mockStore(state);
@@ -70,7 +70,7 @@ describe("VMsActionBar", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: vms,
-        selectedMachines: { items: ["abc123"] },
+        selected: { items: ["abc123"] },
       }),
     });
     const store = mockStore(state);

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -119,7 +119,7 @@ describe("VMsTable", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: vms,
-        selectedMachines: null,
+        selected: null,
       }),
       pod: podStateFactory({ items: [pod], loaded: true }),
     });
@@ -144,11 +144,9 @@ describe("VMsTable", () => {
     );
 
     expect(
-      store
-        .getActions()
-        .find((action) => action.type === "machine/setSelectedMachines")
+      store.getActions().find((action) => action.type === "machine/setSelected")
     ).toStrictEqual({
-      type: "machine/setSelectedMachines",
+      type: "machine/setSelected",
       payload: { filter: { pod: [pod.name] } },
     });
   });
@@ -166,7 +164,7 @@ describe("VMsTable", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: vms,
-        selectedMachines: { filter: {} },
+        selected: { filter: {} },
       }),
       pod: podStateFactory({ items: [pod], loaded: true }),
     });
@@ -195,11 +193,9 @@ describe("VMsTable", () => {
     );
 
     expect(
-      store
-        .getActions()
-        .find((action) => action.type === "machine/setSelectedMachines")
+      store.getActions().find((action) => action.type === "machine/setSelected")
     ).toStrictEqual({
-      type: "machine/setSelectedMachines",
+      type: "machine/setSelected",
       payload: null,
     });
   });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -18,7 +18,12 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 import { mockFormikFormSaved } from "testing/mockFormikFormSaved";
-import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
+import {
+  renderWithBrowserRouter,
+  screen,
+  userEvent,
+  waitFor,
+} from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 
@@ -45,8 +50,7 @@ describe("CloneForm", () => {
         active: null,
         items: machines,
         loaded: true,
-        selected: ["abc123"],
-
+        selected: { items: ["abc123"] },
         lists: {
           "123456": machineStateList({
             groups: [
@@ -124,8 +128,7 @@ describe("CloneForm", () => {
         active: null,
         items: machines,
         loaded: true,
-        selected: ["abc123"],
-
+        selected: { items: ["abc123"] },
         lists: {
           "123456": machineStateList({
             groups: [
@@ -151,7 +154,6 @@ describe("CloneForm", () => {
     const { rerender } = renderWithBrowserRouter(
       <CloneForm
         clearSidePanelContent={jest.fn()}
-        machines={[]}
         processingCount={0}
         selectedMachines={{ items: [machines[1].system_id] }}
         viewingDetails={false}
@@ -175,13 +177,15 @@ describe("CloneForm", () => {
     rerender(
       <CloneForm
         clearSidePanelContent={jest.fn()}
-        machines={[]}
         processingCount={0}
+        selectedMachines={{ items: [machines[1].system_id] }}
         viewingDetails={false}
       />
     );
 
-    expect(screen.getByText("Cloning complete")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("Cloning complete")).toBeInTheDocument()
+    );
   });
 
   it("can dispatch an action to clone to the given machines", async () => {
@@ -200,8 +204,7 @@ describe("CloneForm", () => {
         active: null,
         items: machines,
         loaded: true,
-        selected: ["abc123", "def456"],
-
+        selected: { items: ["abc123", "def456"] },
         lists: {
           "123456": machineStateList({
             groups: [

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.test.tsx
@@ -126,9 +126,8 @@ it("clears selected machines and invalidates queries on delete success", async (
   );
 
   expect(
-    store
-      .getActions()
-      .find((action) => action.type === "machine/setSelectedMachines").payload
+    store.getActions().find((action) => action.type === "machine/setSelected")
+      .payload
   ).toEqual(null);
   expect(
     store

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
@@ -82,7 +82,7 @@ export const MachineActionFormWrapper = ({
     selectedCountLoading,
   };
   const clearSelectedMachines = () => {
-    dispatch(machineActions.setSelectedMachines(null));
+    dispatch(machineActions.setSelected(null));
     dispatch(machineActions.invalidateQueries());
   };
 

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/ReleaseForm/ReleaseForm.test.tsx
@@ -53,7 +53,7 @@ describe("ReleaseForm", () => {
   });
 
   it("sets the initial disk erase behaviour from global config", () => {
-    state.machine.selectedMachines = { items: ["abc123", "def456"] };
+    state.machine.selected = { items: ["abc123", "def456"] };
     state.config.items = [
       configFactory({
         name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
@@ -91,7 +91,7 @@ describe("ReleaseForm", () => {
 
   it("correctly dispatches action to release given machines", async () => {
     const store = mockStore(state);
-    state.machine.selectedMachines = { items: ["abc123", "def456"] };
+    state.machine.selected = { items: ["abc123", "def456"] };
     renderWithBrowserRouter(
       <Provider store={store}>
         <ReleaseForm

--- a/src/app/machines/components/TableCheckbox/TableCheckbox.test.tsx
+++ b/src/app/machines/components/TableCheckbox/TableCheckbox.test.tsx
@@ -143,7 +143,7 @@ it("can dispatch a generated selected state", async () => {
     { store }
   );
   await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelectedMachines(selected);
+  const expected = machineActions.setSelected(selected);
   await waitFor(() => {
     expect(
       store.getActions().find((action) => action.type === expected.type)

--- a/src/app/machines/components/TableCheckbox/TableCheckbox.tsx
+++ b/src/app/machines/components/TableCheckbox/TableCheckbox.tsx
@@ -61,7 +61,7 @@ const TableCheckbox = ({
         window.getSelection()?.removeAllRanges();
         const isRange = !!event.nativeEvent.shiftKey;
         dispatch(
-          machineActions.setSelectedMachines(
+          machineActions.setSelected(
             onGenerateSelected(event.target.checked, isRange)
           )
         );

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddBridgeForm/AddBridgeForm.test.tsx
@@ -117,7 +117,7 @@ describe("AddBridgeForm", () => {
   });
 
   it("can dispatch an action to add a bridge", async () => {
-    state.machine.selectedMachines = { items: ["abc123", "def456"] };
+    state.machine.selected = { items: ["abc123", "def456"] };
     const store = mockStore(state);
     renderWithBrowserRouter(
       <AddBridgeForm

--- a/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/AddInterface/AddInterface.test.tsx
@@ -86,7 +86,7 @@ describe("AddInterface", () => {
   });
 
   it("correctly dispatches actions to add a physical interface", async () => {
-    state.machine.selectedMachines = { items: ["abc123", "def456"] };
+    state.machine.selected = { items: ["abc123", "def456"] };
     const store = mockStore(state);
     renderWithBrowserRouter(
       <AddInterface close={jest.fn()} systemId="abc123" />,

--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditBridgeForm/EditBridgeForm.test.tsx
@@ -104,7 +104,7 @@ describe("EditBridgeForm", () => {
   });
 
   it("can dispatch an action to update a bridge", async () => {
-    state.machine.selectedMachines = { items: ["abc123", "def456"] };
+    state.machine.selected = { items: ["abc123", "def456"] };
     const store = mockStore(state);
     renderWithBrowserRouter(
       <EditBridgeForm

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -360,11 +360,9 @@ describe("MachineList", () => {
       store.getActions().some((action) => action.type === "machine/cleanup")
     ).toBe(true);
     expect(
-      store
-        .getActions()
-        .find((action) => action.type === "machine/setSelectedMachines")
+      store.getActions().find((action) => action.type === "machine/setSelected")
     ).toStrictEqual({
-      type: "machine/setSelectedMachines",
+      type: "machine/setSelected",
       payload: null,
     });
   });

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -73,7 +73,7 @@ const MachineList = ({
     () => () => {
       // Clear machine selected state and clean up any machine errors etc.
       // when closing the list.
-      dispatch(machineActions.setSelectedMachines(null));
+      dispatch(machineActions.setSelected(null));
       dispatch(machineActions.cleanup());
     },
     [dispatch]

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
@@ -112,7 +112,7 @@ describe("MachineListControls", () => {
   });
 
   it("hides search bar, filter accordion, and grouping select when machines are selected", () => {
-    initialState.machine.selectedMachines = { items: ["abc123"] };
+    initialState.machine.selected = { items: ["abc123"] };
     renderWithBrowserRouter(
       <MachineListControls
         filter=""
@@ -154,7 +154,7 @@ describe("MachineListControls", () => {
   });
 
   it("dispatches an action to clear selected machines when the 'Clear selection' button is clicked", async () => {
-    initialState.machine.selectedMachines = { items: ["abc123"] };
+    initialState.machine.selected = { items: ["abc123"] };
     const store = mockStore(initialState);
     renderWithBrowserRouter(
       <MachineListControls
@@ -180,7 +180,7 @@ describe("MachineListControls", () => {
 
     const actions = store.getActions();
     expect(actions).toEqual(
-      expect.arrayContaining([machineActions.setSelectedMachines(null)])
+      expect.arrayContaining([machineActions.setSelected(null)])
     );
   });
 });

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -181,9 +181,7 @@ const MachineListControls = ({
             <div className="machine-list-controls__item">
               <Button
                 appearance="link"
-                onClick={() =>
-                  dispatch(machineActions.setSelectedMachines(null))
-                }
+                onClick={() => dispatch(machineActions.setSelected(null))}
               >
                 Clear selection <Icon name="close-link" />
               </Button>

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -68,7 +68,7 @@ describe("MachineListHeader", () => {
   });
 
   it("displays a loader if machines have not loaded", () => {
-    state.machine.selectedMachines = {
+    state.machine.selected = {
       groups: ["admin"],
       grouping: FetchGroupKey.Owner,
     };
@@ -115,7 +115,7 @@ describe("MachineListHeader", () => {
   });
 
   it("displays a spinner if the selected group count is loading", () => {
-    state.machine.selectedMachines = {
+    state.machine.selected = {
       groups: ["admin"],
       grouping: FetchGroupKey.Owner,
     };
@@ -139,7 +139,7 @@ describe("MachineListHeader", () => {
   });
 
   it("does not display a spinner if only machines are selected and the count is loading", () => {
-    state.machine.selectedMachines = { items: ["abc123"] };
+    state.machine.selected = { items: ["abc123"] };
     state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
       count: 10,
       loaded: true,
@@ -164,7 +164,7 @@ describe("MachineListHeader", () => {
   });
 
   it("hides the add hardware menu when machines are selected", () => {
-    state.machine.selectedMachines = { items: ["abc123"] };
+    state.machine.selected = { items: ["abc123"] };
     renderWithBrowserRouter(
       <MachineListHeader
         grouping={null}
@@ -181,7 +181,7 @@ describe("MachineListHeader", () => {
     expect(
       screen.queryByTestId("add-hardware-dropdown")
     ).not.toBeInTheDocument();
-    state.machine.selectedMachines.items = [];
+    state.machine.selected.items = [];
     renderWithBrowserRouter(
       <MachineListHeader
         grouping={null}
@@ -199,7 +199,7 @@ describe("MachineListHeader", () => {
   });
 
   it("closes action form when all machines are deselected", async () => {
-    state.machine.selectedMachines = { items: ["abc123"] };
+    state.machine.selected = { items: ["abc123"] };
     const allMachinesCount = 10;
     state.machine.counts["mocked-nanoid-2"] = machineStateCountFactory({
       count: allMachinesCount,
@@ -221,7 +221,7 @@ describe("MachineListHeader", () => {
     );
     expect(setSidePanelContent).not.toHaveBeenCalled();
     expect(screen.getByText("Deploy")).toBeInTheDocument();
-    state.machine.selectedMachines.items = [];
+    state.machine.selected = null;
     renderWithBrowserRouter(
       <MachineListHeader
         grouping={null}
@@ -233,7 +233,10 @@ describe("MachineListHeader", () => {
         setSidePanelContent={setSidePanelContent}
         sidePanelContent={{ view: MachineHeaderViews.DEPLOY_MACHINE }}
       />,
-      { state, route: urls.machines.index }
+      {
+        state: { ...state, machine: { ...state.machine, selected: null } },
+        route: urls.machines.index,
+      }
     );
     await waitFor(() => expect(setSidePanelContent).toHaveBeenCalledWith(null));
   });
@@ -266,7 +269,7 @@ describe("MachineListHeader", () => {
 
   it("displays a new label for the tag action", async () => {
     // Set a selected machine so the take action menu becomes enabled.
-    state.machine.selectedMachines = { items: ["abc123"] };
+    state.machine.selected = { items: ["abc123"] };
     // A machine needs the tag action for it to appear in the menu.
     state.machine.items = [
       machineFactory({ system_id: "abc123", actions: [NodeActions.TAG] }),
@@ -296,7 +299,7 @@ describe("MachineListHeader", () => {
   it("hides the tag action's new label after it has been clicked", async () => {
     jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
     // Set a selected machine so the take action menu becomes enabled.
-    state.machine.selectedMachines = { items: ["abc123"] };
+    state.machine.selected = { items: ["abc123"] };
     // A machine needs the tag action for it to appear in the menu.
     const machine = machineFactory({
       system_id: "abc123",

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -56,7 +56,7 @@ export const MachineListHeader = ({
   // Get the count of selected machines that match the current filter
   const { selectedCount, selectedCountLoading } =
     useMachineSelectedCount(filter);
-  const selectedMachines = useSelector(machineSelectors.selectedMachines);
+  const selectedMachines = useSelector(machineSelectors.selected);
 
   // Clear the header when there are no selected machines
   useEffect(() => {
@@ -78,7 +78,7 @@ export const MachineListHeader = ({
       // we cannot reliably preserve the selected state for groups of machines
       // as we are only fetching information about a group from the back-end
       // and the contents of a group may change when different filters are applied
-      dispatch(machineActions.setSelectedMachines(null));
+      dispatch(machineActions.setSelected(null));
     },
     [dispatch, setSearchFilter]
   );

--- a/src/app/machines/views/MachineList/MachineListTable/AllCheckbox/AllCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/AllCheckbox/AllCheckbox.test.tsx
@@ -27,7 +27,7 @@ beforeEach(() => {
 });
 
 it("is unchecked if there are no filters, groups or items selected", () => {
-  state.machine.selectedMachines = null;
+  state.machine.selected = null;
   renderWithMockStore(<AllCheckbox callId={callId} />, { state });
   expect(
     screen.getByRole("checkbox", { name: Label.AllMachines })
@@ -35,7 +35,7 @@ it("is unchecked if there are no filters, groups or items selected", () => {
 });
 
 it("is checked if there is a selected filter", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     filter: {
       owner: "admin",
     },
@@ -47,7 +47,7 @@ it("is checked if there is a selected filter", () => {
 });
 
 it("is partially checked if a group is selected", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     groups: ["admin1"],
   };
   renderWithMockStore(<AllCheckbox callId={callId} />, { state });
@@ -57,7 +57,7 @@ it("is partially checked if a group is selected", () => {
 });
 
 it("is partially checked if a machine is selected", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     items: ["abc123"],
   };
   renderWithMockStore(<AllCheckbox callId={callId} />, { state });
@@ -77,7 +77,7 @@ it("can dispatch an action to select all", async () => {
   await userEvent.click(
     screen.getByRole("checkbox", { name: Label.AllMachines })
   );
-  const expected = machineActions.setSelectedMachines({
+  const expected = machineActions.setSelected({
     filter,
   });
   expect(
@@ -89,7 +89,7 @@ it("can dispatch an action to unselect all", async () => {
   const filter = {
     owner: ["admin1"],
   };
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     filter,
   };
   const store = mockStore(state);
@@ -99,7 +99,7 @@ it("can dispatch an action to unselect all", async () => {
   await userEvent.click(
     screen.getByRole("checkbox", { name: Label.AllMachines })
   );
-  const expected = machineActions.setSelectedMachines(null);
+  const expected = machineActions.setSelected(null);
   expect(
     store.getActions().find((action) => action.type === expected.type)
   ).toStrictEqual(expected);

--- a/src/app/machines/views/MachineList/MachineListTable/AllCheckbox/AllCheckbox.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/AllCheckbox/AllCheckbox.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 const AllCheckbox = ({ callId, filter }: Props): JSX.Element => {
-  const selected = useSelector(machineSelectors.selectedMachines);
+  const selected = useSelector(machineSelectors.selected);
   // A filter exists in the selected state when all machines in the current
   // table are selected.
   const allSelected = !!selected && "filter" in selected;

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -35,7 +35,7 @@ beforeEach(() => {
 });
 
 it("is disabled if all machines are selected", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     filter: {
       owner: "admin",
     },
@@ -98,7 +98,7 @@ it("is not disabled if there are machines in the group", () => {
 });
 
 it("is unchecked if there are no filters, groups or items selected", () => {
-  state.machine.selectedMachines = null;
+  state.machine.selected = null;
   renderWithMockStore(
     <GroupCheckbox
       callId={callId}
@@ -114,7 +114,7 @@ it("is unchecked if there are no filters, groups or items selected", () => {
 });
 
 it("is checked if all machines are selected", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     filter: {
       owner: "admin",
     },
@@ -134,7 +134,7 @@ it("is checked if all machines are selected", () => {
 });
 
 it("is checked if the group is selected", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     groups: ["admin-2"],
   };
   renderWithMockStore(
@@ -159,7 +159,7 @@ it("is partially checked if a machine in the group is selected", () => {
     value: "admin-2",
   });
   state.machine.lists[callId].groups = [group];
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     items: ["abc123"],
   };
   renderWithMockStore(
@@ -191,7 +191,7 @@ it("is not checked if a selected machine is in another group", () => {
     }),
     group,
   ];
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     items: ["def456"],
   };
   renderWithMockStore(
@@ -222,7 +222,7 @@ it("can dispatch an action to select the group", async () => {
     }
   );
   await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelectedMachines({
+  const expected = machineActions.setSelected({
     grouping: FetchGroupKey.AgentName,
     groups: ["admin-2"],
   });
@@ -239,7 +239,7 @@ it("removes selected machines that are in the group that was clicked", async () 
     value: "admin-2",
   });
   state.machine.lists[callId].groups = [group];
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     items: ["abc123", "def456"],
   };
   const store = mockStore(state);
@@ -255,7 +255,7 @@ it("removes selected machines that are in the group that was clicked", async () 
     }
   );
   await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelectedMachines({
+  const expected = machineActions.setSelected({
     items: ["def456"],
     groups: [],
   });
@@ -279,7 +279,7 @@ it("does not overwrite selected machines in different groups", async () => {
     }),
     group,
   ];
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     items: ["def456"],
   };
   const store = mockStore(state);
@@ -295,7 +295,7 @@ it("does not overwrite selected machines in different groups", async () => {
     }
   );
   await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelectedMachines({
+  const expected = machineActions.setSelected({
     grouping: FetchGroupKey.AgentName,
     groups: ["admin-2"],
     items: ["def456"],
@@ -321,7 +321,7 @@ it("can dispatch an action to unselect the group", async () => {
     }),
     group,
   ];
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     groups: ["admin-1", "admin-2"],
     items: ["def456"],
   };
@@ -338,7 +338,7 @@ it("can dispatch an action to unselect the group", async () => {
     }
   );
   await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelectedMachines({
+  const expected = machineActions.setSelected({
     groups: ["admin-1"],
     items: ["def456"],
   });

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
@@ -22,7 +22,7 @@ const GroupCheckbox = ({
   grouping,
   groupName,
 }: Props): JSX.Element | null => {
-  const selected = useSelector(machineSelectors.selectedMachines);
+  const selected = useSelector(machineSelectors.selected);
   const allSelected = !!selected && "filter" in selected;
   if (!group) {
     return null;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineCheckbox/MachineCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineCheckbox/MachineCheckbox.test.tsx
@@ -37,7 +37,7 @@ beforeEach(() => {
 });
 
 it("is disabled if all machines are selected", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     filter: {
       owner: "admin",
     },
@@ -55,7 +55,7 @@ it("is disabled if all machines are selected", () => {
 });
 
 it("is checked and disabled if the machine's group is selected", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     groups: ["admin2"],
   };
   renderWithMockStore(
@@ -72,7 +72,7 @@ it("is checked and disabled if the machine's group is selected", () => {
 });
 
 it("is checked and disabled if the machine's group is selected and is nullish", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     groups: [""],
   };
   renderWithMockStore(
@@ -89,7 +89,7 @@ it("is checked and disabled if the machine's group is selected and is nullish", 
 });
 
 it("is unchecked and enabled if there are no filters or groups selected", () => {
-  state.machine.selectedMachines = null;
+  state.machine.selected = null;
   renderWithMockStore(
     <MachineCheckbox
       callId={callId}
@@ -104,7 +104,7 @@ it("is unchecked and enabled if there are no filters or groups selected", () => 
 });
 
 it("is checked if the machine is selected", () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     items: ["abc123"],
   };
   renderWithMockStore(
@@ -133,14 +133,14 @@ it("can dispatch an action to select the machine", async () => {
     }
   );
   await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelectedMachines({ items: ["abc123"] });
+  const expected = machineActions.setSelected({ items: ["abc123"] });
   expect(
     store.getActions().find((action) => action.type === expected.type)
   ).toStrictEqual(expected);
 });
 
 it("can dispatch an action to unselect a machine", async () => {
-  state.machine.selectedMachines = {
+  state.machine.selected = {
     groups: ["admin1"],
     items: ["abc123", "def456"],
   };
@@ -157,7 +157,7 @@ it("can dispatch an action to unselect a machine", async () => {
     }
   );
   await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelectedMachines({
+  const expected = machineActions.setSelected({
     groups: ["admin1"],
     items: ["def456"],
   });
@@ -176,13 +176,13 @@ describe("getSelectedMachinesRange tests", () => {
   const machines = systemIds.map((id) => machineFactory({ system_id: id }));
 
   it("getSelectedMachinesRange selects a range of machines", () => {
-    const selectedMachines = { groups: [""], items: [systemIds[0]] };
+    const selected = { groups: [""], items: [systemIds[0]] };
     const systemId = systemIds.at(-1)!;
 
     const newSelected = getSelectedMachinesRange({
       systemId,
       machines,
-      selected: selectedMachines,
+      selected: selected,
     });
 
     expect(newSelected.items?.sort()).toStrictEqual(systemIds.sort());
@@ -190,12 +190,12 @@ describe("getSelectedMachinesRange tests", () => {
 
   it("Selects only one machine if there's no previously selected machine", () => {
     const systemId = systemIds[0];
-    const selectedMachines = { groups: [""], items: [] };
+    const selected = { groups: [""], items: [] };
 
     const newSelected = getSelectedMachinesRange({
       systemId,
       machines,
-      selected: selectedMachines,
+      selected: selected,
     });
     const { items } = newSelected;
     expect(items?.length).toBe(1);

--- a/src/app/machines/views/MachineList/MachineListTable/MachineCheckbox/MachineCheckbox.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineCheckbox/MachineCheckbox.tsx
@@ -79,7 +79,7 @@ const MachineCheckbox = ({
   systemId,
   machines,
 }: Props): JSX.Element => {
-  const selected = useSelector(machineSelectors.selectedMachines);
+  const selected = useSelector(machineSelectors.selected);
   const allSelected = !!selected && "filter" in selected;
   // Whether the group this machine appears in is selected.
   const groupSelected =

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/MachineListSelectedCount.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/MachineListSelectedCount.test.tsx
@@ -91,7 +91,7 @@ describe("MachineListSelectedCount", () => {
       screen.getByRole("button", { name: "Select all 20 machines" })
     );
 
-    const expectedAction = machineActions.setSelectedMachines({ filter: {} });
+    const expectedAction = machineActions.setSelected({ filter: {} });
 
     expect(
       store.getActions().find((action) => action.type === expectedAction.type)
@@ -113,7 +113,7 @@ describe("MachineListSelectedCount", () => {
       screen.getByRole("button", { name: "Select all 20 filtered machines" })
     );
 
-    const expectedAction = machineActions.setSelectedMachines({
+    const expectedAction = machineActions.setSelected({
       filter: { free_text: ["this-is-a-filter"] },
     });
 
@@ -137,7 +137,7 @@ describe("MachineListSelectedCount", () => {
       screen.getByRole("button", { name: "Clear selection" })
     );
 
-    const expectedAction = machineActions.setSelectedMachines(null);
+    const expectedAction = machineActions.setSelected(null);
 
     expect(
       store.getActions().find((action) => action.type === expectedAction.type)

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/MachineListSelectedCount.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListSelectedCount/MachineListSelectedCount.tsx
@@ -27,7 +27,7 @@ export const MachineListSelectedCount = ({
             appearance="link"
             onClick={() => {
               dispatch(
-                machineActions.setSelectedMachines({
+                machineActions.setSelected({
                   filter: FilterMachines.parseFetchFilters(filter),
                 })
               );
@@ -45,7 +45,7 @@ export const MachineListSelectedCount = ({
           <Button
             appearance="link"
             onClick={() => {
-              dispatch(machineActions.setSelectedMachines(null));
+              dispatch(machineActions.setSelected(null));
             }}
           >
             Clear selection

--- a/src/app/machines/views/Machines.tsx
+++ b/src/app/machines/views/Machines.tsx
@@ -59,7 +59,7 @@ const Machines = (): JSX.Element => {
       // clear selected machines on grouping change
       // we cannot reliably preserve the selected state for individual machines
       // as we are only fetching information about a group from the back-end
-      dispatch(machineActions.setSelectedMachines(null));
+      dispatch(machineActions.setSelected(null));
     },
     [setStoredGrouping, dispatch]
   );

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -116,10 +116,8 @@ describe("machine actions", () => {
   });
 
   it("can set selected machines", () => {
-    expect(
-      actions.setSelectedMachines({ items: ["abc123", "def456"] })
-    ).toEqual({
-      type: "machine/setSelectedMachines",
+    expect(actions.setSelected({ items: ["abc123", "def456"] })).toEqual({
+      type: "machine/setSelected",
       payload: { items: ["abc123", "def456"] },
     });
   });

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -33,8 +33,7 @@ describe("machine reducer", () => {
       loading: false,
       saved: false,
       saving: false,
-      selected: [],
-      selectedMachines: null,
+      selected: null,
       statuses: {},
     });
   });
@@ -139,11 +138,11 @@ describe("machine reducer", () => {
 
   it("updates selected machines on delete notify", () => {
     const initialState = machineStateFactory({
-      selectedMachines: { items: ["abc123"] },
+      selected: { items: ["abc123"] },
     });
     expect(reducers(initialState, actions.deleteNotify("abc123"))).toEqual(
       machineStateFactory({
-        selectedMachines: { items: [] },
+        selected: { items: [] },
       })
     );
   });
@@ -1066,7 +1065,7 @@ describe("machine reducer", () => {
         machineFactory({ system_id: "abc123" }),
         machineFactory({ system_id: "def456" }),
       ],
-      selected: ["abc123"],
+      selected: { items: ["abc123"] },
       statuses: {
         abc123: machineStatusFactory(),
         def456: machineStatusFactory(),
@@ -1076,7 +1075,7 @@ describe("machine reducer", () => {
     expect(reducers(initialState, actions.deleteNotify("abc123"))).toEqual(
       machineStateFactory({
         items: [initialState.items[1]],
-        selected: [],
+        selected: { items: [] },
         statuses: { def456: machineStatusFactory() },
       })
     );
@@ -1149,17 +1148,14 @@ describe("machine reducer", () => {
     );
   });
 
-  it("reduces setSelectedMachines", () => {
+  it("reduces setSelected", () => {
     const initialState = machineStateFactory({ selected: [] });
 
     expect(
-      reducers(
-        initialState,
-        actions.setSelectedMachines({ items: ["abcde", "fghij"] })
-      )
+      reducers(initialState, actions.setSelected({ items: ["abcde", "fghij"] }))
     ).toEqual(
       machineStateFactory({
-        selectedMachines: { items: ["abcde", "fghij"] },
+        selected: { items: ["abcde", "fghij"] },
       })
     );
   });
@@ -1507,7 +1503,7 @@ describe("machine reducer", () => {
         machineFactory({ system_id: "abc123" }),
         machineFactory({ system_id: "def456" }),
       ],
-      selected: ["abc123"],
+      selected: { items: ["abc123"] },
       statuses: {
         abc123: machineStatusFactory(),
         def456: machineStatusFactory(),
@@ -1518,7 +1514,7 @@ describe("machine reducer", () => {
     ).toEqual(
       machineStateFactory({
         items: [initialState.items[1]],
-        selected: [],
+        selected: initialState.selected,
         statuses: { def456: machineStatusFactory() },
       })
     );

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -91,10 +91,10 @@ describe("machine selectors", () => {
   it("can get the selected machines", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
-        selectedMachines: { items: ["abc123", "def456"] },
+        selected: { items: ["abc123", "def456"] },
       }),
     });
-    expect(machine.selectedMachines(state)).toStrictEqual({
+    expect(machine.selected(state)).toStrictEqual({
       items: ["abc123", "def456"],
     });
   });

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -152,10 +152,7 @@ const active = createSelector(
  * @param {RootState} state - The redux state.
  * @returns {Machine[]} Selected machines.
  */
-const selectedMachines = createSelector(
-  [machineState],
-  ({ selectedMachines }) => selectedMachines
-);
+const selected = createSelector([machineState], ({ selected }) => selected);
 
 /**
  * Select the event errors for all machines.
@@ -686,7 +683,7 @@ const selectors = {
   overridingFailedTesting: statusSelectors["overridingFailedTesting"],
   processing,
   releasing: statusSelectors["releasing"],
-  selectedMachines,
+  selected,
   settingPool: statusSelectors["settingPool"],
   settingZone: statusSelectors["settingZone"],
   statuses,

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -506,8 +506,7 @@ const machineSlice = createSlice({
     filtersLoaded: false,
     filtersLoading: false,
     lists: {},
-    selected: [],
-    selectedMachines: null,
+    selected: null,
     statuses: {},
   } as MachineState,
   reducers: {
@@ -933,16 +932,13 @@ const machineSlice = createSlice({
         (item: Machine) => item.system_id === action.payload
       );
       state.items.splice(index, 1);
-      state.selected = state.selected.filter(
-        (machineId: Machine[MachineMeta.PK]) => machineId !== action.payload
-      );
       if (
-        state.selectedMachines &&
-        "items" in state.selectedMachines &&
-        state.selectedMachines.items &&
-        state.selectedMachines.items.length > 0
+        state.selected &&
+        "items" in state.selected &&
+        state.selected.items &&
+        state.selected.items.length > 0
       ) {
-        state.selectedMachines.items = state.selectedMachines.items.filter(
+        state.selected.items = state.selected.items.filter(
           (machineId: Machine[MachineMeta.PK]) => machineId !== action.payload
         );
       }
@@ -1706,20 +1702,6 @@ const machineSlice = createSlice({
     setPoolStart: statusHandlers.setPool.start,
     setPoolSuccess: statusHandlers.setPool.success,
     setSelected: {
-      prepare: (machineIDs: Machine[MachineMeta.PK][]) => ({
-        payload: machineIDs,
-      }),
-      reducer: (
-        state: MachineState,
-        action: PayloadAction<Machine[MachineMeta.PK][]>
-      ) => {
-        state.selected = action.payload;
-      },
-    },
-    // TODO: rename this to setSelected once everything has been migrated to the
-    // new selected type.
-    // https://github.com/canonical/app-tribe/issues/1256
-    setSelectedMachines: {
       prepare: (selected: SelectedMachines | null) => ({
         payload: selected,
       }),
@@ -1727,7 +1709,7 @@ const machineSlice = createSlice({
         state: MachineState,
         action: PayloadAction<SelectedMachines | null>
       ) => {
-        state.selectedMachines = action.payload;
+        state.selected = action.payload;
       },
     },
     setZone: generateActionParams<SetZoneParams>(NodeActions.SET_ZONE),
@@ -1881,9 +1863,6 @@ const machineSlice = createSlice({
           (item: Machine) => item.system_id === id
         );
         state.items.splice(index, 1);
-        state.selected = state.selected.filter(
-          (machineId: Machine[MachineMeta.PK]) => machineId !== id
-        );
         // Clean up the statuses for model.
         delete state.statuses[id];
       });

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -357,7 +357,6 @@ export type MachineState = {
   filtersLoaded: boolean;
   filtersLoading: boolean;
   lists: MachineStateLists;
-  selected: Machine[MachineMeta.PK][];
-  selectedMachines: SelectedMachines | null;
+  selected: SelectedMachines | null;
   statuses: MachineStatuses;
 } & GenericState<Machine, APIError>;

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -646,8 +646,8 @@ describe("machine hook utils", () => {
 
     it("can fetch selected machines", async () => {
       jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
-      const selectedMachines = { items: ["abc123", "def456"] };
-      state.machine.selectedMachines = selectedMachines;
+      const selected = { items: ["abc123", "def456"] };
+      state.machine.selected = selected;
       const store = mockStore(state);
       renderHook(useFetchSelectedMachines, {
         wrapper: generateWrapper(store),
@@ -657,7 +657,7 @@ describe("machine hook utils", () => {
         .getActions()
         .find((action) => action.type === expected.type);
       expect(actual.payload.params.filter).toStrictEqual(
-        selectedToFilters(selectedMachines)
+        selectedToFilters(selected)
       );
     });
   });
@@ -1305,7 +1305,7 @@ describe("machine hook utils", () => {
 
   describe("useHasSelection", () => {
     it("can have no selected machines", () => {
-      state.machine.selectedMachines = null;
+      state.machine.selected = null;
       const store = mockStore(state);
       const { result } = renderHook(() => useHasSelection(), {
         wrapper: generateWrapper(store),
@@ -1314,7 +1314,7 @@ describe("machine hook utils", () => {
     });
 
     it("is selected if there are filters", () => {
-      state.machine.selectedMachines = {
+      state.machine.selected = {
         filter: { hostname: "wistful-wallaby" },
       };
       const store = mockStore(state);
@@ -1325,7 +1325,7 @@ describe("machine hook utils", () => {
     });
 
     it("is selected if there are empty filters", () => {
-      state.machine.selectedMachines = { filter: {} };
+      state.machine.selected = { filter: {} };
       const store = mockStore(state);
       const { result } = renderHook(() => useHasSelection(), {
         wrapper: generateWrapper(store),
@@ -1334,7 +1334,7 @@ describe("machine hook utils", () => {
     });
 
     it("is selected if there are groups", () => {
-      state.machine.selectedMachines = { groups: ["Admin 2"] };
+      state.machine.selected = { groups: ["Admin 2"] };
       const store = mockStore(state);
       const { result } = renderHook(() => useHasSelection(), {
         wrapper: generateWrapper(store),
@@ -1343,7 +1343,7 @@ describe("machine hook utils", () => {
     });
 
     it("is selected if there are items", () => {
-      state.machine.selectedMachines = { items: ["abc123"] };
+      state.machine.selected = { items: ["abc123"] };
       const store = mockStore(state);
       const { result } = renderHook(() => useHasSelection(), {
         wrapper: generateWrapper(store),

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -275,7 +275,7 @@ export const useMachineSelectedCount = (
   selectedCountLoading: boolean;
 } => {
   const { isEnabled } = queryOptions || { isEnabled: true };
-  let selectedState = useSelector(machineSelectors.selectedMachines);
+  let selectedState = useSelector(machineSelectors.selected);
   let selectedCount = 0;
   // Shallow clone the selected state so that object can be modified.
   let selectedMachines = selectedState ? { ...selectedState } : null;
@@ -324,7 +324,7 @@ export const useFetchSelectedMachines = (
   queryOptions: UseFetchQueryOptions
 ): UseFetchMachinesData => {
   const { isEnabled } = queryOptions || { isEnabled: true };
-  const selectedMachines = useSelector(machineSelectors.selectedMachines);
+  const selectedMachines = useSelector(machineSelectors.selected);
   const getIsSingleFilter = (
     selectedMachines: SelectedMachines | null
   ): selectedMachines is { filter: FetchFilters } => {
@@ -957,7 +957,7 @@ export const useCanAddVLAN = (
  * Whether any machines are selected.
  */
 export const useHasSelection = (): boolean => {
-  const selectedMachines = useSelector(machineSelectors.selectedMachines);
+  const selectedMachines = useSelector(machineSelectors.selected);
   if (!selectedMachines) {
     return false;
   }

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,3 @@
+declare module globalThis {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,8 @@ import "@testing-library/jest-dom";
 import { enableFetchMocks } from "jest-fetch-mock";
 
 enableFetchMocks();
+
+beforeAll(() => {
+  // disable act warnings
+  global.IS_REACT_ACT_ENVIRONMENT = false;
+});

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -341,8 +341,7 @@ export const machineState = define<MachineState>({
   filtersLoaded: false,
   filtersLoading: false,
   lists: () => ({}),
-  selected: () => [],
-  selectedMachines: null,
+  selected: null,
   statuses: () => ({}),
 });
 

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -157,12 +157,16 @@ export const renderWithBrowserRouter = (
   const { route, ...wrapperProps } = options || {};
   window.history.pushState({}, "", route);
 
-  return render(ui, {
+  const rendered = render(ui, {
     wrapper: (props) => (
       <BrowserRouterWithProvider {...props} {...wrapperProps} />
     ),
     ...options,
   });
+
+  return {
+    ...rendered,
+  };
 };
 
 export const renderWithMockStore = (
@@ -181,6 +185,8 @@ export const renderWithMockStore = (
   });
   return {
     ...rendered,
+    rerender: (ui: React.ReactElement) =>
+      renderWithMockStore(ui, { container: rendered.container, ...options }),
   };
 };
 


### PR DESCRIPTION
## Done

- rename selected state
- disable act warnings

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to machine list
- Select a number of machines and dispatch an action
- verify the action has been dispatched for selected machines
- Go to KVM -> LXD
- Select a few machines and dispatch an action
- Verify the action has need dispatched for selected machines

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1837

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
