### PR TITLE
fix: machine delete notify backport 3.4 lp#2023138

### DIFF
--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -942,6 +942,30 @@ const machineSlice = createSlice({
           (machineId: Machine[MachineMeta.PK]) => machineId !== action.payload
         );
       }
+      // Remove deleted machine from all lists
+      Object.values(state.lists).forEach((list) => {
+        list.groups?.forEach((group) => {
+          let index = group.items.indexOf(action.payload);
+          if (index !== -1) {
+            group.items.splice(index, 1);
+            // update the count
+            if (group.count > 0) {
+              group.count = group.count - 1;
+            }
+            if (list.count && list.count > 0) {
+              list.count = list.count! - 1;
+            }
+            // Exit the loop early if the item has been found and removed
+            return;
+          }
+        });
+        // remove any empty groups
+        if (list.groups) {
+          list.groups = list.groups?.filter((group) => group.items.length > 0);
+        }
+      });
+
+      // we do not know if the deleted machine is in the the requested count
       // mark all machine count queries as stale and in need of re-fetch
       Object.keys(state.counts).forEach((callId) => {
         state.counts[callId].stale = true;


### PR DESCRIPTION
## Done

- fix: machine delete notify backport 3.4 

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Launchpad issue

`lp#2023138`
https://bugs.launchpad.net/maas-ui/+bug/2023138

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
