### PR TITLE
fix: machine list pagination lp#2025375

### DIFF
--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -59,15 +59,22 @@ const MachineList = ({
       ? storedPageSize
       : DEFAULT_PAGE_SIZE;
 
-  const { callId, loading, machineCount, machines, machinesErrors, groups } =
-    useFetchMachines({
-      collapsedGroups: hiddenGroups,
-      filters: FilterMachines.parseFetchFilters(searchFilter),
-      grouping,
-      sortDirection,
-      sortKey,
-      pagination: { currentPage, setCurrentPage, pageSize },
-    });
+  const {
+    callId,
+    groups,
+    loading,
+    machineCount,
+    machines,
+    machinesErrors,
+    totalPages,
+  } = useFetchMachines({
+    collapsedGroups: hiddenGroups,
+    filters: FilterMachines.parseFetchFilters(searchFilter),
+    grouping,
+    sortDirection,
+    sortKey,
+    pagination: { currentPage, setCurrentPage, pageSize },
+  });
 
   useEffect(
     () => () => {
@@ -114,6 +121,7 @@ const MachineList = ({
         setSortKey={setSortKey}
         sortDirection={sortDirection}
         sortKey={sortKey}
+        totalPages={totalPages}
       />
     </>
   );

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
@@ -9,6 +9,7 @@ describe("MachineListPagination", () => {
     props = {
       currentPage: 1,
       itemsPerPage: 20,
+      totalPages: 4,
       machineCount: 100,
       machinesLoading: false,
       paginate: jest.fn(),

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -21,6 +21,7 @@ export type Props = PropsWithSpread<
     currentPage: PaginationProps["currentPage"];
     itemsPerPage: PaginationProps["itemsPerPage"];
     machineCount: number | null;
+    totalPages: number | null;
     machinesLoading?: boolean | null;
     paginate: PaginationProps["paginate"];
   },
@@ -30,6 +31,7 @@ export type Props = PropsWithSpread<
 const MachineListPagination = ({
   machineCount,
   machinesLoading,
+  totalPages,
   ...props
 }: Props): JSX.Element | null => {
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -48,9 +50,7 @@ const MachineListPagination = ({
   }, []);
 
   const count = useFetchedCount(machineCount, machinesLoading);
-  const totalPages = machineCount
-    ? Math.ceil(machineCount / props.itemsPerPage)
-    : 1;
+  const pages = useFetchedCount(totalPages, machinesLoading);
 
   return count > 0 ? (
     <nav aria-label={Label.Pagination} className="p-pagination">
@@ -80,7 +80,7 @@ const MachineListPagination = ({
               }
               intervalRef.current = setTimeout(() => {
                 if (
-                  e.target.valueAsNumber > totalPages ||
+                  e.target.valueAsNumber > pages ||
                   e.target.valueAsNumber < 1
                 ) {
                   setError(
@@ -100,11 +100,11 @@ const MachineListPagination = ({
           type="number"
           value={pageNumber}
         />{" "}
-        <strong className="u-no-wrap"> of {totalPages}</strong>
+        <strong className="u-no-wrap"> of {pages}</strong>
         <Button
           aria-label={Label.NextPage}
           className="p-pagination__link--next"
-          disabled={props.currentPage === totalPages}
+          disabled={props.currentPage === pages}
           onClick={() => props.paginate(props.currentPage + 1)}
         >
           <Icon name="chevron-down" />

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -67,6 +67,7 @@ type Props = {
   hiddenColumns?: string[];
   hiddenGroups?: (string | null)[];
   machineCount: number | null;
+  totalPages: number | null;
   machines: Machine[];
   machinesLoading?: boolean | null;
   pageSize: number;
@@ -514,6 +515,7 @@ const generateGroupRows = ({
 export const MachineListTable = ({
   callId,
   currentPage,
+  totalPages,
   filter = "",
   groups,
   grouping,
@@ -899,6 +901,7 @@ export const MachineListTable = ({
               machineCount={machineCount}
               machinesLoading={machinesLoading}
               paginate={setCurrentPage}
+              totalPages={totalPages}
             />
             {setPageSize ? (
               <PageSizeSelect

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -432,6 +432,17 @@ const listCount = createSelector(
 );
 
 /**
+ * Get the total page count for a machine list request with a given callId.
+ */
+const listTotalPages = createSelector(
+  [
+    machineState,
+    (_state: RootState, callId: string | null | undefined) => callId,
+  ],
+  (machineState, callId) => getList(machineState, callId)?.num_pages ?? null
+);
+
+/**
  * Get the stale value for a machine count request with a given callId
  */
 const countStale = createSelector(
@@ -659,6 +670,7 @@ const selectors = {
   linkingSubnet: statusSelectors["linkingSubnet"],
   list,
   listCount,
+  listTotalPages,
   listErrors,
   listGroup,
   listGroups,

--- a/src/app/store/machine/utils/hooks.ts
+++ b/src/app/store/machine/utils/hooks.ts
@@ -533,6 +533,7 @@ type UseFetchMachinesData = {
   machineCount: number | null;
   machines: Machine[];
   machinesErrors: APIError;
+  totalPages: number | null;
 };
 
 /**
@@ -567,6 +568,9 @@ export const useFetchMachines = (
   );
   const machineCount = useSelector((state: RootState) =>
     machineSelectors.listCount(state, callId)
+  );
+  const totalPages = useSelector((state: RootState) =>
+    machineSelectors.listTotalPages(state, callId)
   );
   const machinesErrors = useSelector((state: RootState) =>
     machineSelectors.listErrors(state, callId)
@@ -653,6 +657,7 @@ export const useFetchMachines = (
     loading,
     groups,
     machineCount,
+    totalPages,
     machines,
     machinesErrors,
   };


### PR DESCRIPTION
## Done

- fix: machine list pagination

### QA steps

- Go to machine listing on a MAAS with multiple machines
- If needed, you can set the page size manually to a low value in developer tools console by typing `localStorage.setItem("machineListPageSize", "1")` and refreshing the page
- collapse a group of machines
- total number of pages should update
- expand a group of machines
- the total number of machines should update

## Launchpad issue
https://bugs.launchpad.net/maas-ui/+bug/2025375
lp#2025375
