### PR TITLE
integrate zones list endpoint MAASENG-1975

### DIFF
--- a/scripts/proxy.js
+++ b/scripts/proxy.js
@@ -16,9 +16,15 @@ app.get(`${BASENAME}/`, (req, res) =>
   res.redirect(`${BASENAME}${REACT_BASENAME}`)
 );
 
+const API_ENDPOINTS = [
+  `${BASENAME}/api`,
+  `${BASENAME}/accounts`,
+  `${BASENAME}/a`,
+];
+
 // Proxy API endpoints to the MAAS.
 app.use(
-  createProxyMiddleware([`${BASENAME}/api`, `${BASENAME}/accounts`], {
+  createProxyMiddleware(API_ENDPOINTS, {
     changeOrigin: true,
     onProxyReq(proxyReq) {
       // Django's CSRF protection requires requests to come from the correct

--- a/src/app/base/sagas/http.test.ts
+++ b/src/app/base/sagas/http.test.ts
@@ -15,380 +15,398 @@ import {
   deleteLicenseKeySaga,
   addMachineChassisSaga,
   ROOT_API,
+  SERVICE_API,
 } from "./http";
 
 import { ScriptType } from "app/store/script/types";
 import { ScriptResultNames } from "app/store/scriptresult/types";
 import { getCookie } from "app/utils";
+import { zone as zoneFactory } from "testing/factories";
 
 jest.mock("../../../bakery", () => {
   // Mock the bakery module.
 });
 
-describe("http sagas", () => {
-  describe("Auth API", () => {
+describe("Auth API", () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  describe("check authenticated", () => {
+    it("returns a SUCCESS action", () => {
+      const payload = { authenticated: true };
+      return expectSaga(checkAuthenticatedSaga)
+        .provide([[matchers.call.fn(api.auth.checkAuthenticated), payload]])
+        .put({ type: "status/checkAuthenticatedStart" })
+        .put({
+          type: "status/checkAuthenticatedSuccess",
+          payload,
+        })
+        .run();
+    });
+
+    it("handles errors", () => {
+      const error = new Error("kerblam!");
+      return expectSaga(checkAuthenticatedSaga)
+        .provide([
+          [matchers.call.fn(api.auth.checkAuthenticated), throwError(error)],
+        ])
+        .put({ type: "status/checkAuthenticatedStart" })
+        .put({
+          error: true,
+          type: "status/checkAuthenticatedError",
+          payload: error.message,
+        })
+        .run();
+    });
+  });
+
+  describe("login", () => {
+    it("returns a SUCCESS action", () => {
+      const payload = {
+        username: "koala",
+        password: "gumtree",
+      };
+      const action = {
+        type: "status/login",
+        payload,
+      };
+      return expectSaga(loginSaga, action)
+        .provide([[matchers.call.fn(api.auth.login), payload]])
+        .put({ type: "status/loginStart" })
+        .put({ type: "status/loginSuccess" })
+        .put({ type: "status/websocketConnect" })
+        .run();
+    });
+
+    it("handles errors", () => {
+      const payload = {
+        username: "koala",
+        password: "gumtree",
+      };
+      const action = {
+        type: "status/login",
+        payload,
+      };
+      const error = {
+        message: "Username not provided",
+        name: "error",
+      };
+      return expectSaga(loginSaga, action)
+        .provide([[matchers.call.fn(api.auth.login), throwError(error)]])
+        .put({ type: "status/loginStart" })
+        .put({ type: "status/loginError", error: true, payload: error })
+        .run();
+    });
+
+    it("encodes special characters", () => {
+      api.auth.login({
+        username: "ko&ala",
+        password: "gum%tree",
+      });
+      expect(fetch).toHaveBeenCalled();
+      expect(fetch.mock.calls[0][1]?.body?.toString()).toBe(
+        "username=ko%26ala&password=gum%25tree"
+      );
+    });
+  });
+
+  describe("externalLogin", () => {
+    it("returns a SUCCESS action", () => {
+      return expectSaga(externalLoginSaga)
+        .provide([[matchers.call.fn(api.auth.externalLogin), null]])
+        .put({ type: "status/externalLoginStart" })
+        .put({ type: "status/externalLoginSuccess" })
+        .put({ type: "status/websocketConnect" })
+        .run();
+    });
+
+    it("handles errors", () => {
+      const error = new Error("Unable to log in");
+      return expectSaga(externalLoginSaga)
+        .provide([
+          [matchers.call.fn(api.auth.externalLogin), throwError(error)],
+        ])
+        .put({ type: "status/externalLoginStart" })
+        .put({
+          type: "status/externalLoginError",
+          error: true,
+          payload: error.message,
+        })
+        .run();
+    });
+  });
+
+  describe("logout", () => {
+    it("returns a SUCCESS action", () => {
+      return expectSaga(logoutSaga)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.auth.logout), "csrf-token"],
+        ])
+        .put({ type: "status/logoutStart" })
+        .put({ type: "status/logoutSuccess" })
+        .put({ type: "status/websocketDisconnect" })
+        .run();
+    });
+
+    it("handles errors", () => {
+      const error = new Error("Username not provided");
+      return expectSaga(logoutSaga)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.auth.logout), throwError(error)],
+        ])
+        .put({ type: "status/logoutStart" })
+        .put({
+          type: "status/logoutError",
+          error: true,
+          payload: { error: error.message },
+        })
+        .run();
+    });
+  });
+});
+
+describe("Scripts API", () => {
+  describe("upload scripts", () => {
+    it("returns a SUCCESS action", () => {
+      const script = {
+        name: "script-1",
+        type: ScriptType.COMMISSIONING,
+        contents: "#!/bin/sh/necho 'hi'",
+      };
+      const action = {
+        type: "script/upload",
+        payload: script,
+      };
+      return expectSaga(uploadScriptSaga, action)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.scripts.upload), script],
+        ])
+        .put({ type: "script/uploadStart" })
+        .put({ type: "script/uploadSuccess", payload: script })
+        .run();
+    });
+
+    it("handles errors", () => {
+      const script = {
+        name: "script-1",
+        type: ScriptType.COMMISSIONING,
+        contents: "#!/bin/sh/necho 'hi'",
+      };
+      const action = { type: "script/upload", payload: script };
+      const error = {
+        message: "Script with that name already exists",
+        name: "error",
+      };
+      return expectSaga(uploadScriptSaga, action)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.scripts.upload), throwError(error)],
+        ])
+        .put({ type: "script/uploadStart" })
+        .put({
+          errors: true,
+          payload: error,
+          type: "script/uploadError",
+        })
+        .run();
+    });
+  });
+});
+
+describe("License Key API", () => {
+  describe("fetch license keys", () => {
+    it("returns a SUCCESS action", () => {
+      const payload = [{ osystem: "windows", distro_series: "2012" }];
+      return expectSaga(fetchLicenseKeysSaga)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.licenseKeys.fetch), payload],
+        ])
+        .put({ type: "licensekeys/fetchStart" })
+        .put({ type: "licensekeys/fetchSuccess", payload })
+        .run();
+    });
+  });
+
+  describe("update license keys", () => {
+    it("returns a SUCCESS action", () => {
+      const payload = {
+        id: 1,
+        osystem: "windows",
+        distro_series: "2012",
+        license_key: "foo",
+        resource_uri: "/key",
+      };
+      const action = {
+        type: "licensekeys/update",
+        payload,
+      };
+      return expectSaga(updateLicenseKeySaga, action)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.licenseKeys.update), payload],
+        ])
+        .put({ type: "licensekeys/updateStart" })
+        .put({ type: "licensekeys/updateSuccess", payload })
+        .run();
+    });
+  });
+
+  describe("delete license keys", () => {
+    it("returns a SUCCESS action", () => {
+      const payload = { osystem: "windows", distro_series: "2012" };
+      const action = {
+        type: "licensekeys/delete",
+        payload,
+      };
+      return expectSaga(deleteLicenseKeySaga, action)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.licenseKeys.delete), true],
+        ])
+        .put({ type: "licensekeys/deleteStart" })
+        .put({ type: "licensekeys/deleteSuccess", payload })
+        .run();
+    });
+  });
+});
+
+describe("Machines API", () => {
+  describe("add machine chassis", () => {
+    it("returns a success action", () => {
+      const payload = {
+        params: {
+          chassis_type: "powerkvm",
+          hostname: "qemu+ssh://virsh@127.0.0.1/system",
+        },
+      };
+      const action = {
+        type: "machine/addChassis",
+        payload,
+      };
+      return expectSaga(addMachineChassisSaga, action)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.machines.addChassis), payload],
+        ])
+        .put({ type: "machine/addChassisStart" })
+        .put({ type: "machine/addChassisSuccess", payload })
+        .run();
+    });
+
+    it("handles errors", () => {
+      const payload = {
+        params: {
+          hostname: "qemu+ssh://virsh@127.0.0.1/system",
+        },
+      };
+      const action = { type: "machine/addChassis", payload };
+      const error = new Error("Chassis type not provided");
+      return expectSaga(addMachineChassisSaga, action)
+        .provide([
+          [matchers.call.fn(getCookie), "csrf-token"],
+          [matchers.call.fn(api.machines.addChassis), throwError(error)],
+        ])
+        .put({ type: "machine/addChassisStart" })
+        .put({
+          type: "machine/addChassisError",
+          payload: error,
+        })
+        .run();
+    });
+  });
+});
+
+describe("scriptresults", () => {
+  describe("download", () => {
     beforeEach(() => {
       fetch.resetMocks();
     });
 
-    describe("check authenticated", () => {
-      it("returns a SUCCESS action", () => {
-        const payload = { authenticated: true };
-        return expectSaga(checkAuthenticatedSaga)
-          .provide([[matchers.call.fn(api.auth.checkAuthenticated), payload]])
-          .put({ type: "status/checkAuthenticatedStart" })
-          .put({
-            type: "status/checkAuthenticatedSuccess",
-            payload,
-          })
-          .run();
-      });
-
-      it("handles errors", () => {
-        const error = new Error("kerblam!");
-        return expectSaga(checkAuthenticatedSaga)
-          .provide([
-            [matchers.call.fn(api.auth.checkAuthenticated), throwError(error)],
-          ])
-          .put({ type: "status/checkAuthenticatedStart" })
-          .put({
-            error: true,
-            type: "status/checkAuthenticatedError",
-            payload: error.message,
-          })
-          .run();
-      });
+    it("handles a tar.xz file", async () => {
+      const blob = new Blob();
+      fetchMock.mockResponseOnce(JSON.stringify(blob));
+      const response = await api.scriptresults.download(
+        "abc123",
+        "current-installation",
+        ScriptResultNames.CURTIN_LOG,
+        "tar.xz"
+      );
+      expect(response).toMatchObject(blob);
+      expect(fetch).toHaveBeenCalledWith(
+        `${ROOT_API}nodes/abc123/results/current-installation/?op=download` +
+          "&filetype=tar.xz&filters=%2Ftmp%2Fcurtin-logs.tar",
+        expect.anything()
+      );
     });
 
-    describe("login", () => {
-      it("returns a SUCCESS action", () => {
-        const payload = {
-          username: "koala",
-          password: "gumtree",
-        };
-        const action = {
-          type: "status/login",
-          payload,
-        };
-        return expectSaga(loginSaga, action)
-          .provide([[matchers.call.fn(api.auth.login), payload]])
-          .put({ type: "status/loginStart" })
-          .put({ type: "status/loginSuccess" })
-          .put({ type: "status/websocketConnect" })
-          .run();
-      });
-
-      it("handles errors", () => {
-        const payload = {
-          username: "koala",
-          password: "gumtree",
-        };
-        const action = {
-          type: "status/login",
-          payload,
-        };
-        const error = {
-          message: "Username not provided",
-          name: "error",
-        };
-        return expectSaga(loginSaga, action)
-          .provide([[matchers.call.fn(api.auth.login), throwError(error)]])
-          .put({ type: "status/loginStart" })
-          .put({ type: "status/loginError", error: true, payload: error })
-          .run();
-      });
-
-      it("encodes special characters", () => {
-        api.auth.login({
-          username: "ko&ala",
-          password: "gum%tree",
-        });
-        expect(fetch).toHaveBeenCalled();
-        expect(fetch.mock.calls[0][1]?.body?.toString()).toBe(
-          "username=ko%26ala&password=gum%25tree"
-        );
-      });
+    it("handles a txt file", async () => {
+      fetch.mockResponse("file contents");
+      const response = await api.scriptresults.download(
+        "abc123",
+        "current-installation",
+        "/tmp/curtin-logs.txt",
+        "txt"
+      );
+      expect(response).toBe("file contents");
+      expect(fetch).toHaveBeenCalledWith(
+        `${ROOT_API}nodes/abc123/results/current-installation/?op=download` +
+          "&filetype=txt&filters=%2Ftmp%2Fcurtin-logs.txt",
+        expect.anything()
+      );
     });
 
-    describe("externalLogin", () => {
-      it("returns a SUCCESS action", () => {
-        return expectSaga(externalLoginSaga)
-          .provide([[matchers.call.fn(api.auth.externalLogin), null]])
-          .put({ type: "status/externalLoginStart" })
-          .put({ type: "status/externalLoginSuccess" })
-          .put({ type: "status/websocketConnect" })
-          .run();
-      });
-
-      it("handles errors", () => {
-        const error = new Error("Unable to log in");
-        return expectSaga(externalLoginSaga)
-          .provide([
-            [matchers.call.fn(api.auth.externalLogin), throwError(error)],
-          ])
-          .put({ type: "status/externalLoginStart" })
-          .put({
-            type: "status/externalLoginError",
-            error: true,
-            payload: error.message,
-          })
-          .run();
-      });
-    });
-
-    describe("logout", () => {
-      it("returns a SUCCESS action", () => {
-        return expectSaga(logoutSaga)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.auth.logout), "csrf-token"],
-          ])
-          .put({ type: "status/logoutStart" })
-          .put({ type: "status/logoutSuccess" })
-          .put({ type: "status/websocketDisconnect" })
-          .run();
-      });
-
-      it("handles errors", () => {
-        const error = new Error("Username not provided");
-        return expectSaga(logoutSaga)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.auth.logout), throwError(error)],
-          ])
-          .put({ type: "status/logoutStart" })
-          .put({
-            type: "status/logoutError",
-            error: true,
-            payload: { error: error.message },
-          })
-          .run();
-      });
-    });
-  });
-  describe("Scripts API", () => {
-    describe("upload scripts", () => {
-      it("returns a SUCCESS action", () => {
-        const script = {
-          name: "script-1",
-          type: ScriptType.COMMISSIONING,
-          contents: "#!/bin/sh/necho 'hi'",
-        };
-        const action = {
-          type: "script/upload",
-          payload: script,
-        };
-        return expectSaga(uploadScriptSaga, action)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.scripts.upload), script],
-          ])
-          .put({ type: "script/uploadStart" })
-          .put({ type: "script/uploadSuccess", payload: script })
-          .run();
-      });
-
-      it("handles errors", () => {
-        const script = {
-          name: "script-1",
-          type: ScriptType.COMMISSIONING,
-          contents: "#!/bin/sh/necho 'hi'",
-        };
-        const action = { type: "script/upload", payload: script };
-        const error = {
-          message: "Script with that name already exists",
-          name: "error",
-        };
-        return expectSaga(uploadScriptSaga, action)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.scripts.upload), throwError(error)],
-          ])
-          .put({ type: "script/uploadStart" })
-          .put({
-            errors: true,
-            payload: error,
-            type: "script/uploadError",
-          })
-          .run();
-      });
-    });
-  });
-
-  describe("License Key API", () => {
-    describe("fetch license keys", () => {
-      it("returns a SUCCESS action", () => {
-        const payload = [{ osystem: "windows", distro_series: "2012" }];
-        return expectSaga(fetchLicenseKeysSaga)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.licenseKeys.fetch), payload],
-          ])
-          .put({ type: "licensekeys/fetchStart" })
-          .put({ type: "licensekeys/fetchSuccess", payload })
-          .run();
-      });
-    });
-
-    describe("update license keys", () => {
-      it("returns a SUCCESS action", () => {
-        const payload = {
-          id: 1,
-          osystem: "windows",
-          distro_series: "2012",
-          license_key: "foo",
-          resource_uri: "/key",
-        };
-        const action = {
-          type: "licensekeys/update",
-          payload,
-        };
-        return expectSaga(updateLicenseKeySaga, action)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.licenseKeys.update), payload],
-          ])
-          .put({ type: "licensekeys/updateStart" })
-          .put({ type: "licensekeys/updateSuccess", payload })
-          .run();
-      });
-    });
-
-    describe("delete license keys", () => {
-      it("returns a SUCCESS action", () => {
-        const payload = { osystem: "windows", distro_series: "2012" };
-        const action = {
-          type: "licensekeys/delete",
-          payload,
-        };
-        return expectSaga(deleteLicenseKeySaga, action)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.licenseKeys.delete), true],
-          ])
-          .put({ type: "licensekeys/deleteStart" })
-          .put({ type: "licensekeys/deleteSuccess", payload })
-          .run();
-      });
-    });
-  });
-
-  describe("Machines API", () => {
-    describe("add machine chassis", () => {
-      it("returns a success action", () => {
-        const payload = {
-          params: {
-            chassis_type: "powerkvm",
-            hostname: "qemu+ssh://virsh@127.0.0.1/system",
-          },
-        };
-        const action = {
-          type: "machine/addChassis",
-          payload,
-        };
-        return expectSaga(addMachineChassisSaga, action)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.machines.addChassis), payload],
-          ])
-          .put({ type: "machine/addChassisStart" })
-          .put({ type: "machine/addChassisSuccess", payload })
-          .run();
-      });
-
-      it("handles errors", () => {
-        const payload = {
-          params: {
-            hostname: "qemu+ssh://virsh@127.0.0.1/system",
-          },
-        };
-        const action = { type: "machine/addChassis", payload };
-        const error = new Error("Chassis type not provided");
-        return expectSaga(addMachineChassisSaga, action)
-          .provide([
-            [matchers.call.fn(getCookie), "csrf-token"],
-            [matchers.call.fn(api.machines.addChassis), throwError(error)],
-          ])
-          .put({ type: "machine/addChassisStart" })
-          .put({
-            type: "machine/addChassisError",
-            payload: error,
-          })
-          .run();
-      });
-    });
-  });
-
-  describe("scriptresults", () => {
-    describe("download", () => {
-      beforeEach(() => {
-        fetch.resetMocks();
-      });
-
-      it("handles a tar.xz file", async () => {
-        const blob = new Blob();
-        fetchMock.mockResponseOnce(JSON.stringify(blob));
-        const response = await api.scriptresults.download(
+    it("handles errors", async () => {
+      const errorMessage = new Error("Uh oh!");
+      fetch.mockReject(errorMessage);
+      const error = await api.scriptresults
+        .download(
           "abc123",
           "current-installation",
           ScriptResultNames.CURTIN_LOG,
-          "tar.xz"
-        );
-        expect(response).toMatchObject(blob);
-        expect(fetch).toHaveBeenCalledWith(
-          `${ROOT_API}nodes/abc123/results/current-installation/?op=download` +
-            "&filetype=tar.xz&filters=%2Ftmp%2Fcurtin-logs.tar",
-          expect.anything()
-        );
-      });
-
-      it("handles a txt file", async () => {
-        fetch.mockResponse("file contents");
-        const response = await api.scriptresults.download(
-          "abc123",
-          "current-installation",
-          "/tmp/curtin-logs.txt",
           "txt"
-        );
-        expect(response).toBe("file contents");
-        expect(fetch).toHaveBeenCalledWith(
-          `${ROOT_API}nodes/abc123/results/current-installation/?op=download` +
-            "&filetype=txt&filters=%2Ftmp%2Fcurtin-logs.txt",
-          expect.anything()
-        );
-      });
+        )
+        .catch((error) => error);
+      expect(error).toBe(errorMessage);
+    });
+  });
 
-      it("handles errors", async () => {
-        const errorMessage = new Error("Uh oh!");
-        fetch.mockReject(errorMessage);
-        const error = await api.scriptresults
-          .download(
-            "abc123",
-            "current-installation",
-            ScriptResultNames.CURTIN_LOG,
-            "txt"
-          )
-          .catch((error) => error);
-        expect(error).toBe(errorMessage);
-      });
+  describe("getCurtinLogsTar", () => {
+    beforeEach(() => {
+      fetch.resetMocks();
     });
 
-    describe("getCurtinLogsTar", () => {
-      beforeEach(() => {
-        fetch.resetMocks();
-      });
-
-      it("can fetch a curtin log", async () => {
-        const testFile = "test file";
-        fetch.mockResponse(testFile);
-        const response = await api.scriptresults.getCurtinLogsTar("abc123");
-        expect(response).toBe(testFile);
-        expect(fetch).toHaveBeenCalledWith(
-          `${ROOT_API}nodes/abc123/results/current-installation/?op=download` +
-            "&filters=%2Ftmp%2Fcurtin-logs.tar",
-          expect.anything()
-        );
-      });
+    it("can fetch a curtin log", async () => {
+      const testFile = "test file";
+      fetch.mockResponse(testFile);
+      const response = await api.scriptresults.getCurtinLogsTar("abc123");
+      expect(response).toBe(testFile);
+      expect(fetch).toHaveBeenCalledWith(
+        `${ROOT_API}nodes/abc123/results/current-installation/?op=download` +
+          "&filters=%2Ftmp%2Fcurtin-logs.tar",
+        expect.anything()
+      );
     });
+  });
+});
+
+describe("zone list API", () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+
+  it("can fetch zones", async () => {
+    const zones = [zoneFactory()];
+    fetch.mockResponse(JSON.stringify(zones));
+    const response = await api.zones.fetch("csrf-token");
+    expect(response).toMatchObject(zones);
+    expect(fetch).toHaveBeenCalledWith(
+      `${SERVICE_API}zones`,
+      expect.anything()
+    );
   });
 });

--- a/src/app/base/sagas/index.ts
+++ b/src/app/base/sagas/index.ts
@@ -10,6 +10,7 @@ import {
   watchFetchLicenseKeys,
   watchUploadScript,
   watchAddMachineChassis,
+  watchZonesFetch,
 } from "./http";
 import { watchWebSockets } from "./websockets";
 
@@ -26,4 +27,5 @@ export {
   watchFetchLicenseKeys,
   watchUploadScript,
   watchAddMachineChassis,
+  watchZonesFetch,
 };

--- a/src/app/store/zone/actions.test.ts
+++ b/src/app/store/zone/actions.test.ts
@@ -26,10 +26,6 @@ it("can create an action for creating a zone", () => {
 it("can create an action for fetching zones", () => {
   expect(zoneActions[ZONE_ACTIONS.fetch]()).toEqual({
     type: `${ZoneMeta.MODEL}/${ZONE_ACTIONS.fetch}`,
-    meta: {
-      model: ZoneMeta.MODEL,
-      method: ZONE_WEBSOCKET_METHODS.list,
-    },
     payload: null,
   });
 });

--- a/src/app/store/zone/slice.ts
+++ b/src/app/store/zone/slice.ts
@@ -181,10 +181,6 @@ const zoneSlice = createSlice({
     },
     [fetch]: {
       prepare: () => ({
-        meta: {
-          model: ZoneMeta.MODEL,
-          method: ZONE_WEBSOCKET_METHODS.list,
-        },
         payload: null,
       }),
       reducer: () => {

--- a/src/root-saga.ts
+++ b/src/root-saga.ts
@@ -14,6 +14,7 @@ import {
   watchFetchLicenseKeys,
   watchUploadScript,
   watchAddMachineChassis,
+  watchZonesFetch,
 } from "./app/base/sagas";
 
 import type { MessageHandler } from "app/base/sagas/actions";
@@ -34,5 +35,6 @@ export default function* rootSaga(
     watchFetchLicenseKeys(),
     watchUploadScript(),
     watchAddMachineChassis(),
+    watchZonesFetch(),
   ]);
 }


### PR DESCRIPTION
## Done

- integrate zones list endpoint MAASENG-1975
  - call `/MAAS/a/v1/zones` REST endpoint instead of `zone.list` websocket API whenever `zone/fetch` redux action is called
  - reduce redundant tests nesting in `describe("http sagas", () => {`

## QA

### QA steps

- open developer tools and go to Network tab
- Go to machines list
- Verify that zones list has been fetched via REST API (should be in Fetch/XHR list) and there is no zone.list in websocket messages

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1975
