### PR TITLE
chore: Refactor DomainsList to use PageContent MAASENG-1812

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -76,6 +76,14 @@ const Routes = (): JSX.Element => (
     <Route
       element={
         <ErrorBoundary>
+          <DomainsList />
+        </ErrorBoundary>
+      }
+      path={`${urls.domains.index}/*`}
+    />
+    <Route
+      element={
+        <ErrorBoundary>
           <DomainDetails />
         </ErrorBoundary>
       }
@@ -123,14 +131,6 @@ const Routes = (): JSX.Element => (
           </ErrorBoundary>
         }
         path={`${urls.devices.index}/*`}
-      />
-      <Route
-        element={
-          <ErrorBoundary>
-            <DomainsList />
-          </ErrorBoundary>
-        }
-        path={`${urls.domains.index}/*`}
       />
       <Route
         element={

--- a/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.test.tsx
@@ -1,4 +1,4 @@
-import { Labels as DomainListHeaderFormLabels } from "../DomainListHeaderForm/DomainListHeaderForm";
+import { DomainListSidePanelViews } from "../constants";
 
 import DomainListHeader, {
   Labels as DomainListHeaderLabels,
@@ -32,41 +32,47 @@ describe("DomainListHeader", () => {
     const state = { ...initialState };
     state.domain.loaded = false;
 
-    renderWithBrowserRouter(<DomainListHeader />, {
-      route: "/domains",
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainListHeader setSidePanelContent={jest.fn()} />,
+      {
+        route: "/domains",
+        state,
+      }
+    );
     expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("displays a domain count if domains have loaded", () => {
     const state = { ...initialState };
     state.domain.loaded = true;
-    renderWithBrowserRouter(<DomainListHeader />, {
-      route: "/domains",
-      state,
-    });
+    renderWithBrowserRouter(
+      <DomainListHeader setSidePanelContent={jest.fn()} />,
+      {
+        route: "/domains",
+        state,
+      }
+    );
 
     expect(screen.getByText("2 domains available")).toBeInTheDocument();
   });
 
   it("displays the form when Add domains is clicked", async () => {
     const state = { ...initialState };
-    renderWithBrowserRouter(<DomainListHeader />, {
-      route: "/domains",
-      state,
-    });
-
-    expect(
-      screen.queryByRole("form", { name: DomainListHeaderFormLabels.FormLabel })
-    ).not.toBeInTheDocument();
+    const setSidePanelContent = jest.fn();
+    renderWithBrowserRouter(
+      <DomainListHeader setSidePanelContent={setSidePanelContent} />,
+      {
+        route: "/domains",
+        state,
+      }
+    );
 
     await userEvent.click(
       screen.getByRole("button", { name: DomainListHeaderLabels.AddDomains })
     );
 
-    expect(
-      screen.getByRole("form", { name: DomainListHeaderFormLabels.FormLabel })
-    ).toBeInTheDocument();
+    expect(setSidePanelContent).toHaveBeenCalledWith({
+      view: DomainListSidePanelViews.ADD_DOMAIN,
+    });
   });
 });

--- a/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -4,11 +4,10 @@ import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
-import DomainListHeaderForm from "../DomainListHeaderForm";
 import { DomainListSidePanelViews } from "../constants";
 
 import SectionHeader from "app/base/components/SectionHeader";
-import { useSidePanel } from "app/base/side-panel-context";
+import type { SetSidePanelContent } from "app/base/side-panel-context";
 import { actions as domainActions } from "app/store/domain";
 import domainSelectors from "app/store/domain/selectors";
 
@@ -16,11 +15,14 @@ export enum Labels {
   AddDomains = "Add domains",
 }
 
-const DomainListHeader = (): JSX.Element => {
+const DomainListHeader = ({
+  setSidePanelContent,
+}: {
+  setSidePanelContent: SetSidePanelContent;
+}): JSX.Element => {
   const dispatch = useDispatch();
   const domainCount = useSelector(domainSelectors.count);
   const domainsLoaded = useSelector(domainSelectors.loaded);
-  const { sidePanelContent, setSidePanelContent } = useSidePanel();
 
   useEffect(() => {
     dispatch(domainActions.fetch());
@@ -38,22 +40,9 @@ const DomainListHeader = (): JSX.Element => {
     </Button>,
   ];
 
-  let content: JSX.Element | null = null;
-
-  if (sidePanelContent?.view === DomainListSidePanelViews.ADD_DOMAIN) {
-    content = (
-      <DomainListHeaderForm
-        closeForm={() => {
-          setSidePanelContent(null);
-        }}
-      />
-    );
-  }
   return (
     <SectionHeader
       buttons={buttons}
-      sidePanelContent={content}
-      sidePanelTitle="Add domains"
       subtitle={`${pluralize("domain", domainCount, true)} available`}
       subtitleLoading={!domainsLoaded}
       title="DNS"

--- a/src/app/domains/views/DomainsList/DomainsList.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsList.test.tsx
@@ -1,35 +1,23 @@
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import DomainsList from "./DomainsList";
 import { Labels as DomainsTableLabels } from "./DomainsTable/DomainsTable";
 
+import type { RootState } from "app/store/root/types";
 import {
   domain as domainFactory,
   domainState as domainStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { screen, render, renderWithBrowserRouter } from "testing/utils";
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("DomainsList", () => {
   it("correctly fetches the necessary data", () => {
     const state = rootStateFactory();
     const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/domains", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <DomainsList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<DomainsList />, { route: "/domains", store });
     const expectedActions = ["domain/fetch"];
     const actualActions = store.getActions();
     expect(

--- a/src/app/domains/views/DomainsList/DomainsList.tsx
+++ b/src/app/domains/views/DomainsList/DomainsList.tsx
@@ -3,16 +3,35 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import DomainListHeader from "./DomainListHeader";
+import DomainListHeaderForm from "./DomainListHeaderForm";
 import DomainsTable from "./DomainsTable";
+import type { DomainListSidePanelContent } from "./constants";
+import { DomainListSidePanelViews } from "./constants";
 
-import MainContentSection from "app/base/components/MainContentSection";
+import PageContent from "app/base/components/PageContent";
 import { useWindowTitle } from "app/base/hooks";
+import type { SidePanelContextType } from "app/base/side-panel-context";
+import { useSidePanel } from "app/base/side-panel-context";
 import { actions } from "app/store/domain";
 import domainsSelectors from "app/store/domain/selectors";
 
 const DomainsList = (): JSX.Element => {
   const dispatch = useDispatch();
   const domains = useSelector(domainsSelectors.all);
+  const { sidePanelContent, setSidePanelContent } =
+    useSidePanel() as SidePanelContextType<DomainListSidePanelContent>;
+
+  let content: JSX.Element | null = null;
+
+  if (sidePanelContent?.view === DomainListSidePanelViews.ADD_DOMAIN) {
+    content = (
+      <DomainListHeaderForm
+        closeForm={() => {
+          setSidePanelContent(null);
+        }}
+      />
+    );
+  }
 
   useWindowTitle("DNS");
 
@@ -21,9 +40,13 @@ const DomainsList = (): JSX.Element => {
   }, [dispatch]);
 
   return (
-    <MainContentSection header={<DomainListHeader />}>
+    <PageContent
+      header={<DomainListHeader setSidePanelContent={setSidePanelContent} />}
+      sidePanelContent={content}
+      sidePanelTitle={"Add domains"}
+    >
       {domains.length > 0 && <DomainsTable />}
-    </MainContentSection>
+    </PageContent>
   );
 };
 


### PR DESCRIPTION
## Done

- Refactored DomainsList and DomainsListHeader to use PageContent

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to `/domains`
- Click "Add domain"
- Ensure side panel opens correctly

## Fixes

Fixes [MAASENG-1812](https://warthogs.atlassian.net/browse/MAASENG-1812)


[MAASENG-1812]: https://warthogs.atlassian.net/browse/MAASENG-1812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ