### PR TITLE
test: set channel for cypress tests to 3.4 beta

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,6 +14,7 @@ jobs:
         uses: canonical/setup-maas@main
         with:
           maas-url: ${{env.MAAS_URL}}/MAAS
+          channel: 3.4/beta
       - name: Install Cypress
         uses: cypress-io/github-action@v4
         with:


### PR DESCRIPTION
## Done

- test: set channel for cypress tests to 3.4 beta
