### PR TITLE
docs: expand redux saga readme section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 - [About](#about)
+- [MAAS UI Overview](#maas-ui-overview)
 - [Contributing](#contributing)
 - [Feedback](#feedback)
+- [Integration testing](#integration-testing)
+- [Release Process](#release-process)
 - [Related Projects](#related-projects)
 - [Built With](#built-with)
 - [Team Members](#team-members)
@@ -22,6 +25,10 @@ MAAS is an open-source tool that lets you build a data centre from bare-metal se
 ![screenshot of MAAS UI displaying 1000 machines](https://user-images.githubusercontent.com/7452681/234197707-a25b2231-1ca4-4d80-9e42-53d99c4e2cf1.png)
 
 This repository contains the sourcecode for the [MAAS](https://maas.io) web app, maas-ui.
+
+## MAAS UI Overview
+
+[MAAS UI Overview](docs/MAASUI.md)
 
 ## Contributing
 
@@ -41,6 +48,14 @@ Please see [HACKING](/docs/HACKING.md) for details on setting up a MAAS UI devel
 - Ask a question about MAAS on [Discourse](https://discourse.maas.io/).
 - File a [MAAS issue](https://bugs.launchpad.net/maas/+filebug).
   - If you think that the issue is related to the UI, please add a `ui` tag
+
+## Integration testing
+
+[Integration testing](docs/INTEGRATION.md)
+
+## Release Process
+
+[Release Process](docs/RELEASE.md)
 
 ## Related Projects
 

--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -598,7 +598,7 @@ export function* sendMessage(
 }
 
 /**
- * Connect to the WebSocket and watch for message.
+ * Set up a WebSocket connection and start listening for messages from the server.
  * @param {Array} messageHandlers - Sagas that should handle specific messages
  * via the websocket channel.
  */
@@ -663,7 +663,7 @@ export function* setupWebSocket({
 }
 
 /**
- * Set up websocket connections when requested.
+ * Set up websocket connection on request via status/websocketConnect action
  * @param {Array} messageHandlers - Additional sagas to be handled by the
  * websocket channel.
  */


### PR DESCRIPTION
## Done

- docs: update readme
  - expand section on redux saga and websockets
  - add links to nested docs sections in `/docs`

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)


## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
