### PR TITLE
fix: subnets subtitle position

### DIFF
--- a/src/app/subnets/views/SubnetsList/SubnetsList.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsList.tsx
@@ -95,7 +95,7 @@ const SubnetsList = (): JSX.Element => {
           }
           sidePanelTitle={activeForm ? `Add ${activeForm}` : ""}
           subtitle={
-            <div className="u-flex--wrap u-flex--align-center u-nudge-right">
+            <div className="u-flex--wrap u-flex--align-center">
               <SegmentedControl
                 aria-label="Group by"
                 buttonClassName="u-no-margin--bottom u-upper-case--first"


### PR DESCRIPTION
## Done

- fix: subnets subtitle position

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to subnets list page
- Verify the subtitle is positioned correctly

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots
### before
![image](https://github.com/canonical/maas-ui/assets/7452681/2e17c602-38fb-41bc-92cf-3cddf48162f0)

### after
![image](https://github.com/canonical/maas-ui/assets/7452681/c88540da-e585-49d4-b816-2e7c9019ba79)
