### PR TITLE
feat: tag management panel MAASENG-1427

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,7 +154,7 @@ module.exports = {
         "no-only-tests/no-only-tests": "error",
         // vanilla framework often hides default inputs and displays styled ones instead
         // because of this we need to use use force option to allow interacting with hidden fields
-        "cypress/no-force": "warn",
+        "cypress/no-force": "off",
         "prettier/prettier": "error",
       },
     },

--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -52,7 +52,6 @@ context("Machine listing", () => {
     cy.findByRole("searchbox").type(searchFilter);
     cy.findByText(/Showing 2 out of 2 machines/).should("exist");
     cy.findByRole("grid", { name: /Machines/ }).within(() =>
-      // eslint-disable-next-line cypress/no-force
       cy
         .findByRole("checkbox", { name: /Commissioning/i })
         .click({ force: true })
@@ -113,7 +112,6 @@ context("Machine listing", () => {
 
     cy.findAllByRole("button", { name: "Columns" }).click();
     cy.findByLabelText("columns menu").within(() =>
-      // eslint-disable-next-line cypress/no-force
       cy.findByRole("checkbox", { name: "Status" }).click({ force: true })
     );
 
@@ -134,11 +132,9 @@ context("Machine listing", () => {
     cy.findByRole("combobox", { name: "Group by" }).select("No grouping");
     cy.findByRole("searchbox", { name: "Search" }).type(name);
     cy.findByText(/Showing 3 out of 3 machines/).should("exist");
-    // eslint-disable-next-line cypress/no-force
     cy.findByRole("checkbox", { name: `${newMachines[0]}.maas` }).click({
       force: true,
     });
-    // eslint-disable-next-line cypress/no-force
     cy.findByRole("checkbox", { name: `${newMachines[2]}.maas` }).click({
       shiftKey: true,
       force: true,

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -55,8 +55,7 @@ Cypress.Commands.add("deleteMachine", (hostname: string) => {
   cy.findByRole("combobox", { name: "Group by" }).select("No grouping");
   cy.findByRole("searchbox").type(hostname);
   cy.findByText(/Showing 1 out of 1 machines/).should("exist");
-  cy.findByRole("grid", { name: "Machines" }).within(() =>
-    // eslint-disable-next-line cypress/no-force
+  cy.findByRole("grid", { name: /Machines/ }).within(() =>
     cy
       .findByRole("checkbox", { name: new RegExp(hostname) })
       .click({ force: true })

--- a/src/app/base/components/AppSidePanel/AppSidePanel.test.tsx
+++ b/src/app/base/components/AppSidePanel/AppSidePanel.test.tsx
@@ -18,9 +18,9 @@ it("displays side panel as a child of #maas-ui DOM node", async () => {
 });
 
 it("adds a correct className for a wide panel", async () => {
-  renderWithBrowserRouter(
-    <AppSidePanel size="wide" title="side panel title" />
-  );
+  renderWithBrowserRouter(<AppSidePanel title="side panel title" />, {
+    sidePanelSize: "wide",
+  });
   expect(
     screen
       .getByRole("complementary", { name: "side panel title" })

--- a/src/app/base/components/AppSidePanel/index.ts
+++ b/src/app/base/components/AppSidePanel/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./AppSidePanel";
+export { default, type AppSidePanelProps } from "./AppSidePanel";

--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type {
   ButtonAppearance,
   ButtonProps,
+  ContextualMenuDropdownProps,
   ValueOf,
 } from "@canonical/react-components";
 import { ContextualMenu, Tooltip } from "@canonical/react-components";
@@ -39,7 +40,7 @@ type Props = {
   toggleAppearance?: ValueOf<typeof ButtonAppearance>;
   toggleClassName?: string | null;
   toggleLabel?: string;
-};
+} & Pick<ContextualMenuDropdownProps, "constrainPanelWidth">;
 
 const actionGroups: ActionGroup[] = [
   {
@@ -166,6 +167,7 @@ export const NodeActionMenu = ({
   toggleAppearance = "positive",
   toggleClassName,
   toggleLabel = Label.TakeAction,
+  constrainPanelWidth,
 }: Props): JSX.Element => {
   return (
     <Tooltip
@@ -178,6 +180,7 @@ export const NodeActionMenu = ({
     >
       <ContextualMenu
         className={className}
+        constrainPanelWidth={constrainPanelWidth}
         data-testid="take-action-dropdown"
         hasToggleIcon
         links={getTakeActionLinks(

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -179,7 +179,7 @@ const generateActionMenus = (
           dropdownProps={{ "aria-label": `${group.title} submenu` }}
           hasToggleIcon
           links={groupLinks}
-          position="center"
+          position="left"
           toggleLabel={
             !group.icon ? (
               group.title

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -10,6 +10,7 @@ import Footer from "../Footer";
 import MainContentSection from "../MainContentSection";
 import SecondaryNavigation from "../SecondaryNavigation";
 
+import type { AppSidePanelProps } from "app/base/components/AppSidePanel";
 import { useThemeContext } from "app/base/theme-context";
 import { preferencesNavItems } from "app/preferences/constants";
 import { settingsNavItems } from "app/settings/constants";
@@ -20,9 +21,9 @@ export type Props = {
   header?: ReactNode;
   sidebar?: ReactNode;
   isNotificationListHidden?: boolean;
-  sidePanelContent: React.ReactNode;
-  sidePanelSize?: "wide";
-  sidePanelTitle: string | null;
+  sidePanelContent: AppSidePanelProps["content"];
+  sidePanelSize?: AppSidePanelProps["size"];
+  sidePanelTitle: AppSidePanelProps["title"];
 } & HTMLProps<HTMLDivElement>;
 
 const PageContent = ({
@@ -31,7 +32,6 @@ const PageContent = ({
   sidebar,
   isNotificationListHidden = false,
   sidePanelContent,
-  sidePanelSize,
   sidePanelTitle,
   ...props
 }: Props): JSX.Element => {
@@ -82,11 +82,7 @@ const PageContent = ({
           <Footer />
         </div>
       </main>
-      <AppSidePanel
-        content={sidePanelContent}
-        size={sidePanelSize}
-        title={sidePanelTitle}
-      />
+      <AppSidePanel content={sidePanelContent} title={sidePanelTitle} />
     </>
   );
 };

--- a/src/app/base/side-panel-context.test.tsx
+++ b/src/app/base/side-panel-context.test.tsx
@@ -1,0 +1,24 @@
+import SidePanelContextProvider, { useSidePanel } from "./side-panel-context";
+
+import { renderHook, act } from "testing/utils";
+
+it("resets side panel size on close", () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <SidePanelContextProvider>{children}</SidePanelContextProvider>
+  );
+
+  const { result } = renderHook(() => useSidePanel(), { wrapper });
+
+  act(() => {
+    result.current.setSidePanelSize("large");
+  });
+
+  expect(result.current.sidePanelSize).toBe("large");
+
+  act(() => {
+    result.current.setSidePanelContent(null);
+  });
+
+  expect(result.current.sidePanelSize).toBe("regular");
+  expect(result.current.sidePanelContent).toBeNull();
+});

--- a/src/app/controllers/components/ControllerForms/ControllerForms.tsx
+++ b/src/app/controllers/components/ControllerForms/ControllerForms.tsx
@@ -3,12 +3,12 @@ import { useCallback } from "react";
 import AddController from "./AddController";
 import ControllerActionFormWrapper from "./ControllerActionFormWrapper";
 
-import type { SidePanelContextTypes } from "app/base/side-panel-context";
+import type { SidePanelContentTypes } from "app/base/side-panel-context";
 import { ControllerSidePanelViews } from "app/controllers/constants";
 import type { ControllerActionSidePanelContent } from "app/controllers/types";
 import type { Controller } from "app/store/controller/types";
 
-type Props = SidePanelContextTypes & {
+type Props = SidePanelContentTypes & {
   controllers: Controller[];
   viewingDetails?: boolean;
 };

--- a/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/DeviceHeaderForms.tsx
@@ -5,12 +5,12 @@ import type { ValueOf } from "@canonical/react-components";
 import AddDeviceForm from "./AddDeviceForm";
 import DeviceActionFormWrapper from "./DeviceActionFormWrapper";
 
-import type { SidePanelContextTypes } from "app/base/side-panel-context";
+import type { SidePanelContentTypes } from "app/base/side-panel-context";
 import type { DeviceActionHeaderViews } from "app/devices/constants";
 import { DeviceSidePanelViews } from "app/devices/constants";
 import type { Device } from "app/store/device/types";
 
-type Props = SidePanelContextTypes & {
+type Props = SidePanelContentTypes & {
   devices: Device[];
   viewingDetails?: boolean;
 };

--- a/src/app/kvm/components/KVMForms/KVMForms.tsx
+++ b/src/app/kvm/components/KVMForms/KVMForms.tsx
@@ -9,7 +9,7 @@ import DeleteForm from "./DeleteForm";
 import RefreshForm from "./RefreshForm";
 
 import { useScrollOnRender } from "app/base/hooks";
-import type { SidePanelContextTypes } from "app/base/side-panel-context";
+import type { SidePanelContentTypes } from "app/base/side-panel-context";
 import type { ClearSidePanelContent, SetSearchFilter } from "app/base/types";
 import { KVMSidePanelViews } from "app/kvm/constants";
 import MachineForms from "app/machines/components/MachineForms";
@@ -18,7 +18,7 @@ import type { SelectedMachines } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
 import { useMachineSelectedCount } from "app/store/machine/utils/hooks";
 
-type Props = SidePanelContextTypes & {
+type Props = SidePanelContentTypes & {
   searchFilter?: string;
   setSearchFilter?: SetSearchFilter;
 };

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/AddTagForm/AddTagForm.tsx
@@ -8,6 +8,7 @@ export type Props = {
   onTagCreated: (tag: Tag) => void;
   viewingDetails?: boolean;
   viewingMachineConfig?: boolean;
+  onCancel?: () => void;
 } & Partial<MachineActionFormProps>;
 
 export const AddTagForm = ({
@@ -17,6 +18,7 @@ export const AddTagForm = ({
   searchFilter,
   viewingDetails,
   viewingMachineConfig,
+  onCancel,
 }: Props): JSX.Element => {
   let location = "list";
   if (viewingMachineConfig) {
@@ -37,6 +39,7 @@ export const AddTagForm = ({
           : `${count} selected machines are deployed. The new kernel options will not be applied to these machines until they are redeployed.`
       }
       name={name}
+      onCancel={onCancel}
       onSaveAnalytics={{
         action: "Manual tag created",
         category: `Machine ${location} create tag form`,

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagForm.tsx
@@ -1,13 +1,15 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-import { NotificationSeverity } from "@canonical/react-components";
+import { Col, NotificationSeverity, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
+import AddTagForm from "./AddTagForm";
 import TagFormFields from "./TagFormFields";
 import type { TagFormValues } from "./types";
 
 import ActionForm from "app/base/components/ActionForm";
+import { useSidePanel } from "app/base/side-panel-context";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as machineActions } from "app/store/machine";
 import type { MachineEventErrors } from "app/store/machine/types";
@@ -17,6 +19,7 @@ import { actions as messageActions } from "app/store/message";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
 import { NodeActions } from "app/store/types/node";
+import TagDetails from "app/tags/components/TagDetails";
 
 type Props = MachineActionFormProps & {
   viewingMachineConfig?: boolean;
@@ -30,6 +33,8 @@ const TagFormSchema = Yup.object().shape({
   added: Yup.array().of(Yup.string()),
   removed: Yup.array().of(Yup.string()),
 });
+
+export type TagFormSecondaryContent = "addTag" | "tagDetails" | null;
 
 export const TagForm = ({
   clearSidePanelContent,
@@ -58,82 +63,140 @@ export const TagForm = ({
     delete formErrors.name;
   }
 
+  const [newTagName, setNewTagName] = useState<string | null>(null);
+  const { setSidePanelSize } = useSidePanel();
+
+  const [secondaryContent, setSecondaryContent] =
+    useState<TagFormSecondaryContent>(null);
+  useEffect(() => {
+    // increase the side panel size when the secondary content is open
+    if (secondaryContent !== null) {
+      setSidePanelSize("large");
+    } else {
+      setSidePanelSize("regular");
+    }
+  }, [secondaryContent, setSidePanelSize]);
+
+  const [tagDetails, setTagDetails] = useState<Tag | null>(null);
+
+  const toggleTagDetails = (tag: Tag | null) => {
+    setTagDetails(tag);
+    if (tag) {
+      setSecondaryContent("tagDetails");
+    } else {
+      setSecondaryContent(null);
+    }
+  };
+
   return (
-    <ActionForm<TagFormValues, MachineEventErrors>
-      actionName={NodeActions.TAG}
-      cleanup={machineActions.cleanup}
-      errors={formErrors || errors}
-      initialValues={{
-        added: [],
-        removed: [],
-      }}
-      loaded={tagsLoaded}
-      modelName="machine"
-      onCancel={clearSidePanelContent}
-      onSaveAnalytics={{
-        action: "Submit",
-        category: `Machine ${viewingDetails ? "details" : "list"} action form`,
-        label: "Tag",
-      }}
-      onSubmit={(values) => {
-        dispatch(machineActions.cleanup());
-        if (values.added.length) {
-          if (filter) {
-            dispatchForSelectedMachines(machineActions.tag, {
-              tags: values.added.map((id) => Number(id)),
-            });
-          } else {
-            machines?.forEach((machine) => {
-              dispatch(
-                machineActions.tag({
-                  system_id: machine.system_id,
+    <Row>
+      {secondaryContent === "addTag" ? (
+        <Col size={6}>
+          <AddTagForm
+            machines={machines}
+            name={newTagName}
+            onCancel={() => setSecondaryContent(null)}
+            onTagCreated={(tag) => {
+              setNewTagName(null);
+              setNewTags([...newTags, tag.id]);
+              setSecondaryContent(null);
+            }}
+            searchFilter={searchFilter}
+            selectedMachines={selectedMachines}
+            viewingDetails={viewingDetails}
+            viewingMachineConfig={viewingMachineConfig}
+          />
+        </Col>
+      ) : null}
+      {secondaryContent === "tagDetails" && tagDetails ? (
+        <Col size={6}>
+          <h4>{tagDetails.name}</h4>
+          <TagDetails id={tagDetails.id} narrow />
+        </Col>
+      ) : null}
+      <Col size={secondaryContent !== null ? 6 : 12}>
+        <ActionForm<TagFormValues, MachineEventErrors>
+          actionName={NodeActions.TAG}
+          cleanup={machineActions.cleanup}
+          errors={formErrors || errors}
+          initialValues={{
+            added: [],
+            removed: [],
+          }}
+          loaded={tagsLoaded}
+          modelName="machine"
+          onCancel={clearSidePanelContent}
+          onSaveAnalytics={{
+            action: "Submit",
+            category: `Machine ${
+              viewingDetails ? "details" : "list"
+            } action form`,
+            label: "Tag",
+          }}
+          onSubmit={(values) => {
+            dispatch(machineActions.cleanup());
+            if (values.added.length) {
+              if (filter) {
+                dispatchForSelectedMachines(machineActions.tag, {
                   tags: values.added.map((id) => Number(id)),
-                })
-              );
-            });
-          }
-        }
-        if (values.removed.length) {
-          if (selectedMachines) {
-            dispatchForSelectedMachines(machineActions.untag, {
-              tags: values.removed.map((id) => Number(id)),
-            });
-          } else {
-            machines?.forEach((machine) => {
-              dispatch(
-                machineActions.untag({
-                  system_id: machine.system_id,
+                });
+              } else {
+                machines?.forEach((machine) => {
+                  dispatch(
+                    machineActions.tag({
+                      system_id: machine.system_id,
+                      tags: values.added.map((id) => Number(id)),
+                    })
+                  );
+                });
+              }
+            }
+            if (values.removed.length) {
+              if (selectedMachines) {
+                dispatchForSelectedMachines(machineActions.untag, {
                   tags: values.removed.map((id) => Number(id)),
-                })
-              );
-            });
-          }
-        }
-      }}
-      onSuccess={() => {
-        clearSidePanelContent();
-        dispatch(
-          messageActions.add(Label.Saved, NotificationSeverity.POSITIVE)
-        );
-      }}
-      processingCount={processingCount}
-      selectedCount={machines ? machines.length : selectedCount ?? 0}
-      showProcessingCount={!viewingMachineConfig}
-      submitLabel="Save"
-      validationSchema={TagFormSchema}
-      {...actionProps}
-    >
-      <TagFormFields
-        machines={machines || []}
-        newTags={newTags}
-        searchFilter={searchFilter}
-        selectedCount={selectedCount}
-        selectedMachines={selectedMachines}
-        setNewTags={setNewTags}
-        viewingDetails={viewingDetails}
-        viewingMachineConfig={viewingMachineConfig}
-      />
-    </ActionForm>
+                });
+              } else {
+                machines?.forEach((machine) => {
+                  dispatch(
+                    machineActions.untag({
+                      system_id: machine.system_id,
+                      tags: values.removed.map((id) => Number(id)),
+                    })
+                  );
+                });
+              }
+            }
+          }}
+          onSuccess={() => {
+            clearSidePanelContent();
+            dispatch(
+              messageActions.add(Label.Saved, NotificationSeverity.POSITIVE)
+            );
+          }}
+          processingCount={processingCount}
+          selectedCount={machines ? machines.length : selectedCount ?? 0}
+          showProcessingCount={!viewingMachineConfig}
+          submitLabel="Save tag changes"
+          validationSchema={TagFormSchema}
+          {...actionProps}
+        >
+          <TagFormFields
+            machines={machines || []}
+            newTags={newTags}
+            searchFilter={searchFilter}
+            selectedCount={selectedCount}
+            selectedMachines={selectedMachines}
+            setNewTagName={setNewTagName}
+            setNewTags={setNewTags}
+            setSecondaryContent={setSecondaryContent}
+            toggleTagDetails={toggleTagDetails}
+            viewingDetails={viewingDetails}
+            viewingMachineConfig={viewingMachineConfig}
+          />
+        </ActionForm>
+      </Col>
+    </Row>
   );
 };
 

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
@@ -23,6 +23,10 @@ const mockStore = configureStore();
 
 let state: RootState;
 let tags: Tag[];
+const commonProps = {
+  selectedCount: 0,
+  toggleTagDetails: jest.fn(),
+};
 
 beforeEach(() => {
   jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
@@ -62,7 +66,7 @@ it("displays manual tags", () => {
             initialValues={{ added: [], removed: [] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[]} tags={tags} />
+            <TagFormChanges {...commonProps} newTags={[]} tags={tags} />
           </Formik>
         </CompatRouter>
       </MemoryRouter>
@@ -93,7 +97,7 @@ it("displays automatic tags", () => {
             initialValues={{ added: [], removed: [] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[]} tags={tags} />
+            <TagFormChanges {...commonProps} newTags={[]} tags={tags} />
           </Formik>
         </CompatRouter>
       </MemoryRouter>
@@ -124,7 +128,11 @@ it("displays added tags, with a 'NEW' prefix for newly created tags", () => {
             initialValues={{ added: [tags[0].id, tags[1].id], removed: [] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[tags[1].id]} tags={tags} />
+            <TagFormChanges
+              {...commonProps}
+              newTags={[tags[1].id]}
+              tags={tags}
+            />
           </Formik>
         </CompatRouter>
       </MemoryRouter>
@@ -153,7 +161,7 @@ it("discards added tags", async () => {
             initialValues={{ added: [tags[0].id, tags[1].id], removed: [] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[]} tags={[]} />
+            <TagFormChanges {...commonProps} newTags={[]} tags={[]} />
           </Formik>
         </CompatRouter>
       </MemoryRouter>
@@ -170,9 +178,11 @@ it("discards added tags", async () => {
 });
 
 it("displays a tag details modal when chips are clicked", async () => {
-  tags[0].name = "tag1";
-  tags[0].machine_count = 2;
+  const expectedTag = tags[0];
+  expectedTag.name = "tag1";
+  expectedTag.machine_count = 2;
   const store = mockStore(state);
+  const handleToggleTagDetails = jest.fn();
   render(
     <Provider store={store}>
       <MemoryRouter>
@@ -181,14 +191,21 @@ it("displays a tag details modal when chips are clicked", async () => {
             initialValues={{ added: [], removed: [] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[]} selectedCount={2} tags={tags} />
+            <TagFormChanges
+              newTags={[]}
+              selectedCount={2}
+              tags={tags}
+              toggleTagDetails={handleToggleTagDetails}
+            />
           </Formik>
         </CompatRouter>
       </MemoryRouter>
     </Provider>
   );
-  await userEvent.click(screen.getByRole("button", { name: "tag1 (2/2)" }));
-  expect(screen.getByRole("dialog", { name: "tag1" })).toBeInTheDocument();
+  await userEvent.click(
+    screen.getByRole("button", { name: `${expectedTag.name} (2/2)` })
+  );
+  expect(handleToggleTagDetails).toHaveBeenCalledWith(expectedTag);
 });
 
 it("can remove manual tags", async () => {
@@ -201,7 +218,7 @@ it("can remove manual tags", async () => {
             initialValues={{ added: [], removed: [] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[]} tags={tags} />
+            <TagFormChanges {...commonProps} newTags={[]} tags={tags} />
           </Formik>
         </CompatRouter>
       </MemoryRouter>
@@ -231,7 +248,7 @@ it("displays removed tags", () => {
             initialValues={{ added: [], removed: [tags[0].id, tags[1].id] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[]} tags={[]} />
+            <TagFormChanges {...commonProps} newTags={[]} tags={[]} />
           </Formik>
         </CompatRouter>
       </MemoryRouter>
@@ -262,7 +279,7 @@ it("discards removed tags", async () => {
             initialValues={{ added: [], removed: [tags[0].id, tags[1].id] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[]} tags={tags} />
+            <TagFormChanges {...commonProps} newTags={[]} tags={tags} />
           </Formik>
         </CompatRouter>
       </MemoryRouter>
@@ -303,7 +320,7 @@ it("shows a message if no tags are assigned to the selected machines", () => {
             initialValues={{ added: [], removed: [] }}
             onSubmit={jest.fn()}
           >
-            <TagFormChanges newTags={[]} tags={tags} />
+            <TagFormChanges {...commonProps} newTags={[]} tags={tags} />
           </Formik>
         </CompatRouter>
       </MemoryRouter>

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -1,10 +1,15 @@
 import type { ReactNode } from "react";
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 
 import type { ChipProps } from "@canonical/react-components";
-import { Modal, Button, Icon, ModularTable } from "@canonical/react-components";
+import {
+  Button,
+  Col,
+  Icon,
+  ModularTable,
+  Row,
+} from "@canonical/react-components";
 import { useFormikContext } from "formik";
-import { Portal } from "react-portal";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 
@@ -19,12 +24,12 @@ import type { RootState } from "app/store/root/types";
 import tagSelectors from "app/store/tag/selectors";
 import type { Tag, TagMeta } from "app/store/tag/types";
 import { getTagCounts } from "app/store/tag/utils";
-import TagDetails from "app/tags/components/TagDetails";
 import { toFormikNumber } from "app/utils";
 
 type Props = {
   tags: Tag[];
   newTags: Tag[TagMeta.PK][];
+  toggleTagDetails: (tag: Tag | null) => void;
 } & Pick<MachineActionFormProps, "selectedCount">;
 
 export enum Label {
@@ -114,18 +119,9 @@ export const TagFormChanges = ({
   tags,
   selectedCount,
   newTags,
+  toggleTagDetails,
 }: Props): JSX.Element | null => {
   const { setFieldValue, values } = useFormikContext<TagFormValues>();
-  const [tagDetails, setTagDetails] = useState<Tag | null>(null);
-  const [isOpen, setIsOpen] = useState(false);
-  const toggleTagDetails = (tag: Tag | null) => {
-    setTagDetails(tag);
-    if (tag) {
-      setIsOpen(true);
-    } else {
-      setIsOpen(false);
-    }
-  };
   const tagIdsAndCounts = getTagCounts(tags);
   const tagIds = tagIdsAndCounts ? Array.from(tagIdsAndCounts?.keys()) : [];
   const automaticTags = useSelector((state: RootState) =>
@@ -142,6 +138,7 @@ export const TagFormChanges = ({
   const hasManualTags = manualTags.length > 0;
   const hasAddedTags = addedTags.length > 0;
   const hasRemovedTags = removedTags.length > 0;
+
   const columns = useMemo(
     () => [
       {
@@ -173,120 +170,112 @@ export const TagFormChanges = ({
   if (!hasAutomaticTags && !hasManualTags && !hasAddedTags && !hasRemovedTags) {
     return <p className="u-text--muted">{Label.NoTags}</p>;
   }
+
   addedTags.forEach((tag) => {
     // Added tags will be applied to all machines.
     tagIdsAndCounts?.set(tag.id, machineCount);
   });
   return (
-    <>
-      <ModularTable
-        aria-label={Label.Table}
-        className="tag-form__changes"
-        columns={columns}
-        data={[
-          ...generateRows(
-            RowType.Added,
-            addedTags,
-            machineCount,
-            tagIdsAndCounts,
-            Label.Added,
-            toggleTagDetails,
-            newTags,
-            "positive",
-            (tag) => {
-              setFieldValue(
-                "added",
-                values.added.filter((id) => tag.id !== toFormikNumber(id))
-              );
-            },
-            <>
-              <span className="u-nudge-left--small">{Label.Discard}</span>
-              <Icon name="close" />
-            </>
-          ),
-          ...generateRows(
-            RowType.Removed,
-            removedTags,
-            machineCount,
-            tagIdsAndCounts,
-            Label.Removed,
-            toggleTagDetails,
-            newTags,
-            "negative",
-            (tag) => {
-              setFieldValue(
-                "removed",
-                values.removed.filter((id) => tag.id !== toFormikNumber(id))
-              );
-            },
-            <>
-              <span className="u-nudge-left--small">{Label.Discard}</span>
-              <Icon aria-hidden="true" name="close" />
-            </>
-          ),
-          ...generateRows(
-            RowType.Manual,
-            manualTags,
-            machineCount,
-            tagIdsAndCounts,
-            Label.Manual,
-            toggleTagDetails,
-            newTags,
-            "information",
-            (tag) => {
-              setFieldValue(
-                "removed",
-                values.removed.concat([tag.id.toString()])
-              );
-            },
-            <>
-              <span className="u-nudge-left--small">{Label.Remove}</span>
-              <Icon aria-hidden="true" name="delete" />
-            </>
-          ),
-          ...generateRows(
-            RowType.Auto,
-            automaticTags,
-            machineCount,
-            tagIdsAndCounts,
-            Label.Automatic,
-            toggleTagDetails,
-            newTags
-          ),
-        ]}
-        getCellProps={(props) => {
-          if (props.column.id === Column.Label) {
-            if (props.value?.rowSpan) {
-              // Apply the rowspan prop to those that provide the prop. This will
-              // appear as the first row in each type of tag change.
-              return { rowSpan: props.value?.rowSpan };
+    <Row>
+      <Col size={12}>
+        <ModularTable
+          aria-label={Label.Table}
+          className="tag-form__changes"
+          columns={columns}
+          data={[
+            ...generateRows(
+              RowType.Added,
+              addedTags,
+              machineCount,
+              tagIdsAndCounts,
+              Label.Added,
+              toggleTagDetails,
+              newTags,
+              "positive",
+              (tag) => {
+                setFieldValue(
+                  "added",
+                  values.added.filter((id) => tag.id !== toFormikNumber(id))
+                );
+              },
+              <>
+                <span className="u-nudge-left--small">{Label.Discard}</span>
+                <Icon name="close" />
+              </>
+            ),
+            ...generateRows(
+              RowType.Removed,
+              removedTags,
+              machineCount,
+              tagIdsAndCounts,
+              Label.Removed,
+              toggleTagDetails,
+              newTags,
+              "negative",
+              (tag) => {
+                setFieldValue(
+                  "removed",
+                  values.removed.filter((id) => tag.id !== toFormikNumber(id))
+                );
+              },
+              <>
+                <span className="u-nudge-left--small">{Label.Discard}</span>
+                <Icon aria-hidden="true" name="close" />
+              </>
+            ),
+            ...generateRows(
+              RowType.Manual,
+              manualTags,
+              machineCount,
+              tagIdsAndCounts,
+              Label.Manual,
+              toggleTagDetails,
+              newTags,
+              "information",
+              (tag) => {
+                setFieldValue(
+                  "removed",
+                  values.removed.concat([tag.id.toString()])
+                );
+              },
+              <>
+                <span className="u-nudge-left--small">{Label.Remove}</span>
+                <Icon aria-hidden="true" name="delete" />
+              </>
+            ),
+            ...generateRows(
+              RowType.Auto,
+              automaticTags,
+              machineCount,
+              tagIdsAndCounts,
+              Label.Automatic,
+              toggleTagDetails,
+              newTags
+            ),
+          ]}
+          getCellProps={(props) => {
+            if (props.column.id === Column.Label) {
+              if (props.value?.rowSpan) {
+                // Apply the rowspan prop to those that provide the prop. This will
+                // appear as the first row in each type of tag change.
+                return { rowSpan: props.value?.rowSpan };
+              }
+              // Hide all other label columns as this space will be taken up by the
+              // rowspan column.
+              return { className: "p-table--cell-collapse" };
             }
-            // Hide all other label columns as this space will be taken up by the
-            // rowspan column.
-            return { className: "p-table--cell-collapse" };
-          }
-          return {};
-        }}
-        getRowProps={(row) => row.values.label.row}
-      />
-      {hasAutomaticTags && (
-        <p className="u-text--muted u-nudge-right--small">
-          These tags cannot be unassigned. Go to the{" "}
-          <Link to={urls.tags.index}>Tags tab</Link> to manage automatic tags.
-        </p>
-      )}
-      {isOpen && tagDetails ? (
-        <Portal>
-          <Modal
-            className="tag-form__modal"
-            close={() => toggleTagDetails(null)}
-            title={tagDetails.name}
-          >
-            <TagDetails id={tagDetails.id} narrow />
-          </Modal>
-        </Portal>
-      ) : null}
-    </>
+            return {};
+          }}
+          getRowProps={(row) => row.values.label.row}
+        />
+        {hasAutomaticTags && (
+          <p className="u-text--muted u-nudge-right--small">
+            These tags cannot be unassigned. Go to the{" "}
+            <Link to={urls.tags.index}>Tags tab</Link> to manage automatic tags.
+          </p>
+        )}
+      </Col>
+    </Row>
   );
 };
 

--- a/src/app/machines/components/MachineForms/MachineForms.tsx
+++ b/src/app/machines/components/MachineForms/MachineForms.tsx
@@ -6,7 +6,7 @@ import AddChassisForm from "./AddChassis/AddChassisForm";
 import AddMachineForm from "./AddMachine/AddMachineForm";
 import MachineActionFormWrapper from "./MachineActionFormWrapper";
 
-import type { SidePanelContextTypes } from "app/base/side-panel-context";
+import type { SidePanelContentTypes } from "app/base/side-panel-context";
 import type { SetSearchFilter } from "app/base/types";
 import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineActionSidePanelViews } from "app/machines/constants";
@@ -15,7 +15,7 @@ import type {
   MachineSidePanelContent,
 } from "app/machines/types";
 
-type Props = SidePanelContextTypes & {
+type Props = SidePanelContentTypes & {
   setSearchFilter?: SetSearchFilter;
   viewingDetails?: boolean;
 } & MachineActionVariableProps;

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -38,33 +38,19 @@ export type MachineListControlsProps = {
   setSidePanelContent: MachineSetSidePanelContent;
 };
 
-const MachineListControls = ({
-  machineCount,
-  resourcePoolsCount,
-  filter,
-  grouping,
-  setFilter,
-  setGrouping,
-  setHiddenGroups,
-  hiddenColumns,
-  setHiddenColumns,
+const ResponsiveNodeActionMenu = ({
+  hasSelection,
   setSidePanelContent,
-}: MachineListControlsProps): JSX.Element => {
-  const [searchText, setSearchText] = useState(filter);
-  const hasSelection = useHasSelection();
+}: {
+  hasSelection: ReturnType<typeof useHasSelection>;
+  setSidePanelContent: MachineSetSidePanelContent;
+}) => {
   const sendAnalytics = useSendAnalytics();
-  const dispatch = useDispatch();
   const [tagsSeen, setTagsSeen] = useStorageState(
     localStorage,
     "machineViewTagsSeen",
     false
   );
-
-  useEffect(() => {
-    // If the filters change then update the search input text.
-    setSearchText(filter);
-  }, [filter]);
-
   const getTitle = useCallback(
     (action: NodeActions) => {
       if (action === NodeActions.TAG) {
@@ -82,6 +68,88 @@ const MachineListControls = ({
     },
     [tagsSeen]
   );
+
+  return (
+    <>
+      <div className="u-hide--medium u-hide--small">
+        <NodeActionMenuGroup
+          alwaysShowLifecycle
+          excludeActions={[NodeActions.IMPORT_IMAGES]}
+          getTitle={getTitle}
+          hasSelection={hasSelection}
+          nodeDisplay="machine"
+          onActionClick={(action) => {
+            if (action === NodeActions.TAG && !tagsSeen) {
+              setTagsSeen(true);
+            }
+            const view = Object.values(MachineSidePanelViews).find(
+              ([, actionName]) => actionName === action
+            );
+            if (view) {
+              setSidePanelContent({ view });
+            }
+            sendAnalytics(
+              "Machine list action form",
+              getNodeActionTitle(action),
+              "Open"
+            );
+          }}
+        />
+      </div>
+      <div className="u-hide--large">
+        <NodeActionMenu
+          alwaysShowLifecycle
+          className="is-maas-select"
+          constrainPanelWidth
+          excludeActions={[NodeActions.IMPORT_IMAGES]}
+          getTitle={getTitle}
+          hasSelection={hasSelection}
+          menuPosition="left"
+          nodeDisplay="machine"
+          onActionClick={(action) => {
+            if (action === NodeActions.TAG && !tagsSeen) {
+              setTagsSeen(true);
+            }
+            const view = Object.values(MachineSidePanelViews).find(
+              ([, actionName]) => actionName === action
+            );
+            if (view) {
+              setSidePanelContent({ view });
+            }
+            sendAnalytics(
+              "Machine list action form",
+              getNodeActionTitle(action),
+              "Open"
+            );
+          }}
+          toggleAppearance=""
+          toggleClassName="p-action-menu"
+          toggleLabel="Menu"
+        />
+      </div>
+    </>
+  );
+};
+const MachineListControls = ({
+  machineCount,
+  resourcePoolsCount,
+  filter,
+  grouping,
+  setFilter,
+  setGrouping,
+  setHiddenGroups,
+  hiddenColumns,
+  setHiddenColumns,
+  setSidePanelContent,
+}: MachineListControlsProps): JSX.Element => {
+  const [searchText, setSearchText] = useState(filter);
+  const hasSelection = useHasSelection();
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    // If the filters change then update the search input text.
+    setSearchText(filter);
+  }, [filter]);
 
   return (
     <div className="machine-list-controls">
@@ -123,60 +191,10 @@ const MachineListControls = ({
         ) : (
           <>
             <div className="machine-list-controls__item">
-              <div className="u-hide--medium u-hide--small">
-                <NodeActionMenuGroup
-                  alwaysShowLifecycle
-                  excludeActions={[NodeActions.IMPORT_IMAGES]}
-                  getTitle={getTitle}
-                  hasSelection={hasSelection}
-                  nodeDisplay="machine"
-                  onActionClick={(action) => {
-                    if (action === NodeActions.TAG && !tagsSeen) {
-                      setTagsSeen(true);
-                    }
-                    const view = Object.values(MachineSidePanelViews).find(
-                      ([, actionName]) => actionName === action
-                    );
-                    if (view) {
-                      setSidePanelContent({ view });
-                    }
-                    sendAnalytics(
-                      "Machine list action form",
-                      getNodeActionTitle(action),
-                      "Open"
-                    );
-                  }}
-                />
-              </div>
-              <div className="u-hide--large">
-                <NodeActionMenu
-                  alwaysShowLifecycle
-                  className="is-maas-select"
-                  excludeActions={[NodeActions.IMPORT_IMAGES]}
-                  getTitle={getTitle}
-                  hasSelection={hasSelection}
-                  nodeDisplay="machine"
-                  onActionClick={(action) => {
-                    if (action === NodeActions.TAG && !tagsSeen) {
-                      setTagsSeen(true);
-                    }
-                    const view = Object.values(MachineSidePanelViews).find(
-                      ([, actionName]) => actionName === action
-                    );
-                    if (view) {
-                      setSidePanelContent({ view });
-                    }
-                    sendAnalytics(
-                      "Machine list action form",
-                      getNodeActionTitle(action),
-                      "Open"
-                    );
-                  }}
-                  toggleAppearance=""
-                  toggleClassName="p-action-menu"
-                  toggleLabel="Menu"
-                />
-              </div>
+              <ResponsiveNodeActionMenu
+                hasSelection={hasSelection}
+                setSidePanelContent={setSidePanelContent}
+              />
             </div>
             <div className="machine-list-controls__item">
               <Button

--- a/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.tsx
@@ -3,10 +3,10 @@ import { Button } from "@canonical/react-components";
 import { SpaceDetailsSidePanelViews } from "../constants";
 
 import SectionHeader from "app/base/components/SectionHeader";
-import type { SidePanelContextTypes } from "app/base/side-panel-context";
+import type { SidePanelContentTypes } from "app/base/side-panel-context";
 import type { Space } from "app/store/space/types";
 
-type Props = SidePanelContextTypes & {
+type Props = SidePanelContentTypes & {
   space: Space;
 };
 

--- a/src/app/tags/components/TagsHeader/TagForms/TagForms.tsx
+++ b/src/app/tags/components/TagsHeader/TagForms/TagForms.tsx
@@ -1,11 +1,11 @@
 import AddTagForm from "../AddTagForm";
 import DeleteTagForm from "../DeleteTagForm";
 
-import type { SidePanelContextTypes } from "app/base/side-panel-context";
+import type { SidePanelContentTypes } from "app/base/side-panel-context";
 import { TagSidePanelViews } from "app/tags/constants";
 import type { TagSidePanelContent } from "app/tags/types";
 
-type Props = SidePanelContextTypes;
+type Props = SidePanelContentTypes;
 
 export const TagForms = ({
   sidePanelContent,

--- a/src/scss/_patterns_application.scss
+++ b/src/scss/_patterns_application.scss
@@ -23,18 +23,22 @@
   }
   .l-aside {
     z-index: $side-panel-z-index;
-    // TODO: remove .l-aside visibility workaround once https://github.com/canonical/vanilla-framework/issues/4629 is fixed
+    background-color: $color-x-light;
+  }
+  // override to allow for large width aside
+  .l-aside {
+    // add width transition for transition between aside sizes
     @include vf-transition(
       $property: #{transform,
       box-shadow,
-      visibility},
+      visibility, width},
       $duration: snap
     );
-    background-color: $color-x-light;
-  }
-  // TODO: remove .l-aside visibility workaround once https://github.com/canonical/vanilla-framework/issues/4629 is fixed
-  .l-aside.is-collapsed {
-    visibility: hidden;
+    @media (min-width: $breakpoint-x-small) {
+      &.is-large {
+        width: 67rem;
+      }
+    }
   }
   .l-navigation-bar.is-pinned {
     width: 100%;

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -7,7 +7,10 @@ import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
 import type { MockStoreEnhanced } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 
-import type { SidePanelContent } from "app/base/side-panel-context";
+import type {
+  SidePanelContent,
+  SidePanelSize,
+} from "app/base/side-panel-context";
 import SidePanelContextProvider from "app/base/side-panel-context";
 import { ConfigNames } from "app/store/config/types";
 import type { RootState } from "app/store/root/types";
@@ -94,6 +97,7 @@ type WrapperProps = {
   state?: RootState;
   store?: MockStoreEnhanced<RootState, {}>;
   sidePanelContent?: SidePanelContent;
+  sidePanelSize?: SidePanelSize;
 };
 
 export const BrowserRouterWithProvider = ({
@@ -101,6 +105,7 @@ export const BrowserRouterWithProvider = ({
   parentRoute,
   routePattern,
   sidePanelContent,
+  sidePanelSize,
   state,
   store,
 }: WrapperProps & { children: React.ReactNode }): React.ReactElement => {
@@ -112,7 +117,10 @@ export const BrowserRouterWithProvider = ({
   const route = <Route element={children} path={routePattern} />;
   return (
     <Provider store={store ?? getMockStore(state || rootStateFactory())}>
-      <SidePanelContextProvider value={sidePanelContent}>
+      <SidePanelContextProvider
+        initialSidePanelContent={sidePanelContent}
+        initialSidePanelSize={sidePanelSize}
+      >
         <BrowserRouter>
           <CompatRouter>
             {routePattern ? (


### PR DESCRIPTION
## Done

- feat: tag management panel MAASENG-1427
  - remove .l-aside visibility workaround 
  - refactor AppSidePanel
  - update node action menu dropdown styles
  - remove eslint-disable-next-line cypress/no-force comments as we disable the rule globally due to vanillaframework implementation of form elements

Details on the design: https://warthogs.atlassian.net/browse/MAASENG-1422

## QA


### QA steps

- Go to machine list page
- Select a machine
- Click categorise -> tag
- type a name of a new tag in the search field
- add a new tag
- Click save
- Ensure the machine has been updated correctly
---
- go to machine details page
- Click categorise -> tag
- type a name of a new tag in the search field
- add a new tag
- Click save
- Ensure the machine has been updated correctly
- ---
- Go to devices page
- Press "Add"
- Click "Controllers" in the navigation menu
- Verify the side panel has been closed 

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1427

## Screenshots
#### After
![image](https://github.com/canonical/maas-ui/assets/7452681/97cbcc3d-ae8d-4a1a-935f-e209e1d44d5a)
![image](https://github.com/canonical/maas-ui/assets/7452681/3edafa3e-e31f-4585-85a3-d519377a2898)

### Node action menu - mobile
#### Before
<img src="https://github.com/canonical/maas-ui/assets/7452681/9728d232-c4b0-4e48-b8ef-0bad0a987f26" width="600" />

#### After
<img src="https://github.com/canonical/maas-ui/assets/7452681/d0246451-a74f-4e6a-9786-c09c147465f1" width="600" />

### Node action menu - desktop
#### Before
<img src="https://github.com/canonical/maas-ui/assets/7452681/dcf4a94c-8ec6-4539-b1f7-31e17771461e" width="600" />

#### After
<img src="https://github.com/canonical/maas-ui/assets/7452681/dbe41cd9-6acd-4d53-97d7-f61ea2c3c0a4" width="600" />

