### PR TITLE
Maaseng 1850 improve ux for adding network booted machines

### DIFF
--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionForm.test.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionForm.test.tsx
@@ -5,6 +5,8 @@ import CommissionForm from "./CommissionForm";
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import { ScriptName, ScriptType } from "app/store/script/types";
+import { PowerState } from "app/store/types/enum";
+import { NodeStatusCode } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -243,5 +245,36 @@ describe("CommissionForm", () => {
       store.getActions().find((action) => action.type === "machine/commission")
         ?.payload.params.extra.testing_scripts
     ).toStrictEqual([ScriptName.NONE]);
+  });
+
+  it("Displays an error notification if power type is not set and status is unknown", () => {
+    state.machine.items[0].power_state = PowerState.UNKNOWN;
+    state.machine.items[0].status_code = NodeStatusCode.NEW;
+
+    const store = mockStore(state);
+    renderWithBrowserRouter(
+      <CommissionForm
+        clearSidePanelContent={jest.fn()}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      {
+        route: "/machine/abc123",
+        store,
+        routePattern: "/machine/:id",
+      }
+    );
+
+    expect(
+      screen.getByRole("heading", {
+        name: /error/i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/unconfigured power type*/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", {
+        name: /configure the power type/i,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionForm.tsx
+++ b/src/app/machines/components/MachineHeaderForms/MachineActionFormWrapper/CommissionForm/CommissionForm.tsx
@@ -1,16 +1,24 @@
 import { useEffect } from "react";
 
+import { Notification } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 import * as Yup from "yup";
 
 import CommissionFormFields from "./CommissionFormFields";
 import type { CommissionFormValues, FormattedScript } from "./types";
 
 import ActionForm from "app/base/components/ActionForm";
+import { useGetURLId } from "app/base/hooks";
+import urls from "app/base/urls";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
-import type { MachineEventErrors } from "app/store/machine/types";
-import { useSelectedMachinesActionsDispatch } from "app/store/machine/utils/hooks";
+import { MachineMeta, type MachineEventErrors } from "app/store/machine/types";
+import { isUnconfiguredPowerType } from "app/store/machine/utils/common";
+import {
+  useFetchMachine,
+  useSelectedMachinesActionsDispatch,
+} from "app/store/machine/utils/hooks";
 import { actions as scriptActions } from "app/store/script";
 import scriptSelectors from "app/store/script/selectors";
 import type { Script } from "app/store/script/types";
@@ -59,6 +67,8 @@ export const CommissionForm = ({
   viewingDetails,
   selectedMachines,
 }: Props): JSX.Element => {
+  const id = useGetURLId(MachineMeta.PK);
+  const { machine } = useFetchMachine(id);
   const dispatch = useDispatch();
   const { dispatch: dispatchForSelectedMachines, ...actionProps } =
     useSelectedMachinesActionsDispatch({ selectedMachines, searchFilter });
@@ -181,6 +191,15 @@ export const CommissionForm = ({
       validationSchema={CommissionFormSchema}
       {...actionProps}
     >
+      {machine && isUnconfiguredPowerType(machine) && (
+        <Notification severity="negative" title="Error">
+          Unconfigured power type. Please{" "}
+          <Link to={urls.machines.machine.configuration(id ? { id } : null)}>
+            configure the power type{" "}
+          </Link>
+          and try again.
+        </Notification>
+      )}
       <CommissionFormFields
         commissioningScripts={formatScripts(commissioningScripts)}
         preselectedCommissioning={formatScripts(preselectedCommissioningSorted)}

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -7,7 +7,7 @@ import { MachineHeaderViews } from "app/machines/constants";
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
 import { PowerState } from "app/store/types/enum";
-import { NodeActions } from "app/store/types/node";
+import { NodeActions, NodeStatusCode } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -262,5 +262,24 @@ describe("MachineHeader", () => {
     expect(
       store.getActions().find((action) => action.type === expectedAction.type)
     ).toStrictEqual(expectedAction);
+  });
+
+  it("displays an error icon with configuration tab link when power type is not set and status is unknown", () => {
+    state.machine.items[0].power_state = PowerState.UNKNOWN;
+    state.machine.items[0].status_code = NodeStatusCode.NEW;
+    const store = mockStore(state);
+
+    renderWithBrowserRouter(
+      <MachineHeader
+        setSidePanelContent={jest.fn()}
+        sidePanelContent={null}
+        systemId="abc123"
+      />,
+      { store, route: "/machine/abc123" }
+    );
+
+    expect(
+      screen.getByRole("link", { name: /error configuration/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -25,6 +25,7 @@ import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
+import { isUnconfiguredPowerType } from "app/store/machine/utils/common";
 import {
   useFetchMachine,
   useSelectedMachinesActionsDispatch,
@@ -91,6 +92,7 @@ const MachineHeader = ({
 
   const urlBase = `/machine/${systemId}`;
   const checkingPower = statuses?.checkingPower;
+  const needsPowerConfiguration = isUnconfiguredPowerType(machine);
 
   return (
     <SectionHeader
@@ -258,7 +260,17 @@ const MachineHeader = ({
         {
           active: pathname.startsWith(`${urlBase}/configuration`),
           component: Link,
-          label: "Configuration",
+          label: (
+            <ScriptStatus
+              status={
+                needsPowerConfiguration
+                  ? ScriptResultStatus.FAILED
+                  : ScriptResultStatus.NONE
+              }
+            >
+              Configuration
+            </ScriptStatus>
+          ),
           to: `${urlBase}/configuration`,
         },
       ]}

--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
@@ -4,6 +4,7 @@ import { StatusColumn } from "./StatusColumn";
 
 import type { Machine } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { PowerState } from "app/store/types/enum";
 import {
   NodeActions,
   NodeStatus,
@@ -244,6 +245,25 @@ describe("StatusColumn", () => {
       expect(
         screen.queryByRole("button", { name: /take action/i })
       ).not.toBeInTheDocument();
+    });
+
+    it("shows an error icon button and a tooltip if power type is not set and status is unknown", () => {
+      machine.power_state = PowerState.UNKNOWN;
+      machine.status_code = NodeStatusCode.NEW;
+      const store = mockStore(state);
+      renderWithBrowserRouter(
+        <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />,
+        { route: "/machines", store }
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Unconfigured power type" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("tooltip", {
+          name: "Unconfigured power type. Go to the configuration tab of this machine.",
+        })
+      ).toBeInTheDocument();
     });
   });
 });

--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -14,6 +14,7 @@ import type { MachineMenuToggleHandler } from "app/machines/types";
 import machineSelectors from "app/store/machine/selectors";
 import type { Machine } from "app/store/machine/types";
 import { isTransientStatus, useFormattedOS } from "app/store/machine/utils";
+import { isUnconfiguredPowerType } from "app/store/machine/utils/common";
 import type { RootState } from "app/store/root/types";
 import {
   NodeActions,
@@ -54,6 +55,14 @@ const getStatusIcon = (machine: Machine | null) => {
         iconProps={{ "data-testid": "status-icon" }}
         message="Machine has failed tests; use with caution."
         position="top-left"
+      />
+    );
+  } else if (isUnconfiguredPowerType(machine)) {
+    return (
+      <TooltipButton
+        aria-label="Unconfigured power type"
+        iconName="error"
+        message="Unconfigured power type. Go to the configuration tab of this machine."
       />
     );
   }

--- a/src/app/store/machine/utils/common.test.ts
+++ b/src/app/store/machine/utils/common.test.ts
@@ -6,12 +6,14 @@ import {
   isDeployedWithHardwareSync,
   mapSortDirection,
   selectedToFilters,
+  isUncomissionedPowerType,
 } from "./common";
 
 import { SortDirection } from "app/base/types";
 import { PowerFieldScope } from "app/store/general/types";
 import { FetchSortDirection, FetchGroupKey } from "app/store/machine/types";
-import { NodeStatus } from "app/store/types/node";
+import { PowerState } from "app/store/types/enum";
+import { NodeStatus, NodeStatusCode } from "app/store/types/node";
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
@@ -171,6 +173,30 @@ describe("common machine utils", () => {
 
     it("handles no filters", () => {
       expect(selectedToFilters({ items: [], groups: [] })).toBeNull();
+    });
+  });
+
+  describe("isUncomissionedPowerType", () => {
+    it("returns true for unknown power state and new status code", () => {
+      const machine = machineFactory({
+        power_state: PowerState.UNKNOWN,
+        status_code: NodeStatusCode.NEW,
+      });
+
+      expect(isUncomissionedPowerType(machine)).toBe(true);
+    });
+
+    it("returns false if either power state or status criteria are not met", () => {
+      const machine1 = machineFactory({
+        power_state: PowerState.UNKNOWN,
+        status_code: NodeStatusCode.READY,
+      });
+      const machine2 = machineFactory({
+        power_state: PowerState.OFF,
+        status_code: NodeStatusCode.NEW,
+      });
+      expect(isUncomissionedPowerType(machine1)).toBe(false);
+      expect(isUncomissionedPowerType(machine2)).toBe(false);
     });
   });
 });

--- a/src/app/store/machine/utils/common.test.ts
+++ b/src/app/store/machine/utils/common.test.ts
@@ -6,7 +6,7 @@ import {
   isDeployedWithHardwareSync,
   mapSortDirection,
   selectedToFilters,
-  isUncomissionedPowerType,
+  isUnconfiguredPowerType,
 } from "./common";
 
 import { SortDirection } from "app/base/types";
@@ -176,14 +176,14 @@ describe("common machine utils", () => {
     });
   });
 
-  describe("isUncomissionedPowerType", () => {
+  describe("isUnconfiguredPowerType", () => {
     it("returns true for unknown power state and new status code", () => {
       const machine = machineFactory({
         power_state: PowerState.UNKNOWN,
         status_code: NodeStatusCode.NEW,
       });
 
-      expect(isUncomissionedPowerType(machine)).toBe(true);
+      expect(isUnconfiguredPowerType(machine)).toBe(true);
     });
 
     it("returns false if either power state or status criteria are not met", () => {
@@ -195,8 +195,8 @@ describe("common machine utils", () => {
         power_state: PowerState.OFF,
         status_code: NodeStatusCode.NEW,
       });
-      expect(isUncomissionedPowerType(machine1)).toBe(false);
-      expect(isUncomissionedPowerType(machine2)).toBe(false);
+      expect(isUnconfiguredPowerType(machine1)).toBe(false);
+      expect(isUnconfiguredPowerType(machine2)).toBe(false);
     });
   });
 });

--- a/src/app/store/machine/utils/common.ts
+++ b/src/app/store/machine/utils/common.ts
@@ -215,7 +215,7 @@ export const mergeGroupUpdates = ({
   return groups;
 };
 
-export const isUncomissionedPowerType = (machine: Machine): boolean => {
+export const isUnconfiguredPowerType = (machine: Machine): boolean => {
   return (
     machine.power_state === PowerState.UNKNOWN &&
     machine.status_code === NodeStatusCode.NEW

--- a/src/app/store/machine/utils/common.ts
+++ b/src/app/store/machine/utils/common.ts
@@ -12,7 +12,8 @@ import type {
 } from "app/store/machine/types";
 import { FetchSortDirection, FilterGroupKey } from "app/store/machine/types";
 import type { Tag, TagMeta } from "app/store/tag/types";
-import { NodeStatus } from "app/store/types/node";
+import { PowerState } from "app/store/types/enum";
+import { NodeStatus, NodeStatusCode } from "app/store/types/node";
 
 /**
  * Whether a machine has a Machine or MachineDetails type.
@@ -212,4 +213,11 @@ export const mergeGroupUpdates = ({
     return initialGroups;
   }
   return groups;
+};
+
+export const isUncomissionedPowerType = (machine: Machine): boolean => {
+  return (
+    machine.power_state === PowerState.UNKNOWN &&
+    machine.status_code === NodeStatusCode.NEW
+  );
 };


### PR DESCRIPTION
## Done

- Notify users about machines that have unconfigured power types
- Direct users to configuration page to configure power type

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Take an existing machine in MAAS, note it's power credentials.
- Delete the machine in MAAS
- Power on the machine using credentials from 1
- Note the machine show up in Commissioning, wait for it to finish and land in New
- Find the machine in machine listing, and go to Commission it.

## Fixes

Fixes: #1495 
[MAASENG-1850](https://warthogs.atlassian.net/browse/MAASENG-1850)

## Launchpad issue

`lp#1881560`

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

<img width="1227" alt="image" src="https://github.com/canonical/maas-ui/assets/47540149/b1445b33-23ab-425c-8e2f-f48191cc5b28">
<img width="995" alt="image" src="https://github.com/canonical/maas-ui/assets/47540149/a896912f-1be7-49f3-8599-ba5ce0bd806e">
<img width="577" alt="image" src="https://github.com/canonical/maas-ui/assets/47540149/936a3911-68b8-4483-9dd3-0a8cc0f3af0a">
