### PR TITLE
fix: use defaultChecked in ThemedRadioButton

### DIFF
--- a/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/ThemedRadioButton.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/ThemedRadioButton.tsx
@@ -36,8 +36,8 @@ const ThemedRadioButton = ({
   return (
     <label className={classNames(className, "general-form__radio--themed")}>
       <input
-        checked={value === color}
         className={`general-form__radio is-maas-${color}`}
+        defaultChecked={value === color}
         name={name}
         type="radio"
         {...inputProps}


### PR DESCRIPTION
## Done

- fix: use `defaultChecked` in ThemedRadioButton

Removes the following warning:
```
Warning: You provided a `checked` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultChecked`. Otherwise, set either `onChange` or `readOnly`.
          at input
          at label
          at ThemedRadioButton (/Users/makowski/Documents/GitHub/maas-ui/src/app/settings/views/Configuration/GeneralForm/ThemedRadioButton/ThemedRadioButton.tsx:28:3)
```
## QA

### QA steps

- Go to theme settings
- Verify that the current theme is set as active radio button and you can change the theme
