### PR TITLE
fix: DHCP snippets machine pagination

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.test.tsx
@@ -135,4 +135,20 @@ describe("MachineListPagination", () => {
 
     expect(pageInput).toHaveValue(1);
   });
+
+  // this is important if pagination is nested in a form that has a submit handler and does not use preventDefault
+  it("does not trigger native form event when the pagination buttons are pressed", async () => {
+    const handleSubmit = jest.fn();
+    render(
+      <form onSubmit={handleSubmit}>
+        <MachineListPagination {...props} />
+      </form>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+    expect(handleSubmit).not.toHaveBeenCalled();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Previous page" })
+    );
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination.tsx
@@ -63,6 +63,7 @@ const MachineListPagination = ({
             setPageNumber((page) => Number(page) - 1);
             props.paginate(props.currentPage - 1);
           }}
+          type="button"
         >
           <Icon name="chevron-down" />
         </Button>
@@ -112,6 +113,7 @@ const MachineListPagination = ({
             setPageNumber((page) => Number(page) + 1);
             props.paginate(props.currentPage + 1);
           }}
+          type="button"
         >
           <Icon name="chevron-down" />
         </Button>


### PR DESCRIPTION
## Done

- fix: DHCP snippets machine pagination


### QA steps

- Go to DHCP snippets
- click "add snippet"
- select type machine
- ensure that pagination buttons work correctly and requested page is displayed
