### PR TITLE
update document semantics MAASENG-1263

### DIFF
--- a/cypress/e2e/with-users/base/navigation.spec.ts
+++ b/cypress/e2e/with-users/base/navigation.spec.ts
@@ -77,7 +77,7 @@ context("Navigation - admin - collapse", () => {
         name: /main navigation/i,
       });
     getMainNavigation().should("not.be.visible");
-    cy.findByRole("banner").within(() =>
+    cy.findByRole("banner", { name: /navigation/i }).within(() =>
       cy.findByRole("button", { name: "Menu" }).click()
     );
     getMainNavigation()

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -122,7 +122,7 @@ const AppSideNavigation = (): JSX.Element => {
 
   return (
     <>
-      <header className="l-navigation-bar">
+      <header aria-label="navigation" className="l-navigation-bar">
         <div className={classNames("p-panel is-dark", `is-maas-${theme}`)}>
           <div className="p-panel__header">
             <NavigationBanner />

--- a/src/app/base/components/MainContentSection/MainContentSection.test.tsx
+++ b/src/app/base/components/MainContentSection/MainContentSection.test.tsx
@@ -1,35 +1,45 @@
 import MainContentSection from "./MainContentSection";
 
-import { renderWithMockStore, screen } from "testing/utils";
+import { renderWithMockStore, screen, within } from "testing/utils";
 
-describe("MainContentSection", () => {
-  it("renders sidebar", () => {
-    renderWithMockStore(
-      <MainContentSection header="Settings" sidebar={<div>Sidebar</div>}>
-        content
-      </MainContentSection>
-    );
-    expect(screen.getByRole("complementary")).toBeInTheDocument();
-  });
+it("renders sidebar", () => {
+  renderWithMockStore(
+    <MainContentSection header="Settings" sidebar={<div>Sidebar</div>}>
+      content
+    </MainContentSection>
+  );
+  expect(screen.getByRole("complementary")).toBeInTheDocument();
+});
 
-  it("renders without a sidebar", () => {
-    renderWithMockStore(
-      <MainContentSection header="Settings">content</MainContentSection>
-    );
-    expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
-  });
+it("renders without a sidebar", () => {
+  renderWithMockStore(
+    <MainContentSection header="Settings">content</MainContentSection>
+  );
+  expect(screen.queryByRole("complementary")).not.toBeInTheDocument();
+});
 
-  it("can render a node as a title", () => {
-    renderWithMockStore(
-      <MainContentSection header={<h5>Node title</h5>}>
-        content
-      </MainContentSection>
-    );
-    expect(
-      screen.getByRole("heading", {
+it("can render without a header", () => {
+  renderWithMockStore(
+    <MainContentSection header={null}>content</MainContentSection>
+  );
+  expect(
+    screen.queryByRole("banner", { name: "main content" })
+  ).not.toBeInTheDocument();
+});
+
+it("can render a node as a title", () => {
+  renderWithMockStore(
+    <MainContentSection header={<h5>Node title</h5>}>
+      content
+    </MainContentSection>
+  );
+  expect(
+    within(screen.getByRole("banner", { name: "main content" })).getByRole(
+      "heading",
+      {
         name: "Node title",
         level: 5,
-      })
-    ).toBeInTheDocument();
-  });
+      }
+    )
+  ).toBeInTheDocument();
 });

--- a/src/app/base/components/MainContentSection/MainContentSection.tsx
+++ b/src/app/base/components/MainContentSection/MainContentSection.tsx
@@ -1,6 +1,6 @@
 import type { HTMLProps, ReactNode } from "react";
 
-import { Col, Row, Strip } from "@canonical/react-components";
+import { Col, Strip } from "@canonical/react-components";
 import type { ColSize } from "@canonical/react-components";
 
 import NotificationList from "app/base/components/NotificationList";
@@ -25,9 +25,9 @@ const MainContentSection = ({
     <div {...props} id="main-content-section">
       <div>
         {header ? (
-          <Row>
+          <header aria-label="main content" className="row">
             <Col size={12}>{header}</Col>
-          </Row>
+          </header>
         ) : null}
         <Strip element="section" includeCol={false} shallow>
           {sidebar && (

--- a/src/app/base/components/ModelNotFound/ModelNotFound.tsx
+++ b/src/app/base/components/ModelNotFound/ModelNotFound.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom-v5-compat";
 
-import MainContentSection from "app/base/components/MainContentSection";
+import PageContent from "../PageContent";
+
 import SectionHeader from "app/base/components/SectionHeader";
 import { capitaliseFirst, isId } from "app/utils";
 
@@ -34,12 +35,14 @@ const ModelNotFound = ({
     </p>
   );
   return inSection ? (
-    <MainContentSection
+    <PageContent
       data-testid={TestIds.NotFound}
       header={<SectionHeader title={title} />}
+      sidePanelContent={null}
+      sidePanelTitle={null}
     >
       {content}
-    </MainContentSection>
+    </PageContent>
   ) : (
     <>
       <h4>{title}</h4>

--- a/src/app/dashboard/views/Dashboard.tsx
+++ b/src/app/dashboard/views/Dashboard.tsx
@@ -8,7 +8,6 @@ import ClearAllForm from "./DashboardHeader/ClearAllForm";
 import DiscoveriesList from "./DiscoveriesList";
 import { DashboardSidePanelViews } from "./constants";
 
-import MainContentSection from "app/base/components/MainContentSection";
 import PageContent from "app/base/components/PageContent";
 import SectionHeader from "app/base/components/SectionHeader";
 import { useSidePanel } from "app/base/side-panel-context";
@@ -30,8 +29,10 @@ const Dashboard = (): JSX.Element => {
 
   if (!isAdmin) {
     return (
-      <MainContentSection
+      <PageContent
         header={<SectionHeader title={Label.Permissions} />}
+        sidePanelContent={null}
+        sidePanelTitle={null}
       />
     );
   }

--- a/src/app/intro/views/Intro.tsx
+++ b/src/app/intro/views/Intro.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { useEffect } from "react";
 
-import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import {
   Route,
@@ -19,6 +18,7 @@ import MaasIntroSuccess from "./MaasIntroSuccess";
 import UserIntro from "./UserIntro";
 
 import PageContent from "app/base/components/PageContent";
+import SectionHeader from "app/base/components/SectionHeader";
 import { useCompletedIntro, useCompletedUserIntro } from "app/base/hooks";
 import urls from "app/base/urls";
 import authSelectors from "app/store/auth/selectors";
@@ -66,18 +66,19 @@ const Intro = (): JSX.Element => {
 
   let content: ReactNode;
   if (authLoading || configLoading) {
-    content = <Spinner text="Loading..." />;
+    content = (
+      <PageContent
+        header={<SectionHeader loading />}
+        sidePanelContent={null}
+        sidePanelTitle={null}
+      />
+    );
   } else if (showIncomplete) {
-    // Prevent the user from reaching any of the intro urls if they are not an
-    // admin.
+    // Prevent the user from reaching any of the intro urls if they are not an admin
     content = <IncompleteCard />;
   }
   if (content) {
-    return (
-      <PageContent sidePanelContent={null} sidePanelTitle={null}>
-        {content}
-      </PageContent>
-    );
+    return <>{content}</>;
   }
   const base = `${urls.intro.index}`;
   return (


### PR DESCRIPTION
## Done

- update document semantics MAASENG-1263
  - add labels to header elements 

## QA

### QA steps

- Go to dashboard
- verify it's displayed correctly
- In a new MAAS instance (alternatively you can remove redirects from components in order to force /intro routes to persist) that doesn't have user intro completed:
  - Go through all user setup steps
  - Verify each step is displayed correctly

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1263


## Screenshots

### user intro notifications along with regular notifications
![image](https://github.com/canonical/maas-ui/assets/7452681/ec995117-4734-48dc-b5ef-6baf1921d693)

### user intro loading state
#### before
![image](https://github.com/canonical/maas-ui/assets/7452681/9eedb9ef-ac1a-46aa-ab56-d09eca5e1918)

#### after
![image](https://github.com/canonical/maas-ui/assets/7452681/21f1ff1a-5e49-49ac-be54-8d30fe7257f7)

