### PR TITLE
fix: keep websocket connection alive (#5047) 3.4 backport

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -31,6 +31,10 @@ export type WebSocketRequestMessage = {
   params?: Record<string, unknown> | Record<string, unknown>[];
 };
 
+export type WebSocketPingMessage = {
+  type: WebSocketMessageType.PING;
+};
+
 export type WebSocketRequest = WebSocketMessage & WebSocketRequestMessage;
 
 export type WebSocketResponseResult<R = unknown> = WebSocketMessage & {
@@ -52,6 +56,10 @@ export type WebSocketResponseNotify = {
   data: unknown;
   name: string;
   type: WebSocketMessageType.NOTIFY;
+};
+
+export type WebSocketResponsePing = WebSocketResponseResult<number> & {
+  type: WebSocketMessageType.PING_REPLY;
 };
 
 export type WebSocketActionParams = AnyObject | AnyObject[];


### PR DESCRIPTION
## Done

fix: keep websocket connection alive by sending a ping message every 50 seconds
- setup heartbeat ping/pong message handlers

## Launchpad issue
Fixes: lp#1930001
https://bugs.launchpad.net/maas/+bug/1930001
