### PR TITLE
Maaseng 2102 extend storage card fullwifth

### DIFF
--- a/src/app/kvm/components/LXDVMsTable/VMsTable/_index.scss
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/_index.scss
@@ -34,9 +34,9 @@
     .select-all-dropdown {
       display: inline-flex;
       margin-left: -0.8rem;
-      margin-top: -0.5rem;
-      padding: 0.5rem;
-      margin-right: 0.5rem;
+      margin-top: -$spv--small;
+      padding: $sph--small;
+      margin-right: $sph--small;
     }
   }
 }

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/_index.scss
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/_index.scss
@@ -30,5 +30,13 @@
     .pool-col {
       @include breakpoint-widths(0, 0, 0, 0, 12%);
     }
+
+    .select-all-dropdown {
+      display: inline-flex;
+      margin-left: -0.8rem;
+      margin-top: -0.5rem;
+      padding: 0.5rem;
+      margin-right: 0.5rem;
+    }
   }
 }

--- a/src/app/kvm/components/StorageResources/StorageResources.tsx
+++ b/src/app/kvm/components/StorageResources/StorageResources.tsx
@@ -25,13 +25,20 @@ const StorageResources = ({
   const freeStorage = formatBytes(free, "B");
   const totalStorage = formatBytes(allocated + other + free, "B");
   const singlePool = Object.keys(pools).length === 1;
+  const noPool = Object.keys(pools).length === 0;
 
   return (
     <div
-      className={classNames("storage-resources", { "single-pool": singlePool })}
+      className={classNames("storage-resources", {
+        "single-pool": singlePool,
+      })}
       data-testid="lxd-cluster-storage"
     >
-      <div className="storage-resources__header">
+      <div
+        className={classNames("storage-resources__header", {
+          "storage-resources__header-no-pool": noPool,
+        })}
+      >
         <h4 className="p-text--x-small-capitalised">Storage</h4>
         {!singlePool && (
           <div data-testid="storage-summary">
@@ -57,13 +64,15 @@ const StorageResources = ({
           </div>
         )}
       </div>
-      <div className="storage-resources__content">
-        {singlePool ? (
-          <StorageMeter defaultPoolId={defaultPoolId} pools={pools} />
-        ) : (
-          <StorageCards defaultPoolId={defaultPoolId} pools={pools} />
-        )}
-      </div>
+      {!noPool && (
+        <div className="storage-resources__content">
+          {singlePool ? (
+            <StorageMeter defaultPoolId={defaultPoolId} pools={pools} />
+          ) : (
+            <StorageCards defaultPoolId={defaultPoolId} pools={pools} />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/app/kvm/components/StorageResources/_index.scss
+++ b/src/app/kvm/components/StorageResources/_index.scss
@@ -18,6 +18,10 @@
   .storage-resources__header {
     flex: 0;
     margin-right: 0;
+
+    &-no-pool {
+      flex: 1;
+    }
   }
 
   @media only screen and (min-width: $breakpoint-small) {
@@ -43,6 +47,10 @@
     .storage-resources__header {
       flex: 0;
       margin-right: 0;
+
+      &-no-pool {
+        flex: 1;
+      }
     }
 
     .storage-resources__content {


### PR DESCRIPTION
## Done

- Extend storage card to full width
- Fix dropdown button position on VM table

### QA steps

- Goto `/kvm/lxd`
- Click on a host from the list to view the details page
- Ensure that the storage card info spans the whole card
- Scroll down to the table and ensure that the dropdown beside the checkbox is well positioned as in the screenshot below

## Fixes
[MAASENG-2102](https://warthogs.atlassian.net/browse/MAASENG-2102)


## Screenshots
![image](https://github.com/canonical/maas-ui/assets/47540149/8ddfba67-a564-4b66-b837-a95802726180)



[MAASENG-2102]: https://warthogs.atlassian.net/browse/MAASENG-2102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ