### PR TITLE
feat: add temporal & agent services

### DIFF
--- a/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerSummary/ServicesCard/ServicesCard.tsx
@@ -53,6 +53,10 @@ const SERVICE_ITEMS: ServiceItem[] = [
     types: [NodeType.REGION_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
   },
   {
+    name: ServiceName.TEMPORAL,
+    types: [NodeType.REGION_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
+  },
+  {
     name: ServiceName.RACKD,
     types: [NodeType.RACK_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
     children: [
@@ -62,6 +66,10 @@ const SERVICE_ITEMS: ServiceItem[] = [
       },
       {
         name: ServiceName.TFTP,
+        types: [NodeType.RACK_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
+      },
+      {
+        name: ServiceName.AGENT,
         types: [NodeType.RACK_CONTROLLER, NodeType.REGION_AND_RACK_CONTROLLER],
       },
     ],

--- a/src/app/store/service/types/enum.ts
+++ b/src/app/store/service/types/enum.ts
@@ -4,6 +4,7 @@ export enum ServiceMeta {
 }
 
 export enum ServiceName {
+  AGENT = "agent",
   BIND9 = "bind9",
   DHCPD = "dhcpd",
   DHCPD6 = "dhcpd6",
@@ -19,6 +20,7 @@ export enum ServiceName {
   SYSLOG_RACK = "syslog_rack",
   SYSLOG_REGION = "syslog_region",
   TFTP = "tftp",
+  TEMPORAL = "temporal",
 }
 
 export enum ServiceStatus {


### PR DESCRIPTION
## Done

- This PR adds new services under Controller summary. Service `agent` runs on the Rack Controller (also in Region+Rack setup). Service `temporal` runs on the Region controller (also in Region+Rack setup).
## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

## Screenshots

<img width="477" alt="image" src="https://github.com/canonical/maas-ui/assets/3663203/74e71373-2c5e-4ab3-9f5a-db3a76d59465">
