### PR TITLE
fix:(navigation): Display non-admin usernames correctly 3.4 backport

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItems/AppSideNavItems.tsx
@@ -124,8 +124,8 @@ export const AppSideNavItems = ({
       ) : null}
       {isAuthenticated ? (
         <>
-          <ul className="p-side-navigation__list">
-            {isAdmin && showLinks ? (
+          {isAdmin && showLinks ? (
+            <ul className="p-side-navigation__list">
               <>
                 <AppSideNavItem
                   icon="settings"
@@ -133,8 +133,8 @@ export const AppSideNavItems = ({
                   path={path}
                 />
               </>
-            ) : null}
-          </ul>
+            </ul>
+          ) : null}
           <ul className="p-side-navigation__list">
             <AppSideNavItem
               icon="profile"


### PR DESCRIPTION
## Done

- Display non-admin usernames correctly in side nav

## QA

QA was completed as part of https://github.com/canonical/maas-ui/pull/5068

