### PR TITLE
fix: machine list in sync with URL MAASENG-1836

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -74,11 +74,14 @@ context("Machine listing", () => {
     );
 
     // verify that the searchbox and URL are updated
-    cy.findByRole("searchbox").should("have.value", "status:(=testing)");
-    cy.location().should((loc) => {
-      expect(loc.search).to.eq("?status=%3Dtesting");
-      expect(loc.pathname).to.eq(generateMAASURL("/machines"));
-    });
+    const expectMachineFilters = () => {
+      cy.findByRole("searchbox").should("have.value", "status:(=testing)");
+      cy.location().should((loc) => {
+        expect(loc.search).to.eq("?status=%3Dtesting");
+        expect(loc.pathname).to.eq(generateMAASURL("/machines"));
+      });
+    };
+    expectMachineFilters();
 
     cy.go("back");
     // verify the user is navigated back to the previous page
@@ -87,6 +90,10 @@ context("Machine listing", () => {
       expect(loc.search).to.eq("");
       expect(loc.pathname).to.eq(intialPage);
     });
+
+    cy.go("forward");
+    // verify that previously selected filters are restored
+    expectMachineFilters();
   });
 
   it("can load filters from the URL", () => {

--- a/src/app/machines/views/Machines.tsx
+++ b/src/app/machines/views/Machines.tsx
@@ -29,7 +29,12 @@ const Machines = (): JSX.Element => {
     (searchText) => {
       setFilter(searchText);
       const filters = FilterMachines.getCurrentFilters(searchText);
-      navigate({ search: FilterMachines.filtersToQueryString(filters) });
+      navigate(
+        {
+          search: FilterMachines.filtersToQueryString(filters),
+        },
+        { replace: true }
+      );
     },
     [navigate, setFilter]
   );


### PR DESCRIPTION
## Done

- fix: machine list in sync with URL MAASENG-1836

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to controller list page
- Click the machines navigation item to navigate to machine list page
- Select a filter
- Click "back" button in the browser
- you should be taken to the previous page (controller list in this case) and not one step back in filters history

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1836

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
