### PR TITLE
test: disable no-multi-comp eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -125,7 +125,7 @@ module.exports = {
     {
       files: ["src/**/*.tsx"],
       rules: {
-        "react/no-multi-comp": ["error", { ignoreStateless: false }],
+        "react/no-multi-comp": ["off"],
       },
     },
     {

--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import { useMemo } from "react";
 
 import { Button, Icon } from "@canonical/react-components";

--- a/src/app/base/components/Meter/Meter.tsx
+++ b/src/app/base/components/Meter/Meter.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as React from "react";
 

--- a/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
+++ b/src/app/base/components/NodeName/NodeNameFields/NodeNameFields.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";

--- a/src/app/base/components/SecondaryNavigation/SecondaryNavigation.tsx
+++ b/src/app/base/components/SecondaryNavigation/SecondaryNavigation.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-multi-comp */
-
 import classNames from "classnames";
 import type { Location } from "react-router-dom-v5-compat";
 import { Link, matchPath, useLocation } from "react-router-dom-v5-compat";

--- a/src/app/base/components/TitledSection/TitledSection.tsx
+++ b/src/app/base/components/TitledSection/TitledSection.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import React from "react";
 import type { ReactNode } from "react";
 

--- a/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerVLANs/ControllerVLANsTable/ControllerVLANsTable.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import { useMemo } from "react";
 
 import { ModularTable } from "@canonical/react-components";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import { Col, Row } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import type { ReactNode } from "react";
 import { useState, useMemo } from "react";
 

--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import * as React from "react";
 
 import { Spinner, Tooltip } from "@canonical/react-components";

--- a/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import { Col, Row, Textarea } from "@canonical/react-components";
 import type { TextareaProps } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/app/subnets/views/FormActions/components/AddSubnet.tsx
+++ b/src/app/subnets/views/FormActions/components/AddSubnet.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import { Row, Col, Input } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useDispatch, useSelector } from "react-redux";

--- a/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import type { PropsWithChildren } from "react";
 import { useState } from "react";
 

--- a/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetailsHeader/VLANDetailsHeader.tsx
@@ -40,7 +40,7 @@ const generateTitle = (
 };
 
 const VLANDetailsHeader = ({ id }: Props): JSX.Element => {
-  const { sidePanelContent, setSidePanelContent } = useSidePanel();
+  const { setSidePanelContent } = useSidePanel();
   const dispatch = useDispatch();
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-multi-comp */
 import type { ValueOf } from "@canonical/react-components";
 import type { RenderOptions, RenderResult } from "@testing-library/react";
 import { render, screen } from "@testing-library/react";


### PR DESCRIPTION
## Done

- disable no-multi-comp eslint rule

## Why

TLDR; Strict enforcement of this rule often leads to adopting anti-patterns and unnecessary complexity.

For instance, it promotes creating monolithic components to avoid breaking the rule, creating additional simple functions instead of React components so that they can be placed in the same file, or overusing custom hooks, even when a simple component could do the job. As a result, this leads to unnecessary complexity and makes code more difficult to parse.
