### PR TITLE
refactor: machine request cache keys MAASENG-1905

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "eslint-plugin-unused-imports": "2.0.0",
     "formik-devtools-extension": "0.1.8",
     "http-proxy-middleware": "2.0.6",
+    "immer": "9.0.16",
     "jest-fetch-mock": "3.0.3",
     "mock-socket": "9.2.1",
     "mockdate": "3.0.5",

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter } from "react-router-dom-v5-compat";
@@ -9,6 +8,7 @@ import { Labels } from "./DhcpFormFields";
 import DhcpForm from "app/base/components/DhcpForm";
 import { getIpRangeDisplayName } from "app/store/iprange/utils";
 import type { RootState } from "app/store/root/types";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   ipRange as ipRangeFactory,
   ipRangeState as ipRangeStateFactory,
@@ -26,14 +26,15 @@ import {
 } from "testing/factories";
 import { userEvent, render, screen, waitFor, within } from "testing/utils";
 
+enableCallIdMocks();
 const mockStore = configureStore();
 const machines = [machineFactory()];
 const ipRange = ipRangeFactory();
+
 describe("DhcpFormFields", () => {
   let state: RootState;
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
     state = rootStateFactory({
       controller: controllerStateFactory({ loaded: true }),
       device: deviceStateFactory({ loaded: true }),
@@ -58,7 +59,7 @@ describe("DhcpFormFields", () => {
       machine: machineStateFactory({
         items: machines,
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loading: false,
             loaded: true,
             groups: [

--- a/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
+++ b/src/app/base/components/DhcpFormFields/MachineSelect/MachineSelectBox/MachineSelectBox.test.tsx
@@ -1,10 +1,10 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import MachineSelectBox from "./MachineSelectBox";
 
 import { DEFAULT_DEBOUNCE_INTERVAL } from "app/base/components/DebounceSearchBox/DebounceSearchBox";
 import { actions as machineActions } from "app/store/machine";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import { rootState as rootStateFactory } from "testing/factories";
 import { userEvent, screen, waitFor, renderWithMockStore } from "testing/utils";
@@ -13,7 +13,7 @@ const mockStore = configureStore<RootState>();
 
 beforeEach(() => {
   jest
-    .spyOn(reduxToolkit, "nanoid")
+    .spyOn(query, "generateCallId")
     .mockReturnValueOnce("mocked-nanoid-1")
     .mockReturnValueOnce("mocked-nanoid-2");
   jest.useFakeTimers();

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -8,6 +7,7 @@ import configureStore from "redux-mock-store";
 import MachinesHeader from "./MachinesHeader";
 
 import type { RootState } from "app/store/root/types";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -17,18 +17,18 @@ import {
   rootState as rootStateFactory,
 } from "testing/factories";
 
+enableCallIdMocks();
 const mockStore = configureStore();
 
 describe("MachinesHeader", () => {
   let state: RootState;
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
     state = rootStateFactory({
       machine: machineStateFactory({
         loaded: true,
         counts: machineStateCountsFactory({
-          "mocked-nanoid": machineStateCountFactory({
+          [callId]: machineStateCountFactory({
             count: 2,
             loaded: true,
             loading: false,
@@ -44,10 +44,6 @@ describe("MachinesHeader", () => {
         },
       }),
     });
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
   });
 
   it("renders", () => {

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.test.tsx
@@ -1,10 +1,10 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import DiscoveriesList, {
   Labels as DiscoveriesListLabels,
 } from "./DiscoveriesList";
 
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import {
   NodeStatus,
@@ -38,12 +38,11 @@ import {
 
 const mockStore = configureStore<RootState, {}>();
 const route = "/dashboard";
-
 describe("DiscoveriesList", () => {
   let state: RootState;
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+    jest.spyOn(query, "generateCallId").mockReturnValueOnce("123456");
     const machines = [
       machineFactory({
         actions: [],

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import DiscoveryAddForm, {
@@ -16,6 +15,7 @@ import {
   NodeStatusCode,
   TestStatusStatus,
 } from "app/store/types/node";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   discovery as discoveryFactory,
   domain as domainFactory,
@@ -41,15 +41,15 @@ import {
   within,
   renderWithBrowserRouter,
 } from "testing/utils";
-
 const mockStore = configureStore<RootState, {}>();
+
+enableCallIdMocks();
 
 describe("DiscoveryAddForm", () => {
   let state: RootState;
   let discovery: Discovery;
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
     const machines = [
       machineFactory({
         actions: [],
@@ -117,7 +117,7 @@ describe("DiscoveryAddForm", () => {
         loaded: true,
         items: machines,
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loaded: true,
             groups: [
               machineStateListGroupFactory({

--- a/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import KVMResourcesCard from "./KVMResourcesCard";
@@ -16,10 +15,6 @@ import { renderWithBrowserRouter, screen } from "testing/utils";
 const mockStore = configureStore<RootState>();
 
 describe("KVMResourcesCard", () => {
-  beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
-  });
-
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/NumaResourcesCard.test.tsx
+++ b/src/app/kvm/components/LXDHostVMs/NumaResources/NumaResourcesCard/NumaResourcesCard.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import NumaResourcesCard from "./NumaResourcesCard";
@@ -23,10 +22,6 @@ import { renderWithMockStore, screen, within } from "testing/utils";
 const mockStore = configureStore<RootState>();
 
 describe("NumaResourcesCard", () => {
-  beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
-  });
-
   afterEach(() => {
     jest.restoreAllMocks();
   });

--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -7,16 +6,13 @@ import LXDVMsTable from "./LXDVMsTable";
 
 import { actions as machineActions } from "app/store/machine";
 import { FetchSortDirection, FetchGroupKey } from "app/store/machine/types";
+import { generateCallId } from "app/store/machine/utils/query";
 import { rootState as rootStateFactory } from "testing/factories";
 import { render, screen } from "testing/utils";
 
 const mockStore = configureStore();
 
 describe("LXDVMsTable", () => {
-  beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
-  });
-
   afterEach(() => {
     jest.restoreAllMocks();
   });
@@ -40,7 +36,16 @@ describe("LXDVMsTable", () => {
       </Provider>
     );
 
-    const expectedAction = machineActions.fetch("mocked-nanoid", {
+    const options = {
+      filter: { pod: ["pod1"] },
+      group_collapsed: undefined,
+      group_key: null,
+      page_number: 1,
+      page_size: 10,
+      sort_direction: FetchSortDirection.Descending,
+      sort_key: FetchGroupKey.Hostname,
+    };
+    const expectedAction = machineActions.fetch(generateCallId(options), {
       filter: { pod: ["pod1"] },
       group_collapsed: undefined,
       group_key: null,

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/VMsTable.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import VMsTable, { Label } from "./VMsTable";
@@ -6,6 +5,7 @@ import VMsTable, { Label } from "./VMsTable";
 import { SortDirection } from "app/base/types";
 import { FetchGroupKey } from "app/store/machine/types";
 import type { RootState } from "app/store/root/types";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   pod as podFactory,
   podState as podStateFactory,
@@ -25,13 +25,13 @@ import {
   renderWithBrowserRouter,
 } from "testing/utils";
 
+enableCallIdMocks();
 const mockStore = configureStore<RootState>();
 
 describe("VMsTable", () => {
   let getResources: jest.Mock;
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
     getResources = jest.fn().mockReturnValue({
       hugepagesBacked: false,
       pinnedCores: [],
@@ -75,7 +75,7 @@ describe("VMsTable", () => {
       machine: machineStateFactory({
         items: vms,
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loaded: true,
             groups: [
               machineStateListGroupFactory({

--- a/src/app/kvm/components/VmResources/VmResources.test.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import VmResources, { Label } from "./VmResources";
@@ -7,6 +6,7 @@ import { Label as MachineListLabel } from "app/machines/views/MachineList/Machin
 import { actions as machineActions } from "app/store/machine";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   rootState as rootStateFactory,
   machineState as machineStateFactory,
@@ -23,19 +23,19 @@ import {
   renderWithMockStore,
 } from "testing/utils";
 
+enableCallIdMocks();
 const mockStore = configureStore<RootState, {}>();
 
 describe("VmResources", () => {
   let state: RootState;
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
     const machines = [machineFactory(), machineFactory()];
     state = rootStateFactory({
       machine: machineStateFactory({
         items: machines,
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             count: machines.length,
             loaded: true,
             groups: [
@@ -54,8 +54,8 @@ describe("VmResources", () => {
   });
 
   it("disables the dropdown if no VMs are provided", () => {
-    state.machine.lists["123456"].count = 0;
-    state.machine.lists["123456"].groups = [
+    state.machine.lists[callId].count = 0;
+    state.machine.lists[callId].groups = [
       machineStateListGroupFactory({
         items: [],
         name: "Deployed",
@@ -73,7 +73,7 @@ describe("VmResources", () => {
       <VmResources filters={{ id: ["abc123"] }} podId={1} />,
       { store }
     );
-    const expected = machineActions.fetch("123456");
+    const expected = machineActions.fetch(callId);
     const result = store
       .getActions()
       .find((action) => action.type === expected.type);

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import LXDClusterVMs from "./LXDClusterVMs";
@@ -6,6 +5,7 @@ import LXDClusterVMs from "./LXDClusterVMs";
 import urls from "app/base/urls";
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -19,13 +19,10 @@ import {
 } from "testing/factories";
 import { renderWithBrowserRouter, screen } from "testing/utils";
 
+enableCallIdMocks();
 const mockStore = configureStore<RootState, {}>();
 
 describe("LXDClusterVMs", () => {
-  beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
-  });
-
   it("renders a link to a cluster's host's VM page", () => {
     const machine = machineFactory({
       pod: { id: 11, name: "podrick" },
@@ -35,7 +32,7 @@ describe("LXDClusterVMs", () => {
       machine: machineStateFactory({
         items: [machine],
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loaded: true,
             groups: [
               machineStateListGroupFactory({
@@ -96,7 +93,7 @@ describe("LXDClusterVMs", () => {
       />,
       { route: urls.kvm.lxd.cluster.vms.index({ clusterId: 1 }), store }
     );
-    const expected = machineActions.fetch("123456", {
+    const expected = machineActions.fetch([callId], {
       filter: { pod: ["host 1", "host 2"] },
     });
     const fetches = store

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneForm.test.tsx
@@ -4,6 +4,7 @@ import configureStore from "redux-mock-store";
 import CloneForm from "./CloneForm";
 
 import { actions as machineActions } from "app/store/machine";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
@@ -24,12 +25,12 @@ import {
   userEvent,
   waitFor,
 } from "testing/utils";
-
 const mockStore = configureStore<RootState>();
 
 describe("CloneForm", () => {
   beforeEach(() => {
     jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+    jest.spyOn(query, "generateCallId").mockReturnValueOnce("123456");
   });
 
   afterEach(() => {

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import { Formik } from "formik";
 import configureStore from "redux-mock-store";
 
@@ -6,6 +5,7 @@ import CloneFormFields from "./CloneFormFields";
 
 import { actions as machineActions } from "app/store/machine";
 import type { RootState } from "app/store/root/types";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   fabricState as fabricStateFactory,
   machineDetails as machineDetailsFactory,
@@ -20,6 +20,8 @@ import { renderWithMockStore, screen, userEvent, waitFor } from "testing/utils";
 
 const mockStore = configureStore<RootState>();
 
+enableCallIdMocks();
+
 describe("CloneFormFields", () => {
   let state: RootState;
   const machine = machineDetailsFactory({
@@ -27,15 +29,13 @@ describe("CloneFormFields", () => {
     system_id: "abc123",
   });
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
-
     state = rootStateFactory({
       fabric: fabricStateFactory({ loaded: true }),
 
       machine: machineStateFactory({
         loaded: true,
         lists: {
-          "mocked-nanoid": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loaded: true,
             groups: [
               machineStateListGroupFactory({
@@ -103,10 +103,7 @@ describe("CloneFormFields", () => {
       { store }
     );
     await userEvent.click(screen.getAllByTestId("machine-select-row")[0]);
-    const expectedAction = machineActions.get(
-      machine.system_id,
-      "mocked-nanoid"
-    );
+    const expectedAction = machineActions.get(machine.system_id, callId);
 
     await waitFor(() => {
       const actualActions = store.getActions();

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/SourceMachineSelect/SourceMachineSelect.test.tsx
@@ -1,9 +1,8 @@
-import reduxToolkit from "@reduxjs/toolkit";
-
 import { Labels as SourceMachineDetailsLabel } from "./SourceMachineDetails/SourceMachineDetails";
 import SourceMachineSelect, { Label } from "./SourceMachineSelect";
 
 import type { Machine } from "app/store/machine/types";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import {
   machine as machineFactory,
@@ -22,7 +21,7 @@ describe("SourceMachineSelect", () => {
   let state: RootState;
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+    jest.spyOn(query, "generateCallId").mockReturnValueOnce("123456");
     machines = [
       machineFactory({
         system_id: "abc123",

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import configureStore from "redux-mock-store";
 
 import AddTagForm from "./AddTagForm";
@@ -7,6 +6,7 @@ import type { Props } from "./AddTagForm";
 import { actions as machineActions } from "app/store/machine";
 import type { FetchFilters } from "app/store/machine/types";
 import { FetchGroupKey } from "app/store/machine/types";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import { FetchNodeStatus } from "app/store/types/node";
 import {
@@ -30,7 +30,7 @@ const mockStore = configureStore<RootState, {}>();
 let state: RootState;
 
 beforeEach(() => {
-  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+  jest.spyOn(query, "generateCallId").mockReturnValueOnce("mocked-nanoid");
   state = rootStateFactory({
     machine: machineStateFactory({
       counts: machineStateCountsFactory({
@@ -172,8 +172,9 @@ it("fetches deployed machine count for selected machines", async () => {
 });
 
 it("fetches deployed machine count separately for deployed group when selected", async () => {
+  jest.spyOn(query, "generateCallId").mockRestore();
   jest
-    .spyOn(reduxToolkit, "nanoid")
+    .spyOn(query, "generateCallId")
     .mockReturnValueOnce("mocked-nanoid-1")
     .mockReturnValueOnce("mocked-nanoid-2");
   const store = mockStore(state);
@@ -209,10 +210,6 @@ it("fetches deployed machine count separately for deployed group when selected",
 });
 
 it("fetches deployed machine count when all machines are selected", async () => {
-  jest
-    .spyOn(reduxToolkit, "nanoid")
-    .mockReturnValueOnce("mocked-nanoid-1")
-    .mockReturnValueOnce("mocked-nanoid-2");
   const store = mockStore(state);
   const selectedMachines = {
     filter: {},
@@ -225,7 +222,7 @@ it("fetches deployed machine count when all machines are selected", async () => 
     />,
     { route: "/tags", store }
   );
-  const expected = machineActions.count("mocked-nanoid-1", {
+  const expected = machineActions.count("mocked-nanoid", {
     status: FetchNodeStatus.DEPLOYED,
   });
   const countActions = store
@@ -237,7 +234,6 @@ it("fetches deployed machine count when all machines are selected", async () => 
 
 it(`fetches deployed machine count only for selected items
     when grouping by status and group other than deployed is selected`, async () => {
-  jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid-1");
   const store = mockStore(state);
   const selectedMachines = {
     items: ["abc", "def"],
@@ -252,7 +248,7 @@ it(`fetches deployed machine count only for selected items
     />,
     { route: "/tags", store }
   );
-  const expected = machineActions.count("mocked-nanoid-1", {
+  const expected = machineActions.count("mocked-nanoid", {
     status: FetchNodeStatus.DEPLOYED,
     id: selectedMachines.items,
   });

--- a/src/app/machines/views/MachineList/MachineList.test.tsx
+++ b/src/app/machines/views/MachineList/MachineList.test.tsx
@@ -5,6 +5,7 @@ import MachineList from "./MachineList";
 import { DEFAULTS } from "./MachineListTable/constants";
 
 import { actions as machineActions } from "app/store/machine";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import {
   FetchNodeStatus,
@@ -37,7 +38,7 @@ describe("MachineList", () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
+    jest.spyOn(query, "generateCallId").mockReturnValue("123456");
     const machines = [
       machineFactory({
         actions: [],
@@ -396,7 +397,7 @@ describe("MachineList", () => {
 
   it("can change pages", async () => {
     jest
-      .spyOn(reduxToolkit, "nanoid")
+      .spyOn(query, "generateCallId")
       .mockReturnValueOnce("mocked-nanoid-1")
       .mockReturnValueOnce("mocked-nanoid-2");
     // Create two pages of machines.

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.test.tsx
@@ -5,6 +5,7 @@ import MachineListHeader from "./MachineListHeader";
 import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { NodeActions } from "app/store/types/node";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   machine as machineFactory,
   machineStateCount as machineStateCountFactory,
@@ -19,15 +20,12 @@ import {
 } from "testing/factories";
 import { screen, renderWithBrowserRouter, userEvent } from "testing/utils";
 
+enableCallIdMocks();
+
 describe("MachineListHeader", () => {
   let state: RootState;
 
   beforeEach(() => {
-    jest
-      .spyOn(reduxToolkit, "nanoid")
-      .mockReturnValueOnce("mocked-nanoid-1")
-      .mockReturnValueOnce("mocked-nanoid-2")
-      .mockReturnValueOnce("mocked-nanoid-3");
     const machines = [
       machineFactory({ system_id: "abc123" }),
       machineFactory({ system_id: "def456" }),
@@ -35,7 +33,7 @@ describe("MachineListHeader", () => {
     state = rootStateFactory({
       machine: machineStateFactory({
         counts: machineStateCountsFactory({
-          "mocked-nanoid-1": machineStateCountFactory({
+          [callId]: machineStateCountFactory({
             count: 10,
             loaded: true,
             loading: false,
@@ -60,7 +58,7 @@ describe("MachineListHeader", () => {
   });
 
   it("displays a machine count if machines have loaded", () => {
-    state.machine.counts["mocked-nanoid-1"] = machineStateCountFactory({
+    state.machine.counts[callId] = machineStateCountFactory({
       count: 2,
       loaded: true,
     });

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -59,7 +59,10 @@ const MachineListPagination = ({
           aria-label={Label.PreviousPage}
           className="p-pagination__link--previous"
           disabled={props.currentPage === 1}
-          onClick={() => props.paginate(props.currentPage - 1)}
+          onClick={() => {
+            setPageNumber((page) => Number(page) - 1);
+            props.paginate(props.currentPage - 1);
+          }}
         >
           <Icon name="chevron-down" />
         </Button>
@@ -105,7 +108,10 @@ const MachineListPagination = ({
           aria-label={Label.NextPage}
           className="p-pagination__link--next"
           disabled={props.currentPage === pages}
-          onClick={() => props.paginate(props.currentPage + 1)}
+          onClick={() => {
+            setPageNumber((page) => Number(page) + 1);
+            props.paginate(props.currentPage + 1);
+          }}
         >
           <Icon name="chevron-down" />
         </Button>

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.test.tsx
@@ -1,5 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
-
 import { MachineListTable, Label } from "./MachineListTable";
 
 import { SortDirection } from "app/base/types";
@@ -12,6 +10,7 @@ import {
   NodeStatusCode,
   TestStatusStatus,
 } from "app/store/types/node";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   generalState as generalStateFactory,
   machine as machineFactory,
@@ -39,13 +38,14 @@ import {
   renderWithMockStore,
 } from "testing/utils";
 
+enableCallIdMocks();
+
 describe("MachineListTable", () => {
   let state: RootState;
   let machines: Machine[] = [];
   let groups: MachineStateListGroup[] = [];
 
   beforeEach(() => {
-    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("123456");
     machines = [
       machineFactory({
         actions: [],
@@ -197,7 +197,7 @@ describe("MachineListTable", () => {
       machine: machineStateFactory({
         items: machines,
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loading: true,
             groups,
           }),
@@ -238,7 +238,7 @@ describe("MachineListTable", () => {
   it("displays skeleton rows when loading", () => {
     renderWithMockStore(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={FetchGroupKey.Status}
@@ -276,7 +276,7 @@ describe("MachineListTable", () => {
     state.machine = machineStateFactory({
       items: [],
       lists: {
-        "123456": machineStateListFactory({
+        [callId]: machineStateListFactory({
           loading: false,
           groups,
         }),
@@ -285,7 +285,7 @@ describe("MachineListTable", () => {
 
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter="this does not match anything"
         grouping={FetchGroupKey.Status}
@@ -309,7 +309,7 @@ describe("MachineListTable", () => {
   it("includes groups", () => {
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={FetchGroupKey.Status}
@@ -342,7 +342,7 @@ describe("MachineListTable", () => {
   it("does not display a group header if the table is ungrouped", () => {
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={null}
@@ -368,7 +368,7 @@ describe("MachineListTable", () => {
   it("can change machines to display PXE MAC instead of FQDN", async () => {
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={null}
@@ -414,7 +414,7 @@ describe("MachineListTable", () => {
     });
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={null}
@@ -453,7 +453,7 @@ describe("MachineListTable", () => {
     const setSortKey = jest.fn();
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={null}
@@ -484,7 +484,7 @@ describe("MachineListTable", () => {
     const setSortKey = jest.fn();
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={null}
@@ -515,7 +515,7 @@ describe("MachineListTable", () => {
     const setSortKey = jest.fn();
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={null}
@@ -546,7 +546,7 @@ describe("MachineListTable", () => {
     const setSortKey = jest.fn();
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={null}
@@ -577,7 +577,7 @@ describe("MachineListTable", () => {
     const setSortKey = jest.fn();
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={null}
@@ -607,7 +607,7 @@ describe("MachineListTable", () => {
     machines[1].status_code = NodeStatusCode.DEPLOYED;
     renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         filter=""
         grouping={FetchGroupKey.Status}
@@ -635,7 +635,7 @@ describe("MachineListTable", () => {
   it("does not show checkboxes if showActions is false", () => {
     const { rerender } = renderWithBrowserRouter(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         groups={groups}
         machineCount={10}
@@ -654,7 +654,7 @@ describe("MachineListTable", () => {
 
     rerender(
       <MachineListTable
-        callId="123456"
+        callId={callId}
         currentPage={1}
         groups={groups}
         machineCount={10}
@@ -675,7 +675,7 @@ describe("MachineListTable", () => {
     it("can hide columns", () => {
       const { rerender } = renderWithBrowserRouter(
         <MachineListTable
-          callId="123456"
+          callId={callId}
           currentPage={1}
           groups={groups}
           hiddenColumns={[]}
@@ -699,7 +699,7 @@ describe("MachineListTable", () => {
 
       rerender(
         <MachineListTable
-          callId="123456"
+          callId={callId}
           currentPage={1}
           groups={groups}
           hiddenColumns={["power", "zone"]}
@@ -725,7 +725,7 @@ describe("MachineListTable", () => {
     it("still displays fqdn if showActions is true", () => {
       renderWithBrowserRouter(
         <MachineListTable
-          callId="123456"
+          callId={callId}
           currentPage={1}
           groups={groups}
           hiddenColumns={["fqdn"]}
@@ -750,7 +750,7 @@ describe("MachineListTable", () => {
     it("hides fqdn if if showActions is false", () => {
       renderWithBrowserRouter(
         <MachineListTable
-          callId="123456"
+          callId={callId}
           currentPage={1}
           groups={groups}
           hiddenColumns={["fqdn"]}

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -15,6 +15,7 @@ import Machines from "./Machines";
 
 import { actions as machineActions } from "app/store/machine";
 import { FetchGroupKey } from "app/store/machine/types";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import {
   NodeStatus,
@@ -291,7 +292,7 @@ describe("Machines", () => {
 
   it("can hide groups", async () => {
     jest
-      .spyOn(reduxToolkit, "nanoid")
+      .spyOn(query, "generateCallId")
       .mockReturnValueOnce("123456")
       .mockReturnValueOnce("78910");
     const store = mockStore(state);
@@ -396,7 +397,7 @@ describe("Machines", () => {
 
   it("can store hidden groups in local storage", async () => {
     jest
-      .spyOn(reduxToolkit, "nanoid")
+      .spyOn(query, "generateCallId")
       .mockReturnValueOnce("mocked-nanoid-1")
       .mockReturnValueOnce("mocked-nanoid-2");
     state.machine.lists = {

--- a/src/app/store/machine/selectors.test.ts
+++ b/src/app/store/machine/selectors.test.ts
@@ -3,6 +3,7 @@ import { FilterGroupKey } from "./types";
 
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import { NodeActions, NodeStatusCode } from "app/store/types/node";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   machine as machineFactory,
   machineDetails as machineDetailsFactory,
@@ -20,6 +21,8 @@ import {
   networkLink as networkLinkFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
+
+enableCallIdMocks();
 
 describe("machine selectors", () => {
   it("can get all items", () => {
@@ -586,7 +589,7 @@ describe("machine selectors", () => {
       machine: machineStateFactory({
         items: [...machines, machineFactory()],
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loading: true,
             groups: [
               machineStateListGroupFactory({
@@ -597,20 +600,20 @@ describe("machine selectors", () => {
         },
       }),
     });
-    expect(machine.list(state, "123456")).toStrictEqual(machines);
+    expect(machine.list(state, callId)).toStrictEqual(machines);
   });
 
   it("can get the count for a list", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             count: 5,
           }),
         },
       }),
     });
-    expect(machine.listCount(state, "123456")).toBe(5);
+    expect(machine.listCount(state, callId)).toBe(5);
   });
 
   it("can get a group in a list", () => {
@@ -625,13 +628,13 @@ describe("machine selectors", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             groups,
           }),
         },
       }),
     });
-    expect(machine.listGroups(state, "123456")).toStrictEqual(groups);
+    expect(machine.listGroups(state, callId)).toStrictEqual(groups);
   });
 
   it("can get all groups in a list", () => {
@@ -646,15 +649,13 @@ describe("machine selectors", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             groups,
           }),
         },
       }),
     });
-    expect(machine.listGroup(state, "123456", "admin2")).toStrictEqual(
-      groups[1]
-    );
+    expect(machine.listGroup(state, callId, "admin2")).toStrictEqual(groups[1]);
   });
 
   it("can get a nullish group in a list", () => {
@@ -669,39 +670,39 @@ describe("machine selectors", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             groups,
           }),
         },
       }),
     });
-    expect(machine.listGroup(state, "123456", "")).toStrictEqual(groups[1]);
+    expect(machine.listGroup(state, callId, "")).toStrictEqual(groups[1]);
   });
 
   it("can get the loaded state for a list", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loaded: true,
           }),
         },
       }),
     });
-    expect(machine.listLoaded(state, "123456")).toBe(true);
+    expect(machine.listLoaded(state, callId)).toBe(true);
   });
 
   it("can get the loading state for a list", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         lists: {
-          "123456": machineStateListFactory({
+          [callId]: machineStateListFactory({
             loading: true,
           }),
         },
       }),
     });
-    expect(machine.listLoading(state, "123456")).toBe(true);
+    expect(machine.listLoading(state, callId)).toBe(true);
   });
 
   it("can get an interface by id", () => {
@@ -744,7 +745,7 @@ describe("machine selectors", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         details: {
-          123456: machineStateDetailsItemFactory({
+          [callId]: machineStateDetailsItemFactory({
             system_id: "abc123",
           }),
           78910: machineStateDetailsItemFactory({
@@ -752,7 +753,7 @@ describe("machine selectors", () => {
           }),
         },
         lists: {
-          123456: machineStateListFactory({
+          [callId]: machineStateListFactory({
             groups: [
               machineStateListGroupFactory({
                 items: ["abc123", "def456"],
@@ -762,19 +763,19 @@ describe("machine selectors", () => {
         },
       }),
     });
-    expect(machine.unusedIdsInCall(state, "123456")).toStrictEqual([]);
+    expect(machine.unusedIdsInCall(state, callId)).toStrictEqual([]);
   });
 
   it("can get unused ids for a details request when the id is not being used", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         details: {
-          123456: machineStateDetailsItemFactory({
+          [callId]: machineStateDetailsItemFactory({
             system_id: "abc123",
           }),
         },
         lists: {
-          123456: machineStateListFactory({
+          [callId]: machineStateListFactory({
             groups: [
               machineStateListGroupFactory({
                 items: ["def456", "ghi789"],
@@ -784,14 +785,14 @@ describe("machine selectors", () => {
         },
       }),
     });
-    expect(machine.unusedIdsInCall(state, "123456")).toStrictEqual(["abc123"]);
+    expect(machine.unusedIdsInCall(state, callId)).toStrictEqual(["abc123"]);
   });
 
   it("can get unused ids for a list request when the ids are being used", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         details: {
-          123456: machineStateDetailsItemFactory({
+          [callId]: machineStateDetailsItemFactory({
             system_id: "abc123",
           }),
         },
@@ -820,7 +821,7 @@ describe("machine selectors", () => {
     const state = rootStateFactory({
       machine: machineStateFactory({
         details: {
-          123456: machineStateDetailsItemFactory({
+          [callId]: machineStateDetailsItemFactory({
             system_id: "abc123",
           }),
         },

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -218,6 +218,14 @@ export type MachineStateListGroup = {
   value: FilterGroupOption["key"] | null;
 };
 
+type MachineQuery = {
+  // parameters used to fetch the list
+  params: FetchParams | null;
+  refetching: boolean;
+  fetchedAt: number | null;
+  refetchedAt: number | null;
+};
+
 export type MachineStateList = {
   count: number | null;
   cur_page: number | null;
@@ -227,8 +235,7 @@ export type MachineStateList = {
   loading: boolean;
   stale: boolean;
   num_pages: number | null;
-  params: FetchParams | null;
-};
+} & MachineQuery;
 
 export type MachineStateLists = Record<string, MachineStateList>;
 
@@ -330,8 +337,7 @@ export type MachineStateCount = {
   loaded: boolean;
   loading: boolean;
   stale: boolean;
-  params: FetchParams | null;
-};
+} & MachineQuery;
 
 export type MachineStateCounts = Record<string, MachineStateCount>;
 

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -25,6 +25,7 @@ import {
   useFetchMachineCount,
   useFetchedCount,
 } from "./hooks";
+import { generateCallId } from "./query";
 
 import { actions as machineActions } from "app/store/machine";
 import type {
@@ -33,6 +34,7 @@ import type {
   Machine,
   SelectedMachines,
 } from "app/store/machine/types";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import { NetworkInterfaceTypes } from "app/store/types/enum";
 import type { FetchNodeStatus, TestParams } from "app/store/types/node";
@@ -64,6 +66,7 @@ const mockStore = configureStore();
 describe("machine hook utils", () => {
   let state: RootState;
   let machine: Machine | null;
+  const mockCallId = "123456";
 
   beforeEach(() => {
     machine = machineFactory({
@@ -86,6 +89,7 @@ describe("machine hook utils", () => {
         items: [machine],
       }),
     });
+    jest.spyOn(query, "generateCallId").mockReturnValue(mockCallId);
   });
 
   afterEach(() => {
@@ -93,18 +97,6 @@ describe("machine hook utils", () => {
   });
 
   describe("useFetchMachineCount", () => {
-    beforeEach(() => {
-      jest
-        .spyOn(reduxToolkit, "nanoid")
-        .mockReturnValueOnce("mocked-nanoid-1")
-        .mockReturnValueOnce("mocked-nanoid-2")
-        .mockReturnValueOnce("mocked-nanoid-3");
-    });
-
-    afterEach(() => {
-      jest.restoreAllMocks();
-    });
-
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
       ({ children }: { children?: ReactNode; filters?: FetchFilters }) =>
@@ -115,7 +107,7 @@ describe("machine hook utils", () => {
       renderHook(() => useFetchMachineCount(), {
         wrapper: generateWrapper(store),
       });
-      const expected = machineActions.count("mocked-nanoid-1");
+      const expected = machineActions.count(mockCallId);
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
@@ -131,7 +123,7 @@ describe("machine hook utils", () => {
           wrapper: generateWrapper(store),
         }
       );
-      const expectedActionType = machineActions.count("mocked-nanoid-1").type;
+      const expectedActionType = machineActions.count(mockCallId).type;
       const getDispatches = () =>
         store
           .getActions()
@@ -151,7 +143,7 @@ describe("machine hook utils", () => {
           wrapper: generateWrapper(store),
         }
       );
-      const expectedActionType = machineActions.count("mocked-nanoid-1").type;
+      const expectedActionType = machineActions.count(mockCallId).type;
       const getDispatches = () =>
         store
           .getActions()
@@ -165,7 +157,7 @@ describe("machine hook utils", () => {
 
     it("returns the machine count", async () => {
       jest.restoreAllMocks();
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid");
+      jest.spyOn(query, "generateCallId").mockReturnValue("mocked-nanoid");
       const machineCount = 2;
       const counts = machineStateCountsFactory({
         "mocked-nanoid": machineStateCountFactory({
@@ -192,7 +184,7 @@ describe("machine hook utils", () => {
         wrapper: generateWrapper(store),
       });
       rerender();
-      const expected = machineActions.count("mocked-nanoid-1");
+      const expected = machineActions.count(mockCallId);
       const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
@@ -208,7 +200,7 @@ describe("machine hook utils", () => {
         }
       );
       rerender({ filters: { hostname: "spotted-quoll" } });
-      const expected = machineActions.count("mocked-nanoid-1");
+      const expected = machineActions.count(mockCallId);
       const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
@@ -216,6 +208,8 @@ describe("machine hook utils", () => {
     });
 
     it("fetches again if the filters change", () => {
+      // clera all spies
+      jest.restoreAllMocks();
       const store = mockStore(state);
       const { rerender } = renderHook(
         ({ filters }) => useFetchMachineCount(filters),
@@ -229,7 +223,7 @@ describe("machine hook utils", () => {
         }
       );
       rerender({ filters: { hostname: "eastern-quoll" } });
-      const expected = machineActions.count("mocked-nanoid-1");
+      const expected = machineActions.count(mockCallId);
       const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
@@ -238,7 +232,7 @@ describe("machine hook utils", () => {
 
     it("fetches again if the query has been marked as stale", async () => {
       state.machine.counts = {
-        "mocked-nanoid-1": machineStateCountFactory({
+        [mockCallId]: machineStateCountFactory({
           stale: true,
         }),
       };
@@ -246,7 +240,7 @@ describe("machine hook utils", () => {
       renderHook(() => useFetchMachineCount(), {
         wrapper: generateWrapper(store),
       });
-      const expected = machineActions.count("mocked-nanoid-1");
+      const expected = machineActions.count(mockCallId);
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
@@ -260,9 +254,10 @@ describe("machine hook utils", () => {
     beforeEach(() => {
       jest
         .spyOn(reduxToolkit, "nanoid")
-        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce(mockCallId)
         .mockReturnValueOnce("mocked-nanoid-2")
         .mockReturnValueOnce("mocked-nanoid-3");
+      jest.spyOn(query, "generateCallId").mockReturnValueOnce(mockCallId);
     });
 
     afterEach(() => {
@@ -279,7 +274,7 @@ describe("machine hook utils", () => {
       renderHook(() => useFetchMachines(), {
         wrapper: generateWrapper(store),
       });
-      const expected = machineActions.fetch("mocked-nanoid-1");
+      const expected = machineActions.fetch(mockCallId);
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
@@ -287,7 +282,7 @@ describe("machine hook utils", () => {
 
     it("fetches again if the query has been marked as stale", async () => {
       state.machine.lists = {
-        "mocked-nanoid-1": machineStateListFactory({
+        [mockCallId]: machineStateListFactory({
           stale: true,
         }),
       };
@@ -295,7 +290,7 @@ describe("machine hook utils", () => {
       renderHook(() => useFetchMachines(), {
         wrapper: generateWrapper(store),
       });
-      const expected = machineActions.fetch("mocked-nanoid-1");
+      const expected = machineActions.fetch(mockCallId);
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
@@ -310,7 +305,7 @@ describe("machine hook utils", () => {
         loaded: true,
         items: [...machines, machineFactory()],
         lists: {
-          "mocked-nanoid-1": machineStateListFactory({
+          [mockCallId]: machineStateListFactory({
             loading: true,
             groups: [
               machineStateListGroupFactory({
@@ -330,7 +325,7 @@ describe("machine hook utils", () => {
     it("returns the loaded and loading states", () => {
       state.machine = machineStateFactory({
         lists: {
-          "mocked-nanoid-1": machineStateListFactory({
+          [mockCallId]: machineStateListFactory({
             loaded: false,
             loading: true,
           }),
@@ -350,7 +345,7 @@ describe("machine hook utils", () => {
         wrapper: generateWrapper(store),
       });
       rerender();
-      const expected = machineActions.fetch("mocked-nanoid-1");
+      const expected = machineActions.fetch(mockCallId);
       const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
@@ -367,7 +362,7 @@ describe("machine hook utils", () => {
         }
       );
       rerender({ filters: { hostname: "spotted-quoll" } });
-      const expected = machineActions.fetch("mocked-nanoid-1");
+      const expected = machineActions.fetch(mockCallId);
       const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
@@ -387,7 +382,7 @@ describe("machine hook utils", () => {
           wrapper: generateWrapper(store),
         }
       );
-      const expectedActionType = machineActions.fetch("mocked-nanoid-1").type;
+      const expectedActionType = machineActions.fetch(mockCallId).type;
       const getDispatches = () =>
         store
           .getActions()
@@ -407,7 +402,7 @@ describe("machine hook utils", () => {
           wrapper: generateWrapper(store),
         }
       );
-      const expectedActionType = machineActions.fetch("mocked-nanoid-1").type;
+      const expectedActionType = machineActions.fetch(mockCallId).type;
       const getDispatches = () =>
         store
           .getActions()
@@ -429,7 +424,7 @@ describe("machine hook utils", () => {
         }
       );
       rerender(null);
-      const expected = machineActions.fetch("mocked-nanoid-1");
+      const expected = machineActions.fetch(mockCallId);
       const getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
@@ -437,6 +432,7 @@ describe("machine hook utils", () => {
     });
 
     it("fetches again if the options change", () => {
+      jest.restoreAllMocks();
       const store = mockStore(state);
       const { rerender } = renderHook(
         (options: UseFetchMachinesOptions) => useFetchMachines(options),
@@ -449,7 +445,7 @@ describe("machine hook utils", () => {
           wrapper: generateWrapper(store),
         }
       );
-      const expected = machineActions.fetch("mocked-nanoid-1");
+      const expected = machineActions.fetch(mockCallId);
       let getDispatches = store
         .getActions()
         .filter((action) => action.type === expected.type);
@@ -485,13 +481,12 @@ describe("machine hook utils", () => {
     });
 
     it("cleans up list request on unmount", async () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid-1");
       const store = mockStore(state);
       renderHook(() => useFetchMachines(), {
         wrapper: generateWrapper(store),
       });
       cleanup();
-      const expected = machineActions.cleanupRequest("mocked-nanoid-1");
+      const expected = machineActions.cleanupRequest(generateCallId());
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
@@ -514,7 +509,7 @@ describe("machine hook utils", () => {
         <Provider store={store}>{children}</Provider>;
 
     it("can fetch selected machines", async () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+      jest.spyOn(query, "generateCallId").mockReturnValueOnce(mockCallId);
       const selected = { items: ["abc123", "def456"] };
       state.machine.selected = selected;
       const store = mockStore(state);
@@ -532,13 +527,15 @@ describe("machine hook utils", () => {
   });
 
   describe("useDispatchWithCallId", () => {
+    beforeEach(() => {
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+    });
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
       ({ children }: { children?: ReactNode }) =>
         <Provider store={store}>{children}</Provider>;
 
     it("adds a callId to redux dispatch function", async () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
       const store = mockStore(state);
       const { result } = renderHook(() => useDispatchWithCallId(), {
         wrapper: generateWrapper(store),
@@ -557,13 +554,12 @@ describe("machine hook utils", () => {
     });
 
     it("cleans up request on unmount", async () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid-1");
       const store = mockStore(state);
       renderHook(() => useDispatchWithCallId(), {
         wrapper: generateWrapper(store),
       });
       cleanup();
-      const expected = machineActions.removeRequest("mocked-nanoid-1");
+      const expected = machineActions.removeRequest("mocked-nanoid");
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
@@ -571,13 +567,15 @@ describe("machine hook utils", () => {
   });
 
   describe("useMachineActionDispatch", () => {
+    beforeEach(() => {
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+    });
     const generateWrapper =
       (store: MockStoreEnhanced<unknown>) =>
       ({ children }: { children?: ReactNode }) =>
         <Provider store={store}>{children}</Provider>;
 
     it("adds a callId to redux dispatch function and returns action state", async () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
       state.machine.actions["mocked-nanoid"] = machineActionState({
         status: "success",
       });
@@ -602,7 +600,6 @@ describe("machine hook utils", () => {
     });
 
     it("can return an error message", async () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
       state.machine.actions["mocked-nanoid"] = machineActionState({
         status: "success",
         failedSystemIds: ["abc123"],
@@ -640,7 +637,7 @@ describe("machine hook utils", () => {
       jest
         .spyOn(reduxToolkit, "nanoid")
         .mockReturnValueOnce("mocked-nanoid")
-        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce(mockCallId)
         .mockReturnValueOnce("mocked-nanoid-2");
       state.machine.actions["mocked-nanoid"] = machineActionState({
         status: "success",
@@ -687,7 +684,7 @@ describe("machine hook utils", () => {
       jest
         .spyOn(reduxToolkit, "nanoid")
         .mockReturnValueOnce("mocked-nanoid")
-        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce(mockCallId)
         .mockReturnValueOnce("mocked-nanoid-2");
       state.machine.actions["mocked-nanoid"] = machineActionState({
         status: "success",
@@ -725,7 +722,7 @@ describe("machine hook utils", () => {
       jest
         .spyOn(reduxToolkit, "nanoid")
         .mockReturnValueOnce("mocked-nanoid")
-        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce(mockCallId)
         .mockReturnValueOnce("mocked-nanoid-2");
       state.machine.actions["mocked-nanoid"] = machineActionState({
         status: "success",
@@ -780,7 +777,7 @@ describe("machine hook utils", () => {
 
   describe("useFetchMachine", () => {
     beforeEach(() => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+      jest.spyOn(query, "generateCallId").mockReturnValueOnce(mockCallId);
     });
     afterEach(() => {
       jest.restoreAllMocks();
@@ -791,7 +788,7 @@ describe("machine hook utils", () => {
         <Provider store={store}>{children}</Provider>;
 
     it("can get a machine", () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid");
       const store = mockStore(state);
       renderHook(
         ({ id }: { children?: ReactNode; id: string }) => useFetchMachine(id),
@@ -830,7 +827,7 @@ describe("machine hook utils", () => {
     it("gets a machine if the id changes", () => {
       jest
         .spyOn(reduxToolkit, "nanoid")
-        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce(mockCallId)
         .mockReturnValueOnce("mocked-nanoid-2");
       const store = mockStore(state);
       const { rerender } = renderHook(
@@ -852,14 +849,14 @@ describe("machine hook utils", () => {
     });
 
     it("returns the machine and loading states", () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid-1");
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValue(mockCallId);
       const machine = machineFactory({
         system_id: "abc123",
       });
       state.machine = machineStateFactory({
         items: [machine, machineFactory()],
         details: {
-          "mocked-nanoid-1": machineStateDetailsItemFactory({
+          [mockCallId]: machineStateDetailsItemFactory({
             loaded: true,
             loading: true,
             system_id: "abc123",
@@ -882,7 +879,7 @@ describe("machine hook utils", () => {
     });
 
     it("cleans up machine request on unmount", async () => {
-      jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce("mocked-nanoid-1");
+      jest.spyOn(reduxToolkit, "nanoid").mockReturnValueOnce(mockCallId);
       const store = mockStore(state);
       renderHook(
         ({ id }: { children?: ReactNode; id: string }) => useFetchMachine(id),
@@ -894,7 +891,7 @@ describe("machine hook utils", () => {
         }
       );
       cleanup();
-      const expected = machineActions.cleanupRequest("mocked-nanoid-1");
+      const expected = machineActions.cleanupRequest(mockCallId);
       expect(
         store.getActions().find((action) => action.type === expected.type)
       ).toStrictEqual(expected);
@@ -903,7 +900,7 @@ describe("machine hook utils", () => {
     it("cleans up machine requests when the id changes", async () => {
       jest
         .spyOn(reduxToolkit, "nanoid")
-        .mockReturnValueOnce("mocked-nanoid-1")
+        .mockReturnValueOnce(mockCallId)
         .mockReturnValueOnce("mocked-nanoid-2");
       const store = mockStore(state);
       const { rerender } = renderHook(
@@ -916,7 +913,7 @@ describe("machine hook utils", () => {
         }
       );
 
-      const expected1 = machineActions.cleanupRequest("mocked-nanoid-1");
+      const expected1 = machineActions.cleanupRequest(mockCallId);
       const expected2 = machineActions.cleanupRequest("mocked-nanoid-2");
       const getCleanupActions = () =>
         store.getActions().filter((action) => action.type === expected1.type);

--- a/src/app/store/machine/utils/query.test.ts
+++ b/src/app/store/machine/utils/query.test.ts
@@ -1,0 +1,72 @@
+import { FetchGroupByKey, FetchGroupKey } from "../types/actions";
+
+import { mapSortDirection } from "./common";
+import {
+  timeUntilStale,
+  transformToFetchParams,
+  generateCallId,
+} from "./query";
+
+import type { Sort } from "app/base/types";
+
+describe("machine utilities", () => {
+  beforeEach(() => {
+    jest.spyOn(Date, "now").mockImplementation(() => 1000);
+  });
+
+  afterEach(() => {
+    jest.spyOn(Date, "now").mockRestore();
+  });
+
+  describe("timeUntilStale", () => {
+    it("should return the remaining time until stale", () => {
+      expect(timeUntilStale(500, 1000)).toBe(500);
+    });
+
+    it("should return 0 if the time is already stale", () => {
+      expect(timeUntilStale(500)).toBe(0);
+    });
+  });
+
+  describe("transformToFetchParams", () => {
+    const options = {
+      filters: {},
+      collapsedGroups: [],
+      grouping: FetchGroupByKey.Status,
+      pagination: {
+        currentPage: 1,
+        pageSize: 10,
+        setCurrentPage: jest.fn(),
+      },
+      sortDirection: "asc" as Sort["direction"],
+      sortKey: FetchGroupKey.Status,
+    };
+
+    it("should return the correct fetch parameters when options are provided", () => {
+      expect(transformToFetchParams(options)).toEqual({
+        filter: {},
+        group_collapsed: [],
+        group_key: "status",
+        page_number: 1,
+        page_size: 10,
+        sort_direction: mapSortDirection(options.sortDirection),
+        sort_key: "status",
+      });
+    });
+
+    it("should return null when no options are provided", () => {
+      expect(transformToFetchParams()).toBe(null);
+    });
+  });
+
+  describe("generateCallId", () => {
+    it("should return a sorted, stringified version of the parameters when options are provided", () => {
+      const options = { b: 1, a: 2, c: { e: 3, d: 4 } };
+      expect(generateCallId(options)).toBe('{"a":2,"b":1,"c":{"d":4,"e":3}}');
+    });
+
+    it('should return "{}" when no options are provided', () => {
+      expect(generateCallId()).toBe("{}");
+    });
+  });
+});

--- a/src/app/store/machine/utils/query.ts
+++ b/src/app/store/machine/utils/query.ts
@@ -1,0 +1,45 @@
+import type { FetchParams } from "../types";
+
+import { mapSortDirection } from "./common";
+import type { UseFetchMachinesOptions } from "./hooks";
+
+export function timeUntilStale(updatedAt: number, staleTime?: number): number {
+  return Math.max(updatedAt + (staleTime || 0) - Date.now(), 0);
+}
+
+export const transformToFetchParams = (
+  options?: UseFetchMachinesOptions | null
+): FetchParams | null => {
+  return options
+    ? {
+        filter: options.filters ?? null,
+        group_collapsed: options.collapsedGroups,
+        group_key: options.grouping ?? null,
+        page_number: options?.pagination?.currentPage,
+        page_size: options?.pagination?.pageSize,
+        sort_direction: mapSortDirection(options.sortDirection),
+        sort_key: options.sortKey ?? null,
+      }
+    : null;
+};
+
+export const generateCallId = (options?: {} | null): string => {
+  return options ? JSON.stringify(sortObjectKeys(options)) : "{}";
+};
+
+function sortObjectKeys(obj: any): any {
+  if (obj === null || typeof obj !== "object") {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sortObjectKeys);
+  }
+
+  return Object.keys(obj)
+    .sort()
+    .reduce((result, key) => {
+      result[key] = sortObjectKeys(obj[key]);
+      return result;
+    }, {} as any);
+}

--- a/src/app/tags/components/KernelOptionsField/KernelOptionsField.test.tsx
+++ b/src/app/tags/components/KernelOptionsField/KernelOptionsField.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
@@ -8,6 +7,7 @@ import KernelOptionsField, { Label } from "./KernelOptionsField";
 
 import { actions as machineActions } from "app/store/machine";
 import type { FetchFilters } from "app/store/machine/types";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import { FetchNodeStatus, NodeStatus } from "app/store/types/node";
 import {
@@ -20,12 +20,11 @@ import {
   tagState as tagStateFactory,
 } from "testing/factories";
 import { userEvent, render, screen } from "testing/utils";
-
 const mockStore = configureStore();
 let state: RootState;
 
 beforeEach(() => {
-  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+  jest.spyOn(query, "generateCallId").mockReturnValueOnce("mocked-nanoid");
   state = rootStateFactory({
     machine: machineStateFactory({
       counts: machineStateCountsFactory({

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -1,5 +1,4 @@
 import { NotificationSeverity } from "@canonical/react-components";
-import reduxToolkit from "@reduxjs/toolkit";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
@@ -13,6 +12,7 @@ import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { NodeStatus } from "app/store/types/node";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -23,13 +23,13 @@ import {
 } from "testing/factories";
 import { userEvent, render, screen, waitFor } from "testing/utils";
 
+enableCallIdMocks();
 const mockStore = configureStore();
 
 let state: RootState;
 let scrollToSpy: jest.Mock;
 
 beforeEach(() => {
-  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
   state = rootStateFactory({
     machine: machineStateFactory({
       items: [
@@ -186,7 +186,7 @@ it("can return to the details on cancel", async () => {
     }),
   ];
   state.machine.counts = {
-    "mocked-nanoid": machineStateCountFactory({
+    [callId]: machineStateCountFactory({
       count: 1,
       loaded: true,
     }),

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
@@ -9,6 +9,7 @@ import DeleteTagFormWarnings from "./DeleteTagFormWarnings";
 import urls from "app/base/urls";
 import type { RootState } from "app/store/root/types";
 import { NodeStatus } from "app/store/types/node";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -23,8 +24,10 @@ const mockStore = configureStore();
 
 let state: RootState;
 
+enableCallIdMocks();
+
 beforeEach(() => {
-  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("{}");
   state = rootStateFactory({
     machine: machineStateFactory({
       items: [
@@ -38,10 +41,6 @@ beforeEach(() => {
       items: [tagFactory({ id: 1 })],
     }),
   });
-});
-
-afterEach(() => {
-  jest.restoreAllMocks();
 });
 
 it("does not display a kernel options warning for non-deployed machines", async () => {
@@ -60,7 +59,7 @@ it("does not display a kernel options warning for non-deployed machines", async 
     }),
   ];
   state.machine.counts = {
-    "mocked-nanoid": machineStateCountFactory({
+    [callId]: machineStateCountFactory({
       count: 0,
       loaded: true,
     }),
@@ -90,7 +89,7 @@ it("displays warning when deleting a tag with kernel options", async () => {
     }),
   ];
   state.machine.counts = {
-    "mocked-nanoid": machineStateCountFactory({
+    [callId]: machineStateCountFactory({
       count: 1,
       loaded: true,
     }),
@@ -126,7 +125,7 @@ it("displays a kernel options warning with multiple machines", async () => {
     }),
   ];
   state.machine.counts = {
-    "mocked-nanoid": machineStateCountFactory({
+    [callId]: machineStateCountFactory({
       count: 2,
       loaded: true,
     }),
@@ -156,7 +155,7 @@ it("displays a kernel options warning with one machine", async () => {
     }),
   ];
   state.machine.counts = {
-    "mocked-nanoid": machineStateCountFactory({
+    [callId]: machineStateCountFactory({
       count: 1,
       loaded: true,
     }),
@@ -186,7 +185,7 @@ it("links to a page to display deployed machines", async () => {
     }),
   ];
   state.machine.counts = {
-    "mocked-nanoid": machineStateCountFactory({
+    [callId]: machineStateCountFactory({
       count: 1,
       loaded: true,
     }),

--- a/src/app/tags/views/TagMachines/TagMachines.test.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.test.tsx
@@ -1,4 +1,3 @@
-import reduxToolkit from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
@@ -10,9 +9,11 @@ import urls from "app/base/urls";
 import { columnLabels, MachineColumns } from "app/machines/constants";
 import { actions as machineActions } from "app/store/machine";
 import { FetchGroupKey, FetchSortDirection } from "app/store/machine/types";
+import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import { actions as tagActions } from "app/store/tag";
 import { NodeStatus, FetchNodeStatus } from "app/store/types/node";
+import { callId, enableCallIdMocks } from "testing/callId-mock";
 import {
   machine as machineFactory,
   machineState as machineStateFactory,
@@ -25,11 +26,12 @@ import {
 } from "testing/factories";
 import { render, screen } from "testing/utils";
 
+enableCallIdMocks();
 const mockStore = configureStore();
 let state: RootState;
 
 beforeEach(() => {
-  jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
+  jest.spyOn(query, "generateCallId").mockReturnValue(callId);
   const machines = [
     machineFactory({
       domain: modelRefFactory({ id: 1, name: "test" }),
@@ -42,7 +44,7 @@ beforeEach(() => {
     machine: machineStateFactory({
       items: machines,
       lists: {
-        "mocked-nanoid": machineStateListFactory({
+        [callId]: machineStateListFactory({
           loaded: true,
           groups: [
             machineStateListGroupFactory({
@@ -85,7 +87,7 @@ it("dispatches actions to fetch necessary data", () => {
     </Provider>
   );
   const expectedActions = [
-    machineActions.fetch("mocked-nanoid", {
+    machineActions.fetch(callId, {
       filter: {
         status: FetchNodeStatus.DEPLOYED,
         tags: ["rad"],

--- a/src/testing/callId-mock.ts
+++ b/src/testing/callId-mock.ts
@@ -1,0 +1,17 @@
+import reduxToolkit from "@reduxjs/toolkit";
+
+import * as query from "app/store/machine/utils/query";
+
+export const callId = "mocked-call-id";
+
+export const enableCallIdMocks = (): void => {
+  beforeEach(() => {
+    jest.spyOn(query, "generateCallId").mockReturnValue(callId);
+    jest.spyOn(reduxToolkit, "nanoid").mockReturnValue(callId);
+  });
+
+  afterEach(() => {
+    jest.spyOn(query, "generateCallId").mockRestore();
+    jest.spyOn(reduxToolkit, "nanoid").mockRestore();
+  });
+};

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -20,6 +20,7 @@ export {
   domainState,
   eventState,
   fabricState,
+  fetchedAt,
   generalState,
   generatedCertificateState,
   hweKernelsState,

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -259,6 +259,8 @@ export const machineStateListGroup = define<MachineStateListGroup>({
   value: null,
 });
 
+export const fetchedAt = define<number>(Date.now());
+
 export const machineStateList = define<MachineStateList>({
   count: null,
   cur_page: null,
@@ -269,6 +271,9 @@ export const machineStateList = define<MachineStateList>({
   stale: false,
   num_pages: null,
   params: null,
+  fetchedAt: () => fetchedAt(),
+  refetchedAt: null,
+  refetching: false,
 });
 
 export const machineActionState = define<ActionState>({
@@ -294,6 +299,9 @@ export const machineStateCount = define<MachineStateCount>({
   loading: false,
   stale: false,
   params: null,
+  fetchedAt,
+  refetchedAt: null,
+  refetching: false,
 });
 
 export const machineFilterGroup = define<FilterGroup>({

--- a/yarn.lock
+++ b/yarn.lock
@@ -7585,7 +7585,7 @@ image-size@^1.0.0:
   dependencies:
     queue "6.0.2"
 
-immer@^9.0.16:
+immer@9.0.16, immer@^9.0.16:
   version "9.0.16"
   resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.16.tgz#8e7caab80118c2b54b37ad43e05758cdefad0198"
   integrity sha512-qenGE7CstVm1NrHQbMh8YaSzTZTFNP3zPqr3YU0S0UY441j4bJTg4A2Hh5KAhwgaiU6ZZ1Ar6y/2f4TblnMReQ==


### PR DESCRIPTION
## Done

- refactor: machine request cache keys MAASENG-1905
- drive-by fixes:
  - add explicit immer import (already imported as a peer dependency of redux toolkit)
  - fix machine list pagination not to rely on a re-render for the buttons to work
  - reduce duplication with enableCallIdMocks util

### Rationale
This replaces random strings used as callId with `JSON.stringify` of used request parameters. This ensures there's only a single state for each possible permutation of machin list at a time.

It also introduces `fetchedAt`, `refetchedAt` to enable time-based cache invalidation in the future.

#### before
- machine.count & machine.list are requested multiple times in quick succession on initial page load
- on machine list or count request
  - loading state is displayed when requested for the first time and items added to cache
  - loading state is displayed for subsequent requests and previously cached state is discarded
#### after
- machine.count & machine.list are requested only once on initial page load
- on machine list or count request
  - loading state is displayed when requested for the first time and items added to cache
  - no loading state is displayed for subsequent requests and previously cached state is displayed whilst an update is loading

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### QA steps

- Go to machine listing page
- Open one of the machines on the list in a new tab and go back to the previous tab
- Click to go to the next page
- Now in the second tab, perform an action on the machine, e.g. change its name, and go back to the previous tab
- Click to go to the previous page
- Ensure that no loading screen was displayed and the machine's name has been eventually updated

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1905

## Screenshots
