### PR TITLE
fix(machines): Workload annotation filtering lp2023633 (#5131) 3.4 backport

### DIFF
--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.test.tsx
@@ -181,4 +181,65 @@ describe("MachinesFilterOptions", () => {
     await userEvent.click(screen.getByRole("checkbox", { name: "Status 1" }));
     expect(setSearchText).toHaveBeenCalledWith("");
   });
+
+  it("displays workload annotation filters", () => {
+    filterGroup = machineFilterGroupFactory({
+      key: FilterGroupKey.Workloads,
+      loaded: true,
+      options: [
+        { key: "key1:value1", label: "key1: value1" },
+        { key: "key1:value2", label: "key1: value2" },
+        { key: "key2:value1", label: "key2: value1" },
+      ],
+    });
+    state.machine.filters = [filterGroup];
+    renderWithMockStore(
+      <MachinesFilterOptions
+        group={FilterGroupKey.Workloads}
+        setSearchText={jest.fn()}
+      />,
+      { state }
+    );
+
+    // The values don't matter, we just need to display
+    // how many of each key there are.
+    expect(
+      screen.getByRole("checkbox", { name: "key1 (2)" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "key2 (1)" })
+    ).toBeInTheDocument();
+  });
+
+  it("sets search text for workload annotation filters", async () => {
+    filterGroup = machineFilterGroupFactory({
+      key: FilterGroupKey.Workloads,
+      loaded: true,
+      options: [
+        { key: "key1:value1", label: "key1: value1" },
+        { key: "key2:value1", label: "key2: value1" },
+      ],
+    });
+    state.machine.filters = [filterGroup];
+    const setSearchText = jest.fn();
+    renderWithMockStore(
+      <MachinesFilterOptions
+        group={FilterGroupKey.Workloads}
+        setSearchText={setSearchText}
+      />,
+      { state }
+    );
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "key1 (1)" }));
+
+    // "workload-" prefix should be added to the key.
+    expect(setSearchText).toHaveBeenCalledWith("workload-key1:()");
+
+    await userEvent.click(screen.getByRole("checkbox", { name: "key2 (1)" }));
+
+    // second annotation key should be added to search text
+    expect(setSearchText).toHaveBeenCalledWith(
+      "workload-key1:() workload-key2:()"
+    );
+  });
 });

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterOptions/MachinesFilterOptions.tsx
@@ -33,6 +33,7 @@ const MachinesFilterOptions = ({
   setSearchText,
 }: Props): JSX.Element => {
   const dispatch = useDispatch();
+
   const filterOptions = useSelector((state: RootState) =>
     machineSelectors.filterOptions(state, group)
   );


### PR DESCRIPTION
## Done

- Selecting a workload annotation filter will now fill the search box correctly to filter for that annotation key
- A checkbox is now shown next to selected workload annotation filters

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Not needed.

## Launchpad issue

lp#2023633

## Backports

In general, please propose fixes against _main_ rather than release branches (e.g. 2.7), unless the fix is only applicable for that specific release. Please apply backport labels to the PR (e.g. "Backport 2.7") for the appropriate releases to target.

Only bug and security fixes should be backported, new features should only land in main.

