### PR TITLE
fix(websockets): refetch on reconnect MAASENG-2142

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -87,8 +87,7 @@ export const App = (): JSX.Element => {
   useFetchActions([statusActions.checkAuthenticated]);
 
   useEffect(() => {
-    // When a user logs out the redux store is reset so the authentication
-    // info needs to be fetched again to know if external auth is being used.
+    // Needs to be fetched again to know if external auth is being used.
     if (previousAuthenticated && !authenticated) {
       dispatch(statusActions.checkAuthenticated());
     }

--- a/src/app/base/hooks/dataFetching.ts
+++ b/src/app/base/hooks/dataFetching.ts
@@ -1,19 +1,23 @@
 import { useEffect } from "react";
 
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import type { AnyAction } from "redux";
 
+import statusSelectors from "app/store/status/selectors";
+
 /**
- * Runs a set of actions on mount.
+ * A hook to run a set of actions once on mount and again when the websocket
+ * reconnects.
  * @param {Array<() => AnyAction>} actions - The actions to run.
  */
 export const useFetchActions = (actions: (() => AnyAction)[]) => {
   const dispatch = useDispatch();
+  const connectedCount = useSelector(statusSelectors.connectedCount);
 
   useEffect(() => {
     actions.forEach((action) => {
       dispatch(action());
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch]);
+  }, [dispatch, connectedCount]);
 };

--- a/src/app/base/sagas/websockets/websockets.test.ts
+++ b/src/app/base/sagas/websockets/websockets.test.ts
@@ -56,6 +56,7 @@ describe("websocket sagas", () => {
     socketClient.connect();
     if (socketClient.rws) {
       socketClient.rws.onerror = jest.fn();
+      socketClient.rws.close = jest.fn();
     }
     socketChannel = eventChannel(() => () => null);
   });
@@ -115,6 +116,22 @@ describe("websocket sagas", () => {
       .run();
   });
 
+  it("stops pinging the websocket when disconnected", () => {
+    return expectSaga(watchWebSockets, socketClient)
+      .dispatch({
+        type: "status/websocketDisconnected",
+      })
+      .put({
+        type: "status/websocketPingStop",
+        meta: {
+          pollStop: true,
+          model: "status",
+          method: "ping",
+        },
+      })
+      .run();
+  });
+
   it("can create a WebSocket connection", () => {
     expect.assertions(1);
     const socket = createConnection(socketClient);
@@ -136,6 +153,13 @@ describe("websocket sagas", () => {
     expect(response).toEqual({
       data: '{"message": "secret"}',
     });
+  });
+
+  it("closes WebSocket connection when channel is closed", () => {
+    const channel = watchWebsocketEvents(socketClient);
+    expect(socketClient.rws?.close).not.toHaveBeenCalled();
+    channel.close();
+    expect(socketClient.rws?.close).toHaveBeenCalled();
   });
 
   it("can send a WebSocket message", () => {
@@ -537,7 +561,7 @@ describe("websocket sagas", () => {
     const saga = handleWebsocketEvent(socketChannel, socketClient);
     expect(saga.next().value).toEqual(take(socketChannel));
     expect(saga.next({ type: "open" }).value).toEqual(
-      put({ type: "status/websocketConnected" })
+      put({ type: "status/websocketConnect" })
     );
   });
 

--- a/src/app/base/sagas/websockets/websockets.ts
+++ b/src/app/base/sagas/websockets/websockets.ts
@@ -204,7 +204,7 @@ export function* handleWebsocketEvent(
       }
 
       case "open": {
-        yield* put({ type: "status/websocketConnected" });
+        yield* put({ type: "status/websocketConnect" });
         resetLoaded();
         break;
       }
@@ -477,6 +477,16 @@ function* handleWebsocketPing() {
     },
   });
 }
+function* handleWebsocketPingStop() {
+  yield* put({
+    type: "status/websocketPingStop",
+    meta: {
+      pollStop: true,
+      model: "status",
+      method: "ping",
+    },
+  });
+}
 
 /**
  * Set up websocket connection on request via status/websocketConnect action
@@ -492,4 +502,5 @@ export function* watchWebSockets(
     messageHandlers,
   });
   yield* takeLatest("status/websocketConnected", handleWebsocketPing);
+  yield* takeLatest("status/websocketDisconnected", handleWebsocketPingStop);
 }

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -10,6 +10,7 @@ import type { SelectedMachines } from "./types";
 import { FilterGroupKey, FilterGroupType } from "./types";
 import { FetchGroupKey } from "./types/actions";
 
+import { actions as statusActions } from "app/store/status/slice";
 import {
   NodeActions,
   NodeStatus,
@@ -306,6 +307,42 @@ describe("machine reducer", () => {
       },
     });
     expect(reducers(initialState, actions.invalidateQueries())).toEqual(
+      machineStateFactory({
+        counts: {
+          [callId]: machineStateCountFactory({
+            loaded: true,
+            stale: true,
+          }),
+        },
+        lists: {
+          [callId]: machineStateListFactory({
+            loaded: true,
+            stale: true,
+          }),
+        },
+      })
+    );
+  });
+
+  it("invalidates queries on status/websocketDisconnected", () => {
+    const initialState = machineStateFactory({
+      loading: false,
+      counts: {
+        [callId]: machineStateCountFactory({
+          loaded: true,
+          stale: false,
+        }),
+      },
+      lists: {
+        [callId]: machineStateListFactory({
+          loaded: true,
+          stale: false,
+        }),
+      },
+    });
+    expect(
+      reducers(initialState, statusActions.websocketDisconnected())
+    ).toEqual(
       machineStateFactory({
         counts: {
           [callId]: machineStateCountFactory({

--- a/src/app/store/status/reducers.test.ts
+++ b/src/app/store/status/reducers.test.ts
@@ -35,6 +35,7 @@ describe("status", () => {
       statusStateFactory({
         connected: true,
         connecting: true,
+        connectedCount: 0,
         error: null,
       })
     );
@@ -78,7 +79,27 @@ describe("status", () => {
     );
   });
 
-  it("should correctly reduce status/websocketConnected", () => {
+  it("should correctly reduce status/websocketConnected on initial connection", () => {
+    expect(
+      reducers(
+        statusStateFactory({
+          connected: false,
+          connecting: true,
+        }),
+        {
+          type: "status/websocketConnected",
+        }
+      )
+    ).toStrictEqual(
+      statusStateFactory({
+        connected: true,
+        connecting: false,
+        connectedCount: 1,
+      })
+    );
+  });
+
+  it("should correctly reduce status/websocketConnected on error", () => {
     expect(
       reducers(
         statusStateFactory({
@@ -96,7 +117,28 @@ describe("status", () => {
         authenticationError: null,
         connected: true,
         connecting: false,
+        connectedCount: 1,
         error: null,
+      })
+    );
+  });
+
+  it("status/websocketConnected should increment connectedCount on reconnect", () => {
+    expect(
+      reducers(
+        statusStateFactory({
+          connected: true,
+          connectedCount: 1,
+        }),
+        {
+          type: "status/websocketConnected",
+        }
+      )
+    ).toStrictEqual(
+      statusStateFactory({
+        connected: true,
+        connecting: false,
+        connectedCount: 2,
       })
     );
   });

--- a/src/app/store/status/selectors.ts
+++ b/src/app/store/status/selectors.ts
@@ -31,6 +31,13 @@ const connected = (state: RootState): boolean => state.status.connected;
 const connecting = (state: RootState): boolean => state.status.connecting;
 
 /**
+ * Number of times the websocket has been connected.
+ * @param {RootState} state - The redux state.
+ * @returns {StatusState["connecting"]} TheStatusState connecting status.
+ */
+const connectedCount = (state: RootState) => state.status.connectedCount;
+
+/**
  * Status errors.
  * @param {RootState} state - The redux state.
  * @returns {StatusState["error"]} TheStatusState error status.
@@ -74,6 +81,7 @@ const status = {
   authenticationError,
   connected,
   connecting,
+  connectedCount,
   error,
   externalAuthURL,
   externalLoginURL,

--- a/src/app/store/status/slice.ts
+++ b/src/app/store/status/slice.ts
@@ -15,8 +15,10 @@ const statusSlice = createSlice({
     externalLoginURL: null,
     connected: false,
     connecting: false,
-    noUsers: false,
+    // The number of times the websocket connection has been successful
+    connectedCount: 0,
     error: null,
+    noUsers: false,
   } as StatusState,
   reducers: {
     checkAuthenticated: {
@@ -115,6 +117,7 @@ const statusSlice = createSlice({
       state.connecting = false;
       state.authenticationError = null;
       state.error = null;
+      state.connectedCount = state.connectedCount + 1;
     },
     websocketDisconnect: (
       state: StatusState,

--- a/src/app/store/status/types/base.ts
+++ b/src/app/store/status/types/base.ts
@@ -6,6 +6,7 @@ export type StatusState = {
   authenticationError: APIError;
   connected: boolean;
   connecting: boolean;
+  connectedCount: number;
   error: APIError;
   externalAuthURL: string | null;
   externalLoginURL: string | null;

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -514,6 +514,7 @@ export const statusState = define<StatusState>({
   authenticationError: null,
   connected: false,
   connecting: false,
+  connectedCount: 0,
   error: null,
   externalAuthURL: "http://example.com/auth",
   externalLoginURL: "http://example.com/login",


### PR DESCRIPTION
## Done

- fix(websockets): refetch all WS endpoints on reconnect
- add `useFetchActions` hook that runs a set of actions on mount and every time websocket reconnects
- replace all instances of `useEffect` with fetch actions on mount with `useFetchActions`
- add `connectedCount` to redux store to keep track of the number of times the websocket has connected successfully
- stop websocket ping on disconnect via `handlePingStop`
- run `invalidateQueries` on websocket disconnect to mark machine list and count requests as stale 

## QA

### QA steps

1. go to machine list
2. Open one of the machines visible in the list in another tab
3. restart MAAS
4. wait for front-end to reconnect
5. In the tab with machine details, make changes to the machine that will change its status (e.g. start testing)
6. Verify that the machine list in the other tab has been updated to reflect this change

## Fixes

Fixes: MAASENG-2142

## Launchpad issue

lp#1930001

