### PR TITLE
feat: fetch machine group counts MAASENG-1882

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -193,7 +193,7 @@ describe("MachineList", () => {
             loaded: true,
             groups: [
               machineStateListGroupFactory({
-                items: [machines[0].system_id, machines[2].system_id],
+                items: [machines[0].system_id],
                 name: "Deployed",
                 value: FetchNodeStatus.DEPLOYED,
               }),

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListGroupCount/MachineListGroupCount.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListGroupCount/MachineListGroupCount.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+
+import MachineListGroupCount from "./MachineListGroupCount";
+
+import { FetchGroupKey } from "app/store/machine/types";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
+import { FetchNodeStatus } from "app/store/types/node";
+
+jest.mock("app/store/machine/utils/hooks");
+
+const mockedUseFetchMachineCount = useFetchMachineCount as jest.MockedFunction<
+  typeof useFetchMachineCount
+>;
+
+beforeEach(() => {
+  mockedUseFetchMachineCount.mockClear();
+});
+
+it("renders placeholder when count is null and fetched machines count has not loaded", () => {
+  mockedUseFetchMachineCount.mockReturnValue({
+    machineCountLoading: true,
+    machineCountLoaded: false,
+    machineCount: 0,
+  });
+
+  render(
+    <MachineListGroupCount
+      count={null}
+      filter={null}
+      group={""}
+      grouping={null}
+    />
+  );
+
+  expect(screen.getByText("xx machines")).toBeInTheDocument();
+});
+
+it("renders count when count is not null", () => {
+  render(
+    <MachineListGroupCount count={3} filter={null} group={""} grouping={null} />
+  );
+
+  expect(screen.getByText("3 machines")).toBeInTheDocument();
+});
+
+it("renders machineCount when count is null and fetched count has loaded", () => {
+  mockedUseFetchMachineCount.mockReturnValue({
+    machineCountLoading: false,
+    machineCountLoaded: true,
+    machineCount: 5,
+  });
+
+  render(
+    <MachineListGroupCount
+      count={null}
+      filter={null}
+      group={""}
+      grouping={null}
+    />
+  );
+
+  expect(screen.getByText("5 machines")).toBeInTheDocument();
+});
+
+it("calls useFetchMachineCount with correct parameters", () => {
+  mockedUseFetchMachineCount.mockReturnValue({
+    machineCountLoading: false,
+    machineCountLoaded: false,
+    machineCount: 0,
+  });
+
+  render(
+    <MachineListGroupCount
+      count={null}
+      filter={{ owner: ["=admin"] }}
+      group={FetchNodeStatus.NEW}
+      grouping={FetchGroupKey.Status}
+    />
+  );
+
+  expect(useFetchMachineCount).toHaveBeenCalledWith(
+    { owner: ["=admin"], status: ["=new"] },
+    { isEnabled: true }
+  );
+});

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListGroupCount/MachineListGroupCount.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListGroupCount/MachineListGroupCount.tsx
@@ -1,0 +1,46 @@
+import pluralize from "pluralize";
+
+import Placeholder from "app/base/components/Placeholder/Placeholder";
+import type {
+  FetchFilters,
+  MachineStateListGroup,
+  FetchGroupKey,
+} from "app/store/machine/types";
+import { selectedToFilters } from "app/store/machine/utils";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
+
+/**
+ * Displays the aggregate count of machines in a specified machine list group
+ * It optionally retrieves the count if it's not already known.
+ */
+const MachineListGroupCount = ({
+  count,
+  filter,
+  group,
+  grouping,
+}: {
+  count: number | null;
+  filter: FetchFilters | null;
+  group: MachineStateListGroup["value"];
+  grouping: FetchGroupKey | null;
+}): JSX.Element => {
+  const groupFilters = selectedToFilters({
+    groups: [group],
+    grouping,
+  });
+
+  const { machineCount, machineCountLoaded } = useFetchMachineCount(
+    { ...filter, ...groupFilters },
+    {
+      isEnabled: count === null,
+    }
+  );
+
+  if (count === null && !machineCountLoaded) {
+    return <Placeholder>xx machines</Placeholder>;
+  }
+
+  return <span>{pluralize("machine", count || machineCount, true)}</span>;
+};
+
+export default MachineListGroupCount;

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListGroupCount/index.ts
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListGroupCount/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineListGroupCount";

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -1309,7 +1309,7 @@ describe("machine reducer", () => {
                 }),
                 machineStateListGroupFactory({
                   collapsed: false,
-                  count: 1,
+                  count: null,
                   items: ["abc123"],
                   name: NodeStatus.FAILED_COMMISSIONING,
                   value: FetchNodeStatus.FAILED_COMMISSIONING,

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -123,6 +123,42 @@ describe("machine reducer", () => {
     );
   });
 
+  describe("updateNotify", () => {
+    it("marks filtered machine counts as stale", () => {
+      const initialState = machineStateFactory({
+        loading: false,
+        counts: {
+          "1234": machineStateCountFactory({
+            loaded: true,
+            stale: false,
+            params: { filter: { status: FetchNodeStatus.NEW } },
+          }),
+        },
+      });
+      expect(
+        reducers(initialState, actions.updateNotify(machineFactory()))
+      ).toEqual({
+        ...initialState,
+        counts: { "1234": { ...initialState.counts["1234"], stale: true } },
+      });
+    });
+
+    it("doesn't mark unfiltered machine counts as stale", () => {
+      const initialState = machineStateFactory({
+        loading: false,
+        counts: {
+          "1234": machineStateCountFactory({
+            loaded: true,
+            stale: false,
+          }),
+        },
+      });
+      expect(
+        reducers(initialState, actions.updateNotify(machineFactory()))
+      ).toEqual(initialState);
+    });
+  });
+
   it("marks count requests as stale on delete notify", () => {
     const initialState = machineStateFactory({
       loading: false,

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -1749,7 +1749,9 @@ const machineSlice = createSlice({
                 items: group.items.filter(
                   (item) => item !== action.payload.system_id
                 ),
-                count: group.count - 1,
+                // decrement count by 1 if count is known,
+                // otherwise set to null indicating it needs to be fetched
+                count: group.count ? group.count - 1 : null,
               };
             }
             return group;
@@ -1765,7 +1767,9 @@ const machineSlice = createSlice({
                 return {
                   ...group,
                   items: [...group.items, action.payload.system_id],
-                  count: group.count + 1,
+                  // increment count by 1 if count is known,
+                  // otherwise set to null indicating it needs to be fetched
+                  count: group.count ? group.count + 1 : null,
                 };
               }
               return group;
@@ -1776,7 +1780,9 @@ const machineSlice = createSlice({
               name: newMachineListGroup.name,
               value: newMachineListGroup.value,
               items: [action.payload.system_id],
-              count: 1,
+              // set count as null to indicate that the count is unknown
+              // and needs to be fetched
+              count: null,
               collapsed: false,
             });
           }

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -98,6 +98,7 @@ const DEFAULT_COUNT_STATE = {
   stale: false,
   count: null,
   errors: null,
+  params: null,
 };
 
 const isArrayOfOptionsType = <T extends FilterGroupOptionType>(
@@ -422,6 +423,7 @@ const machineSlice = createSlice({
           } else {
             state.counts[action.meta.callId] = {
               ...DEFAULT_COUNT_STATE,
+              params: action?.meta.item || null,
               loading: true,
             };
           }
@@ -1780,8 +1782,7 @@ const machineSlice = createSlice({
               name: newMachineListGroup.name,
               value: newMachineListGroup.value,
               items: [action.payload.system_id],
-              // set count as null to indicate that the count is unknown
-              // and needs to be fetched
+              // set count to null indicating it's unknown and needs to be fetched
               count: null,
               collapsed: false,
             });
@@ -1792,6 +1793,14 @@ const machineSlice = createSlice({
 
           // update the list
           list.groups = groups;
+        }
+      });
+
+      // machine update can affect counts of filtered machine lists
+      // - mark all filtered machine counts as stale indicating they need to be fetched
+      Object.keys(state.counts).forEach((callId) => {
+        if (state.counts[callId].params !== null) {
+          state.counts[callId].stale = true;
         }
       });
     },

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -330,6 +330,7 @@ export type MachineStateCount = {
   loaded: boolean;
   loading: boolean;
   stale: boolean;
+  params: FetchParams | null;
 };
 
 export type MachineStateCounts = Record<string, MachineStateCount>;

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -212,7 +212,7 @@ export type FilterGroupOption<K = FilterGroupOptionType> = {
 
 export type MachineStateListGroup = {
   collapsed: boolean;
-  count: number;
+  count: number | null;
   items: Machine[MachineMeta.PK][];
   name: FilterGroupOption["label"] | null;
   value: FilterGroupOption["key"] | null;

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -293,6 +293,7 @@ export const machineStateCount = define<MachineStateCount>({
   loaded: false,
   loading: false,
   stale: false,
+  params: null,
 });
 
 export const machineFilterGroup = define<FilterGroup>({


### PR DESCRIPTION
## Done

- fetch machine group counts MAASENG-1882
  - test: fix duplicated key error due to invalid test data setup

### Note
Will be followed up by https://warthogs.atlassian.net/browse/MAASENG-1834 where parts of the implementation may change.

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- open developer tools and network inspector
- go to machine list page
- select group by status
- select multiple machines with a "ready" status
- click Troubleshooting -> Test
- make sure the machines have been moved to the correct group (Testing) and count updated
- verify there's at least 1 additional count websocket request with the correct filters for the updated testing group (status - testing)
- deselect all machines
- select an additional machine with a ready status
- click Troubleshooting -> Test
- make sure the machine has been moved to the correct group and count updated
- verify there's at least 1 additional count websocket request with the correct filters for the updated testing group (status - testing)

## Fixes

Fixes: MAASENG-1882 
