### PR TITLE
Fix soft power button text

### DIFF
--- a/cypress/e2e/with-users/machines/actions.spec.ts
+++ b/cypress/e2e/with-users/machines/actions.spec.ts
@@ -168,7 +168,7 @@ context("Machine listing - actions", () => {
     cy.findByRole("complementary", { name: /soft power off/i }).should("exist");
     cy.findByRole("heading", { name: /soft power off/i }).should("exist");
     cy.findByText(
-      /a soft power off generally asks the os to shutdown the system gracefully before powering off\. it is only supported by ipmi/i
+      /a soft power off generally asks the os to shutdown the system gracefully before powering off\. it is only supported by ipmi./i
     ).should("exist");
   });
 });

--- a/src/app/base/components/node/PowerOffForm/PowerOffForm.test.tsx
+++ b/src/app/base/components/node/PowerOffForm/PowerOffForm.test.tsx
@@ -62,7 +62,7 @@ describe("PowerOffForm", () => {
 
     await userEvent.click(
       screen.getByRole("button", {
-        name: /power off machine/i,
+        name: /soft power off machine/i,
       })
     );
     expect(

--- a/src/app/base/components/node/PowerOffForm/PowerOffForm.tsx
+++ b/src/app/base/components/node/PowerOffForm/PowerOffForm.tsx
@@ -13,7 +13,7 @@ const PowerOffForm = ({ action, actions, ...props }: FieldlessFormProps) => {
     ) : action === NodeActions.SOFT_OFF ? (
       <p>
         A soft power off generally asks the OS to shutdown the system gracefully
-        before powering off. It is only supported by IPMI
+        before powering off. It is only supported by IPMI.
       </p>
     ) : (
       <></>

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -158,7 +158,7 @@ export const getNodeActionLabel = (
     case NodeActions.SET_ZONE:
       return `${isProcessing ? "Setting" : "Set"} zone for ${modelString}`;
     case NodeActions.SOFT_OFF:
-      return `${isProcessing ? "Powering" : "Soft Power"} off ${modelString}`;
+      return `${isProcessing ? "Powering" : "Soft power"} off ${modelString}`;
     case NodeActions.TAG:
     case NodeActions.UNTAG:
       return `${isProcessing ? "Updating" : "Update"} tags for ${modelString}`;

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -134,7 +134,6 @@ export const getNodeActionLabel = (
     case NodeActions.ON:
       return `${isProcessing ? "Powering" : "Power"} on ${modelString}`;
     case NodeActions.OFF:
-    case NodeActions.SOFT_OFF:
       return `${isProcessing ? "Powering" : "Power"} off ${modelString}`;
     case NodeActions.MARK_BROKEN:
       return `${isProcessing ? "Marking" : "Mark"} ${modelString} broken`;
@@ -158,6 +157,8 @@ export const getNodeActionLabel = (
       return `${isProcessing ? "Setting" : "Set"} pool for ${modelString}`;
     case NodeActions.SET_ZONE:
       return `${isProcessing ? "Setting" : "Set"} zone for ${modelString}`;
+    case NodeActions.SOFT_OFF:
+      return `${isProcessing ? "Powering" : "Soft Power"} off ${modelString}`;
     case NodeActions.TAG:
     case NodeActions.UNTAG:
       return `${isProcessing ? "Updating" : "Update"} tags for ${modelString}`;


### PR DESCRIPTION
## Done

- Corrected soft stop button text

### QA steps

- Go to machine list
- Select a few machines and click on `Power Cycle` > `Soft Power off`
- Ensure the button in the dialog reads "Soft power off machine"

## Screenshots
### Before
![image](https://github.com/canonical/maas-ui/assets/47540149/d32d08f1-30ef-448c-9540-853f3bdd9a6c)

### After
![image](https://github.com/canonical/maas-ui/assets/47540149/371dba59-93aa-45b7-bafd-9944d2466239)

