### PR TITLE
fix: restore websocket on error lp#1930001 (#5133)

### DIFF
--- a/src/app/App.test.tsx
+++ b/src/app/App.test.tsx
@@ -40,15 +40,11 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays connection errors", () => {
+  it("displays correct status on connection errors", () => {
     state.status.error = "Uh oh spaghettio";
     state.status.authenticated = true;
     renderWithBrowserRouter(<App />, { route: "/settings", state });
-    expect(
-      screen.getByText(
-        /The server connection failed with the error "Uh oh spaghettio"/i
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Trying to reconnect/i)).toBeInTheDocument();
   });
 
   it("displays an error if vault is sealed", () => {
@@ -79,10 +75,18 @@ describe("App", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays a loading message if connecting", () => {
+  it("displays a loading message if connecting for the first time", () => {
+    state.status.connected = false;
     state.status.connecting = true;
     renderWithBrowserRouter(<App />, { route: "/settings", state });
     expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("does not display a loading message if reconnecting", () => {
+    state.status.connected = true;
+    state.status.connecting = true;
+    renderWithBrowserRouter(<App />, { route: "/settings", state });
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
 
   it("displays a loading message when authenticating", () => {

--- a/src/app/base/sagas/websockets.test.ts
+++ b/src/app/base/sagas/websockets.test.ts
@@ -18,7 +18,7 @@ import {
   WEBSOCKET_PING_INTERVAL,
   createConnection,
   handleFileContextRequest,
-  handleMessage,
+  handleWebsocketEvent,
   handleNextActions,
   handleNotifyMessage,
   handlePolling,
@@ -27,7 +27,7 @@ import {
   handlePingMessage,
   sendMessage,
   storeFileContextActions,
-  watchMessages,
+  watchWebsocketEvents,
   watchWebSockets,
   handleUnsubscribe,
 } from "./websockets";
@@ -55,8 +55,8 @@ describe("websocket sagas", () => {
     getCookieMock.mockImplementation(() => "abc123");
     socketClient = new WebSocketClient();
     socketClient.connect();
-    if (socketClient.socket) {
-      socketClient.socket.onerror = jest.fn();
+    if (socketClient.rws) {
+      socketClient.rws.onerror = jest.fn();
     }
     socketChannel = eventChannel(() => () => null);
   });
@@ -82,7 +82,7 @@ describe("websocket sagas", () => {
     const error = new Error(
       "No csrftoken found, please ensure you are logged into MAAS."
     );
-    socketClient.socket = null;
+    socketClient.rws = null;
     socketClient.buildURL = jest.fn(() => {
       throw error;
     });
@@ -119,18 +119,18 @@ describe("websocket sagas", () => {
   it("can create a WebSocket connection", () => {
     expect.assertions(1);
     const socket = createConnection(socketClient);
-    if (socketClient.socket?.onopen) {
-      socketClient.socket.onopen({} as Event);
+    if (socketClient.rws?.onopen) {
+      socketClient.rws.onopen({} as Event);
     }
     return expect(socket).resolves.toEqual(socketClient);
   });
 
   it("can watch for WebSocket messages", () => {
-    const channel = watchMessages(socketClient);
+    const channel = watchWebsocketEvents(socketClient);
     let response;
     channel.take((val) => (response = val));
-    if (socketClient.socket?.onmessage) {
-      socketClient.socket.onmessage({
+    if (socketClient.rws?.onmessage) {
+      socketClient.rws.onmessage({
         data: '{"message": "secret"}',
       } as MessageEvent);
     }
@@ -368,7 +368,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket response message", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(
       saga.next({
@@ -390,7 +390,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket response message with a request id", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(
       saga.next({
@@ -431,7 +431,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket error response message", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(
       saga.next({
@@ -455,7 +455,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket error message that is not JSON", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(
       saga.next({
@@ -479,7 +479,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket ping message", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     const response: WebSocketResponsePing = {
       request_id: 1,
       result: 1,
@@ -494,7 +494,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket notify message", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     const response: WebSocketResponseNotify = {
       type: WebSocketMessageType.NOTIFY,
       name: "config",
@@ -510,7 +510,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket close message", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(
       saga.next({
@@ -527,7 +527,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket error message", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(saga.next({ type: "error", message: "Timeout" }).value).toEqual(
       put({ type: "status/websocketError", error: true, payload: "Timeout" })
@@ -535,7 +535,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a WebSocket open message", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(saga.next({ type: "open" }).value).toEqual(
       put({ type: "status/websocketConnected" })
@@ -563,7 +563,7 @@ describe("websocket sagas", () => {
   });
 
   it("can handle a file response", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     saga.next();
     const response: WebSocketResponseResult<string> = {
       request_id: 99,
@@ -576,7 +576,7 @@ describe("websocket sagas", () => {
   });
 
   it("file responses do not dispatch the payload", () => {
-    const saga = handleMessage(socketChannel, socketClient);
+    const saga = handleWebsocketEvent(socketChannel, socketClient);
     saga.next();
     saga.next({
       data: JSON.stringify({

--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/browser";
 import type {
   Event as ReconnectingWebSocketEvent,
   ErrorEvent,
@@ -116,7 +117,7 @@ export function createConnection(
   // As the socket automatically tries to reconnect we don't reject this
   // promise, but rather wait for it to eventually connect.
   return new Promise((resolve, reject) => {
-    const readyState = websocketClient.socket?.readyState;
+    const readyState = websocketClient.rws?.readyState;
     const closedOrClosing: Readonly<Array<number>> = [
       WebSocket.CLOSED,
       WebSocket.CLOSING,
@@ -126,7 +127,7 @@ export function createConnection(
       resolve(websocketClient);
       return;
     } else if (
-      !websocketClient.socket ||
+      !websocketClient.rws ||
       (readyState && closedOrClosing.includes(readyState))
     ) {
       try {
@@ -139,8 +140,8 @@ export function createConnection(
       }
       websocketClient.connect();
     }
-    if (websocketClient.socket) {
-      websocketClient.socket.onopen = () => {
+    if (websocketClient.rws) {
+      websocketClient.rws.onopen = () => {
         resolve(websocketClient);
       };
     }
@@ -150,24 +151,26 @@ export function createConnection(
 /**
  * Create a channel to handle WebSocket messages.
  */
-export function watchMessages(socketClient: WebSocketClient): WebSocketChannel {
+export function watchWebsocketEvents(
+  socketClient: WebSocketClient
+): WebSocketChannel {
   return eventChannel((emit) => {
-    if (socketClient.socket) {
-      socketClient.socket.onmessage = (event) => {
+    if (socketClient.rws) {
+      socketClient.rws.onmessage = (event) => {
         emit(event);
       };
-      socketClient.socket.onopen = (event) => {
+      socketClient.rws.onopen = (event) => {
         emit(event);
       };
-      socketClient.socket.onerror = (event) => {
+      socketClient.rws.onerror = (event) => {
         emit(event);
       };
-      socketClient.socket.onclose = (event) => {
+      socketClient.rws.onclose = (event) => {
         emit(event);
       };
     }
     return () => {
-      socketClient.socket?.close();
+      socketClient.rws?.close();
     };
   });
 }
@@ -374,7 +377,7 @@ export function* handleUnsubscribe(
 /**
  * Handle messages received over the WebSocket.
  */
-export function* handleMessage(
+export function* handleWebsocketEvent(
   socketChannel: WebSocketChannel,
   socketClient: WebSocketClient
 ): SagaGenerator<void> {
@@ -635,17 +638,18 @@ export function* setupWebSocket({
   websocketClient: WebSocketClient;
   messageHandlers?: MessageHandler[];
 }): SagaGenerator<void> {
+  let socketClient: WebSocketClient;
   try {
-    const socketClient = yield* call(createConnection, websocketClient);
+    socketClient = yield* call(createConnection, websocketClient);
     yield* put({ type: "status/websocketConnected" });
     // Set up the list of models that have been loaded.
     resetLoaded();
-    const socketChannel = yield* call(watchMessages, socketClient);
+    const socketChannel = yield* call(watchWebsocketEvents, socketClient);
     while (true) {
       const { cancel } = yield* race({
         task: all(
           [
-            call(handleMessage, socketChannel, socketClient),
+            call(handleWebsocketEvent, socketChannel, socketClient),
             // Using takeEvery() instead of call() here to get around this issue:
             // https://github.com/canonical/maas-ui/issues/172
             takeEvery<
@@ -673,13 +677,14 @@ export function* setupWebSocket({
         cancel: take("status/websocketDisconnect"),
       });
       if (cancel) {
-        socketChannel.close();
         yield* put({ type: "status/websocketDisconnected" });
       }
     }
   } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error(error);
+    Sentry.withScope((scope) => {
+      scope.setTag("action", "status/websocketError");
+      Sentry.captureException(error);
+    });
     yield* put({
       type: "status/websocketError",
       error: true,

--- a/src/app/store/status/reducers.test.ts
+++ b/src/app/store/status/reducers.test.ts
@@ -33,6 +33,27 @@ describe("status", () => {
       )
     ).toStrictEqual(
       statusStateFactory({
+        connected: true,
+        connecting: true,
+        error: null,
+      })
+    );
+  });
+
+  it("should correctly reduce status/websocketConnect on initial connection", () => {
+    expect(
+      reducers(
+        statusStateFactory({
+          connected: false,
+          connecting: false,
+          error: null,
+        }),
+        {
+          type: "status/websocketConnect",
+        }
+      )
+    ).toStrictEqual(
+      statusStateFactory({
         connected: false,
         connecting: true,
         error: null,

--- a/src/app/store/status/slice.ts
+++ b/src/app/store/status/slice.ts
@@ -108,7 +108,6 @@ const statusSlice = createSlice({
       state.error = action.payload;
     },
     websocketConnect: (state: StatusState) => {
-      state.connected = false;
       state.connecting = true;
     },
     websocketConnected: (state: StatusState) => {
@@ -123,8 +122,8 @@ const statusSlice = createSlice({
     ) => {
       state.connected = false;
       if (
-        action.payload.code === 1000 &&
-        action.payload.reason === "Session expired"
+        action.payload?.code === 1000 &&
+        action.payload?.reason === "Session expired"
       ) {
         state.authenticated = false;
         state.authenticationError = action.payload.reason;
@@ -138,8 +137,6 @@ const statusSlice = createSlice({
       action: PayloadAction<StatusState["authenticationError"]>
     ) => {
       state.error = action.payload;
-      state.connected = false;
-      state.connecting = false;
     },
     externalLoginURL: (
       state: StatusState,

--- a/src/root-reducer.test.ts
+++ b/src/root-reducer.test.ts
@@ -27,7 +27,7 @@ describe("rootReducer", () => {
     expect(newState).toMatchSnapshot();
   });
 
-  it("it should clear the state when disconnected from the websocket", () => {
+  it("it should clear the state on status/checkAuthenticatedError", () => {
     const authUser = userFactory();
     const initialState = rootStateFactory({
       machine: machineStateFactory({
@@ -44,11 +44,11 @@ describe("rootReducer", () => {
     const newState = createRootReducer(
       jest.fn().mockReturnValue(routerStateFactory())
     )(initialState, {
-      type: "status/websocketDisconnected",
+      type: "status/checkAuthenticatedError",
     });
 
     expect(newState.machine.items.length).toBe(0);
-    expect(newState.status.authenticating).toBe(true);
+    expect(newState.status.authenticating).toBe(false);
     expect(newState.user.items.length).toBe(0);
     expect(newState.user.auth.user).toStrictEqual(authUser);
   });

--- a/src/root-reducer.ts
+++ b/src/root-reducer.ts
@@ -99,13 +99,7 @@ const createRootReducer =
           authenticating: false,
         } as StatusState,
       };
-    } else if (
-      [
-        "status/websocketError",
-        "status/websocketDisconnected",
-        "status/checkAuthenticatedError",
-      ].includes(action.type)
-    ) {
+    } else if (["status/checkAuthenticatedError"].includes(action.type)) {
       setupState = {
         status: state?.status,
         user: {

--- a/src/websocket-client.test.ts
+++ b/src/websocket-client.test.ts
@@ -20,8 +20,8 @@ describe("websocket client", () => {
     getCookieMock.mockImplementation(() => "abc123");
     client = new WebSocketClient();
     client.connect();
-    if (client.socket) {
-      jest.spyOn(client.socket, "send");
+    if (client.rws) {
+      jest.spyOn(client.rws, "send");
     }
   });
 
@@ -45,7 +45,7 @@ describe("websocket client", () => {
       method: "packagerepository.list",
     });
     expect(
-      JSON.parse((client.socket?.send as jest.Mock).mock.calls[0][0])
+      JSON.parse((client.rws?.send as jest.Mock).mock.calls[0][0])
     ).toStrictEqual({
       method: "packagerepository.list",
       request_id: 0,

--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -107,12 +107,12 @@ export type WebSocketAction<P = WebSocketActionParams> = PayloadAction<
 export class WebSocketClient {
   _nextId: WebSocketRequest["request_id"];
   _requests: Map<WebSocketRequest["request_id"], WebSocketAction>;
-  socket: ReconnectingWebSocket | null;
+  rws: ReconnectingWebSocket | null;
 
   constructor() {
     this._nextId = 0;
     this._requests = new Map();
-    this.socket = null;
+    this.rws = null;
   }
 
   /**
@@ -158,10 +158,10 @@ export class WebSocketClient {
    * @returns {Object} The websocket that was created.
    */
   connect(): ReconnectingWebSocket {
-    this.socket = new ReconnectingWebSocket(this.buildURL(), undefined, {
+    this.rws = new ReconnectingWebSocket(this.buildURL(), undefined, {
       debug: process.env.REACT_APP_WEBSOCKET_DEBUG === "true",
     });
-    return this.socket;
+    return this.rws;
   }
 
   /**
@@ -187,8 +187,8 @@ export class WebSocketClient {
       ...message,
       request_id: id,
     };
-    if (this.socket) {
-      this.socket.send(JSON.stringify(payload));
+    if (this.rws) {
+      this.rws.send(JSON.stringify(payload));
     }
     return id;
   }


### PR DESCRIPTION
## Done
- fix: restore websocket on error lp#1930001 (#5133)
- keep current app state on lost websocket connection
- rename handleMessage, watchMessages to handleWebsocketEvent, watchWebsocketEvents
- rename socket to rws (reconnecting websocket)

## QA

### QA steps

No steps necessary, tested in the original PR.
