### PR TITLE
test: disable explicit boundary types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,6 @@ module.exports = {
           },
         ],
         "@typescript-eslint/consistent-type-imports": 2,
-        "@typescript-eslint/explicit-module-boundary-types": ["error"],
         "import/namespace": "off",
         "import/no-named-as-default": 0,
         "import/order": [

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -175,7 +175,7 @@ export const updateErrors = <
  * @param setErrors - A function to update eventErrors.
  */
 // Defining the return type here means that all the reducers types get lost.
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+
 export const generateCommonReducers = <
   S extends CommonStateTypes,
   K extends keyof S["items"][0],


### PR DESCRIPTION
## Done

- test: disable explicit boundary types

## Rationale
Explicit boundary types come at a cost of having to manually define return types whilst they can be inferred by TypeScript. They are not really necessary unless you're dealing with a component library where you need to be very careful about changing the return types.