### PR TITLE
feat: responsive machine columns MAASENG-1505

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -108,6 +108,8 @@ context("Machine listing", () => {
 
   it("can hide machine table columns", () => {
     const allHeadersCount = 11;
+    cy.viewport("macbook-15");
+
     cy.findAllByRole("columnheader").should("have.length", allHeadersCount);
 
     cy.findAllByRole("button", { name: "Columns" }).click();
@@ -123,6 +125,12 @@ context("Machine listing", () => {
     // verify that the hidden column is still hidden after refresh
     cy.findAllByRole("columnheader").should("have.length", allHeadersCount - 1);
     cy.findByRole("header", { name: "Status" }).should("not.exist");
+
+    // verify that hidden columns are reset to default set for each breakpoint on window resize
+    cy.viewport("samsung-s10");
+    cy.findAllByRole("columnheader").should("have.length", 3);
+    cy.viewport("macbook-15");
+    cy.findAllByRole("columnheader").should("have.length", allHeadersCount);
   });
 
   it("can select a machine range", () => {

--- a/src/app/machines/views/MachineList/MachineList.tsx
+++ b/src/app/machines/views/MachineList/MachineList.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from "react";
 
 import type { ValueOf } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useStorageState } from "react-storage-hooks";
 
 import ErrorsNotification from "./ErrorsNotification";
 import MachineListTable from "./MachineListTable";
 import { DEFAULTS } from "./MachineListTable/constants";
+import { usePageSize, type useResponsiveColumns } from "./hooks";
 
 import VaultNotification from "app/base/components/VaultNotification";
 import { useWindowTitle } from "app/base/hooks";
@@ -21,14 +21,12 @@ import { useFetchMachines } from "app/store/machine/utils/hooks";
 
 type Props = {
   grouping: FetchGroupKey | null;
-  hiddenColumns: string[];
+  hiddenColumns: ReturnType<typeof useResponsiveColumns>[0];
   hiddenGroups: (string | null)[];
   headerFormOpen?: boolean;
   searchFilter: string;
   setHiddenGroups: (groups: (string | null)[]) => void;
 };
-
-const DEFAULT_PAGE_SIZE = DEFAULTS.pageSize;
 
 const MachineList = ({
   grouping,
@@ -48,16 +46,8 @@ const MachineList = ({
   const [sortDirection, setSortDirection] = useState<
     ValueOf<typeof SortDirection>
   >(DEFAULTS.sortDirection);
-  const [storedPageSize, setStoredPageSize] = useStorageState<number>(
-    localStorage,
-    "machineListPageSize",
-    DEFAULT_PAGE_SIZE
-  );
-  // fallback to default if the stored value is not valid
-  const pageSize =
-    storedPageSize && typeof storedPageSize === "number"
-      ? storedPageSize
-      : DEFAULT_PAGE_SIZE;
+
+  const [pageSize, setPageSize] = usePageSize();
 
   const {
     callId,
@@ -116,7 +106,7 @@ const MachineList = ({
         pageSize={pageSize}
         setCurrentPage={setCurrentPage}
         setHiddenGroups={setHiddenGroups}
-        setPageSize={setStoredPageSize}
+        setPageSize={setPageSize}
         setSortDirection={setSortDirection}
         setSortKey={setSortKey}
         sortDirection={sortDirection}

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -6,12 +6,6 @@ import { useDispatch } from "react-redux";
 import { Link } from "react-router-dom-v5-compat";
 import { useStorageState } from "react-storage-hooks";
 
-import AddHardwareMenu from "../MachineListHeader/AddHardwareMenu";
-
-import GroupSelect from "./GroupSelect";
-import HiddenColumnsSelect from "./HiddenColumnsSelect";
-import MachinesFilterAccordion from "./MachinesFilterAccordion";
-
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
 import NodeActionMenu from "app/base/components/NodeActionMenu";
 import NodeActionMenuGroup from "app/base/components/NodeActionMenuGroup";
@@ -19,6 +13,11 @@ import { useSendAnalytics } from "app/base/hooks";
 import urls from "app/base/urls";
 import { MachineSidePanelViews } from "app/machines/constants";
 import type { MachineSetSidePanelContent } from "app/machines/types";
+import GroupSelect from "app/machines/views/MachineList/MachineListControls/GroupSelect";
+import HiddenColumnsSelect from "app/machines/views/MachineList/MachineListControls/HiddenColumnsSelect";
+import MachinesFilterAccordion from "app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion";
+import AddHardwareMenu from "app/machines/views/MachineList/MachineListHeader/AddHardwareMenu";
+import type { useResponsiveColumns } from "app/machines/views/MachineList/hooks";
 import { actions as machineActions } from "app/store/machine";
 import type { FetchGroupKey } from "app/store/machine/types";
 import { useHasSelection } from "app/store/machine/utils/hooks";
@@ -34,7 +33,7 @@ export type MachineListControlsProps = {
   setGrouping: (group: FetchGroupKey | null) => void;
   setHiddenGroups: (groups: string[]) => void;
   hiddenColumns: string[];
-  setHiddenColumns: React.Dispatch<React.SetStateAction<string[]>>;
+  setHiddenColumns: ReturnType<typeof useResponsiveColumns>[1];
   setSidePanelContent: MachineSetSidePanelContent;
 };
 

--- a/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
+++ b/src/app/machines/views/MachineList/MachineListHeader/MachineListHeader.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
 import MachineListControls from "../MachineListControls";
+import type { useResponsiveColumns } from "../hooks";
 
 import MachinesHeader from "app/base/components/node/MachinesHeader";
 import type { SetSearchFilter } from "app/base/types";
@@ -15,10 +16,10 @@ import resourcePoolSelectors from "app/store/resourcepool/selectors";
 
 type Props = {
   grouping: FetchGroupKey | null;
-  hiddenColumns?: string[];
+  hiddenColumns?: ReturnType<typeof useResponsiveColumns>[0];
   setGrouping: (group: FetchGroupKey | null) => void;
   setHiddenGroups: (groups: string[]) => void;
-  setHiddenColumns: React.Dispatch<React.SetStateAction<string[]>>;
+  setHiddenColumns: ReturnType<typeof useResponsiveColumns>[1];
   searchFilter: string;
   setSearchFilter: SetSearchFilter;
   setSidePanelContent: MachineSetSidePanelContent;

--- a/src/app/machines/views/MachineList/_index.scss
+++ b/src/app/machines/views/MachineList/_index.scss
@@ -9,47 +9,47 @@
     margin-bottom: 0;
 
     .fqdn-col {
-      @include breakpoint-widths(45%, 35%, 26%, 24%, 20%);
+      width: 20%;
     }
 
     .power-col {
-      @include breakpoint-widths(25%, 17%, 14%, 12%, 10%);
+      width: 10%;
     }
 
     .status-col {
-      @include breakpoint-widths(30%, 28%, 18%, 18%, 15%);
+      width: 15%;
     }
 
     .owner-col {
-      @include breakpoint-widths(0, 20%, 8%, 9%, 9%);
+      width: 9%;
     }
 
     .pool-col {
-      @include breakpoint-widths(0, 0, 0, 0, 7%);
+      width: 7%;
     }
 
     .zone-col {
-      @include breakpoint-widths(0, 0, 0, 9%, 7%);
+      width: 7%;
     }
 
     .fabric-col {
-      @include breakpoint-widths(0, 0, 0, 0, 7%);
+      width: 7%;
     }
 
     .cores-col {
-      @include breakpoint-widths(0, 0, 8%, 6%, 6%);
+      width: 6%;
     }
 
     .ram-col {
-      @include breakpoint-widths(0, 0, 9%, 8%, 7%);
+      width: 7%;
     }
 
     .disks-col {
-      @include breakpoint-widths(0, 0, 8%, 6%, 6%);
+      width: 6%;
     }
 
     .storage-col {
-      @include breakpoint-widths(0, 0, 9%, 8%, 6%);
+      width: 6%;
     }
   }
 
@@ -70,13 +70,13 @@
   .machine-list__machine .p-table-menu {
     display: none;
   }
-  
+
   .machine-list .select-all-dropdown {
-      display: inline-flex;
-      margin-left: -0.8rem;
-      margin-top: -0.5rem;
-      padding: 0.5rem;
-      margin-right: 0.5rem;
+    display: inline-flex;
+    margin-left: -0.8rem;
+    margin-top: -0.5rem;
+    padding: 0.5rem;
+    margin-right: 0.5rem;
   }
 
   .machine-list__machine:last-child td {

--- a/src/app/machines/views/MachineList/hooks.ts
+++ b/src/app/machines/views/MachineList/hooks.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useMemo } from "react";
+
+import { useDispatch } from "react-redux";
+import { useStorageState } from "react-storage-hooks";
+
+import { DEFAULTS } from "./MachineListTable/constants";
+
+import type { MachineColumnToggle } from "app/machines/constants";
+import { actions as machineActions } from "app/store/machine/slice";
+import { FetchGroupKey } from "app/store/machine/types";
+
+const breakpoints: {
+  max: number;
+  hiddenColumns: MachineColumnToggle[];
+}[] = [
+  {
+    max: 600,
+    hiddenColumns: [
+      "owner",
+      "pool",
+      "zone",
+      "fabric",
+      "cpu",
+      "memory",
+      "disks",
+      "storage",
+    ],
+  },
+  {
+    max: 900,
+    hiddenColumns: [
+      "pool",
+      "zone",
+      "fabric",
+      "cpu",
+      "memory",
+      "disks",
+      "storage",
+    ],
+  },
+  { max: 1030, hiddenColumns: ["pool", "zone", "fabric"] },
+  { max: 1300, hiddenColumns: ["pool", "fabric"] },
+  { max: Infinity, hiddenColumns: [] },
+];
+
+export const useResponsiveColumns = () => {
+  const [persistedHiddenColumns, setHiddenColumns] = useStorageState<
+    string[] | null
+  >(localStorage, "machineListHiddenColumns", null);
+  const hiddenColumns = useMemo(
+    () => (persistedHiddenColumns ? persistedHiddenColumns : []),
+    [persistedHiddenColumns]
+  );
+
+  useEffect(() => {
+    const updateColumns = () => {
+      const breakpoint = breakpoints.find((b) => window.innerWidth <= b.max);
+      setHiddenColumns(breakpoint ? breakpoint.hiddenColumns : []);
+    };
+
+    // Update columns on mount and on window resize
+    if (persistedHiddenColumns === null) {
+      updateColumns();
+    }
+    window.addEventListener("resize", updateColumns);
+
+    // Clean up the event listener on unmount
+    return () => {
+      window.removeEventListener("resize", updateColumns);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return [hiddenColumns, setHiddenColumns] as const;
+};
+
+export const useGrouping = (): [
+  FetchGroupKey,
+  (group: FetchGroupKey | null) => void
+] => {
+  const dispatch = useDispatch();
+  const [storedGrouping, setStoredGrouping] =
+    useStorageState<FetchGroupKey | null>(
+      localStorage,
+      "grouping",
+      DEFAULTS.grouping
+    );
+
+  // fallback to "None" if the stored grouping is not valid
+  const grouping: FetchGroupKey =
+    typeof storedGrouping === "string" &&
+    Object.values(FetchGroupKey).includes(storedGrouping)
+      ? storedGrouping
+      : DEFAULTS.grouping;
+
+  const setGrouping = useCallback(
+    (group: FetchGroupKey | null) => {
+      setStoredGrouping(group);
+      // clear selected machines on grouping change
+      // we cannot reliably preserve the selected state for individual machines
+      // as we are only fetching information about a group from the back-end
+      dispatch(machineActions.setSelected(null));
+    },
+    [setStoredGrouping, dispatch]
+  );
+
+  return [grouping, setGrouping];
+};
+
+export const usePageSize = () => {
+  const [storedPageSize, setPageSize] = useStorageState<number>(
+    localStorage,
+    "machineListPageSize",
+    DEFAULTS.pageSize
+  );
+  // fallback to default if the stored value is not valid
+  const pageSize =
+    storedPageSize && typeof storedPageSize === "number"
+      ? storedPageSize
+      : DEFAULTS.pageSize;
+
+  return [pageSize, setPageSize] as const;
+};

--- a/src/app/machines/views/Machines.tsx
+++ b/src/app/machines/views/Machines.tsx
@@ -1,27 +1,24 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { useDispatch, useSelector } from "react-redux";
+import { useSelector } from "react-redux";
 import { useLocation, useNavigate, useMatch } from "react-router-dom-v5-compat";
 import { useStorageState } from "react-storage-hooks";
 
 import MachineForms from "../components/MachineForms";
 
 import MachineListHeader from "./MachineList/MachineListHeader";
-import { DEFAULTS } from "./MachineList/MachineListTable/constants";
+import { useGrouping, useResponsiveColumns } from "./MachineList/hooks";
 
 import PageContent from "app/base/components/PageContent/PageContent";
 import { useSidePanel } from "app/base/side-panel-context";
 import urls from "app/base/urls";
 import MachineList from "app/machines/views/MachineList";
-import { actions as machineActions } from "app/store/machine";
 import machineSelectors from "app/store/machine/selectors";
-import { FetchGroupKey } from "app/store/machine/types";
 import { selectedToFilters, FilterMachines } from "app/store/machine/utils";
 import { useMachineSelectedCount } from "app/store/machine/utils/hooks";
 import { getSidePanelTitle } from "app/store/utils/node/base";
 
 const Machines = (): JSX.Element => {
-  const dispatch = useDispatch();
   const navigate = useNavigate();
   const location = useLocation();
   const currentFilters = FilterMachines.queryStringToFilters(location.search);
@@ -56,35 +53,9 @@ const Machines = (): JSX.Element => {
     [navigate, setFilter]
   );
 
-  const [storedGrouping, setStoredGrouping] =
-    useStorageState<FetchGroupKey | null>(
-      localStorage,
-      "grouping",
-      DEFAULTS.grouping
-    );
-  // fallback to "None" if the stored grouping is not valid
-  const grouping: FetchGroupKey =
-    typeof storedGrouping === "string" &&
-    Object.values(FetchGroupKey).includes(storedGrouping)
-      ? storedGrouping
-      : DEFAULTS.grouping;
+  const [grouping, setGrouping] = useGrouping();
 
-  const [hiddenColumns, setHiddenColumns] = useStorageState<string[]>(
-    localStorage,
-    "machineListHiddenColumns",
-    []
-  );
-
-  const handleSetGrouping = useCallback(
-    (group: FetchGroupKey | null) => {
-      setStoredGrouping(group);
-      // clear selected machines on grouping change
-      // we cannot reliably preserve the selected state for individual machines
-      // as we are only fetching information about a group from the back-end
-      dispatch(machineActions.setSelected(null));
-    },
-    [setStoredGrouping, dispatch]
-  );
+  const [hiddenColumns, setHiddenColumns] = useResponsiveColumns();
 
   // Get the count of selected machines that match the current filter
   const { selectedCount, selectedCountLoading } =
@@ -103,7 +74,7 @@ const Machines = (): JSX.Element => {
           grouping={grouping}
           hiddenColumns={hiddenColumns}
           searchFilter={searchFilter}
-          setGrouping={handleSetGrouping}
+          setGrouping={setGrouping}
           setHiddenColumns={setHiddenColumns}
           setHiddenGroups={setHiddenGroups}
           setSearchFilter={setSearchFilter}


### PR DESCRIPTION
## Done

- feat: responsive machine columns MAASENG-1505
- extract machine list table utils to hooks: `usePageSize`, `useGrouping`, `useResponsiveColumns`

## QA

### QA steps

- Go to machine list
- Open the columns dropdown
- Make sure you have all columns checked
- WIth the dropdown still open, start resizing the widow down and verify that columns are unchecked progressively as the window size decreases
- With the window size set to the smallest size, enable additional columns
- Without changing the window size, refresh the page
- Columns should remain the same
- Slowly start to increase the window size
- As you increase the window size the columns should reset to the default set for each breakpoint

## Fixes

Fixes:  https://warthogs.atlassian.net/browse/MAASENG-1505


