### PR TITLE
fix: cache zones list requests

### DIFF
--- a/src/app/base/sagas/loaded-endpoints.test.ts
+++ b/src/app/base/sagas/loaded-endpoints.test.ts
@@ -1,0 +1,26 @@
+import {
+  loadedEndpoints,
+  isLoaded,
+  setIsLoaded,
+  clearAllLoaded,
+} from "./loaded-endpoints";
+
+beforeEach(() => {
+  loadedEndpoints.clear();
+});
+
+it("returns false for unloaded endpoints", () => {
+  expect(isLoaded("test-endpoint")).toBe(false);
+});
+
+it("returns true for loaded endpoints", () => {
+  setIsLoaded("test-endpoint");
+  expect(isLoaded("test-endpoint")).toBe(true);
+});
+
+it("clears loaded endpoints", () => {
+  setIsLoaded("test-endpoint-1");
+  setIsLoaded("test-endpoint-2");
+  clearAllLoaded();
+  expect(loadedEndpoints.size).toBe(0);
+});

--- a/src/app/base/sagas/loaded-endpoints.ts
+++ b/src/app/base/sagas/loaded-endpoints.ts
@@ -1,0 +1,25 @@
+type Endpoint = string;
+type EndpointState = { fetchedAt: number };
+
+export const loadedEndpoints = new Map<Endpoint, EndpointState>();
+
+/**
+ * Whether an endpoint associated with an action type has already been fetched.
+ */
+export const isLoaded = (endpoint: Endpoint): boolean => {
+  return loadedEndpoints.has(endpoint);
+};
+
+/**
+ * Mark an endpoint associated with an action type as having been fetched.
+ */
+export const setIsLoaded = (endpoint: Endpoint): void => {
+  loadedEndpoints.set(endpoint, { fetchedAt: Date.now() });
+};
+
+/**
+ * Clear the loaded state of all endpoints.
+ */
+export const clearAllLoaded = (): void => {
+  loadedEndpoints.clear();
+};


### PR DESCRIPTION
## Done

- fix: cache zones list requests
  - replicate [existing logic for websocket messages](https://github.com/canonical/maas-ui/blob/8791189ade1660b822481cbe4cfaaca80082ab2d/src/app/base/sagas/websockets/websockets.ts#L331) for zones REST API endpoint

## Fixes

Cypress failures due to infinite loop of zones list API requests https://github.com/canonical/maas-ui/actions/runs/5620547616

## QA

### QA steps

1. Go to devices
2. Click Add device
3. Make sure zones list REST API endpoint has been called at least once and form displayed
