### PR TITLE
fix(navigation): Prevent secondary navigation from displaying without auth MAASENG-1986

### DIFF
--- a/src/app/base/components/PageContent/PageContent.test.tsx
+++ b/src/app/base/components/PageContent/PageContent.test.tsx
@@ -1,6 +1,15 @@
 import PageContent from "./PageContent";
 
-import { renderWithBrowserRouter, screen, within } from "testing/utils";
+import { preferencesNavItems } from "app/preferences/constants";
+import { settingsNavItems } from "app/settings/constants";
+import {
+  getTestState,
+  renderWithBrowserRouter,
+  screen,
+  within,
+} from "testing/utils";
+
+const state = getTestState();
 
 it("displays sidebar with provided content", () => {
   renderWithBrowserRouter(
@@ -28,4 +37,80 @@ it("displays hidden sidebar when no content provided", () => {
     </PageContent>
   );
   expect(screen.queryByRole("complementary")).toHaveClass("is-collapsed");
+});
+
+it("shows the secondary navigation for settings", () => {
+  state.status.authenticated = true;
+  state.status.connected = true;
+  renderWithBrowserRouter(
+    <PageContent
+      header="Settings"
+      sidePanelContent={null}
+      sidePanelTitle={null}
+    >
+      content
+    </PageContent>,
+    { route: "/settings/configuration/general", state }
+  );
+
+  expect(screen.getByRole("navigation")).toBeInTheDocument();
+
+  settingsNavItems.forEach((item) => {
+    expect(screen.getByText(item.label)).toBeInTheDocument();
+  });
+});
+
+it("shows the secondary navigation for preferences", () => {
+  state.status.authenticated = true;
+  state.status.connected = true;
+  renderWithBrowserRouter(
+    <PageContent
+      header="Preferences"
+      sidePanelContent={null}
+      sidePanelTitle={null}
+    >
+      content
+    </PageContent>,
+    { route: "/account/prefs/details", state }
+  );
+
+  expect(screen.getByRole("navigation")).toBeInTheDocument();
+
+  preferencesNavItems.forEach((item) => {
+    expect(screen.getByText(item.label)).toBeInTheDocument();
+  });
+});
+
+it("doesn't show the side nav if not authenticated", () => {
+  state.status.authenticated = false;
+  state.status.connected = true;
+  renderWithBrowserRouter(
+    <PageContent
+      header="Preferences"
+      sidePanelContent={null}
+      sidePanelTitle={null}
+    >
+      content
+    </PageContent>,
+    { route: "/account/prefs/details", state }
+  );
+
+  expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
+});
+
+it("doesn't show the side nav if not connected", () => {
+  state.status.authenticated = true;
+  state.status.connected = false;
+  renderWithBrowserRouter(
+    <PageContent
+      header="Preferences"
+      sidePanelContent={null}
+      sidePanelTitle={null}
+    >
+      content
+    </PageContent>,
+    { route: "/account/prefs/details", state }
+  );
+
+  expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
 });

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -40,19 +40,18 @@ const PageContent = ({
   const authenticated = useSelector(status.authenticated);
   const connected = useSelector(status.connected);
   const hasSecondaryNav = isSettingsPage || isPreferencesPage;
-  const isSecondaryNavVisible =
-    hasSecondaryNav && authenticated && connected;
+  const isSecondaryNavVisible = hasSecondaryNav && authenticated && connected;
   const { theme } = useThemeContext();
 
   return (
     <>
       <main className="l-main">
-        {isSideNavVisible ? (
+        {isSecondaryNavVisible ? (
           <div
             className={classNames("l-main__nav", `is-maas-${theme}--accent`)}
           >
             <SecondaryNavigation
-              isOpen={!!isSideNavVisible}
+              isOpen={!!isSecondaryNavVisible}
               items={
                 isSettingsPage
                   ? settingsNavItems

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -39,8 +39,9 @@ const PageContent = ({
   const isPreferencesPage = matchPath("account/prefs/*", pathname);
   const authenticated = useSelector(status.authenticated);
   const connected = useSelector(status.connected);
-  const isSideNavVisible =
-    (isSettingsPage || isPreferencesPage) && authenticated && connected;
+  const hasSecondaryNav = isSettingsPage || isPreferencesPage;
+  const isSecondaryNavVisible =
+    hasSecondaryNav && authenticated && connected;
   const { theme } = useThemeContext();
 
   return (

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -1,6 +1,7 @@
 import type { HTMLProps, ReactNode } from "react";
 
 import classNames from "classnames";
+import { useSelector } from "react-redux";
 import { matchPath, useLocation } from "react-router-dom-v5-compat";
 
 import AppSidePanel from "../AppSidePanel";
@@ -11,6 +12,7 @@ import SecondaryNavigation from "../SecondaryNavigation";
 import { useThemeContext } from "app/base/theme-context";
 import { preferencesNavItems } from "app/preferences/constants";
 import { settingsNavItems } from "app/settings/constants";
+import status from "app/store/status/selectors";
 
 export type Props = {
   children?: ReactNode;
@@ -35,7 +37,10 @@ const PageContent = ({
   const { pathname } = useLocation();
   const isSettingsPage = matchPath("settings/*", pathname);
   const isPreferencesPage = matchPath("account/prefs/*", pathname);
-  const isSideNavVisible = isSettingsPage || isPreferencesPage;
+  const authenticated = useSelector(status.authenticated);
+  const connected = useSelector(status.connected);
+  const isSideNavVisible =
+    (isSettingsPage || isPreferencesPage) && authenticated && connected;
   const { theme } = useThemeContext();
 
   return (


### PR DESCRIPTION
## Done

- Prevent secondary navigation from displaying if user is not authenticated or connected
- Add tests to ensure secondary nav can display on /settings and /account routes
- Add tests to ensure secondary nav does not display without auth or connection

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

1. Go to /settings
2. Log out
3. Ensure navigation does not display
4. Log in
5. Go to /account 
6. Repeat steps 2-4
7. Stop MAAS-UI in the terminal
8. Ensure side navigation does not display

## Fixes

Fixes [MAASENG-1986](https://warthogs.atlassian.net/browse/MAASENG-1986)

[MAASENG-1986]: https://warthogs.atlassian.net/browse/MAASENG-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ