### PR TITLE
test: run cypress on release branches only

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,5 +1,9 @@
 name: accessibility
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - "3.*"
 jobs:
   cypress-axe:
     name: cypress-axe

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,9 @@
 name: Cypress
-on: [push]
+on:
+  push:
+    branches:
+      - main
+      - "3.*"
 jobs:
   cypress:
     name: Cypress


### PR DESCRIPTION
## Done

- test: run cypress on release branches only

Previously cypress tests would be also run on other branches created in canonical/maas-ui, e.g. dependabot
This fixes it and ensures that it is only run on main/3.x branches