### PR TITLE
feat: global "/" search key shortcut

### DIFF
--- a/src/app/base/components/ActionBar/ActionBar.tsx
+++ b/src/app/base/components/ActionBar/ActionBar.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
 
 import type { SearchBoxProps } from "@canonical/react-components";
-import { SearchBox } from "@canonical/react-components";
 
 import ArrowPagination from "app/base/components/ArrowPagination";
+import SearchBox from "app/base/components/SearchBox";
 
 type Props = {
   actions?: ReactNode;

--- a/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
+++ b/src/app/base/components/DebounceSearchBox/DebounceSearchBox.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from "react";
 
 import type { SearchBoxProps } from "@canonical/react-components";
-import { Icon, SearchBox } from "@canonical/react-components";
+import { Icon } from "@canonical/react-components";
 import classNames from "classnames";
+
+import SearchBox from "app/base/components/SearchBox";
 
 type Props = {
   debounceInterval?: number;

--- a/src/app/base/components/SearchBox/SearchBox.test.tsx
+++ b/src/app/base/components/SearchBox/SearchBox.test.tsx
@@ -1,0 +1,11 @@
+import SearchBox from "./SearchBox";
+
+import { render, screen, userEvent } from "testing/utils";
+
+it("focuses on the search box when pressing '/' key", async () => {
+  render(<SearchBox />);
+  const searchBox = screen.getByRole("searchbox");
+  expect(searchBox).not.toHaveFocus();
+  await userEvent.type(document.body, "/");
+  expect(searchBox).toHaveFocus();
+});

--- a/src/app/base/components/SearchBox/SearchBox.tsx
+++ b/src/app/base/components/SearchBox/SearchBox.tsx
@@ -1,0 +1,19 @@
+import { useRef } from "react";
+
+import type { SearchBoxProps } from "@canonical/react-components";
+import { SearchBox as BaseSearchBox } from "@canonical/react-components";
+
+import { useGlobalKeyShortcut } from "app/base/hooks/base";
+
+const SearchBox = (props: SearchBoxProps): JSX.Element => {
+  const searchBoxRef = useRef<HTMLInputElement>(null);
+
+  useGlobalKeyShortcut("/", (e) => {
+    e.preventDefault();
+    searchBoxRef.current?.focus?.();
+  });
+
+  return <BaseSearchBox {...props} ref={searchBoxRef} />;
+};
+
+export default SearchBox;

--- a/src/app/base/components/SearchBox/index.ts
+++ b/src/app/base/components/SearchBox/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SearchBox";

--- a/src/app/base/components/node/NodeLogs/EventLogs/EventLogs.tsx
+++ b/src/app/base/components/node/NodeLogs/EventLogs/EventLogs.tsx
@@ -1,19 +1,13 @@
 import { useEffect, useState } from "react";
 
-import {
-  Col,
-  Link,
-  Row,
-  SearchBox,
-  Select,
-  Spinner,
-} from "@canonical/react-components";
+import { Col, Link, Row, Select, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import { useStorageState } from "react-storage-hooks";
 
 import EventLogsTable from "./EventLogsTable";
 
 import ArrowPagination from "app/base/components/ArrowPagination";
+import SearchBox from "app/base/components/SearchBox";
 import type { ControllerDetails } from "app/store/controller/types";
 import { actions as eventActions } from "app/store/event";
 import eventSelectors from "app/store/event/selectors";

--- a/src/app/base/constants.ts
+++ b/src/app/base/constants.ts
@@ -42,5 +42,5 @@ export const COLOURS = {
 } as const;
 
 // global keyboard shortcuts
-export const KEYBOARD_SHORTCUTS = ["["] as const;
+export const KEYBOARD_SHORTCUTS = ["[", "/"] as const;
 export type KeyboardShortcut = (typeof KEYBOARD_SHORTCUTS)[number];

--- a/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
+++ b/src/app/dashboard/views/DiscoveriesList/DiscoveriesList.tsx
@@ -6,7 +6,6 @@ import {
   ContextualMenu,
   MainTable,
   Row,
-  SearchBox,
   Spinner,
 } from "@canonical/react-components";
 import classNames from "classnames";
@@ -19,6 +18,7 @@ import DiscoveriesFilterAccordion from "./DiscoveriesFilterAccordion";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import MacAddressDisplay from "app/base/components/MacAddressDisplay";
+import SearchBox from "app/base/components/SearchBox";
 import TableDeleteConfirm from "app/base/components/TableDeleteConfirm";
 import TooltipButton from "app/base/components/TooltipButton";
 import { useWindowTitle } from "app/base/hooks";

--- a/src/app/settings/components/SettingsTable/SettingsTable.tsx
+++ b/src/app/settings/components/SettingsTable/SettingsTable.tsx
@@ -2,13 +2,14 @@ import {
   Button,
   Link as VanillaLink,
   MainTable,
-  SearchBox,
   Spinner,
   Tooltip,
 } from "@canonical/react-components";
 import type { MainTableProps } from "@canonical/react-components";
 import classNames from "classnames";
 import { Link } from "react-router-dom-v5-compat";
+
+import SearchBox from "app/base/components/SearchBox";
 
 export type TableButtons = {
   disabled?: boolean;


### PR DESCRIPTION
## Done

- feat: global "/" search key shortcut

## QA

### QA steps
Repeat the steps below on pages: machine list, tags, controllers subnets, network discovery, settings/users

- Open the page
- Press "/"
- Verify that the search box has focus and you can start typing immediately

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-2106
