### PR TITLE
test: fix cypress machine list test #5041

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -6,6 +6,12 @@ context("Machine listing", () => {
     cy.visit(generateMAASURL("/machines"));
   });
 
+  afterEach(() => {
+    cy.window()
+      // reset grouping to default
+      .then((win) => win.localStorage.removeItem("grouping"));
+  });
+
   it("renders the correct heading", () => {
     cy.findByRole("heading", {
       name: /[0-9]+ machine[s]? in [0-9]+ pool[s]?/i,
@@ -33,7 +39,7 @@ context("Machine listing", () => {
     });
     GROUP_BY_OPTIONS.forEach((option) => {
       getGroupBySelect().select(option);
-      cy.waitForTableToLoad({ name: "Machines" });
+      cy.findByRole("grid", { name: `Machines - ${option}` }).should("exist");
     });
   });
 
@@ -45,7 +51,7 @@ context("Machine listing", () => {
     cy.findByRole("combobox", { name: "Group by" }).select("Group by status");
     cy.findByRole("searchbox").type(searchFilter);
     cy.findByText(/Showing 2 out of 2 machines/).should("exist");
-    cy.findByRole("grid", { name: "Machines" }).within(() =>
+    cy.findByRole("grid", { name: /Machines/ }).within(() =>
       // eslint-disable-next-line cypress/no-force
       cy
         .findByRole("checkbox", { name: /Commissioning/i })

--- a/src/app/kvm/components/VmResources/VmResources.test.tsx
+++ b/src/app/kvm/components/VmResources/VmResources.test.tsx
@@ -92,7 +92,7 @@ describe("VmResources", () => {
     );
     expect(
       screen.getByRole("grid", {
-        name: MachineListLabel.Machines,
+        name: new RegExp(MachineListLabel.Machines, "i"),
       })
     ).toBeInTheDocument();
   });

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -1,3 +1,4 @@
+import { FetchGroupKey } from "app/store/machine/types";
 import { NodeActions } from "app/store/types/node";
 
 export const MachineActionSidePanelViews = {
@@ -85,3 +86,51 @@ export const columnLabels: Record<MachineColumns, string> = {
   disks: "Disks",
   storage: "Storage",
 };
+
+export const groupOptions: Array<{ value: FetchGroupKey | ""; label: string }> =
+  [
+    {
+      value: "",
+      label: "No grouping",
+    },
+    {
+      value: FetchGroupKey.Status,
+      label: "Group by status",
+    },
+    {
+      value: FetchGroupKey.Owner,
+      label: "Group by owner",
+    },
+    {
+      value: FetchGroupKey.Pool,
+      label: "Group by resource pool",
+    },
+    {
+      value: FetchGroupKey.Architecture,
+      label: "Group by architecture",
+    },
+    {
+      value: FetchGroupKey.Domain,
+      label: "Group by domain",
+    },
+    {
+      value: FetchGroupKey.Parent,
+      label: "Group by parent",
+    },
+    {
+      value: FetchGroupKey.Pod,
+      label: "Group by KVM",
+    },
+    {
+      value: FetchGroupKey.PodType,
+      label: "Group by KVM type",
+    },
+    {
+      value: FetchGroupKey.PowerState,
+      label: "Group by power state",
+    },
+    {
+      value: FetchGroupKey.Zone,
+      label: "Group by zone",
+    },
+  ];

--- a/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/GroupSelect/GroupSelect.tsx
@@ -1,59 +1,13 @@
 import { Select } from "@canonical/react-components";
 
-import { FetchGroupKey } from "app/store/machine/types/actions";
+import { groupOptions } from "app/machines/constants";
+import type { FetchGroupKey } from "app/store/machine/types/actions";
 
 type Props = {
   grouping: FetchGroupKey | null;
   setGrouping: (group: FetchGroupKey | null) => void;
   setHiddenGroups: (groups: string[]) => void;
 };
-
-const groupOptions: Array<{ value: FetchGroupKey | ""; label: string }> = [
-  {
-    value: "",
-    label: "No grouping",
-  },
-  {
-    value: FetchGroupKey.Status,
-    label: "Group by status",
-  },
-  {
-    value: FetchGroupKey.Owner,
-    label: "Group by owner",
-  },
-  {
-    value: FetchGroupKey.Pool,
-    label: "Group by resource pool",
-  },
-  {
-    value: FetchGroupKey.Architecture,
-    label: "Group by architecture",
-  },
-  {
-    value: FetchGroupKey.Domain,
-    label: "Group by domain",
-  },
-  {
-    value: FetchGroupKey.Parent,
-    label: "Group by parent",
-  },
-  {
-    value: FetchGroupKey.Pod,
-    label: "Group by KVM",
-  },
-  {
-    value: FetchGroupKey.PodType,
-    label: "Group by KVM type",
-  },
-  {
-    value: FetchGroupKey.PowerState,
-    label: "Group by power state",
-  },
-  {
-    value: FetchGroupKey.Zone,
-    label: "Group by zone",
-  },
-];
 
 const GroupSelect = ({
   grouping,

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListTable.tsx
@@ -19,7 +19,12 @@ import type { MachineListTableProps } from "./types";
 import TableHeader from "app/base/components/TableHeader";
 import { useSendAnalytics } from "app/base/hooks";
 import { SortDirection } from "app/base/types";
-import { columnLabels, columns, MachineColumns } from "app/machines/constants";
+import {
+  columnLabels,
+  columns,
+  MachineColumns,
+  groupOptions,
+} from "app/machines/constants";
 import { actions as generalActions } from "app/store/general";
 import { FetchGroupKey } from "app/store/machine/types";
 import { FilterMachines } from "app/store/machine/utils";
@@ -407,6 +412,11 @@ export const MachineListTable = ({
     [rows, selectionState]
   );
 
+  const groupByStatus = useMemo(
+    () => groupOptions.find(({ value }) => value === grouping)?.label ?? "",
+    [grouping]
+  );
+
   return (
     <>
       {machineCount ? (
@@ -438,7 +448,12 @@ export const MachineListTable = ({
         </div>
       ) : null}
       <MainTable
-        aria-label={machinesLoading ? Label.Loading : Label.Machines}
+        aria-describedby="machine-list-description"
+        aria-label={
+          machinesLoading
+            ? Label.Loading
+            : `${Label.Machines} - ${groupByStatus}`
+        }
         className={classNames("p-table-expanding--light", "machine-list", {
           "machine-list--grouped": grouping,
           "machine-list--loading": machinesLoading,

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -175,7 +175,7 @@ describe("Machines", () => {
     loaded: true,
     groups: [
       machineStateListGroupFactory({
-        items: [machines[0].system_id, machines[2].system_id],
+        items: [machines[0].system_id],
         name: "Deployed",
         value: FetchNodeStatus.DEPLOYED,
       }),
@@ -374,7 +374,9 @@ describe("Machines", () => {
     jest.spyOn(reduxToolkit, "nanoid").mockReturnValue("mocked-nanoid");
     const store = mockStore(state);
     renderWithBrowserRouter(<Machines />, { store });
-    expect(screen.getByLabelText(/Group by/)).toHaveValue(DEFAULTS.grouping);
+    expect(screen.getByRole("combobox", { name: /Group by/ })).toHaveValue(
+      DEFAULTS.grouping
+    );
     const expected = machineActions.fetch("123456", {
       group_key: DEFAULTS.grouping,
     });


### PR DESCRIPTION
## Done

- test: fix cypress machine list test #5041
  - add grouping status to machine list table label
  - cleanup stored machine list grouping after each test
  - fix invalid test setup data resulting in duplicate keys
  - move `groupOptions` to shared `constants.ts` file 

## Fixes

Fixes:  #5041
