### PR TITLE
feat(machines): bulk failure reason MAASENG-1689

### DIFF
--- a/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -159,6 +159,19 @@ describe("FormikFormContent", () => {
     ).toBeInTheDocument();
   });
 
+  it("can display custom components for non-field errors", () => {
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={jest.fn()}>
+        <FormikFormContent errors={<div>Errors component text</div>}>
+          Content
+        </FormikFormContent>
+      </Formik>,
+      { state }
+    );
+
+    expect(screen.getByText("Errors component text")).toBeInTheDocument();
+  });
+
   it("can be inline", () => {
     renderWithBrowserRouter(
       <Formik initialValues={{}} onSubmit={jest.fn()}>

--- a/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react";
 import type { ReactNode, AriaAttributes } from "react";
+import React, { useEffect, useRef } from "react";
 
 import { Form, Notification } from "@canonical/react-components";
 import { useFormikContext } from "formik";
@@ -50,7 +50,7 @@ const generateNonFieldError = <V extends object, E = null>(
   errors?: APIError<E>
 ) => {
   if (errors) {
-    if (typeof errors === "string") {
+    if (typeof errors === "string" || React.isValidElement(errors)) {
       return errors;
     } else if (typeof errors === "object") {
       let otherErrors: string[] = [];

--- a/src/app/base/hooks/forms.ts
+++ b/src/app/base/hooks/forms.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 
 import { usePrevious } from "@canonical/react-components/dist/hooks";
 import { useFormikContext } from "formik";
@@ -22,6 +22,7 @@ export const useFormikErrors = <V = AnyObject, E = null>(
     if (
       errors &&
       typeof errors === "object" &&
+      !React.isValidElement(errors) &&
       !simpleObjectEquality(errors, previousErrors)
     ) {
       Object.entries(errors).forEach(([field, fieldErrors]) => {
@@ -58,7 +59,7 @@ export const useFormikFormDisabled = <V extends {}>({
   const newValues = { ...values };
   let hasErrors = false;
   if (errors) {
-    hasErrors = Object.keys(errors).length > 0;
+    hasErrors = React.isValidElement(errors) || Object.keys(errors).length > 0;
   }
   if (allowAllEmpty) {
     // If all fields are allowed to be empty then remove the empty fields from

--- a/src/app/base/types.ts
+++ b/src/app/base/types.ts
@@ -56,6 +56,7 @@ export type AnyObject = Record<string, unknown>;
 export type EmptyObject = Record<string, never>;
 
 export type APIError<E = null> =
+  | JSX.Element
   | string
   | string[]
   | Record<"__all__" | string, string | string[]>
@@ -82,10 +83,12 @@ type UsabillaConfig =
 export type UsabillaLive = (type: string, config?: UsabillaConfig) => void;
 
 export type ActionStatuses = ValueOf<typeof ACTION_STATUS>;
+type ErrorMessage = string;
 export type ActionState = {
   status: ActionStatuses;
   errors: APIError;
   failedSystemIds?: Machine["system_id"][];
+  failureDetails?: Partial<Record<ErrorMessage, Machine["system_id"][]>>;
   successCount: number;
 };
 

--- a/src/app/machines/components/ErrorDetails/ErrorDetails.test.tsx
+++ b/src/app/machines/components/ErrorDetails/ErrorDetails.test.tsx
@@ -1,0 +1,34 @@
+import ErrorDetails from "./ErrorDetails";
+
+import { renderWithMockStore, screen } from "testing/utils";
+
+const errorMessage = "error message text";
+const failedSystemIds = ["abc123", "def456"];
+const failureDetails = {
+  [errorMessage]: failedSystemIds,
+};
+
+it("displays correct count of failed machines", () => {
+  renderWithMockStore(
+    <ErrorDetails
+      failedSystemIds={failedSystemIds}
+      failureDetails={failureDetails}
+    />
+  );
+
+  expect(screen.getByText(/failed for 2 machines/)).toBeInTheDocument();
+});
+
+it("displays error message with machine systemIds", () => {
+  renderWithMockStore(
+    <ErrorDetails
+      failedSystemIds={failedSystemIds}
+      failureDetails={failureDetails}
+    />
+  );
+
+  expect(screen.getByRole("term")).toHaveTextContent(errorMessage);
+  screen.getAllByRole("definition").forEach((definition, i) => {
+    expect(definition).toHaveTextContent(failedSystemIds[i]);
+  });
+});

--- a/src/app/machines/components/ErrorDetails/ErrorDetails.tsx
+++ b/src/app/machines/components/ErrorDetails/ErrorDetails.tsx
@@ -1,0 +1,66 @@
+import pluralize from "pluralize";
+
+import MachineHostname from "../MachineHostname";
+
+import type { ActionState } from "app/base/types";
+
+const ErrorDetailsItem = ({
+  errorMessage,
+  systemIds,
+}: {
+  errorMessage: keyof NonNullable<ActionState["failureDetails"]>;
+  systemIds: ActionState["failedSystemIds"];
+}) => {
+  return (
+    <dl>
+      <dt>{errorMessage}</dt>
+      {systemIds?.map((systemId) => (
+        <dd key={systemId}>
+          <MachineHostname systemId={systemId} />
+        </dd>
+      ))}
+    </dl>
+  );
+};
+
+const ErrorDetailsList = ({
+  failureDetails,
+}: {
+  failureDetails: NonNullable<ActionState["failureDetails"]>;
+}): JSX.Element => {
+  return (
+    <>
+      {Object.keys(failureDetails).length > 0
+        ? Object.entries(failureDetails).map(
+            ([errorMessage, systemIds], index) => (
+              <ErrorDetailsItem
+                errorMessage={errorMessage}
+                key={`${errorMessage}-${index}`}
+                systemIds={systemIds}
+              />
+            )
+          )
+        : null}
+    </>
+  );
+};
+
+const ErrorDetails = ({
+  failureDetails,
+  failedSystemIds,
+}: Pick<ActionState, "failedSystemIds" | "failureDetails">) => {
+  const failedSystemIdsCount = failedSystemIds?.length ?? 0;
+
+  return failedSystemIdsCount > 0 ? (
+    <>
+      <div>
+        Action failed for {pluralize("machine", failedSystemIdsCount, true)}.
+      </div>
+      {failureDetails ? (
+        <ErrorDetailsList failureDetails={failureDetails} />
+      ) : null}
+    </>
+  ) : null;
+};
+
+export default ErrorDetails;

--- a/src/app/machines/components/ErrorDetails/index.ts
+++ b/src/app/machines/components/ErrorDetails/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ErrorDetails";

--- a/src/app/machines/components/MachineHostname/MachineHostname.test.tsx
+++ b/src/app/machines/components/MachineHostname/MachineHostname.test.tsx
@@ -1,0 +1,33 @@
+import MachineHostname from "./MachineHostname";
+
+import { callId, enableCallIdMocks } from "testing/callId-mock";
+import {
+  machineStateDetailsItem as machineStateDetailsItemFactory,
+  machine as machineFactory,
+  rootState,
+} from "testing/factories";
+import { screen, renderWithMockStore } from "testing/utils";
+
+enableCallIdMocks();
+
+it("displays machine systemId when hostname is not available", async () => {
+  renderWithMockStore(<MachineHostname systemId="abc123" />);
+  expect(screen.getByText(/abc123/i)).toBeInTheDocument();
+});
+
+it("displays machine hostname once loaded", () => {
+  const state = rootState();
+  state.machine.items = [
+    machineFactory({
+      system_id: "abc123",
+      hostname: "test-machine",
+    }),
+  ];
+  state.machine.details = {
+    [callId]: machineStateDetailsItemFactory({
+      system_id: "abc123",
+    }),
+  };
+  renderWithMockStore(<MachineHostname systemId="abc123" />, { state });
+  expect(screen.getByText(/test-machine/i)).toBeInTheDocument();
+});

--- a/src/app/machines/components/MachineHostname/MachineHostname.tsx
+++ b/src/app/machines/components/MachineHostname/MachineHostname.tsx
@@ -1,0 +1,13 @@
+import type { Machine } from "app/store/machine/types";
+import { useFetchMachine } from "app/store/machine/utils/hooks";
+
+const MachineHostname = ({
+  systemId,
+}: {
+  systemId: Machine["system_id"];
+}): JSX.Element => {
+  const { machine } = useFetchMachine(systemId);
+  return <span>{machine?.hostname || systemId}</span>;
+};
+
+export default MachineHostname;

--- a/src/app/machines/components/MachineHostname/index.ts
+++ b/src/app/machines/components/MachineHostname/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./MachineHostname";

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -154,6 +154,7 @@ const statusHandlers = generateStatusHandlers<
               errors: null,
               successCount: 0,
               failedSystemIds: [],
+              failureDetails: {},
             };
           }
         }
@@ -175,6 +176,9 @@ const statusHandlers = generateStatusHandlers<
               actionsItem.failedSystemIds = [
                 ...action.payload.failed_system_ids,
               ] as Machine[MachineMeta.PK][];
+              actionsItem.failureDetails = {
+                ...action.payload.failure_details,
+              };
             }
           } else if (actionsItem) {
             actionsItem.status = ACTION_STATUS.error;

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -189,6 +189,7 @@ export type MachineStatus = {
 export type MachineActionStatus = {
   errors: APIError;
   failed_system_ids: Machine["system_id"][];
+  failure_details: Partial<Record<string, Machine["system_id"][]>>;
   success_count: number;
 } | null;
 

--- a/src/app/store/machine/utils/hooks.test.tsx
+++ b/src/app/store/machine/utils/hooks.test.tsx
@@ -1,7 +1,6 @@
-import type { ReactNode } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 import reduxToolkit from "@reduxjs/toolkit";
-import { renderHook, cleanup, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import configureStore from "redux-mock-store";
 import type { MockStoreEnhanced } from "redux-mock-store";
@@ -60,6 +59,7 @@ import {
   vlan as vlanFactory,
   machineActionState,
 } from "testing/factories";
+import { renderHook, cleanup, waitFor, screen, render } from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -621,9 +621,10 @@ describe("machine hook utils", () => {
         });
       });
       expect(result.current.actionStatus).toEqual("success");
-      expect(result.current.actionErrors).toEqual(
-        "Action failed for 1 machine"
-      );
+      render(result.current.actionErrors as ReactElement);
+      expect(
+        screen.getByText(/Action failed for 1 machine/)
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/app/store/machine/utils/hooks.tsx
+++ b/src/app/store/machine/utils/hooks.tsx
@@ -5,7 +5,6 @@ import { usePrevious } from "@canonical/react-components/dist/hooks";
 import type { AnyAction } from "@reduxjs/toolkit";
 import { nanoid } from "@reduxjs/toolkit";
 import fastDeepEqual from "fast-deep-equal";
-import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
 
 import { FetchGroupKey } from "../types/actions";
@@ -23,6 +22,7 @@ import type {
   APIError,
   SortDirection,
 } from "app/base/types";
+import ErrorDetails from "app/machines/components/ErrorDetails";
 import type { MachineActionFormProps } from "app/machines/types";
 import { actions as generalActions } from "app/store/general";
 import {
@@ -89,6 +89,7 @@ type MachineActionData = {
   successCount: ActionState["successCount"];
   failedSystemIds: ActionState["failedSystemIds"];
 };
+
 export const useMachineActionDispatch = <
   A extends AnyAction
 >(): MachineActionData & {
@@ -101,25 +102,12 @@ export const useMachineActionDispatch = <
   );
   const actionStatus = actionState?.status || ACTION_STATUS.idle;
   const failedSystemIds = actionState?.failedSystemIds || [];
-  const failedMachinesCount = failedSystemIds.length;
-  const { machines: failedMachines } = useFetchMachines(
-    { filters: { id: failedSystemIds } },
-    { isEnabled: failedMachinesCount > 0 }
-  );
-
-  const failedMachinesDescription =
-    failedMachines.length > 0
-      ? `: ${failedMachines.map((machine) => machine.hostname).join(", ")}`
-      : "";
+  const failedSystemIdsCount = failedSystemIds.length ?? 0;
 
   const actionErrors =
-    actionState?.errors || failedMachinesCount > 0
-      ? `Action failed for ${pluralize(
-          "machine",
-          failedMachinesCount,
-          true
-        )}${failedMachinesDescription}`
-      : null;
+    actionState && failedSystemIdsCount > 0 ? (
+      <ErrorDetails {...actionState} />
+    ) : null;
 
   return {
     dispatch: dispatchWithCallId,


### PR DESCRIPTION
## Done

- feat(machines) bulk failure reason MAASENG-1689
- add failureDetails to redux store machine slice
- create `ErrorDetails` component
- create `MachineHostname` component that takes systemId and fetches machine details

## QA

### QA steps

Using lab maas as back-end, follow steps below:

- Go to machine list
- Abort actions if any actions are in progress for "c-test-machine"
- Refresh the page
- Select "c-test-machine" and click `Actions` -> `Deploy` and perform the action
- Verify that the correct count (1) with error description has been displayed

## Fixes

Fixes: MAASENG-1689

## Screenshots
![Cursor screenshot 000674@2x](https://github.com/canonical/maas-ui/assets/7452681/4a74c92e-a01e-480d-8840-73b62811e0c8)
