### PR TITLE
replace optional machine properties with null

### DIFF
--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -42,20 +42,20 @@ export type BaseMachine = Omit<
   error_description: string;
   extra_macs: string[];
   fabrics: string[];
-  ip_addresses?: NodeIpAddress[];
+  ip_addresses: NodeIpAddress[] | null;
   link_type: NodeLinkType.MACHINE;
   owner: string;
   physical_disk_count: number;
   parent: string | null; // `parent` is a `system_id`
-  pod?: ModelRef;
+  pod: ModelRef | null;
   pool: ModelRef;
   power_state: PowerState;
-  power_type: PowerType["name"] | "";
+  power_type: PowerType["name"] | "" | null;
   pxe_mac?: string;
   spaces: string[];
   storage: number;
   testing_status: Pick<TestStatus, "status">;
-  vlan?: NodeVlan | null;
+  vlan: NodeVlan | null;
   zone: ModelRef;
 };
 


### PR DESCRIPTION
## Done

- replace optional machine properties with null

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Steps for QA.

## Fixes

Fixes: # .

## Launchpad issue

Related Launchpad maas issue in the form `lp#number`.

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
