### PR TITLE
fix: AppSidePanel not closing on route change

### DIFF
--- a/cypress/e2e/with-users/base/side-panel.spec.ts
+++ b/cypress/e2e/with-users/base/side-panel.spec.ts
@@ -3,20 +3,37 @@ import { generateMAASURL } from "../../utils";
 context("Side panel", () => {
   beforeEach(() => {
     cy.login();
+    cy.expandMainNavigation();
     cy.visit(generateMAASURL("/devices"));
     // open side panel
     cy.findByRole("button", { name: /Add device/i }).click();
   });
 
   it("closes the side panel on ESC key press", () => {
-    cy.findByRole("heading", { name: "Add device" }).should("be.visible");
+    cy.findByTestId("app-side-panel").should("be.visible");
+    cy.findByRole("complementary", { name: "Add device" }).should("be.visible");
     cy.get("body").type("{esc}");
-    cy.findByRole("heading", { name: "Add device" }).should("not.exist");
+    cy.findByRole("complementary", { name: "Add device" }).should("not.exist");
+    cy.findByTestId("app-side-panel").should("not.be.visible");
   });
 
   it("closes the side panel when navigating to a different page", () => {
+    cy.findByTestId("app-side-panel").should("be.visible");
     cy.findByRole("heading", { name: "Add device" }).should("be.visible");
     cy.visit(generateMAASURL("/machines"));
-    cy.findByRole("heading", { name: "Add device" }).should("not.exist");
+    cy.findByTestId("app-side-panel").should("not.be.visible");
+    cy.waitForPageToLoad();
+    cy.visit(generateMAASURL("/controllers"));
+    cy.findByRole("button", { name: "Add rack controller" }).click();
+    cy.findByRole("complementary", { name: "Add controller" }).should(
+      "be.visible"
+    );
+    cy.getMainNavigation().within(() =>
+      cy.findByRole("link", { name: "LXD" }).click()
+    );
+    cy.waitForPageToLoad();
+    cy.findByRole("complementary", { name: "Add controller" }).should(
+      "not.exist"
+    );
   });
 });

--- a/src/app/base/components/AppSidePanel/AppSidePanel.tsx
+++ b/src/app/base/components/AppSidePanel/AppSidePanel.tsx
@@ -1,13 +1,8 @@
 import { useEffect, type ReactNode } from "react";
 
-import {
-  Col,
-  Row,
-  useOnEscapePressed,
-  usePrevious,
-} from "@canonical/react-components";
+import { Col, Row, useOnEscapePressed } from "@canonical/react-components";
 import classNames from "classnames";
-import { useLocation } from "react-router-dom-v5-compat";
+import { useHistory } from "react-router-dom";
 
 import type { SidePanelSize } from "app/base/side-panel-context";
 import { useSidePanel } from "app/base/side-panel-context";
@@ -20,15 +15,16 @@ export type AppSidePanelProps = {
 
 const useCloseSidePanelOnRouteChange = (): void => {
   const { setSidePanelContent } = useSidePanel();
-  const { pathname } = useLocation();
-  const previousPathname = usePrevious(pathname);
+  const history = useHistory();
 
   // close side panel on route change
   useEffect(() => {
-    if (pathname !== previousPathname) {
-      setSidePanelContent(null);
-    }
-  }, [pathname, previousPathname, setSidePanelContent]);
+    const unlisten = history.listen(() => setSidePanelContent(null));
+
+    return () => {
+      unlisten();
+    };
+  }, [history, setSidePanelContent]);
 };
 
 const useResetSidePanelOnUnmount = (): void => {
@@ -61,7 +57,7 @@ const AppSidePanelContent = ({
         "is-large": size === "large",
         "is-wide": size === "wide",
       })}
-      data-testid="section-header-content"
+      data-testid="app-side-panel"
       id="aside-panel"
     >
       <Row>

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -447,10 +447,9 @@ describe("Machines", () => {
       "0 machines in 0 pools"
     );
     expect(
-      within(screen.getByTestId("section-header-content")).getByRole(
-        "heading",
-        { level: 3 }
-      )
+      within(screen.getByTestId("app-side-panel")).getByRole("heading", {
+        level: 3,
+      })
     ).toHaveTextContent("Deploy");
   });
 });


### PR DESCRIPTION
## Done

- fix: AppSidePanel not closing on route change
  - add more thorough e2e tests
  - update side panel test id

## QA


### QA steps

- On the controller page, click add rack controller
- From the side navigation menu, go to 'LXD'
- Verify the side panel has been closed
