### PR TITLE
refactor: use builder callback MAASENG-1855

### DIFF
--- a/src/app/store/auth/slice.ts
+++ b/src/app/store/auth/slice.ts
@@ -6,6 +6,7 @@ import type {
   SliceCaseReducers,
 } from "@reduxjs/toolkit";
 
+import { actions as userActions } from "app/store/user";
 import type { AuthState, User, UserState } from "app/store/user/types";
 
 type WithPrepare = {
@@ -135,23 +136,30 @@ const authSlice = createSlice<UserState, Reducers>({
       state.auth.user = action.payload;
     },
   },
-  extraReducers: {
+  extraReducers: (builder) => {
     // If the user list has not yet been loaded the message will be to
     // create the user.
-    "user/createNotify": (state: UserState, action: PayloadAction<User>) => {
-      // Check to see whether the auth user has been updated and if so
-      // update the stored auth user.
-      if (state.auth.user && state.auth.user.id === action.payload.id) {
-        state.auth.user = action.payload;
-      }
-    },
-    "user/updateNotify": (state: UserState, action: PayloadAction<User>) => {
-      // Check to see whether the auth user has been updated and if so
-      // update the stored auth user.
-      if (state.auth.user && state.auth.user.id === action.payload.id) {
-        state.auth.user = action.payload;
-      }
-    },
+    builder
+      .addCase(
+        userActions.createNotify,
+        (state: UserState, action: PayloadAction<User>) => {
+          // Check to see whether the auth user has been updated and if so
+          // update the stored auth user.
+          if (state.auth.user && state.auth.user.id === action.payload.id) {
+            state.auth.user = action.payload;
+          }
+        }
+      )
+      .addCase(
+        userActions.updateNotify,
+        (state: UserState, action: PayloadAction<User>) => {
+          // Check to see whether the auth user has been updated and if so
+          // update the stored auth user.
+          if (state.auth.user && state.auth.user.id === action.payload.id) {
+            state.auth.user = action.payload;
+          }
+        }
+      );
   },
 });
 

--- a/src/app/store/scriptresult/slice.ts
+++ b/src/app/store/scriptresult/slice.ts
@@ -268,27 +268,39 @@ const scriptResultSlice = createSlice({
       },
     },
   },
-  extraReducers: {
-    "noderesult/createNotify": (state, action) => {
-      const existingIdx = state.items.findIndex(
-        (existingItem) => existingItem.id === action.payload.id
-      );
-      if (existingIdx !== -1) {
-        state.items[existingIdx] = action.payload;
-      } else {
-        state.items.push(action.payload);
+  extraReducers: (builder) => {
+    builder.addCase(
+      "noderesult/createNotify",
+      (
+        state,
+        action: PayloadAction<ScriptResult, "noderesult/createNotify">
+      ) => {
+        const existingIdx = state.items.findIndex(
+          (existingItem) => existingItem.id === action.payload.id
+        );
+        if (existingIdx !== -1) {
+          state.items[existingIdx] = action.payload;
+        } else {
+          state.items.push(action.payload);
+        }
       }
-    },
-    "noderesult/updateNotify": (state, action) => {
-      const existingIdx = state.items.findIndex(
-        (existingItem) => existingItem.id === action.payload.id
-      );
-      if (existingIdx !== -1) {
-        state.items[existingIdx] = action.payload;
-      } else {
-        state.items.push(action.payload);
+    );
+    builder.addCase(
+      "noderesult/updateNotify",
+      (
+        state,
+        action: PayloadAction<ScriptResult, "noderesult/updateNotify">
+      ) => {
+        const existingIdx = state.items.findIndex(
+          (existingItem) => existingItem.id === action.payload.id
+        );
+        if (existingIdx !== -1) {
+          state.items[existingIdx] = action.payload;
+        } else {
+          state.items.push(action.payload);
+        }
       }
-    },
+    );
   },
 });
 


### PR DESCRIPTION
## Done

- refactor: use builder callback MAASENG-1855

This removes redux toolkit deprecation warning for extraReducers.

https://redux-toolkit.js.org/api/createSlice#the-extrareducers-builder-callback-notation

## QA
### QA Steps
1. Go to `MAAS/r/account/prefs/details`
2. Open developer tools and redux devtools
3. Edit Full name and submit
4. Verify that auth user `last_name` has been updated

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-1855
