### PR TITLE
fix: update VLANs on subnet/createNotify

### DIFF
--- a/src/app/store/vlan/reducers.test.ts
+++ b/src/app/store/vlan/reducers.test.ts
@@ -1,9 +1,11 @@
 import reducers, { actions } from "./slice";
 
+import { actions as subnetActions } from "app/store/subnet/slice";
 import {
   vlan as vlanFactory,
   vlanEventError as vlanEventErrorFactory,
   vlanState as vlanStateFactory,
+  subnet as subnetFactory,
   vlanStatus as vlanStatusFactory,
   vlanStatuses as vlanStatusesFactory,
 } from "testing/factories";
@@ -395,6 +397,26 @@ describe("vlan reducer", () => {
           statuses: vlanStatusesFactory({
             0: vlanStatusFactory({ configuringDHCP: false }),
           }),
+        })
+      );
+    });
+  });
+
+  describe("subnet/createNotify", () => {
+    it("updates VLAN subnet_ids when a subnet is created", () => {
+      const vlan1 = vlanFactory({ id: 1, subnet_ids: [] });
+      const vlan2 = vlanFactory({ id: 2, subnet_ids: [] });
+      const initialState = vlanStateFactory({
+        items: [vlan1, vlan2],
+      });
+      const subnet = subnetFactory({ id: 3, vlan: 1 });
+      const expectedVlans = [{ ...vlan1, subnet_ids: [subnet.id] }, vlan2];
+
+      expect(
+        reducers(initialState, subnetActions.createNotify(subnet))
+      ).toEqual(
+        vlanStateFactory({
+          items: expectedVlans,
         })
       );
     });

--- a/src/app/store/vlan/slice.ts
+++ b/src/app/store/vlan/slice.ts
@@ -1,6 +1,8 @@
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
+import type { Subnet } from "../subnet/types";
+
 import { VLANMeta } from "./types";
 import type {
   ConfigureDHCPParams,
@@ -168,6 +170,22 @@ const vlanSlice = createSlice({
     ) => {
       state.active = action.payload ? action.payload[VLANMeta.PK] : null;
     },
+  },
+  extraReducers: (builder) => {
+    // Add the newly created subnet's ID to the corresponding VLAN's subnet_ids array
+    builder.addCase(
+      "subnet/createNotify",
+      (state, action: PayloadAction<Subnet, "subnet/createNotify">) => {
+        const { id: subnetId, vlan: vlanId } = action.payload;
+
+        const vlanIndex = state.items.findIndex((item) => item.id === vlanId);
+
+        const vlanExists = vlanIndex !== -1;
+        if (vlanExists) {
+          state.items[vlanIndex].subnet_ids.push(subnetId);
+        }
+      }
+    );
   },
 });
 


### PR DESCRIPTION
## Done

- fix: update VLANs on subnet/createNotify

## QA

### QA steps

- Go to the subnets page
- make sort by Fabric is selected at the top
- Create a new subnet 
- Make sure the table has been updated with the new row

## Fixes

Fixes: https://bugs.launchpad.net/maas-ui/+bug/2037530

