### PR TITLE
fix(machines): Workload annotation filtering lp2023633

### DIFF
--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
@@ -215,7 +215,10 @@ describe("MachinesFilterOptions", () => {
     filterGroup = machineFilterGroupFactory({
       key: FilterGroupKey.Workloads,
       loaded: true,
-      options: [{ key: "key1:value1", label: "key1: value1" }],
+      options: [
+        { key: "key1:value1", label: "key1: value1" },
+        { key: "key2:value1", label: "key2: value1" },
+      ],
     });
     state.machine.filters = [filterGroup];
     const setSearchText = jest.fn();
@@ -231,5 +234,12 @@ describe("MachinesFilterOptions", () => {
 
     // "workload-" prefix should be added to the key.
     expect(setSearchText).toHaveBeenCalledWith("workload-key1:()");
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "key2 (1)" }));
+
+    // second annotation key should be added to search text
+    expect(setSearchText).toHaveBeenCalledWith(
+      "workload-key1:() workload-key2:()"
+    );
   });
 });

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
@@ -181,4 +181,55 @@ describe("MachinesFilterOptions", () => {
     await userEvent.click(screen.getByRole("checkbox", { name: "Status 1" }));
     expect(setSearchText).toHaveBeenCalledWith("");
   });
+
+  it("displays workload annotation filters", () => {
+    filterGroup = machineFilterGroupFactory({
+      key: FilterGroupKey.Workloads,
+      loaded: true,
+      options: [
+        { key: "key1:value1", label: "key1: value1" },
+        { key: "key1:value2", label: "key1: value2" },
+        { key: "key2:value1", label: "key2: value1" },
+      ],
+    });
+    state.machine.filters = [filterGroup];
+    renderWithMockStore(
+      <MachinesFilterOptions
+        group={FilterGroupKey.Workloads}
+        setSearchText={jest.fn()}
+      />,
+      { state }
+    );
+
+    // The values don't matter, we just need to display
+    // how many of each key there are.
+    expect(
+      screen.getByRole("checkbox", { name: "key1 (2)" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "key2 (1)" })
+    ).toBeInTheDocument();
+  });
+
+  it("sets search text for workload annotation filters", async () => {
+    filterGroup = machineFilterGroupFactory({
+      key: FilterGroupKey.Workloads,
+      loaded: true,
+      options: [{ key: "key1:value1", label: "key1: value1" }],
+    });
+    state.machine.filters = [filterGroup];
+    const setSearchText = jest.fn();
+    renderWithMockStore(
+      <MachinesFilterOptions
+        group={FilterGroupKey.Workloads}
+        setSearchText={setSearchText}
+      />,
+      { state }
+    );
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "key1 (1)" }));
+
+    // "workload-" prefix should be added to the key.
+    expect(setSearchText).toHaveBeenCalledWith("workload-key1:()");
+  });
 });

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.tsx
@@ -34,7 +34,7 @@ const MachinesFilterOptions = ({
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
 
-  let filterOptions = useSelector((state: RootState) =>
+  const filterOptions = useSelector((state: RootState) =>
     machineSelectors.filterOptions(state, group)
   );
   const optionsLoading = useSelector((state: RootState) =>
@@ -44,38 +44,6 @@ const MachinesFilterOptions = ({
     machineSelectors.filterOptionsLoaded(state, group)
   );
   const currentFilters = FilterMachines.getCurrentFilters(searchText);
-
-  if (group === "workloads") {
-    // Workload annotations are key/value pairs, but we're given
-    // them as a string "key:value". So we need to split them.
-    const filterKeys = filterOptions.map((filter) => {
-      return filter.key.toString().split(":")[0];
-    });
-
-    // Find the count of each workload annotation key
-    const counts = filterKeys.reduce(
-      (result: { key: string; count: number }[], currentFilterKey) => {
-        const existingFilter = result.find(
-          (filter) => filter.key === currentFilterKey
-        );
-
-        if (existingFilter) {
-          existingFilter.count++;
-        } else {
-          result.push({ key: currentFilterKey, count: 1 });
-        }
-
-        return result;
-      },
-      []
-    );
-
-    // Turn array of keys and counts into valid filter options
-    filterOptions = counts.map((filterCount) => ({
-      key: filterCount.key,
-      label: `${filterCount.key} (${filterCount.count})`,
-    }));
-  }
 
   useEffect(() => {
     if (!optionsLoading && !optionsLoaded) {

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.tsx
@@ -33,7 +33,8 @@ const MachinesFilterOptions = ({
   setSearchText,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
-  const filterOptions = useSelector((state: RootState) =>
+
+  let filterOptions = useSelector((state: RootState) =>
     machineSelectors.filterOptions(state, group)
   );
   const optionsLoading = useSelector((state: RootState) =>
@@ -43,6 +44,38 @@ const MachinesFilterOptions = ({
     machineSelectors.filterOptionsLoaded(state, group)
   );
   const currentFilters = FilterMachines.getCurrentFilters(searchText);
+
+  if (group === "workloads") {
+    // Workload annotations are key/value pairs, but we're given
+    // them as a string "key:value". So we need to split them.
+    const filterKeys = filterOptions.map((filter) => {
+      return filter.key.toString().split(":")[0];
+    });
+
+    // Find the count of each workload annotation key
+    const counts = filterKeys.reduce(
+      (result: { key: string; count: number }[], currentFilterKey) => {
+        const existingFilter = result.find(
+          (filter) => filter.key === currentFilterKey
+        );
+
+        if (existingFilter) {
+          existingFilter.count++;
+        } else {
+          result.push({ key: currentFilterKey, count: 1 });
+        }
+
+        return result;
+      },
+      []
+    );
+
+    // Turn array of keys and counts into valid filter options
+    filterOptions = counts.map((filterCount) => ({
+      key: filterCount.key,
+      label: `${filterCount.key} (${filterCount.count})`,
+    }));
+  }
 
   useEffect(() => {
     if (!optionsLoading && !optionsLoaded) {

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -234,7 +234,7 @@ describe("Machines", () => {
           machineFilterGroupFactory({
             key: FilterGroupKey.Workloads,
             loaded: true,
-            options: [{ key: "animal:springbox", label: "animal: springbok" }],
+            options: [{ key: "animal:springbok", label: "animal: springbok" }],
           }),
         ],
         filtersLoaded: true,

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -11,7 +11,7 @@ import { DEFAULTS } from "./MachineList/MachineListTable/constants";
 import Machines from "./Machines";
 
 import { actions as machineActions } from "app/store/machine";
-import { FetchGroupKey } from "app/store/machine/types";
+import { FetchGroupKey, FilterGroupKey } from "app/store/machine/types";
 import * as query from "app/store/machine/utils/query";
 import type { RootState } from "app/store/root/types";
 import {
@@ -90,6 +90,7 @@ describe("Machines", () => {
       }),
       testing_status: TestStatusStatus.PASSED,
       system_id: "abc123",
+      workload_annotations: { animal: "springbok" },
       zone: modelRefFactory(),
     }),
     machineFactory({
@@ -229,7 +230,13 @@ describe("Machines", () => {
         lists: {
           "78910": machineList,
         },
-        filters: [machineFilterGroupFactory()],
+        filters: [
+          machineFilterGroupFactory({
+            key: FilterGroupKey.Workloads,
+            loaded: true,
+            options: [{ key: "animal:springbox", label: "animal: springbok" }],
+          }),
+        ],
         filtersLoaded: true,
         statuses: {
           abc123: machineStatusFactory(),
@@ -451,5 +458,20 @@ describe("Machines", () => {
         level: 3,
       })
     ).toHaveTextContent("Deploy");
+  });
+
+  it("correctly sets the search text for workload annotation filters", async () => {
+    renderWithBrowserRouter(<Machines />, { route: "/machines", state });
+
+    await userEvent.click(screen.getByRole("button", { name: "Filters" }));
+    await userEvent.click(screen.getByRole("tab", { name: "Workload" }));
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "animal (1)" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("searchbox")).toHaveValue("workload-animal:()");
+    });
+
+    expect(screen.getByRole("checkbox", { name: "animal (1)" })).toBeChecked();
   });
 });

--- a/src/app/store/machine/selectors.ts
+++ b/src/app/store/machine/selectors.ts
@@ -4,7 +4,6 @@ import { createCachedSelector } from "re-reselect";
 
 import { ACTIONS } from "app/store/machine/constants";
 import type {
-  FilterGroupKey,
   Machine,
   MachineState,
   MachineStateCount,
@@ -13,7 +12,7 @@ import type {
   MachineStateListGroup,
   MachineStateList,
 } from "app/store/machine/types";
-import { MachineMeta } from "app/store/machine/types";
+import { FilterGroupKey, MachineMeta } from "app/store/machine/types";
 import { isMachineDetails } from "app/store/machine/utils";
 import type { RootState } from "app/store/root/types";
 import type { NetworkInterface } from "app/store/types/node";
@@ -367,10 +366,43 @@ const filterOptions = createSelector(
     (_state: RootState, groupKey: FilterGroupKey | null | undefined) =>
       groupKey,
   ],
-  (machineState, groupKey) =>
-    [...(getFilterGroup(machineState, groupKey)?.options ?? [])].sort(
-      simpleSortByKey("label")
-    )
+  (machineState, groupKey) => {
+    const filterOptions = [
+      ...(getFilterGroup(machineState, groupKey)?.options ?? []),
+    ].sort(simpleSortByKey("label"));
+
+    if (groupKey !== FilterGroupKey.Workloads) {
+      return filterOptions;
+    } else {
+      const filterKeys = filterOptions.map((filter) => {
+        return filter.key.toString().split(":")[0];
+      });
+
+      // Find the count of each workload annotation key
+      const counts = filterKeys.reduce(
+        (result: { key: string; count: number }[], currentFilterKey) => {
+          const existingFilter = result.find(
+            (filter) => filter.key === currentFilterKey
+          );
+
+          if (existingFilter) {
+            existingFilter.count++;
+          } else {
+            result.push({ key: currentFilterKey, count: 1 });
+          }
+
+          return result;
+        },
+        []
+      );
+
+      // Turn array of keys and counts into valid filter options
+      return counts.map((filterCount) => ({
+        key: filterCount.key,
+        label: `${filterCount.key} (${filterCount.count})`,
+      }));
+    }
+  }
 );
 
 /**


### PR DESCRIPTION
## Done

- Selecting a workload annotation filter will now fill the search box correctly to filter for that annotation key
- A checkbox is now shown next to selected workload annotation filters

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

Using a backend that has deployed machines with workload annotations:
1. Go to /machines
2. Open the filters dropdown
3. Open the "Workloads" section
4. Select a workload
5. Ensure the filter is applied correctly and filtered machines are listed

## Fixes

Fixes [lp#2023633](https://bugs.launchpad.net/maas-ui/+bug/2023633)

## Launchpad issue

lp#2023633

## Backports

This commit will need to be backported to 3.4 once merged.

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/9c81ac09-de8b-4cc1-854f-75a24a13a695)

![image](https://github.com/canonical/maas-ui/assets/35104482/e1738bae-7c5b-461f-8491-6eaaf0bdb162)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/b10f4f7b-6ab0-4a4d-bc3e-e73d011922cc)

![image](https://github.com/canonical/maas-ui/assets/35104482/093dabfe-a2d5-4d89-b100-644bad379b53)
