### PR TITLE
docs(storybook): add actions for setter props

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,7 +7,10 @@ import "../src/scss/index.scss";
 
 const preview: Preview = {
   parameters: {
-    actions: { argTypesRegex: "^on[A-Z].*" },
+    // Add Storybook actions for matching props by default (e.g. onClick, setContent).
+    // Can be overriden in stories.
+    // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args
+    actions: { argTypesRegex: "^on[A-Z].*|^set[A-Z].*" },
     controls: {
       matchers: {
         color: /(background|color)$/i,


### PR DESCRIPTION
## Done

- docs(storybook): add actions for setter props

## QA


### QA steps

- Run storybook locally
- Go to MachineActionMenu
- Click on an action
- Verify it's been displayed in the actions tab

#### Note
There’s an error thrown in the console due to a bug in storybook which will be fixed in the next 7.4.4 release https://github.com/storybookjs/storybook/pull/24237
https://github.com/storybookjs/storybook/issues/23787


## Screenshots
![Google Chrome screenshot 000842@2x](https://github.com/canonical/maas-ui/assets/7452681/35875775-5be7-4a9d-a6b6-b77fc35c1fb0)
