### PR TITLE
chore: Refactor Dashboard to use PageContent MAASENG-1809

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -57,6 +57,14 @@ const Routes = (): JSX.Element => (
       }
       path={`${urls.zones.index}/*`}
     />
+    <Route
+      element={
+        <ErrorBoundary>
+          <Dashboard />
+        </ErrorBoundary>
+      }
+      path={`${urls.dashboard.index}/*`}
+    />
     {/* TODO: Remove this wrapper route once all pages use the new page component wrapper */}
     {/* https://warthogs.atlassian.net/browse/MAASENG-1832 */}
     <Route element={<LegacyPageContentWrapper />}>
@@ -219,14 +227,6 @@ const Routes = (): JSX.Element => (
           </ErrorBoundary>
         }
         path={`${urls.subnets.vlan.index(null)}/*`}
-      />
-      <Route
-        element={
-          <ErrorBoundary>
-            <Dashboard />
-          </ErrorBoundary>
-        }
-        path={`${urls.dashboard.index}/*`}
       />
       <Route element={<NotFound includeSection />} path="*" />
     </Route>

--- a/src/app/dashboard/views/Dashboard.tsx
+++ b/src/app/dashboard/views/Dashboard.tsx
@@ -4,10 +4,14 @@ import { Route, Routes } from "react-router-dom-v5-compat";
 
 import DashboardConfigurationForm from "./DashboardConfigurationForm";
 import DashboardHeader from "./DashboardHeader";
+import ClearAllForm from "./DashboardHeader/ClearAllForm";
 import DiscoveriesList from "./DiscoveriesList";
+import { DashboardSidePanelViews } from "./constants";
 
 import MainContentSection from "app/base/components/MainContentSection";
+import PageContent from "app/base/components/PageContent";
 import SectionHeader from "app/base/components/SectionHeader";
+import { useSidePanel } from "app/base/side-panel-context";
 import urls from "app/base/urls";
 import NotFound from "app/base/views/NotFound";
 import authSelectors from "app/store/auth/selectors";
@@ -22,6 +26,7 @@ export enum Label {
 const Dashboard = (): JSX.Element => {
   const networkDiscovery = useSelector(configSelectors.networkDiscovery);
   const isAdmin = useSelector(authSelectors.isAdmin);
+  const { sidePanelContent, setSidePanelContent } = useSidePanel();
 
   if (!isAdmin) {
     return (
@@ -31,9 +36,27 @@ const Dashboard = (): JSX.Element => {
     );
   }
 
+  let content: JSX.Element | null = null;
+
+  if (
+    sidePanelContent?.view === DashboardSidePanelViews.CLEAR_ALL_DISCOVERIES
+  ) {
+    content = (
+      <ClearAllForm
+        closeForm={() => {
+          setSidePanelContent(null);
+        }}
+      />
+    );
+  }
+
   const base = urls.dashboard.index;
   return (
-    <MainContentSection header={<DashboardHeader />}>
+    <PageContent
+      header={<DashboardHeader setSidePanelContent={setSidePanelContent} />}
+      sidePanelContent={content}
+      sidePanelTitle="Clear all discoveries"
+    >
       {networkDiscovery === "disabled" && (
         <Notification severity="caution">{Label.Disabled}</Notification>
       )}
@@ -45,7 +68,7 @@ const Dashboard = (): JSX.Element => {
         />
         <Route element={<NotFound />} path="*" />
       </Routes>
-    </MainContentSection>
+    </PageContent>
   );
 };
 

--- a/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
+++ b/src/app/dashboard/views/DashboardHeader/DashboardHeader.test.tsx
@@ -1,3 +1,5 @@
+import configureStore from "redux-mock-store";
+
 import DashboardHeader, {
   Labels as DashboardHeaderLabels,
 } from "./DashboardHeader";
@@ -9,7 +11,9 @@ import {
   discoveryState as discoveryStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter, userEvent } from "testing/utils";
+
+const mockStore = configureStore<RootState>();
 
 describe("DashboardHeader", () => {
   let state: RootState;
@@ -31,10 +35,13 @@ describe("DashboardHeader", () => {
   });
 
   it("displays the discovery count in the header", () => {
-    renderWithBrowserRouter(<DashboardHeader />, {
-      route: "/dashboard",
-      state,
-    });
+    renderWithBrowserRouter(
+      <DashboardHeader setSidePanelContent={jest.fn()} />,
+      {
+        route: "/dashboard",
+        state,
+      }
+    );
 
     const indexLink = screen.getByText("2 discoveries");
     expect(indexLink).toBeInTheDocument();
@@ -45,12 +52,34 @@ describe("DashboardHeader", () => {
   });
 
   it("has a button to clear discoveries", () => {
-    renderWithBrowserRouter(<DashboardHeader />, {
-      route: "/dashboard",
-      state,
-    });
+    renderWithBrowserRouter(
+      <DashboardHeader setSidePanelContent={jest.fn()} />,
+      {
+        route: "/dashboard",
+        state,
+      }
+    );
     expect(
       screen.getByRole("button", { name: DashboardHeaderLabels.ClearAll })
     ).toBeInTheDocument();
+  });
+
+  it("opens the side panel when the 'Clear all discoveries' button is clicked", async () => {
+    const store = mockStore(state);
+    const setSidePanelContent = jest.fn();
+    renderWithBrowserRouter(
+      <DashboardHeader setSidePanelContent={setSidePanelContent} />,
+      {
+        route: "/dashboard",
+        store,
+      }
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: DashboardHeaderLabels.ClearAll })
+    );
+    expect(setSidePanelContent).toHaveBeenCalledWith({
+      view: ["", "clearAllDiscoveries"],
+    });
   });
 });

--- a/src/app/dashboard/views/DashboardHeader/DashboardHeader.tsx
+++ b/src/app/dashboard/views/DashboardHeader/DashboardHeader.tsx
@@ -8,10 +8,8 @@ import { Link } from "react-router-dom-v5-compat";
 
 import { DashboardSidePanelViews } from "../constants";
 
-import ClearAllForm from "./ClearAllForm";
-
 import SectionHeader from "app/base/components/SectionHeader";
-import { useSidePanel } from "app/base/side-panel-context";
+import type { SetSidePanelContent } from "app/base/side-panel-context";
 import urls from "app/base/urls";
 import { actions as discoveryActions } from "app/store/discovery";
 import discoverySelectors from "app/store/discovery/selectors";
@@ -20,11 +18,14 @@ export enum Labels {
   ClearAll = "Clear all discoveries",
 }
 
-const DashboardHeader = (): JSX.Element => {
+const DashboardHeader = ({
+  setSidePanelContent,
+}: {
+  setSidePanelContent: SetSidePanelContent;
+}): JSX.Element => {
   const location = useLocation();
   const dispatch = useDispatch();
   const discoveries = useSelector(discoverySelectors.all);
-  const { sidePanelContent, setSidePanelContent } = useSidePanel();
 
   useEffect(() => {
     dispatch(discoveryActions.fetch());
@@ -44,25 +45,10 @@ const DashboardHeader = (): JSX.Element => {
       {Labels.ClearAll}
     </Button>,
   ];
-  let content: JSX.Element | null = null;
-
-  if (
-    sidePanelContent?.view === DashboardSidePanelViews.CLEAR_ALL_DISCOVERIES
-  ) {
-    content = (
-      <ClearAllForm
-        closeForm={() => {
-          setSidePanelContent(null);
-        }}
-      />
-    );
-  }
 
   return (
     <SectionHeader
       buttons={buttons}
-      sidePanelContent={content}
-      sidePanelTitle={Labels.ClearAll}
       tabLinks={[
         {
           active: location.pathname === urls.dashboard.index,


### PR DESCRIPTION
## Done

- Refactored Dashboard and DashboardHeader to use PageContent
- Added test to DashboardHeader suite to ensure "Clear all" button opens the side panel

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/dashboard`
- Click "Clear all discoveries"
- Ensure the side panel is opened

## Fixes

Fixes [MAASENG-1809](https://warthogs.atlassian.net/browse/MAASENG-1809)


[MAASENG-1809]: https://warthogs.atlassian.net/browse/MAASENG-1809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ