### PR TITLE
fix: disallow storage layout update for allocated machines lp#1928623

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -4,6 +4,7 @@ import { storageLayoutOptions } from "./ChangeStorageLayout/ChangeStorageLayout"
 import MachineStorage from "./MachineStorage";
 
 import * as hooks from "app/base/hooks/analytics";
+import { NodeStatusCode } from "app/store/types/node";
 import {
   generalState as generalStateFactory,
   machineDetails as machineDetailsFactory,
@@ -41,6 +42,7 @@ it("renders storage layout dropdown if machine's storage can be edited", async (
         machineDetailsFactory({
           locked: false,
           permissions: ["edit"],
+          status_code: NodeStatusCode.READY,
           system_id: "abc123",
         }),
       ],

--- a/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.test.tsx
@@ -66,7 +66,7 @@ describe("StorageNotifications", () => {
 
     expect(
       screen.getByText(
-        "Storage configuration cannot be modified unless the machine is Ready or Allocated."
+        "Storage configuration cannot be modified unless the machine is Ready."
       )
     ).toBeInTheDocument();
   });

--- a/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/StorageNotifications/StorageNotifications.tsx
@@ -48,7 +48,7 @@ const StorageNotifications = ({ id }: Props): JSX.Element | null => {
           {
             active: canEdit && !machineStorageConfigurable,
             content:
-              "Storage configuration cannot be modified unless the machine is Ready or Allocated.",
+              "Storage configuration cannot be modified unless the machine is Ready.",
           },
           {
             active: canEdit && !osSupportsStorageConfig,

--- a/src/app/store/utils/node/storage.test.ts
+++ b/src/app/store/utils/node/storage.test.ts
@@ -732,14 +732,14 @@ describe("isNodeStorageConfigurable", () => {
         machineDetailsFactory({ status_code: NodeStatusCode.READY })
       )
     ).toBe(true);
+  });
+
+  it("handles a machine in a non-configurable state", () => {
     expect(
       isNodeStorageConfigurable(
         machineDetailsFactory({ status_code: NodeStatusCode.ALLOCATED })
       )
-    ).toBe(true);
-  });
-
-  it("handles a machine in a non-configurable state", () => {
+    ).toBe(false);
     expect(
       isNodeStorageConfigurable(
         machineDetailsFactory({ status_code: NodeStatusCode.NEW })

--- a/src/app/store/utils/node/storage.ts
+++ b/src/app/store/utils/node/storage.ts
@@ -414,8 +414,7 @@ export const isMounted = (fs: Filesystem | null): fs is Filesystem => {
 export const isNodeStorageConfigurable = (
   node?: Controller | Machine | null
 ): boolean =>
-  nodeIsMachine(node) &&
-  [NodeStatusCode.READY, NodeStatusCode.ALLOCATED].includes(node.status_code);
+  nodeIsMachine(node) && [NodeStatusCode.READY].includes(node.status_code);
 
 /**
  * Returns whether a storage device is a partition.


### PR DESCRIPTION
## Done

- fix: disallow storage layout update for allocated machines lp#1928623

## QA

### QA steps
Provided you have a machine with an "Allocated" status

- Go to machine details page for a machine with an "Allocated" status
- Press "Storage" (URL `/MAAS/r/machine/{systemId}/storage`)
- Verify that the "Change storage layout" dropdown is not visible


## Launchpad issue

lp#1928623

## Screenshots
### Before
![CleanShot screenshot 000756@2x](https://github.com/canonical/maas-ui/assets/7452681/bb05e76d-97b9-497e-92cc-c08a6c9723cb)

### After
![Google Chrome screenshot 000755@2x](https://github.com/canonical/maas-ui/assets/7452681/ccbe00ce-ab8f-4648-8273-855f00667fd0)

