### PR TITLE
fix: keep websocket connection alive lp#231930001

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -31,6 +31,10 @@ export type WebSocketRequestMessage = {
   params?: Record<string, unknown> | Record<string, unknown>[];
 };
 
+export type WebSocketPingMessage = {
+  type: WebSocketMessageType.PING;
+};
+
 export type WebSocketRequest = WebSocketMessage & WebSocketRequestMessage;
 
 export type WebSocketResponseResult<R = unknown> = WebSocketMessage & {
@@ -52,6 +56,10 @@ export type WebSocketResponseNotify = {
   data: unknown;
   name: string;
   type: WebSocketMessageType.NOTIFY;
+};
+
+export type WebSocketResponsePing = WebSocketResponseResult<number> & {
+  type: WebSocketMessageType.PING_REPLY;
 };
 
 export type WebSocketActionParams = AnyObject | AnyObject[];


### PR DESCRIPTION
## Done

- fix: keep websocket connection alive by sending a ping message every 50 seconds
  - setup heartbeat ping/pong message handlers

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Log in
- Open developer tools and inspect the websocket connection
- Ensure that every 50 seconds a websocket ping message is sent and replied to by the server

## Fixes

Fixes: lp#231930001
https://bugs.launchpad.net/maas/+bug/1930001
