### PR TITLE
chore: Refactor DomainDetails to use PageContent MAASENG-1811

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -73,6 +73,14 @@ const Routes = (): JSX.Element => (
       }
       path={`${urls.devices.device.index(null)}/*`}
     />
+    <Route
+      element={
+        <ErrorBoundary>
+          <DomainDetails />
+        </ErrorBoundary>
+      }
+      path={`${urls.domains.details(null)}/*`}
+    />
     {/* TODO: Remove this wrapper route once all pages use the new page component wrapper */}
     {/* https://warthogs.atlassian.net/browse/MAASENG-1832 */}
     <Route element={<LegacyPageContentWrapper />}>
@@ -123,14 +131,6 @@ const Routes = (): JSX.Element => (
           </ErrorBoundary>
         }
         path={`${urls.domains.index}/*`}
-      />
-      <Route
-        element={
-          <ErrorBoundary>
-            <DomainDetails />
-          </ErrorBoundary>
-        }
-        path={`${urls.domains.details(null)}/*`}
       />
       <Route
         element={

--- a/src/app/base/side-panel-context.tsx
+++ b/src/app/base/side-panel-context.tsx
@@ -7,6 +7,7 @@ import { useLocation } from "react-router-dom-v5-compat";
 import type { ControllerSidePanelContent } from "app/controllers/types";
 import type { DashboardSidePanelContent } from "app/dashboard/views/constants";
 import type { DeviceSidePanelContent } from "app/devices/types";
+import type { DomainDetailsSidePanelContent } from "app/domains/views/DomainDetails/constants";
 import type { DomainListSidePanelContent } from "app/domains/views/DomainsList/constants";
 import type { KVMSidePanelContent } from "app/kvm/types";
 import type { MachineSidePanelContent } from "app/machines/types";
@@ -25,6 +26,7 @@ export type SidePanelContent =
   | TagSidePanelContent
   | ZoneSidePanelContent
   | SubnetSidePanelContent
+  | DomainDetailsSidePanelContent
   | DomainListSidePanelContent
   | DashboardSidePanelContent
   | VLANDetailsSidePanelContent

--- a/src/app/domains/views/DomainDetails/DomainDetails.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetails.tsx
@@ -1,13 +1,16 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 
 import DomainDetailsHeader from "./DomainDetailsHeader";
+import AddRecordForm from "./DomainDetailsHeader/AddRecordForm";
+import DeleteDomainForm from "./DomainDetailsHeader/DeleteDomainForm";
+import { Labels } from "./DomainDetailsHeader/DomainDetailsHeader";
 import DomainSummary from "./DomainSummary/DomainSummary";
 import ResourceRecords from "./ResourceRecords";
 
-import MainContentSection from "app/base/components/MainContentSection";
 import ModelNotFound from "app/base/components/ModelNotFound";
+import PageContent from "app/base/components/PageContent";
 import { useWindowTitle } from "app/base/hooks";
 import { useGetURLId } from "app/base/hooks/urls";
 import urls from "app/base/urls";
@@ -23,6 +26,9 @@ const DomainDetails = (): JSX.Element => {
     domainsSelectors.getById(state, Number(id))
   );
   const domainsLoading = useSelector(domainsSelectors.loading);
+  const [formOpen, setFormOpen] = useState<"DeleteDomain" | "AddRecord" | null>(
+    null
+  );
 
   const dispatch = useDispatch();
   useWindowTitle(domain?.name ?? "Loading...");
@@ -44,11 +50,29 @@ const DomainDetails = (): JSX.Element => {
       <ModelNotFound id={id} linkURL={urls.domains.index} modelName="domain" />
     );
   }
+  const closeForm = () => {
+    setFormOpen(null);
+  };
   return (
-    <MainContentSection header={<DomainDetailsHeader id={id} />}>
+    <PageContent
+      header={<DomainDetailsHeader id={id} setFormOpen={setFormOpen} />}
+      sidePanelContent={
+        formOpen === null ? null : (
+          <>
+            {formOpen === "DeleteDomain" && (
+              <DeleteDomainForm closeForm={closeForm} id={id} />
+            )}
+            {formOpen === "AddRecord" && (
+              <AddRecordForm closeForm={closeForm} id={id} />
+            )}
+          </>
+        )
+      }
+      sidePanelTitle={formOpen ? Labels[formOpen] : null}
+    >
       <DomainSummary id={id} />
       <ResourceRecords id={id} />
-    </MainContentSection>
+    </PageContent>
   );
 };
 

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
@@ -8,7 +8,7 @@ import {
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter, userEvent } from "testing/utils";
 
 describe("DomainDetailsHeader", () => {
   it("shows a spinner if domain details has not loaded yet", () => {
@@ -16,9 +16,12 @@ describe("DomainDetailsHeader", () => {
       domain: domainStateFactory({ items: [domainFactory({ id: 1 })] }),
     });
 
-    renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      {
+        state,
+      }
+    );
 
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
@@ -29,9 +32,12 @@ describe("DomainDetailsHeader", () => {
         items: [domainFactory({ id: 1, name: "domain-in-the-membrane" })],
       }),
     });
-    renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      {
+        state,
+      }
+    );
 
     expect(
       screen.getByRole("heading", { name: "domain-in-the-membrane" })
@@ -52,9 +58,12 @@ describe("DomainDetailsHeader", () => {
         ],
       }),
     });
-    renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      {
+        state,
+      }
+    );
 
     expect(screen.getByText("5 hosts; 9 resource records")).toBeInTheDocument();
   });
@@ -73,9 +82,12 @@ describe("DomainDetailsHeader", () => {
         ],
       }),
     });
-    renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      {
+        state,
+      }
+    );
 
     expect(screen.getByText("9 resource records")).toBeInTheDocument();
   });
@@ -94,9 +106,12 @@ describe("DomainDetailsHeader", () => {
         ],
       }),
     });
-    renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      {
+        state,
+      }
+    );
 
     expect(
       screen.getByText("5 hosts; No resource records")
@@ -117,9 +132,12 @@ describe("DomainDetailsHeader", () => {
         ],
       }),
     });
-    renderWithBrowserRouter(<DomainDetailsHeader id={1} />, {
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      {
+        state,
+      }
+    );
 
     expect(screen.getByText("No resource records")).toBeInTheDocument();
   });
@@ -135,14 +153,73 @@ describe("DomainDetailsHeader", () => {
         ],
       }),
     });
-    renderWithBrowserRouter(<DomainDetailsHeader id={0} />, {
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={0} setFormOpen={jest.fn()} />,
+      {
+        state,
+      }
+    );
 
     expect(
       screen.queryByRole("button", {
         name: DomainDetailsHeaderLabels.DeleteDomain,
       })
     ).not.toBeInTheDocument();
+  });
+
+  it("calls a function to open the side panel when the 'Add record' button is clicked", async () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: true,
+        items: [
+          domainDetailsFactory({
+            id: 1,
+            name: "domain-in-the-membrane",
+            hosts: 5,
+            resource_count: 9,
+          }),
+        ],
+      }),
+    });
+    const setFormOpen = jest.fn();
+
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={1} setFormOpen={setFormOpen} />,
+      {
+        state,
+      }
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Add record" }));
+    expect(setFormOpen).toHaveBeenCalledWith("AddRecord");
+  });
+
+  it("calls a function to open the side panel when the 'Delete domain' button is clicked", async () => {
+    const state = rootStateFactory({
+      domain: domainStateFactory({
+        loaded: true,
+        items: [
+          domainDetailsFactory({
+            id: 1,
+            name: "domain-in-the-membrane",
+            hosts: 5,
+            resource_count: 9,
+          }),
+        ],
+      }),
+    });
+    const setFormOpen = jest.fn();
+
+    renderWithBrowserRouter(
+      <DomainDetailsHeader id={1} setFormOpen={setFormOpen} />,
+      {
+        state,
+      }
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete domain" })
+    );
+    expect(setFormOpen).toHaveBeenCalledWith("DeleteDomain");
   });
 });

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.test.tsx
@@ -1,3 +1,5 @@
+import { DomainDetailsSidePanelViews } from "../constants";
+
 import DomainDetailsHeader, {
   Labels as DomainDetailsHeaderLabels,
 } from "./DomainDetailsHeader";
@@ -17,7 +19,7 @@ describe("DomainDetailsHeader", () => {
     });
 
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      <DomainDetailsHeader id={1} setSidePanelContent={jest.fn()} />,
       {
         state,
       }
@@ -33,7 +35,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      <DomainDetailsHeader id={1} setSidePanelContent={jest.fn()} />,
       {
         state,
       }
@@ -59,7 +61,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      <DomainDetailsHeader id={1} setSidePanelContent={jest.fn()} />,
       {
         state,
       }
@@ -83,7 +85,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      <DomainDetailsHeader id={1} setSidePanelContent={jest.fn()} />,
       {
         state,
       }
@@ -107,7 +109,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      <DomainDetailsHeader id={1} setSidePanelContent={jest.fn()} />,
       {
         state,
       }
@@ -133,7 +135,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={1} setFormOpen={jest.fn()} />,
+      <DomainDetailsHeader id={1} setSidePanelContent={jest.fn()} />,
       {
         state,
       }
@@ -154,7 +156,7 @@ describe("DomainDetailsHeader", () => {
       }),
     });
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={0} setFormOpen={jest.fn()} />,
+      <DomainDetailsHeader id={0} setSidePanelContent={jest.fn()} />,
       {
         state,
       }
@@ -181,17 +183,19 @@ describe("DomainDetailsHeader", () => {
         ],
       }),
     });
-    const setFormOpen = jest.fn();
+    const setSidePanelContent = jest.fn();
 
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={1} setFormOpen={setFormOpen} />,
+      <DomainDetailsHeader id={1} setSidePanelContent={setSidePanelContent} />,
       {
         state,
       }
     );
 
     await userEvent.click(screen.getByRole("button", { name: "Add record" }));
-    expect(setFormOpen).toHaveBeenCalledWith("AddRecord");
+    expect(setSidePanelContent).toHaveBeenCalledWith({
+      view: DomainDetailsSidePanelViews.ADD_RECORD,
+    });
   });
 
   it("calls a function to open the side panel when the 'Delete domain' button is clicked", async () => {
@@ -208,10 +212,10 @@ describe("DomainDetailsHeader", () => {
         ],
       }),
     });
-    const setFormOpen = jest.fn();
+    const setSidePanelContent = jest.fn();
 
     renderWithBrowserRouter(
-      <DomainDetailsHeader id={1} setFormOpen={setFormOpen} />,
+      <DomainDetailsHeader id={1} setSidePanelContent={setSidePanelContent} />,
       {
         state,
       }
@@ -220,6 +224,8 @@ describe("DomainDetailsHeader", () => {
     await userEvent.click(
       screen.getByRole("button", { name: "Delete domain" })
     );
-    expect(setFormOpen).toHaveBeenCalledWith("DeleteDomain");
+    expect(setSidePanelContent).toHaveBeenCalledWith({
+      view: DomainDetailsSidePanelViews.DELETE_DOMAIN,
+    });
   });
 });

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
@@ -1,11 +1,8 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-
-import AddRecordForm from "./AddRecordForm";
-import DeleteDomainForm from "./DeleteDomainForm";
 
 import SectionHeader from "app/base/components/SectionHeader";
 import { actions as domainActions } from "app/store/domain";
@@ -27,6 +24,9 @@ const pluralizeString = (
 
 type Props = {
   id: Domain["id"];
+  setFormOpen: React.Dispatch<
+    React.SetStateAction<"DeleteDomain" | "AddRecord" | null>
+  >;
 };
 
 export enum Labels {
@@ -34,14 +34,14 @@ export enum Labels {
   DeleteDomain = "Delete domain",
 }
 
-const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
+const DomainDetailsHeader = ({
+  id,
+  setFormOpen,
+}: Props): JSX.Element | null => {
   const domain = useSelector((state: RootState) =>
     domainSelectors.getById(state, id)
   );
   const dispatch = useDispatch();
-  const [formOpen, setFormOpen] = useState<"DeleteDomain" | "AddRecord" | null>(
-    null
-  );
 
   useEffect(() => {
     dispatch(domainActions.get(id));
@@ -50,10 +50,6 @@ const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
   const isDefaultDomain = id === 0;
   const hostsCount = domain?.hosts ?? 0;
   const recordsCount = domain?.resource_count ?? 0;
-
-  const closeForm = () => {
-    setFormOpen(null);
-  };
 
   const buttons = [
     <Button
@@ -81,19 +77,6 @@ const DomainDetailsHeader = ({ id }: Props): JSX.Element | null => {
     <SectionHeader
       buttons={buttons}
       loading={!domain}
-      sidePanelContent={
-        formOpen === null ? null : (
-          <>
-            {formOpen === "DeleteDomain" && (
-              <DeleteDomainForm closeForm={closeForm} id={id} />
-            )}
-            {formOpen === "AddRecord" && (
-              <AddRecordForm closeForm={closeForm} id={id} />
-            )}
-          </>
-        )
-      }
-      sidePanelTitle={formOpen ? Labels[formOpen] : null}
       subtitle={`${pluralizeString("host", hostsCount, "")}${
         hostsCount > 1 ? "; " : ""
       }${pluralizeString(

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DomainDetailsHeader.tsx
@@ -4,7 +4,10 @@ import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
+import { DomainDetailsSidePanelViews } from "../constants";
+
 import SectionHeader from "app/base/components/SectionHeader";
+import type { SetSidePanelContent } from "app/base/side-panel-context";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 import type { Domain } from "app/store/domain/types";
@@ -24,9 +27,7 @@ const pluralizeString = (
 
 type Props = {
   id: Domain["id"];
-  setFormOpen: React.Dispatch<
-    React.SetStateAction<"DeleteDomain" | "AddRecord" | null>
-  >;
+  setSidePanelContent: SetSidePanelContent;
 };
 
 export enum Labels {
@@ -36,7 +37,7 @@ export enum Labels {
 
 const DomainDetailsHeader = ({
   id,
-  setFormOpen,
+  setSidePanelContent,
 }: Props): JSX.Element | null => {
   const domain = useSelector((state: RootState) =>
     domainSelectors.getById(state, id)
@@ -55,7 +56,9 @@ const DomainDetailsHeader = ({
     <Button
       data-testid="add-record"
       key="add-record"
-      onClick={() => setFormOpen("AddRecord")}
+      onClick={() =>
+        setSidePanelContent({ view: DomainDetailsSidePanelViews.ADD_RECORD })
+      }
     >
       {Labels.AddRecord}
     </Button>,
@@ -66,7 +69,11 @@ const DomainDetailsHeader = ({
         appearance="negative"
         data-testid="delete-domain"
         key="delete-domain"
-        onClick={() => setFormOpen("DeleteDomain")}
+        onClick={() =>
+          setSidePanelContent({
+            view: DomainDetailsSidePanelViews.DELETE_DOMAIN,
+          })
+        }
       >
         {Labels.DeleteDomain}
       </Button>

--- a/src/app/domains/views/DomainDetails/constants.ts
+++ b/src/app/domains/views/DomainDetails/constants.ts
@@ -1,0 +1,12 @@
+import type { ValueOf } from "@canonical/react-components";
+
+import type { SidePanelContent } from "app/base/types";
+
+export const DomainDetailsSidePanelViews = {
+  ADD_RECORD: ["", "addRecord"],
+  DELETE_DOMAIN: ["", "deleteDomain"],
+} as const;
+
+export type DomainDetailsSidePanelContent = SidePanelContent<
+  ValueOf<typeof DomainDetailsSidePanelViews>
+>;


### PR DESCRIPTION
## Done

- Refactored DomainDetails to use PageContent
- Added tests to DomainDetailsHeader test suite to check that open side panel function has been called correctly

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to domains and click a domain
- Ensure the side panel opens correctly when "Add record" is clicked
- Ensure the side panel opens correctly when "Delete domain" is clicked (make sure you are on a non-default domain)

## Fixes

Fixes [MAASENG-1811](https://warthogs.atlassian.net/browse/MAASENG-1811)


[MAASENG-1811]: https://warthogs.atlassian.net/browse/MAASENG-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ