### PR TITLE
MAASENG-2150 implement filtering by deployment target

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -154,4 +154,19 @@ context("Machine listing", () => {
     cy.findByRole("button", { name: /Delete 3 machines/ }).click();
     cy.findByText(/No machines match the search criteria./).should("exist");
   });
+
+  it("can filter machine list by deployment target", () => {
+    cy.findByRole("button", { name: /filters/i }).click();
+    cy.findByRole("tab", { name: /deployment target/i })
+      .should("exist")
+      .click();
+    cy.findByRole("checkbox", { name: /deployed to disk/i }).should("exist");
+    cy.findByRole("checkbox", { name: /deployed in memory/i })
+      .should("exist")
+      .click();
+    cy.findByRole("searchbox").should(
+      "have.value",
+      "deployment_target:(=memory)"
+    );
+  });
 });

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
@@ -12,7 +12,7 @@ import { FilterGroupKey } from "app/store/machine/types";
 export enum Label {
   Toggle = "Filters",
   Arch = "Architecture",
-  Deploy = "Deployment Target",
+  DeploymentTarget = "Deployment Target",
   Fabrics = "Fabric",
   Owner = "Owner",
   Pod = "KVM",
@@ -49,7 +49,7 @@ const filterOrder = [
 
 const filterNames = new Map<FilterGroupKey, string>([
   [FilterGroupKey.Arch, Label.Arch],
-  [FilterGroupKey.DeploymentTarget, Label.Deploy],
+  [FilterGroupKey.DeploymentTarget, Label.DeploymentTarget],
   [FilterGroupKey.Fabrics, Label.Fabrics],
   [FilterGroupKey.Owner, Label.Owner],
   [FilterGroupKey.Pod, Label.Pod],

--- a/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachinesFilterAccordion/MachinesFilterAccordion.tsx
@@ -12,6 +12,7 @@ import { FilterGroupKey } from "app/store/machine/types";
 export enum Label {
   Toggle = "Filters",
   Arch = "Architecture",
+  Deploy = "Deployment Target",
   Fabrics = "Fabric",
   Owner = "Owner",
   Pod = "KVM",
@@ -32,6 +33,7 @@ type Props = {
 
 const filterOrder = [
   FilterGroupKey.Status,
+  FilterGroupKey.DeploymentTarget,
   FilterGroupKey.Owner,
   FilterGroupKey.Pool,
   FilterGroupKey.Arch,
@@ -47,6 +49,7 @@ const filterOrder = [
 
 const filterNames = new Map<FilterGroupKey, string>([
   [FilterGroupKey.Arch, Label.Arch],
+  [FilterGroupKey.DeploymentTarget, Label.Deploy],
   [FilterGroupKey.Fabrics, Label.Fabrics],
   [FilterGroupKey.Owner, Label.Owner],
   [FilterGroupKey.Pod, Label.Pod],

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -257,6 +257,7 @@ export enum FilterGroupKey {
   Arch = "arch",
   CpuCount = "cpu_count",
   CpuSpeed = "cpu_speed",
+  DeploymentTarget = "deployment_target",
   Description = "description",
   DistroSeries = "distro_series",
   Domain = "domain",


### PR DESCRIPTION
## Done

- Add Deployment target to machine list filters

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Visit the machine list page
- Click on the `Filter` at the top of the list and ensure that `Deployment target` is among the list of filters
- Expand the deployment accordion and ensure that the filter options ("Deployed in memory" & "Deployed on disk") are visible
- Click on any of them and ensure that the list is filtered adequately and the search box is updated.

## Fixes

[Fixes: MAASENG-2150](https://warthogs.atlassian.net/jira/software/c/projects/MAASENG/issues/MAASENG-2150)

## Designs
https://app.zeplin.io/project/64d256035eca5e52f01ee1ab/screen/64e72abaa08692236d2c54a6

## Screenshots
![image](https://github.com/canonical/maas-ui/assets/47540149/66073c08-2aff-49a1-85e7-3ae83c167b38)

