### PR TITLE
MAASENG-2147 add ephemeral indicator to machine list

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.test.tsx
@@ -268,4 +268,17 @@ describe("StatusColumn", () => {
       ).toBeInTheDocument();
     });
   });
+
+  it('displays a "Deployed in memory" status for epmerally deployed machines', () => {
+    machine.ephemeral_deploy = true;
+    machine.status_code = NodeStatusCode.DEPLOYED;
+    const store = mockStore(state);
+
+    renderWithBrowserRouter(
+      <StatusColumn onToggleMenu={jest.fn()} systemId="abc123" />,
+      { route: "/machines", store }
+    );
+
+    expect(screen.getByText(/deployed in memory/i)).toBeInTheDocument();
+  });
 });

--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -126,6 +126,10 @@ export const StatusColumn = ({
   const toggleMenu = useToggleMenu(onToggleMenu || null);
   const actionLinks = useMachineActions(systemId, actions);
   const statusText = getStatusText(machine, formattedOS);
+  const isEphemerallyDeployed =
+    machine &&
+    machine.status_code === NodeStatusCode.DEPLOYED &&
+    machine.ephemeral_deploy;
   const seeLogs = React.useMemo(
     () => ({
       children: "See logs",
@@ -147,8 +151,13 @@ export const StatusColumn = ({
     [statusText]
   );
   const secondary = React.useMemo(
-    () => <Progress machine={machine} />,
-    [machine]
+    () =>
+      isEphemerallyDeployed ? (
+        <span>Deployed in memory</span>
+      ) : (
+        <Progress machine={machine} />
+      ),
+    [machine, isEphemerallyDeployed]
   );
   const icon = React.useMemo(
     () => (machine ? getStatusIcon(machine) : null),

--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -21,6 +21,7 @@ import {
   TestStatusStatus,
 } from "app/store/types/node";
 import { breakLines, getStatusText } from "app/utils";
+import { isEphemerallyDeployed } from "app/utils/IsEphemerallyDeployed";
 
 // Node statuses for which the failed test warning is not shown.
 const hideFailedTestWarningStatuses = [
@@ -126,10 +127,6 @@ export const StatusColumn = ({
   const toggleMenu = useToggleMenu(onToggleMenu || null);
   const actionLinks = useMachineActions(systemId, actions);
   const statusText = getStatusText(machine, formattedOS);
-  const isEphemerallyDeployed =
-    machine &&
-    machine.status_code === NodeStatusCode.DEPLOYED &&
-    machine.ephemeral_deploy;
   const seeLogs = React.useMemo(
     () => ({
       children: "See logs",
@@ -152,12 +149,12 @@ export const StatusColumn = ({
   );
   const secondary = React.useMemo(
     () =>
-      isEphemerallyDeployed ? (
+      isEphemerallyDeployed(machine) ? (
         <span>Deployed in memory</span>
       ) : (
         <Progress machine={machine} />
       ),
-    [machine, isEphemerallyDeployed]
+    [machine]
   );
   const icon = React.useMemo(
     () => (machine ? getStatusIcon(machine) : null),

--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -20,8 +20,7 @@ import {
   NodeStatusCode,
   TestStatusStatus,
 } from "app/store/types/node";
-import { breakLines, getStatusText } from "app/utils";
-import { isEphemerallyDeployed } from "app/utils/IsEphemerallyDeployed";
+import { breakLines, getStatusText, isEphemerallyDeployed } from "app/utils";
 
 // Node statuses for which the failed test warning is not shown.
 const hideFailedTestWarningStatuses = [

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -39,6 +39,7 @@ export type BaseMachine = Omit<
   "cpu_speed" | "interface_test_status"
 > & {
   actions: MachineActions[];
+  ephemeral_deploy: boolean;
   error_description: string;
   extra_macs: string[];
   fabrics: string[];

--- a/src/app/utils/IsEphemerallyDeployed.ts
+++ b/src/app/utils/IsEphemerallyDeployed.ts
@@ -1,0 +1,15 @@
+import type { Machine } from "app/store/machine/types";
+import { NodeStatusCode } from "app/store/types/node";
+
+/**
+ * Check if a machine is deployed ephemerally or not
+ * @param machine - A machine object
+ * @returns boolean value
+ */
+export const isEphemerallyDeployed = (machine: Machine | null) => {
+  return (
+    machine &&
+    machine.status_code === NodeStatusCode.DEPLOYED &&
+    machine.ephemeral_deploy
+  );
+};

--- a/src/app/utils/IsEphemerallyDeployed.ts
+++ b/src/app/utils/IsEphemerallyDeployed.ts
@@ -1,11 +1,6 @@
 import type { Machine } from "app/store/machine/types";
 import { NodeStatusCode } from "app/store/types/node";
 
-/**
- * Check if a machine is deployed ephemerally or not
- * @param machine - A machine object
- * @returns boolean value
- */
 export const isEphemerallyDeployed = (machine: Machine | null) => {
   return (
     machine &&

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -17,6 +17,7 @@ export { getRelativeRoute } from "./getRelativeRoute";
 export { getStatusText } from "./getStatusText";
 export { groupAsMap } from "./groupAsMap";
 export { isComparable } from "./isComparable";
+export { isEphemerallyDeployed } from "./IsEphemerallyDeployed";
 export { isId } from "./isId";
 export { isVersionNewer } from "./isVersionNewer";
 export { kebabToCamelCase } from "./kebabToCamelCase";

--- a/src/app/utils/isEphemerallyDeployed.test.ts
+++ b/src/app/utils/isEphemerallyDeployed.test.ts
@@ -1,28 +1,24 @@
 import { isEphemerallyDeployed } from "./IsEphemerallyDeployed";
 
-import type { Machine } from "app/store/machine/types";
 import { NodeStatusCode } from "app/store/types/node";
 import { machine as machineFactory } from "testing/factories";
 
-describe("isEphemerallyDeployed", () => {
-  let machine: Machine;
-
-  beforeEach(() => {
-    machine = machineFactory({
-      system_id: "abc123",
-      status_code: NodeStatusCode.DEPLOYED,
-    });
+it("returns true if a machine is deployed ephemerally", () => {
+  const machine = machineFactory({
+    system_id: "abc123",
+    status_code: NodeStatusCode.DEPLOYED,
+    ephemeral_deploy: true,
   });
 
-  it("returns true if a machine is deployed ephemerally", () => {
-    machine.ephemeral_deploy = true;
+  expect(isEphemerallyDeployed(machine)).toBe(true);
+});
 
-    expect(isEphemerallyDeployed(machine)).toBe(true);
+it("returns false if a machine is not deployed ephemerally", () => {
+  const machine = machineFactory({
+    system_id: "abc123",
+    status_code: NodeStatusCode.DEPLOYED,
+    ephemeral_deploy: false,
   });
 
-  it("returns false if a machine is not deployed ephemerally", () => {
-    machine.ephemeral_deploy = false;
-
-    expect(isEphemerallyDeployed(machine)).toBe(false);
-  });
+  expect(isEphemerallyDeployed(machine)).toBe(false);
 });

--- a/src/app/utils/isEphemerallyDeployed.test.ts
+++ b/src/app/utils/isEphemerallyDeployed.test.ts
@@ -1,0 +1,28 @@
+import { isEphemerallyDeployed } from "./IsEphemerallyDeployed";
+
+import type { Machine } from "app/store/machine/types";
+import { NodeStatusCode } from "app/store/types/node";
+import { machine as machineFactory } from "testing/factories";
+
+describe("isEphemerallyDeployed", () => {
+  let machine: Machine;
+
+  beforeEach(() => {
+    machine = machineFactory({
+      system_id: "abc123",
+      status_code: NodeStatusCode.DEPLOYED,
+    });
+  });
+
+  it("returns true if a machine is deployed ephemerally", () => {
+    machine.ephemeral_deploy = true;
+
+    expect(isEphemerallyDeployed(machine)).toBe(true);
+  });
+
+  it("returns false if a machine is not deployed ephemerally", () => {
+    machine.ephemeral_deploy = false;
+
+    expect(isEphemerallyDeployed(machine)).toBe(false);
+  });
+});

--- a/src/testing/factories/nodes.ts
+++ b/src/testing/factories/nodes.ts
@@ -256,6 +256,7 @@ export const machine = extend<SimpleNode, Machine>(simpleNode, {
   actions,
   architecture: "amd64/generic",
   description: "a test machine",
+  ephemeral_deploy: false,
   cpu_count: 1,
   cpu_test_status: testStatus,
   distro_series: "",


### PR DESCRIPTION
## Done

- Added Ephemeral deployment indicator to machine list

### QA steps

- Go to `/machines`
- Filter by deployed machines
- The second row of the status cell should be blank, because there are no ephemeral deployments for now
- You can negate the condition that displays this indicator by negating line 132 of `src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx`
- You should see the indicator display on the machine list as in the screenshot below

## Fixes
[MAASENG-2147](https://warthogs.atlassian.net/browse/MAASENG-2147)


## Screenshots
![image](https://github.com/canonical/maas-ui/assets/47540149/0fbe286d-4663-4217-a85d-896a420fd38e)



[MAASENG-2147]: https://warthogs.atlassian.net/browse/MAASENG-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ