### PR TITLE
fix(websocket): refetch on reconnect MAASENG-2142 (#5146) 3.4 backport

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,7 +55,6 @@ module.exports = {
           },
         ],
         "@typescript-eslint/consistent-type-imports": 2,
-        "@typescript-eslint/explicit-module-boundary-types": ["error"],
         "import/namespace": "off",
         "import/no-named-as-default": 0,
         "import/order": [

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -101,8 +101,7 @@ export const App = (): JSX.Element => {
   useFetchActions([statusActions.checkAuthenticated]);
 
   useEffect(() => {
-    // When a user logs out the redux store is reset so the authentication
-    // info needs to be fetched again to know if external auth is being used.
+    // Needs to be fetched again to know if external auth is being used.
     if (previousAuthenticated && !authenticated) {
       dispatch(statusActions.checkAuthenticated());
     }

--- a/src/app/base/hooks/dataFetching.ts
+++ b/src/app/base/hooks/dataFetching.ts
@@ -1,19 +1,23 @@
 import { useEffect } from "react";
 
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import type { AnyAction } from "redux";
 
+import statusSelectors from "app/store/status/selectors";
+
 /**
- * Runs a set of actions on mount.
+ * A hook to run a set of actions once on mount and again when the websocket
+ * reconnects.
  * @param {Array<() => AnyAction>} actions - The actions to run.
  */
 export const useFetchActions = (actions: (() => AnyAction)[]): void => {
   const dispatch = useDispatch();
+  const connectedCount = useSelector(statusSelectors.connectedCount);
 
   useEffect(() => {
     actions.forEach((action) => {
       dispatch(action());
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch]);
+  }, [dispatch, connectedCount]);
 };

--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -709,6 +709,16 @@ function* handleWebsocketPing() {
     },
   });
 }
+function* handleWebsocketPingStop() {
+  yield* put({
+    type: "status/websocketPingStop",
+    meta: {
+      pollStop: true,
+      model: "status",
+      method: "ping",
+    },
+  });
+}
 
 /**
  * Set up websocket connections when requested.
@@ -724,4 +734,5 @@ export function* watchWebSockets(
     messageHandlers,
   });
   yield* takeLatest("status/websocketConnected", handleWebsocketPing);
+  yield* takeLatest("status/websocketDisconnected", handleWebsocketPingStop);
 }

--- a/src/app/base/sagas/websockets.ts
+++ b/src/app/base/sagas/websockets.ts
@@ -400,7 +400,7 @@ export function* handleWebsocketEvent(
         payload: { code, reason },
       });
     } else if (websocketEvent.type === "open") {
-      yield* put({ type: "status/websocketConnected" });
+      yield* put({ type: "status/websocketConnect" });
       resetLoaded();
     } else if ("data" in websocketEvent) {
       const response = JSON.parse(websocketEvent.data);

--- a/src/app/preferences/views/Preferences.test.tsx
+++ b/src/app/preferences/views/Preferences.test.tsx
@@ -1,40 +1,10 @@
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
-import configureStore from "redux-mock-store";
-
 import Preferences, { Labels as PreferencesLabels } from "./Preferences";
 
-import { routerState as routerStateFactory } from "testing/factories";
-import { screen, render } from "testing/utils";
-
-const mockStore = configureStore();
+import { screen, renderWithBrowserRouter } from "testing/utils";
 
 describe("Preferences", () => {
   it("renders", () => {
-    const store = mockStore({
-      config: {
-        items: [],
-      },
-      message: {
-        items: [],
-      },
-      notification: {
-        items: [],
-      },
-      router: routerStateFactory(),
-    });
-    render(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/preferences", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <Preferences />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<Preferences />, { route: "/preferences" });
 
     expect(screen.getByLabelText(PreferencesLabels.Title)).toBeInTheDocument();
   });

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -4,6 +4,7 @@ import reducers, { actions, DEFAULT_STATUSES } from "./slice";
 import type { SelectedMachines } from "./types";
 import { FilterGroupKey, FilterGroupType } from "./types";
 
+import { actions as statusActions } from "app/store/status/slice";
 import { NodeActions, NodeStatus, NodeStatusCode } from "app/store/types/node";
 import {
   filterGroup as filterGroupFactory,
@@ -109,6 +110,42 @@ describe("machine reducer", () => {
         },
         lists: {
           "5678": machineStateListFactory({
+            loaded: true,
+            stale: true,
+          }),
+        },
+      })
+    );
+  });
+
+  it("invalidates queries on status/websocketDisconnected", () => {
+    const initialState = machineStateFactory({
+      loading: false,
+      counts: {
+        "1234": machineStateCountFactory({
+          loaded: true,
+          stale: false,
+        }),
+      },
+      lists: {
+        "1234": machineStateListFactory({
+          loaded: true,
+          stale: false,
+        }),
+      },
+    });
+    expect(
+      reducers(initialState, statusActions.websocketDisconnected())
+    ).toEqual(
+      machineStateFactory({
+        counts: {
+          "1234": machineStateCountFactory({
+            loaded: true,
+            stale: true,
+          }),
+        },
+        lists: {
+          "1234": machineStateListFactory({
             loaded: true,
             stale: true,
           }),

--- a/src/app/store/status/reducers.test.ts
+++ b/src/app/store/status/reducers.test.ts
@@ -35,6 +35,7 @@ describe("status", () => {
       statusStateFactory({
         connected: true,
         connecting: true,
+        connectedCount: 0,
         error: null,
       })
     );
@@ -78,7 +79,27 @@ describe("status", () => {
     );
   });
 
-  it("should correctly reduce status/websocketConnected", () => {
+  it("should correctly reduce status/websocketConnected on initial connection", () => {
+    expect(
+      reducers(
+        statusStateFactory({
+          connected: false,
+          connecting: true,
+        }),
+        {
+          type: "status/websocketConnected",
+        }
+      )
+    ).toStrictEqual(
+      statusStateFactory({
+        connected: true,
+        connecting: false,
+        connectedCount: 1,
+      })
+    );
+  });
+
+  it("should correctly reduce status/websocketConnected on error", () => {
     expect(
       reducers(
         statusStateFactory({
@@ -96,7 +117,28 @@ describe("status", () => {
         authenticationError: null,
         connected: true,
         connecting: false,
+        connectedCount: 1,
         error: null,
+      })
+    );
+  });
+
+  it("status/websocketConnected should increment connectedCount on reconnect", () => {
+    expect(
+      reducers(
+        statusStateFactory({
+          connected: true,
+          connectedCount: 1,
+        }),
+        {
+          type: "status/websocketConnected",
+        }
+      )
+    ).toStrictEqual(
+      statusStateFactory({
+        connected: true,
+        connecting: false,
+        connectedCount: 2,
       })
     );
   });

--- a/src/app/store/status/selectors.ts
+++ b/src/app/store/status/selectors.ts
@@ -31,6 +31,13 @@ const connected = (state: RootState): boolean => state.status.connected;
 const connecting = (state: RootState): boolean => state.status.connecting;
 
 /**
+ * Number of times the websocket has been connected.
+ * @param {RootState} state - The redux state.
+ * @returns {StatusState["connecting"]} TheStatusState connecting status.
+ */
+const connectedCount = (state: RootState) => state.status.connectedCount;
+
+/**
  * Status errors.
  * @param {RootState} state - The redux state.
  * @returns {StatusState["error"]} TheStatusState error status.
@@ -74,6 +81,7 @@ const status = {
   authenticationError,
   connected,
   connecting,
+  connectedCount,
   error,
   externalAuthURL,
   externalLoginURL,

--- a/src/app/store/status/slice.ts
+++ b/src/app/store/status/slice.ts
@@ -15,8 +15,10 @@ const statusSlice = createSlice({
     externalLoginURL: null,
     connected: false,
     connecting: false,
-    noUsers: false,
+    // The number of times the websocket connection has been successful
+    connectedCount: 0,
     error: null,
+    noUsers: false,
   } as StatusState,
   reducers: {
     checkAuthenticated: {
@@ -115,6 +117,7 @@ const statusSlice = createSlice({
       state.connecting = false;
       state.authenticationError = null;
       state.error = null;
+      state.connectedCount = state.connectedCount + 1;
     },
     websocketDisconnect: (
       state: StatusState,

--- a/src/app/store/status/types/base.ts
+++ b/src/app/store/status/types/base.ts
@@ -6,6 +6,7 @@ export type StatusState = {
   authenticationError: APIError;
   connected: boolean;
   connecting: boolean;
+  connectedCount: number;
   error: APIError;
   externalAuthURL: string | null;
   externalLoginURL: string | null;

--- a/src/testing/factories/state.ts
+++ b/src/testing/factories/state.ts
@@ -505,6 +505,7 @@ export const statusState = define<StatusState>({
   authenticationError: null,
   connected: false,
   connecting: false,
+  connectedCount: 0,
   error: null,
   externalAuthURL: "http://example.com/auth",
   externalLoginURL: "http://example.com/login",


### PR DESCRIPTION
## Done

- fix(websocket): refetch on reconnect MAASENG-2142 (#5146) 3.4 backport
- add `connectedCount` to redux store
- stop WebSocket ping on disconnect
- run invalidateQueries on disconnect
- run `useFetchActions` hook on reconnect

## QA
None required.