### PR TITLE
chore: Refactor FabricDetails to use PageContent MAASENG-1824

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -89,6 +89,14 @@ const Routes = (): JSX.Element => (
       }
       path={`${urls.domains.details(null)}/*`}
     />
+    <Route
+      element={
+        <ErrorBoundary>
+          <FabricDetails />
+        </ErrorBoundary>
+      }
+      path={`${urls.subnets.fabric.index(null)}/*`}
+    />
     {/* TODO: Remove this wrapper route once all pages use the new page component wrapper */}
     {/* https://warthogs.atlassian.net/browse/MAASENG-1832 */}
     <Route element={<LegacyPageContentWrapper />}>
@@ -195,14 +203,6 @@ const Routes = (): JSX.Element => (
           </ErrorBoundary>
         }
         path={`${urls.subnets.index}/*`}
-      />
-      <Route
-        element={
-          <ErrorBoundary>
-            <FabricDetails />
-          </ErrorBoundary>
-        }
-        path={`${urls.subnets.fabric.index(null)}/*`}
       />
       <Route
         element={

--- a/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
@@ -1,39 +1,31 @@
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import FabricDetails from "./FabricDetails";
 
 import urls from "app/base/urls";
 import { actions as fabricActions } from "app/store/fabric";
+import type { RootState } from "app/store/root/types";
 import { actions as subnetActions } from "app/store/subnet";
 import {
   fabricState as fabricStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { render, screen } from "testing/utils";
+import { renderWithBrowserRouter, screen } from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 it("dispatches actions to fetch necessary data and set fabric as active on mount", () => {
   const state = rootStateFactory();
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: urls.subnets.fabric.index({ id: 1 }) }]}
-      >
-        <CompatRouter>
-          <Routes>
-            <Route
-              element={<FabricDetails />}
-              path={urls.subnets.fabric.index(null)}
-            />
-          </Routes>
-        </CompatRouter>
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <Routes>
+      <Route
+        element={<FabricDetails />}
+        path={urls.subnets.fabric.index(null)}
+      />
+    </Routes>,
+    { route: urls.subnets.fabric.index({ id: 1 }), store }
   );
 
   const expectedActions = [
@@ -54,21 +46,14 @@ it("dispatches actions to fetch necessary data and set fabric as active on mount
 it("dispatches actions to unset active fabric and clean up on unmount", () => {
   const state = rootStateFactory();
   const store = mockStore(state);
-  const { unmount } = render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: urls.subnets.fabric.index({ id: 1 }) }]}
-      >
-        <CompatRouter>
-          <Routes>
-            <Route
-              element={<FabricDetails />}
-              path={urls.subnets.fabric.index(null)}
-            />
-          </Routes>
-        </CompatRouter>
-      </MemoryRouter>
-    </Provider>
+  const { unmount } = renderWithBrowserRouter(
+    <Routes>
+      <Route
+        element={<FabricDetails />}
+        path={urls.subnets.fabric.index(null)}
+      />
+    </Routes>,
+    { route: urls.subnets.fabric.index({ id: 1 }), store }
   );
 
   unmount();
@@ -97,22 +82,14 @@ it("displays a message if the fabric does not exist", () => {
       loading: false,
     }),
   });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: urls.subnets.fabric.index({ id: 1 }) }]}
-      >
-        <CompatRouter>
-          <Routes>
-            <Route
-              element={<FabricDetails />}
-              path={urls.subnets.fabric.index(null)}
-            />
-          </Routes>
-        </CompatRouter>
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <Routes>
+      <Route
+        element={<FabricDetails />}
+        path={urls.subnets.fabric.index(null)}
+      />
+    </Routes>,
+    { route: urls.subnets.fabric.index({ id: 1 }), state }
   );
 
   expect(screen.getByText("Fabric not found")).toBeInTheDocument();
@@ -125,22 +102,14 @@ it("shows a spinner if the fabric has not loaded yet", () => {
       loading: true,
     }),
   });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: urls.subnets.fabric.index({ id: 1 }) }]}
-      >
-        <CompatRouter>
-          <Routes>
-            <Route
-              element={<FabricDetails />}
-              path={urls.subnets.fabric.index(null)}
-            />
-          </Routes>
-        </CompatRouter>
-      </MemoryRouter>
-    </Provider>
+  renderWithBrowserRouter(
+    <Routes>
+      <Route
+        element={<FabricDetails />}
+        path={urls.subnets.fabric.index(null)}
+      />
+    </Routes>,
+    { route: urls.subnets.fabric.index({ id: 1 }), state }
   );
 
   expect(

--- a/src/app/subnets/views/FabricDetails/FabricDetails.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetails.tsx
@@ -3,13 +3,18 @@ import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import FabricDetailsHeader from "./FabricDetailsHeader";
+import FabricDeleteForm from "./FabricDetailsHeader/FabricDeleteForm";
+import type { FabricDetailsSidePanelContent } from "./FabricDetailsHeader/constants";
+import { FabricDetailsViews } from "./FabricDetailsHeader/constants";
 import FabricSummary from "./FabricSummary";
 import FabricVLANs from "./FabricVLANs";
 
-import MainContentSection from "app/base/components/MainContentSection";
 import ModelNotFound from "app/base/components/ModelNotFound";
+import PageContent from "app/base/components/PageContent";
 import SectionHeader from "app/base/components/SectionHeader";
 import { useGetURLId, useWindowTitle } from "app/base/hooks";
+import type { SidePanelContextType } from "app/base/side-panel-context";
+import { useSidePanel } from "app/base/side-panel-context";
 import { actions as fabricActions } from "app/store/fabric";
 import fabricSelectors from "app/store/fabric/selectors";
 import { FabricMeta } from "app/store/fabric/types";
@@ -27,6 +32,8 @@ const FabricDetails = (): JSX.Element => {
   const fabricsLoading = useSelector(fabricSelectors.loading);
   const isValidID = isId(id);
   useWindowTitle(`${fabric?.name || "Fabric"} details`);
+  const { sidePanelContent, setSidePanelContent } =
+    useSidePanel() as SidePanelContextType<FabricDetailsSidePanelContent>;
 
   useEffect(() => {
     if (isValidID) {
@@ -54,14 +61,45 @@ const FabricDetails = (): JSX.Element => {
         />
       );
     }
-    return <MainContentSection header={<SectionHeader loading />} />;
+    return (
+      <PageContent
+        header={<SectionHeader loading />}
+        sidePanelContent={null}
+        sidePanelTitle={null}
+      />
+    );
+  }
+
+  let content = null;
+  let title = null;
+
+  if (
+    sidePanelContent &&
+    sidePanelContent.view === FabricDetailsViews.DELETE_FABRIC
+  ) {
+    content = (
+      <FabricDeleteForm
+        closeForm={() => setSidePanelContent(null)}
+        id={fabric.id}
+      />
+    );
+    title = "Delete fabric";
   }
 
   return (
-    <MainContentSection header={<FabricDetailsHeader fabric={fabric} />}>
+    <PageContent
+      header={
+        <FabricDetailsHeader
+          fabric={fabric}
+          setSidePanelContent={setSidePanelContent}
+        />
+      }
+      sidePanelContent={content}
+      sidePanelTitle={title}
+    >
       <FabricSummary fabric={fabric} />
       <FabricVLANs fabric={fabric} />
-    </MainContentSection>
+    </PageContent>
   );
 };
 

--- a/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.test.tsx
@@ -1,4 +1,5 @@
 import FabricDetailsHeader from "./FabricDetailsHeader";
+import { FabricDetailsViews } from "./constants";
 
 import type { Fabric } from "app/store/fabric/types";
 import type { RootState } from "app/store/root/types";
@@ -10,45 +11,81 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { renderWithBrowserRouter, screen } from "testing/utils";
+import { renderWithBrowserRouter, screen, userEvent } from "testing/utils";
 
 let state: RootState;
 let fabric: Fabric;
-beforeEach(() => {
-  fabric = fabricFactory({ id: 1, name: "fabric1" });
-  state = rootStateFactory({
-    fabric: fabricStateFactory({
-      items: [fabric],
-    }),
-  });
-});
 
-it("shows the delete button when the user is an admin", () => {
-  state.user = userStateFactory({
-    auth: authStateFactory({
-      user: userFactory({ is_superuser: true }),
-    }),
-  });
-  renderWithBrowserRouter(<FabricDetailsHeader fabric={fabric} />, {
-    route: "/fabric/1",
-    state,
+describe("FabricDetailsHeader", () => {
+  beforeEach(() => {
+    fabric = fabricFactory({ id: 1, name: "fabric1" });
+    state = rootStateFactory({
+      fabric: fabricStateFactory({
+        items: [fabric],
+      }),
+    });
   });
 
-  expect(
-    screen.getByRole("button", { name: "Delete fabric" })
-  ).toBeInTheDocument();
-});
+  it("shows the delete button when the user is an admin", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ is_superuser: true }),
+      }),
+    });
+    renderWithBrowserRouter(
+      <FabricDetailsHeader fabric={fabric} setSidePanelContent={jest.fn()} />,
+      {
+        route: "/fabric/1",
+        state,
+      }
+    );
 
-it("does not show the delete button if the user is not an admin", () => {
-  state.user = userStateFactory({
-    auth: authStateFactory({
-      user: userFactory({ is_superuser: false }),
-    }),
-  });
-  renderWithBrowserRouter(<FabricDetailsHeader fabric={fabric} />, {
-    route: "/fabric/1",
-    state,
+    expect(
+      screen.getByRole("button", { name: "Delete fabric" })
+    ).toBeInTheDocument();
   });
 
-  expect(screen.queryByRole("button", { name: "Delete fabric" })).toBeNull();
+  it("does not show the delete button if the user is not an admin", () => {
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ is_superuser: false }),
+      }),
+    });
+    renderWithBrowserRouter(
+      <FabricDetailsHeader fabric={fabric} setSidePanelContent={jest.fn()} />,
+      {
+        route: "/fabric/1",
+        state,
+      }
+    );
+
+    expect(screen.queryByRole("button", { name: "Delete fabric" })).toBeNull();
+  });
+
+  it("calls a function to open the Delete form when the button is clicked", async () => {
+    const setSidePanelContent = jest.fn();
+    state.user = userStateFactory({
+      auth: authStateFactory({
+        user: userFactory({ is_superuser: true }),
+      }),
+    });
+    renderWithBrowserRouter(
+      <FabricDetailsHeader
+        fabric={fabric}
+        setSidePanelContent={setSidePanelContent}
+      />,
+      {
+        route: "/fabric/1",
+        state,
+      }
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Delete fabric" })
+    );
+
+    expect(setSidePanelContent).toHaveBeenCalledWith({
+      view: FabricDetailsViews.DELETE_FABRIC,
+    });
+  });
 });

--- a/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDetailsHeader.tsx
@@ -1,20 +1,22 @@
 import { Button } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
-import FabricDeleteForm from "./FabricDeleteForm";
 import { FabricDetailsViews } from "./constants";
 
 import SectionHeader from "app/base/components/SectionHeader";
-import { useSidePanel } from "app/base/side-panel-context";
+import type { SetSidePanelContent } from "app/base/side-panel-context";
 import authSelectors from "app/store/auth/selectors";
 import type { Fabric } from "app/store/fabric/types";
 
 type Props = {
   fabric: Fabric;
+  setSidePanelContent: SetSidePanelContent;
 };
 
-const FabricDetailsHeader = ({ fabric }: Props): JSX.Element => {
-  const { sidePanelContent, setSidePanelContent } = useSidePanel();
+const FabricDetailsHeader = ({
+  fabric,
+  setSidePanelContent,
+}: Props): JSX.Element => {
   const isAdmin = useSelector(authSelectors.isAdmin);
 
   return (
@@ -35,16 +37,6 @@ const FabricDetailsHeader = ({ fabric }: Props): JSX.Element => {
             ]
           : null
       }
-      sidePanelContent={
-        sidePanelContent &&
-        sidePanelContent.view === FabricDetailsViews.DELETE_FABRIC ? (
-          <FabricDeleteForm
-            closeForm={() => setSidePanelContent(null)}
-            id={fabric.id}
-          />
-        ) : null
-      }
-      sidePanelTitle="Delete fabric"
       title={fabric.name}
     />
   );


### PR DESCRIPTION
## Done

- Refactored FabricDetails to use PageContent

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to subnets and click on a fabric
- Click "Delete fabric"
- Ensure the side panel is displayed correctly

## Fixes

Fixes [MAASENG-1824](https://warthogs.atlassian.net/browse/MAASENG-1824)


[MAASENG-1824]: https://warthogs.atlassian.net/browse/MAASENG-1824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ