### PR TITLE
ci: fix upload workflow sha

### DIFF
--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,10 +1,12 @@
 name: Upload
 on:
-  pull_request_target:
-    types: [closed]
+  push:
+    branches:
+      - main
+      - "3.*"
 jobs:
   upload-build:
-    if: github.event.pull_request.merged == true
+    if: github.repository_owner == 'canonical'
     name: Upload build artifacts
     runs-on: ubuntu-22.04
     env:


### PR DESCRIPTION
## Done

- ci: fix upload workflow sha
  - use git push event for triggering upload workflow instead of pull_request

You can verify this method works correctly by looking at [test-upload-base](https://github.com/canonical/maas-ui/tree/test-upload-base) branch: https://github.com/canonical/maas-ui/actions/runs/5949044847 

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/5112
