### PR TITLE
ci: update install command for cypress

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -22,6 +22,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           runTests: false
+          install-command: yarn install
       - name: Create MAAS admin
         run: sudo maas createadmin --username=admin --password=test --email=fake@example.org
       - name: Run cypress-axe accessibility tests

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - "3.*"
-      - fix-cypress-yarn-install
 jobs:
   cypress:
     name: Cypress

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,6 +22,7 @@ jobs:
         uses: cypress-io/github-action@v4
         with:
           runTests: false
+          install-command: yarn install
       - name: Run Cypress tests without a user
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - "3.*"
+      - fix-cypress-yarn-install
 jobs:
   cypress:
     name: Cypress


### PR DESCRIPTION
## Done

- ci: update install command for cypress 
  - remove `--frozen-lockfile` from cypress install as it was triggering an error even though lockfile is up to date (and it's irrelevant to this test as we only care about and use cypress and not all other dependencies)

## QA
Verify that the test run passed in the commit below
[test run on current branch](https://github.com/canonical/maas-ui/pull/5125/commits/62037bcbc88b6d743973a87a8f8cb3644ba72902)
[62037bc](https://github.com/canonical/maas-ui/pull/5125/commits/62037bcbc88b6d743973a87a8f8cb3644ba72902)

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/5121 https://github.com/canonical/maas-ui/issues/5107
