### PR TITLE
test: set BondFormFields initialValues

### DIFF
--- a/src/app/base/components/FormikField/FormikField.test.tsx
+++ b/src/app/base/components/FormikField/FormikField.test.tsx
@@ -29,7 +29,9 @@ describe("FormikField", () => {
       </Formik>
     );
 
-    expect(screen.getByRole("textbox")).toHaveErrorMessage("Error: Uh oh!");
+    expect(screen.getByRole("textbox")).toHaveAccessibleErrorMessage(
+      "Error: Uh oh!"
+    );
   });
 
   it("can hide the errors", () => {
@@ -44,6 +46,6 @@ describe("FormikField", () => {
       </Formik>
     );
 
-    expect(screen.getByRole("textbox")).not.toHaveErrorMessage();
+    expect(screen.getByRole("textbox")).not.toHaveAccessibleErrorMessage();
   });
 });

--- a/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
+++ b/src/app/dashboard/views/DiscoveryAddForm/DiscoveryAddForm.test.tsx
@@ -184,8 +184,8 @@ describe("DiscoveryAddForm", () => {
       screen.getByRole("textbox", {
         name: `${FormFieldLabels.Hostname}`,
       })
-      // react-components uses aria-errormessage to link the errors to the inputs so we can use the toHaveErrorMessage helper here.
-    ).toHaveErrorMessage(`Error: ${error}`);
+      // react-components uses aria-errormessage to link the errors to the inputs so we can use the toHaveAccessibleErrorMessage helper here.
+    ).toHaveAccessibleErrorMessage(`Error: ${error}`);
   });
 
   it("can dispatch to create a device", async () => {

--- a/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/BondForm/BondFormFields/BondFormFields.test.tsx
@@ -1,6 +1,6 @@
 import { Formik } from "formik";
 
-import { LinkMonitoring } from "../types";
+import { LinkMonitoring, MacSource } from "../types";
 
 import BondFormFields from "./BondFormFields";
 
@@ -27,6 +27,25 @@ const route = urls.machines.index;
 
 describe("BondFormFields", () => {
   let state: RootState;
+  const initialValues = {
+    bond_downdelay: 0,
+    bond_lacp_rate: "",
+    bond_miimon: 0,
+    bond_mode: BondMode.ACTIVE_BACKUP,
+    bond_updelay: 0,
+    bond_xmit_hash_policy: "",
+    fabric: "",
+    ip_address: "",
+    linkMonitoring: "",
+    mac_address: "",
+    macSource: MacSource.MANUAL,
+    macNic: "",
+    mode: "",
+    name: "",
+    subnet: "",
+    tags: [],
+    vlan: "",
+  };
   beforeEach(() => {
     state = rootStateFactory({
       general: generalStateFactory({
@@ -76,7 +95,7 @@ describe("BondFormFields", () => {
 
   it("does not display the hash policy field by default", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -89,7 +108,7 @@ describe("BondFormFields", () => {
 
   it("displays the hash policy field for some bond modes", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -107,7 +126,7 @@ describe("BondFormFields", () => {
 
   it("does not display the lacp rate field by default", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -120,7 +139,7 @@ describe("BondFormFields", () => {
 
   it("displays the lacp rate field for some bond modes", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -138,7 +157,7 @@ describe("BondFormFields", () => {
 
   it("does not display the monitoring fields by default", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -159,7 +178,7 @@ describe("BondFormFields", () => {
 
   it("displays the monitoring fields when link monitoring is set", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -183,7 +202,7 @@ describe("BondFormFields", () => {
 
   it("sets the mac address field when the nic field changes", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{ mac_address: "" }} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[{ nicId: 17 }]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -202,7 +221,7 @@ describe("BondFormFields", () => {
 
   it("enables the mac address field when the radio is changed to manual", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{ mac_address: "" }} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -221,7 +240,7 @@ describe("BondFormFields", () => {
 
   it("enables the mac nic field when the radio is changed to 'nic'", async () => {
     renderWithBrowserRouter(
-      <Formik initialValues={{}} onSubmit={jest.fn()}>
+      <Formik initialValues={initialValues} onSubmit={jest.fn()}>
         <BondFormFields selected={[]} systemId="abc123" />
       </Formik>,
       { route, state }
@@ -239,7 +258,11 @@ describe("BondFormFields", () => {
   it("resets the mac address field when the radio is changed to 'nic'", async () => {
     renderWithBrowserRouter(
       <Formik
-        initialValues={{ macNic: "6a:6e:4a:29:a5:42", mac_address: "" }}
+        initialValues={{
+          ...initialValues,
+          macNic: "6a:6e:4a:29:a5:42",
+          mac_address: "",
+        }}
         onSubmit={jest.fn()}
       >
         <BondFormFields selected={[]} systemId="abc123" />

--- a/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
+++ b/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
@@ -180,7 +180,7 @@ describe("DeployFormFields", () => {
     await userEvent.type(hardwareSyncInput, "0");
     await userEvent.tab();
     await waitFor(() =>
-      expect(hardwareSyncInput).toHaveErrorMessage(
+      expect(hardwareSyncInput).toHaveAccessibleErrorMessage(
         /Hardware sync interval must be at least 1 minute/
       )
     );

--- a/src/app/settings/views/Security/SecurityProtocols/TLSEnabled/TLSEnabled.test.tsx
+++ b/src/app/settings/views/Security/SecurityProtocols/TLSEnabled/TLSEnabled.test.tsx
@@ -171,7 +171,7 @@ it("shows an error if TLS notification is enabled but interval is invalid", asyn
   await userEvent.tab();
 
   await waitFor(() => {
-    expect(intervalInput).toHaveErrorMessage(
+    expect(intervalInput).toHaveAccessibleErrorMessage(
       "Error: Notification interval is required."
     );
   });

--- a/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
+++ b/src/app/tags/components/DefinitionField/DefinitionField.test.tsx
@@ -53,7 +53,7 @@ it("overrides the xpath errors", async () => {
   );
   expect(
     screen.getByRole("textbox", { name: Label.Definition })
-  ).toHaveErrorMessage(
+  ).toHaveAccessibleErrorMessage(
     "The definition is an invalid XPath expression. See our XPath expressions documentation for more examples."
   );
 });

--- a/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -227,6 +227,8 @@ it("shows an error if tag name is invalid", async () => {
   await userEvent.tab();
 
   await waitFor(() =>
-    expect(nameInput).toHaveErrorMessage(`Error: ${Label.NameValidation}`)
+    expect(nameInput).toHaveAccessibleErrorMessage(
+      `Error: ${Label.NameValidation}`
+    )
   );
 });


### PR DESCRIPTION
## Done

- test: set BondFormFields initialValues
- test: use toHaveAccessibleErrorMessage


Fixes the following error thrown when running `BondFormFields.test.tsx` test:
```
Warning: A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components
```

Fixes the following error across the codebase: 

```
Warning: toHaveErrorMessage has been deprecated and will be removed in future updates. Please use toHaveAccessibleErrorMessage.
```