### PR TITLE
feat(machines): Add "Deployment target" to deploy form MAASENG-2159

### DIFF
--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployForm.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployForm.test.tsx
@@ -161,7 +161,7 @@ describe("DeployForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Start deployment for 2 machines" })
+      screen.getByRole("button", { name: "Deploy 2 machines" })
     );
 
     expect(
@@ -169,12 +169,14 @@ describe("DeployForm", () => {
     ).toStrictEqual([
       machineActions.deploy({
         distro_series: "bionic",
+        ephemeral_deploy: false,
         hwe_kernel: "",
         osystem: "ubuntu",
         system_id: "abc123",
       }),
       machineActions.deploy({
         distro_series: "bionic",
+        ephemeral_deploy: false,
         hwe_kernel: "",
         osystem: "ubuntu",
         system_id: "def456",
@@ -211,7 +213,7 @@ describe("DeployForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Start deployment for machine" })
+      screen.getByRole("button", { name: "Deploy machine" })
     );
 
     expect(
@@ -219,6 +221,7 @@ describe("DeployForm", () => {
     ).toStrictEqual([
       machineActions.deploy({
         distro_series: "bionic",
+        ephemeral_deploy: false,
         hwe_kernel: "",
         osystem: "ubuntu",
         system_id: "abc123",
@@ -245,7 +248,7 @@ describe("DeployForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Start deployment for machine" })
+      screen.getByRole("button", { name: "Deploy machine" })
     );
 
     expect(
@@ -253,6 +256,7 @@ describe("DeployForm", () => {
     ).toStrictEqual(
       machineActions.deploy({
         distro_series: "bionic",
+        ephemeral_deploy: false,
         hwe_kernel: "",
         osystem: "ubuntu",
         system_id: "abc123",
@@ -282,13 +286,14 @@ describe("DeployForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Start deployment for machine" })
+      screen.getByRole("button", { name: "Deploy machine" })
     );
     expect(
       store.getActions().find((action) => action.type === "machine/deploy")
     ).toStrictEqual(
       machineActions.deploy({
         distro_series: "bionic",
+        ephemeral_deploy: false,
         enable_hw_sync: true,
         hwe_kernel: "",
         osystem: "ubuntu",
@@ -314,13 +319,14 @@ describe("DeployForm", () => {
       screen.getByRole("option", { name: "No minimum kernel" })
     );
     await userEvent.click(
-      screen.getByRole("button", { name: "Start deployment for machine" })
+      screen.getByRole("button", { name: "Deploy machine" })
     );
     expect(
       store.getActions().filter((action) => action.type === "machine/deploy")
     ).toStrictEqual([
       machineActions.deploy({
         distro_series: "bionic",
+        ephemeral_deploy: false,
         hwe_kernel: "",
         osystem: "ubuntu",
         system_id: "abc123",
@@ -361,7 +367,7 @@ describe("DeployForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Start deployment for machine" })
+      screen.getByRole("button", { name: "Deploy machine" })
     );
 
     expect(mockSendAnalytics).toHaveBeenCalled();
@@ -395,7 +401,7 @@ describe("DeployForm", () => {
     );
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Start deployment for machine" })
+      screen.getByRole("button", { name: "Deploy machine" })
     );
 
     const action = store
@@ -429,12 +435,57 @@ describe("DeployForm", () => {
     await userEvent.click(screen.getByRole("radio", { name: /libvirt/i }));
 
     await userEvent.click(
-      screen.getByRole("button", { name: "Start deployment for machine" })
+      screen.getByRole("button", { name: "Deploy machine" })
     );
     const action = store
       .getActions()
       .find((action) => action.type === "machine/deploy");
     expect(action?.payload?.params?.extra?.install_kvm).toBe(true);
     expect(action?.payload?.params?.extra?.register_vmhost).toBeUndefined();
+  });
+
+  it("can deploy machines ephemerally", async () => {
+    const store = mockStore(state);
+    renderWithBrowserRouter(
+      <DeployForm
+        clearSidePanelContent={jest.fn()}
+        machines={state.machine.items}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines", store }
+    );
+
+    await userEvent.selectOptions(
+      screen.getByRole("combobox", { name: "Kernel" }),
+      screen.getByRole("option", { name: "No minimum kernel" })
+    );
+
+    await userEvent.click(
+      screen.getByRole("radio", { name: "Deploy in memory" })
+    );
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Deploy 2 machines" })
+    );
+
+    expect(
+      store.getActions().filter((action) => action.type === "machine/deploy")
+    ).toStrictEqual([
+      machineActions.deploy({
+        distro_series: "bionic",
+        ephemeral_deploy: true,
+        hwe_kernel: "",
+        osystem: "ubuntu",
+        system_id: "abc123",
+      }),
+      machineActions.deploy({
+        distro_series: "bionic",
+        ephemeral_deploy: true,
+        hwe_kernel: "",
+        osystem: "ubuntu",
+        system_id: "def456",
+      }),
+    ]);
   });
 });

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployForm.tsx
@@ -24,10 +24,12 @@ const DeploySchema = Yup.object().shape({
   kernel: Yup.string(),
   includeUserData: Yup.boolean(),
   enableHwSync: Yup.boolean(),
+  ephemeralDeploy: Yup.boolean(),
   vmHostType: Yup.string().oneOf([PodType.LXD, PodType.VIRSH, ""]),
 });
 
 export type DeployFormValues = {
+  ephemeralDeploy: boolean;
   includeUserData: boolean;
   kernel: string;
   oSystem: string;
@@ -102,6 +104,7 @@ export const DeployForm = ({
       cleanup={machineActions.cleanup}
       errors={errors || actionErrors}
       initialValues={{
+        ephemeralDeploy: false,
         oSystem: initialOS,
         release: initialRelease,
         kernel: defaultMinHweKernel || "",
@@ -131,6 +134,7 @@ export const DeployForm = ({
         if (selectedMachines) {
           dispatchForSelectedMachines(machineActions.deploy, {
             distro_series: values.release,
+            ephemeral_deploy: values.ephemeralDeploy,
             hwe_kernel: values.kernel,
             osystem: values.oSystem,
             ...(values.enableHwSync && { enable_hw_sync: true }),
@@ -147,6 +151,7 @@ export const DeployForm = ({
             dispatch(
               machineActions.deploy({
                 distro_series: values.release,
+                ephemeral_deploy: values.ephemeralDeploy,
                 hwe_kernel: values.kernel,
                 osystem: values.oSystem,
                 system_id: machine.system_id,

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -18,7 +18,13 @@ import {
   user as userFactory,
   userState as userStateFactory,
 } from "testing/factories";
-import { userEvent, render, screen, waitFor } from "testing/utils";
+import {
+  userEvent,
+  render,
+  screen,
+  waitFor,
+  renderWithBrowserRouter,
+} from "testing/utils";
 
 const mockStore = configureStore();
 
@@ -674,5 +680,42 @@ describe("DeployFormFields", () => {
         true
       );
     });
+  });
+
+  it("selects 'Deploy to disk' as the default deployment target", () => {
+    renderWithBrowserRouter(
+      <DeployForm
+        clearSidePanelContent={jest.fn()}
+        machines={[]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines/add", state }
+    );
+
+    expect(screen.getByRole("radio", { name: "Deploy to disk" })).toBeChecked();
+    expect(
+      screen.getByRole("radio", { name: "Deploy in memory" })
+    ).not.toBeChecked();
+  });
+
+  it("hides 'Register as MAAS KVM host' if 'Deploy in memory' is selected", async () => {
+    renderWithBrowserRouter(
+      <DeployForm
+        clearSidePanelContent={jest.fn()}
+        machines={[]}
+        processingCount={0}
+        viewingDetails={false}
+      />,
+      { route: "/machines/add", state }
+    );
+
+    await userEvent.click(
+      screen.getByRole("radio", { name: "Deploy in memory" })
+    );
+
+    expect(
+      screen.queryByRole("checkbox", { name: "Register as MAAS KVM host" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -628,7 +628,7 @@ describe("DeployFormFields", () => {
       screen.getByRole("checkbox", { name: /Periodically sync hardware/ })
     ).not.toBeChecked();
     await userEvent.click(
-      screen.getByRole("button", { name: /Start deployment for machine/ })
+      screen.getByRole("button", { name: /Deploy machine/ })
     );
 
     await waitFor(() => {
@@ -664,7 +664,7 @@ describe("DeployFormFields", () => {
       screen.getByRole("checkbox", { name: /Periodically sync hardware/ })
     );
     await userEvent.click(
-      screen.getByRole("button", { name: /Start deployment for machine/ })
+      screen.getByRole("button", { name: /Deploy machine/ })
     );
     await waitFor(() =>
       expect(

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -136,53 +136,86 @@ export const DeployFormFields = (): JSX.Element => {
         </div>
         <Row>
           <Col size={12}>
-            <p>Customise options</p>
+            <p>Deployment target</p>
           </Col>
           <Col size={12}>
             <Input
-              checked={deployVmHost}
-              disabled={!canBeKVMHost || noImages}
-              help="Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially supported."
-              id="deployVmHost"
-              label={
-                <>
-                  Register as MAAS KVM host.{" "}
-                  <a
-                    href={docsUrls.kvmIntroduction}
-                    rel="noreferrer noopener"
-                    target="_blank"
-                  >
-                    KVM docs
-                  </a>
-                </>
-              }
-              onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
-                const { checked } = evt.target;
-                if (checked) {
-                  setDeployVmHost(true);
-                  setFieldValue("vmHostType", PodType.LXD);
-                } else {
-                  clearVmHostOptions();
-                }
+              checked={!values.ephemeralDeploy}
+              label="Deploy to disk"
+              name="ephemeralDeploy"
+              onClick={() => {
+                setFieldValue("ephemeralDeploy", false);
               }}
-              type="checkbox"
+              type="radio"
             />
-            {deployVmHost && (
+            <Input
+              checked={values.ephemeralDeploy}
+              help="No disk layout will be applied during deployment. All system data will be reset upon reboot or shutdown."
+              label="Deploy in memory"
+              name="ephemeralDeploy"
+              onClick={() => {
+                setFieldValue("ephemeralDeploy", true);
+              }}
+              type="radio"
+            />
+          </Col>
+        </Row>
+        <div className="u-sv2">
+          <hr className="u-sv2" />
+        </div>
+        <Row>
+          <Col size={12}>
+            <p>Customise options</p>
+          </Col>
+          <Col size={12}>
+            {!values.ephemeralDeploy && (
               <>
-                <FormikField
-                  label="LXD"
-                  name="vmHostType"
-                  type="radio"
-                  value={PodType.LXD}
-                  wrapperClassName="u-nudge-right--x-large"
+                <Input
+                  checked={deployVmHost}
+                  disabled={!canBeKVMHost || noImages}
+                  help="Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially supported."
+                  id="deployVmHost"
+                  label={
+                    <>
+                      Register as MAAS KVM host.{" "}
+                      <a
+                        href={docsUrls.kvmIntroduction}
+                        rel="noreferrer noopener"
+                        target="_blank"
+                      >
+                        KVM docs
+                      </a>
+                    </>
+                  }
+                  onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
+                    const { checked } = evt.target;
+                    if (checked) {
+                      setDeployVmHost(true);
+                      setFieldValue("vmHostType", PodType.LXD);
+                    } else {
+                      clearVmHostOptions();
+                    }
+                  }}
+                  type="checkbox"
                 />
-                <FormikField
-                  label="libvirt"
-                  name="vmHostType"
-                  type="radio"
-                  value={PodType.VIRSH}
-                  wrapperClassName="u-nudge-right--x-large"
-                />
+                {deployVmHost && (
+                  <>
+                    <FormikField
+                      label="LXD"
+                      name="vmHostType"
+                      type="radio"
+                      value={PodType.LXD}
+                      wrapperClassName="u-nudge-right--x-large"
+                    />
+                    <FormikField
+                      label="libvirt"
+                      name="vmHostType"
+                      type="radio"
+                      value={PodType.VIRSH}
+                      wrapperClassName="u-nudge-right--x-large"
+                    />
+                  </>
+                )}
               </>
             )}
             <FormikField

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -143,7 +143,7 @@ export const DeployFormFields = (): JSX.Element => {
               checked={!values.ephemeralDeploy}
               label="Deploy to disk"
               name="ephemeralDeploy"
-              onClick={() => {
+              onChange={() => {
                 setFieldValue("ephemeralDeploy", false);
               }}
               type="radio"
@@ -153,7 +153,7 @@ export const DeployFormFields = (): JSX.Element => {
               help="No disk layout will be applied during deployment. All system data will be reset upon reboot or shutdown."
               label="Deploy in memory"
               name="ephemeralDeploy"
-              onClick={() => {
+              onChange={() => {
                 setFieldValue("ephemeralDeploy", true);
               }}
               type="radio"

--- a/src/app/store/machine/actions.test.ts
+++ b/src/app/store/machine/actions.test.ts
@@ -444,6 +444,7 @@ describe("machine actions", () => {
     expect(
       actions.deploy({
         distro_series: "bionic",
+        ephemeral_deploy: false,
         hwe_kernel: "ga-16.04",
         install_kvm: false,
         osystem: "ubuntu",
@@ -460,6 +461,7 @@ describe("machine actions", () => {
           action: NodeActions.DEPLOY,
           extra: {
             distro_series: "bionic",
+            ephemeral_deploy: false,
             hwe_kernel: "ga-16.04",
             install_kvm: false,
             osystem: "ubuntu",
@@ -474,6 +476,7 @@ describe("machine actions", () => {
     expect(
       actions.deploy({
         distro_series: "bionic",
+        ephemeral_deploy: false,
         hwe_kernel: "ga-16.04",
         install_kvm: false,
         osystem: "ubuntu",
@@ -490,6 +493,7 @@ describe("machine actions", () => {
           action: NodeActions.DEPLOY,
           extra: {
             distro_series: "bionic",
+            ephemeral_deploy: false,
             hwe_kernel: "ga-16.04",
             install_kvm: false,
             osystem: "ubuntu",

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -249,6 +249,7 @@ export type DeleteVolumeGroupParams = {
 export type DeployParams = BaseMachineActionParams & {
   distro_series?: Machine["distro_series"];
   enable_hw_sync?: boolean;
+  ephemeral_deploy: boolean;
   hwe_kernel?: string;
   install_kvm?: boolean;
   osystem?: Machine["osystem"];

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -249,7 +249,7 @@ export type DeleteVolumeGroupParams = {
 export type DeployParams = BaseMachineActionParams & {
   distro_series?: Machine["distro_series"];
   enable_hw_sync?: boolean;
-  ephemeral_deploy: boolean;
+  ephemeral_deploy?: boolean;
   hwe_kernel?: string;
   install_kvm?: boolean;
   osystem?: Machine["osystem"];

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -120,9 +120,7 @@ export const getNodeActionLabel = (
     case NodeActions.DELETE:
       return `${isProcessing ? "Deleting" : "Delete"} ${modelString}`;
     case NodeActions.DEPLOY:
-      return `${
-        isProcessing ? "Starting" : "Start"
-      } deployment for ${modelString}`;
+      return `${isProcessing ? "Deploying" : "Deploy"} ${modelString}`;
     case NodeActions.EXIT_RESCUE_MODE:
       return `${
         isProcessing ? "Exiting" : "Exit"


### PR DESCRIPTION
## Done

- Added "Deployment target" section to deploy form
- Added `ephemeral_deploy` to node deployment action parameters
- Hide "Register as MAAS KVM host" if "Deploy in memory" is selected
- Changes submit button text from "Start deployment for `n` machines" to "Deploy `n` machines"

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

**Prerequisite**: Ensure you have dev tools open on the network tab, and inspect the websocket connection

1. Go to machine list
2. Select a machine
3. Open the deploy form
4. Ensure that "Deployment target" is shown
5. Click "Deploy in memory"
6. Ensure that "Register as MAAS KVM host" is hidden
7. Submit the form
8. Ensure a websocket message was sent to deploy the machine, containing `ephemeral_deploy: true`
9. Repeat steps 3-8 for a selection of multiple machines

## Fixes

Fixes [MAASENG-2159](https://warthogs.atlassian.net/browse/MAASENG-2159)

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/4a6473fc-2cca-4454-96f0-ba79fd59d16e)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/eeeb3f8a-3c2d-4389-8f3f-185bb3c12f9f)

![image](https://github.com/canonical/maas-ui/assets/35104482/1aa1d268-1dbf-44b8-88c1-f8710ff39903)



[MAASENG-2159]: https://warthogs.atlassian.net/browse/MAASENG-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ