### PR TITLE
refactor: subnet details MAASENG-1826

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -193,6 +193,14 @@ const Routes = (): JSX.Element => (
       }
       path={`${urls.subnets.index}/*`}
     />
+    <Route
+      element={
+        <ErrorBoundary>
+          <SubnetDetails />
+        </ErrorBoundary>
+      }
+      path={`${urls.subnets.subnet.index(null)}/*`}
+    />
     {/* TODO: Remove this wrapper route once all pages use the new page component wrapper */}
     {/* https://warthogs.atlassian.net/browse/MAASENG-1832 */}
     <Route element={<LegacyPageContentWrapper />}>
@@ -211,14 +219,6 @@ const Routes = (): JSX.Element => (
           </ErrorBoundary>
         }
         path={`${urls.pools.index}/*`}
-      />
-      <Route
-        element={
-          <ErrorBoundary>
-            <SubnetDetails />
-          </ErrorBoundary>
-        }
-        path={`${urls.subnets.subnet.index(null)}/*`}
       />
       <Route
         element={

--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -185,6 +185,14 @@ const Routes = (): JSX.Element => (
       }
       path={`${urls.kvm.index}/*`}
     />
+    <Route
+      element={
+        <ErrorBoundary>
+          <SubnetsList />
+        </ErrorBoundary>
+      }
+      path={`${urls.subnets.index}/*`}
+    />
     {/* TODO: Remove this wrapper route once all pages use the new page component wrapper */}
     {/* https://warthogs.atlassian.net/browse/MAASENG-1832 */}
     <Route element={<LegacyPageContentWrapper />}>
@@ -203,14 +211,6 @@ const Routes = (): JSX.Element => (
           </ErrorBoundary>
         }
         path={`${urls.pools.index}/*`}
-      />
-      <Route
-        element={
-          <ErrorBoundary>
-            <SubnetsList />
-          </ErrorBoundary>
-        }
-        path={`${urls.subnets.index}/*`}
       />
       <Route
         element={

--- a/src/app/subnets/types.ts
+++ b/src/app/subnets/types.ts
@@ -7,7 +7,7 @@ import { SubnetForms } from "app/subnets/constants";
 
 export type SubnetForm = keyof typeof SubnetForms;
 
-export const SubnetHeaderViews = {
+export const SubnetSidePanelViews = {
   [SubnetForms.Fabric]: ["addForm", SubnetForms.Fabric],
   [SubnetForms.VLAN]: ["addForm", SubnetForms.VLAN],
   [SubnetForms.Space]: ["addForm", SubnetForms.Space],
@@ -15,6 +15,6 @@ export const SubnetHeaderViews = {
 } as const;
 
 export type SubnetSidePanelContent = SidePanelContent<
-  ValueOf<typeof SubnetHeaderViews>
+  ValueOf<typeof SubnetSidePanelViews>
 >;
 export type SubnetsUrlParams = { by?: GroupByKey; q?: string };

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
@@ -4,7 +4,6 @@ import SectionHeader from "app/base/components/SectionHeader";
 import { useSidePanel } from "app/base/side-panel-context";
 import type { Subnet } from "app/store/subnet/types";
 import { isSubnetDetails } from "app/store/subnet/utils";
-import SubnetActionForms from "app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/SubnetActionForms";
 import {
   subnetActionLabels,
   SubnetActionTypes,
@@ -16,12 +15,7 @@ type Props = {
 };
 
 const SubnetDetailsHeader = ({ subnet }: Props): JSX.Element => {
-  const { sidePanelContent, setSidePanelContent } = useSidePanel();
-  const [, name] = sidePanelContent?.view || [];
-  const activeForm =
-    name && Object.keys(SubnetActionTypes).includes(name)
-      ? (name as keyof typeof SubnetActionTypes)
-      : null;
+  const { setSidePanelContent } = useSidePanel();
   return (
     <SectionHeader
       buttons={[
@@ -41,16 +35,6 @@ const SubnetDetailsHeader = ({ subnet }: Props): JSX.Element => {
           toggleLabel="Take action"
         />,
       ]}
-      sidePanelContent={
-        activeForm ? (
-          <SubnetActionForms
-            activeForm={activeForm}
-            id={subnet.id}
-            setActiveForm={setSidePanelContent}
-          />
-        ) : null
-      }
-      sidePanelTitle={activeForm ? subnetActionLabels[activeForm] : ""}
       subtitleLoading={!isSubnetDetails(subnet)}
       title={subnet.name}
     />

--- a/src/app/subnets/views/SubnetsList/SubnetsList.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsList.tsx
@@ -7,14 +7,14 @@ import SubnetsTable from "./SubnetsTable";
 import { SubnetsColumns } from "./SubnetsTable/constants";
 import type { GroupByKey } from "./SubnetsTable/types";
 
-import MainContentSection from "app/base/components/MainContentSection";
+import PageContent from "app/base/components/PageContent/PageContent";
 import SectionHeader from "app/base/components/SectionHeader";
 import SegmentedControl from "app/base/components/SegmentedControl";
 import { useWindowTitle } from "app/base/hooks";
 import { useQuery } from "app/base/hooks/urls";
 import { useSidePanel } from "app/base/side-panel-context";
 import { SubnetForms, SubnetsUrlParams } from "app/subnets/constants";
-import { SubnetHeaderViews } from "app/subnets/types";
+import { SubnetSidePanelViews } from "app/subnets/types";
 import FormActions from "app/subnets/views/FormActions";
 
 const SubnetsList = (): JSX.Element => {
@@ -62,17 +62,17 @@ const SubnetsList = (): JSX.Element => {
       : null;
 
   return (
-    <MainContentSection
+    <PageContent
       header={
         <SectionHeader
           buttons={[
             <ContextualMenu
               hasToggleIcon
               links={[
-                SubnetHeaderViews.Fabric,
-                SubnetHeaderViews.VLAN,
-                SubnetHeaderViews.Space,
-                SubnetHeaderViews.Subnet,
+                SubnetSidePanelViews.Fabric,
+                SubnetSidePanelViews.VLAN,
+                SubnetSidePanelViews.Space,
+                SubnetSidePanelViews.Subnet,
               ].map((view) => {
                 const [, name] = view;
                 return {
@@ -85,15 +85,6 @@ const SubnetsList = (): JSX.Element => {
               toggleLabel="Add"
             />,
           ]}
-          sidePanelContent={
-            sidePanelContent ? (
-              <FormActions
-                activeForm={activeForm}
-                setActiveForm={setSidePanelContent}
-              />
-            ) : null
-          }
-          sidePanelTitle={activeForm ? `Add ${activeForm}` : ""}
           subtitle={
             <div className="u-flex--wrap u-flex--align-center">
               <SegmentedControl
@@ -117,6 +108,15 @@ const SubnetsList = (): JSX.Element => {
           title="Subnets"
         />
       }
+      sidePanelContent={
+        activeForm ? (
+          <FormActions
+            activeForm={activeForm}
+            setActiveForm={setSidePanelContent}
+          />
+        ) : null
+      }
+      sidePanelTitle={activeForm ? `Add ${activeForm}` : ""}
     >
       {hasValidGroupBy ? (
         <SubnetsTable
@@ -125,7 +125,7 @@ const SubnetsList = (): JSX.Element => {
           setSearchText={setSearchText}
         />
       ) : null}
-    </MainContentSection>
+    </PageContent>
   );
 };
 


### PR DESCRIPTION
## Done

- refactor: subnet details MAASENG-1826

Note: review after https://github.com/canonical/maas-ui/pull/5003

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to subnets list
- Click on a subnet link
- Click "take action" -> "map subnet"
- Verify that the side panel is displayed correctly

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1826

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
