### PR TITLE
MAASENG-2148 machine details ephemeral indicator

### DIFF
--- a/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.test.tsx
@@ -15,9 +15,14 @@ import {
   osInfoState as osInfoStateFactory,
   rootState as rootStateFactory,
 } from "testing/factories";
-import { userEvent, render, screen } from "testing/utils";
+import {
+  userEvent,
+  render,
+  screen,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
-const mockStore = configureStore();
+const mockStore = configureStore<RootState>();
 
 describe("MachineStatusCard", () => {
   let state: RootState;
@@ -205,5 +210,24 @@ describe("MachineStatusCard", () => {
     expect(
       screen.getByText(/This machine hardware info is synced every 15 minutes./)
     ).toBeVisible();
+  });
+
+  it("indicates when a machine is deployed ephemerally", () => {
+    const machine = machineDetailsFactory({
+      ephemeral_deploy: true,
+      status: NodeStatus.DEPLOYED,
+      status_code: NodeStatusCode.DEPLOYED,
+      sync_interval: 900,
+    });
+    const store = mockStore(state);
+
+    renderWithBrowserRouter(<MachineStatusCard machine={machine} />, {
+      store,
+      route: "/machines",
+    });
+
+    expect(
+      screen.getByRole("heading", { name: /deployed in memory/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.tsx
+++ b/src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.tsx
@@ -16,7 +16,7 @@ import {
   NodeStatusCode,
   TestStatusStatus,
 } from "app/store/types/node";
-import { breakLines } from "app/utils";
+import { breakLines, isEphemerallyDeployed } from "app/utils";
 
 type Props = {
   machine: MachineDetails;
@@ -74,6 +74,9 @@ const MachineStatusCard = ({ machine }: Props): JSX.Element => {
             </i>
           )}
           {machine.status}
+          {isEphemerallyDeployed(machine) && (
+            <span className="p-text--small"> in memory</span>
+          )}
         </h4>
 
         {machine.show_os_info ? (


### PR DESCRIPTION
## Done

- Add ephemeral deploy indicator to machine details page


### QA steps

- Go to the details page of any deployed machine
- If that machine is not deployed ephemerally, negate the condition in line 77 of `src/app/base/components/node/OverviewCard/MachineStatusCard/MachineStatusCard.tsx`
- You should see a heading that says 'Deployed in memory'

## Fixes
[MAASENG-2148](https://warthogs.atlassian.net/browse/MAASENG-2148)

## Screenshots
<img width="1048" alt="image" src="https://github.com/canonical/maas-ui/assets/47540149/a9302fcd-a158-4eed-a1f4-9319788e35c8">




[MAASENG-2148]: https://warthogs.atlassian.net/browse/MAASENG-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ