### PR TITLE
fix: restore websocket connection on error lp#1930001

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -41,15 +41,11 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays connection errors", () => {
+  it("displays correct status on connection errors", () => {
     state.status.error = "Uh oh spaghettio";
     state.status.authenticated = true;
     renderWithBrowserRouter(<App />, { route: "/settings", state });
-    expect(
-      screen.getByText(
-        /The server connection failed with the error "Uh oh spaghettio"/i
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Trying to reconnect/i)).toBeInTheDocument();
   });
 
   it("displays an error if vault is sealed", () => {
@@ -80,10 +76,18 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays a loading message if connecting", () => {
+  it("displays a loading message if connecting for the first time", () => {
+    state.status.connected = false;
     state.status.connecting = true;
     renderWithBrowserRouter(<App />, { route: "/settings", state });
     expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("does not display a loading message if reconnecting", () => {
+    state.status.connected = true;
+    state.status.connecting = true;
+    renderWithBrowserRouter(<App />, { route: "/settings", state });
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
 
   it("displays a loading message when authenticating", () => {

--- a/src/app/store/status/reducers.test.ts
+++ b/src/app/store/status/reducers.test.ts
@@ -33,6 +33,27 @@ describe("status", () => {
       )
     ).toStrictEqual(
       statusStateFactory({
+        connected: true,
+        connecting: true,
+        error: null,
+      })
+    );
+  });
+
+  it("should correctly reduce status/websocketConnect on initial connection", () => {
+    expect(
+      reducers(
+        statusStateFactory({
+          connected: false,
+          connecting: false,
+          error: null,
+        }),
+        {
+          type: "status/websocketConnect",
+        }
+      )
+    ).toStrictEqual(
+      statusStateFactory({
         connected: false,
         connecting: true,
         error: null,

--- a/src/app/store/status/slice.ts
+++ b/src/app/store/status/slice.ts
@@ -108,7 +108,6 @@ const statusSlice = createSlice({
       state.error = action.payload;
     },
     websocketConnect: (state: StatusState) => {
-      state.connected = false;
       state.connecting = true;
     },
     websocketConnected: (state: StatusState) => {
@@ -123,8 +122,8 @@ const statusSlice = createSlice({
     ) => {
       state.connected = false;
       if (
-        action.payload.code === 1000 &&
-        action.payload.reason === "Session expired"
+        action.payload?.code === 1000 &&
+        action.payload?.reason === "Session expired"
       ) {
         state.authenticated = false;
         state.authenticationError = action.payload.reason;
@@ -138,8 +137,6 @@ const statusSlice = createSlice({
       action: PayloadAction<StatusState["authenticationError"]>
     ) => {
       state.error = action.payload;
-      state.connected = false;
-      state.connecting = false;
     },
     externalLoginURL: (
       state: StatusState,

--- a/src/root-reducer.test.ts
+++ b/src/root-reducer.test.ts
@@ -27,7 +27,7 @@ describe("rootReducer", () => {
     expect(newState).toMatchSnapshot();
   });
 
-  it("it should clear the state when disconnected from the websocket", () => {
+  it("it should clear the state on status/checkAuthenticatedError", () => {
     const authUser = userFactory();
     const initialState = rootStateFactory({
       machine: machineStateFactory({
@@ -44,11 +44,11 @@ describe("rootReducer", () => {
     const newState = createRootReducer(
       jest.fn().mockReturnValue(routerStateFactory())
     )(initialState, {
-      type: "status/websocketDisconnected",
+      type: "status/checkAuthenticatedError",
     });
 
     expect(newState.machine.items.length).toBe(0);
-    expect(newState.status.authenticating).toBe(true);
+    expect(newState.status.authenticating).toBe(false);
     expect(newState.user.items.length).toBe(0);
     expect(newState.user.auth.user).toStrictEqual(authUser);
   });

--- a/src/root-reducer.ts
+++ b/src/root-reducer.ts
@@ -99,13 +99,7 @@ const createRootReducer =
           authenticating: false,
         } as StatusState,
       };
-    } else if (
-      [
-        "status/websocketError",
-        "status/websocketDisconnected",
-        "status/checkAuthenticatedError",
-      ].includes(action.type)
-    ) {
+    } else if (["status/checkAuthenticatedError"].includes(action.type)) {
       setupState = {
         status: state?.status,
         user: {

--- a/src/websocket-client.test.ts
+++ b/src/websocket-client.test.ts
@@ -20,8 +20,8 @@ describe("websocket client", () => {
     getCookieMock.mockImplementation(() => "abc123");
     client = new WebSocketClient();
     client.connect();
-    if (client.socket) {
-      jest.spyOn(client.socket, "send");
+    if (client.rws) {
+      jest.spyOn(client.rws, "send");
     }
   });
 
@@ -45,7 +45,7 @@ describe("websocket client", () => {
       method: "packagerepository.list",
     });
     expect(
-      JSON.parse((client.socket?.send as jest.Mock).mock.calls[0][0])
+      JSON.parse((client.rws?.send as jest.Mock).mock.calls[0][0])
     ).toStrictEqual({
       method: "packagerepository.list",
       request_id: 0,

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -107,12 +107,12 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
 export class WebSocketClient {
   _nextId: WebSocketRequest["request_id"];
   _requests: Map<WebSocketRequest["request_id"], WebSocketAction>;
-  socket: ReconnectingWebSocket | null;
+  rws: ReconnectingWebSocket | null;
 
   constructor() {
     this._nextId = 0;
     this._requests = new Map();
-    this.socket = null;
+    this.rws = null;
   }
 
   /**
@@ -158,10 +158,10 @@ export class WebSocketClient {
    * @returns {Object} The websocket that was created.
    */
   connect(): ReconnectingWebSocket {
-    this.socket = new ReconnectingWebSocket(this.buildURL(), undefined, {
+    this.rws = new ReconnectingWebSocket(this.buildURL(), undefined, {
       debug: process.env.REACT_APP_WEBSOCKET_DEBUG === "true",
     });
-    return this.socket;
+    return this.rws;
   }
 
   /**
@@ -187,8 +187,8 @@ export class WebSocketClient {
       ...message,
       request_id: id,
     };
-    if (this.socket) {
-      this.socket.send(JSON.stringify(payload));
+    if (this.rws) {
+      this.rws.send(JSON.stringify(payload));
     }
     return id;
   }


### PR DESCRIPTION
## Done

- fix: restore websocket on error lp#1930001
- keep current app state on lost websocket connection
- rename handleMessage, watchMessages to handleWebsocketEvent, watchWebsocketEvents
- rename socket to rws (reconnecting websocket)


## QA

### QA steps

- Checkout this branch locally, and run `yarn start`
- Open MAAS UI in the browser and login
- Go to machine listing, select to add a new machine, enter text into machine name
- go back to the terminal, close the local web server(e.g. by pressing ctrl+c)
- verify that "Trying to reconnect..." has been displayed in the browser
- Go back to the terminal and run `yarn start`
- Go to the browser and verify that "Trying to reconnect..." message has disappeared
- Verify that previously entered text is visible and you can interact with MAAS UI without issues

## Launchpad issue

lp#1930001

## Screenshots

![Google Chrome screenshot 000753@2x](https://github.com/canonical/maas-ui/assets/7452681/6886d13d-f8bc-4a44-a353-efa3209bac8c)

