### PR TITLE
fix(navigation): prevent side nav display without auth 3.4 backport

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -58,8 +58,8 @@ export const App = (): JSX.Element => {
   const { pathname } = useLocation();
   const isSettingsPage = matchPath("settings/*", pathname);
   const isPreferencesPage = matchPath("account/prefs/*", pathname);
-  const isSideNavVisible =
-    (isSettingsPage || isPreferencesPage) && connected && authenticated;
+  const hasSideNav = isSettingsPage || isPreferencesPage;
+  const isSideNavVisible = hasSideNav && connected && authenticated;
 
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -58,7 +58,8 @@ export const App = (): JSX.Element => {
   const { pathname } = useLocation();
   const isSettingsPage = matchPath("settings/*", pathname);
   const isPreferencesPage = matchPath("account/prefs/*", pathname);
-  const isSideNavVisible = isSettingsPage || isPreferencesPage;
+  const isSideNavVisible =
+    (isSettingsPage || isPreferencesPage) && connected && authenticated;
 
   useEffect(() => {
     dispatch(statusActions.checkAuthenticated());


### PR DESCRIPTION
## Done

- Prevent side nav from displaying if user is not connected or authenticated

## QA

QA for this was completed in https://github.com/canonical/maas-ui/pull/5067

