### PR TITLE
fix(navigation): Display usernames correctly for non-admins MAASENG-1987

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -123,8 +123,8 @@ export const AppSideNavItems = ({
       ) : null}
       {isAuthenticated ? (
         <>
-          <ul className="p-side-navigation__list">
-            {isAdmin && showLinks ? (
+          {isAdmin && showLinks ? (
+            <ul className="p-side-navigation__list">
               <>
                 <AppSideNavItem
                   icon="settings"
@@ -132,8 +132,8 @@ export const AppSideNavItems = ({
                   path={path}
                 />
               </>
-            ) : null}
-          </ul>
+            </ul>
+          ) : null}
           <ul className="p-side-navigation__list">
             <AppSideNavItem
               icon="profile"


### PR DESCRIPTION
## Done

- Non-admin usernames are now displayed correctly in the side navigation

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Log in as a non-admin user
- Ensure your name displays correctly in the navigation

## Fixes

Fixes [MAASENG-1987](https://warthogs.atlassian.net/browse/MAASENG-1987)

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/0ec50914-ccbb-4170-b15c-e531e7391bb4)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/9b4eb32c-e347-4489-ade4-09c6cce8d0d4)



[MAASENG-1987]: https://warthogs.atlassian.net/browse/MAASENG-1987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ