### PR TITLE
feat(images): Add column to image list for diskless deployment support MAASENG-255

### DIFF
--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -476,4 +476,47 @@ describe("ImagesTable", () => {
       expect(row).toHaveTextContent(resourcesByReleaseTitle[i].title);
     });
   });
+
+  it("can show support for deploying to memory", async () => {
+    const supported_resource = resourceFactory({ canDeployToMemory: true });
+    const unsupported_resource = resourceFactory({ canDeployToMemory: false });
+    renderWithMockStore(
+      <ImagesTable
+        handleClear={jest.fn()}
+        images={[]}
+        resources={[supported_resource, unsupported_resource]}
+      />,
+      { state }
+    );
+
+    const tableBody = screen.getAllByRole("rowgroup")[1];
+    const rows = within(tableBody).getAllByRole("row");
+
+    expect(
+      within(rows[0]).getByRole("gridcell", { name: "supported" })
+    ).toBeInTheDocument();
+    expect(
+      within(rows[1]).getByRole("gridcell", { name: "not supported" })
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(rows[0]).getByRole("button", { name: "supported" })
+    );
+
+    expect(
+      screen.getByRole("tooltip", {
+        name: "This image can be deployed in memory.",
+      })
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(rows[1]).getByRole("button", { name: "not supported" })
+    );
+
+    expect(
+      screen.getByRole("tooltip", {
+        name: "This image cannot be deployed in memory.",
+      })
+    ).toBeInTheDocument();
+  });
 });

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -8,6 +8,7 @@ import DeleteImageConfirm from "./DeleteImageConfirm";
 
 import DoubleRow from "app/base/components/DoubleRow";
 import TableActions from "app/base/components/TableActions";
+import TooltipButton from "app/base/components/TooltipButton/TooltipButton";
 import type { ImageValue } from "app/images/types";
 import type { BootResource } from "app/store/bootresource/types";
 import { splitResourceName } from "app/store/bootresource/utils";
@@ -151,6 +152,22 @@ const generateResourceRow = ({
       { content: resource.arch, className: "arch-col" },
       { content: resource.size, className: "size-col" },
       {
+        // Icons needed: power-unknown, close, task-outstanding
+        // Aria labels: Unknown, supported, not supported
+        // Messages:
+        // - "It is unknown if this image can be deployed in memory."
+        // - "This image can be deployed in memory."
+        // - "This image cannot be deployed in memory."
+        content: (
+          <TooltipButton
+            iconName="task-outstanding"
+            iconProps={{ "aria-label": "supported" }}
+            message="This image can be deployed in memory."
+          />
+        ),
+        className: "diskless-col",
+      },
+      {
         content: (
           <DoubleRow
             data-testid="resource-status"
@@ -271,6 +288,7 @@ const ImagesTable = ({
         { content: "Release", className: "release-col", sortKey: "title" },
         { content: "Architecture", className: "arch-col", sortKey: "arch" },
         { content: "Size", className: "size-col", sortKey: "size" },
+        { content: "Deployable in memory", className: "diskless-col" },
         {
           content: <span className="p-double-row__header-spacer">Status</span>,
           className: "status-col",

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -50,20 +50,12 @@ const EphemeralSupportIcon = ({
         message="This image can be deployed in memory."
       />
     );
-  } else if (supports_ephemeral === false) {
+  } else {
     return (
       <TooltipButton
         iconName="close"
         iconProps={{ "aria-label": "not supported" }}
         message="This image cannot be deployed in memory."
-      />
-    );
-  } else {
-    return (
-      <TooltipButton
-        iconName="power-unknown"
-        iconProps={{ "aria-label": "unknown" }}
-        message="It is unknown if this image can be deployed in memory."
       />
     );
   }
@@ -184,7 +176,11 @@ const generateResourceRow = ({
       { content: resource.arch, className: "arch-col" },
       { content: resource.size, className: "size-col" },
       {
-        content: <EphemeralSupportIcon supports_ephemeral={null} />,
+        content: (
+          <EphemeralSupportIcon
+            supports_ephemeral={resource.canDeployToMemory}
+          />
+        ),
         className: "diskless-col",
       },
       {

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -37,6 +37,38 @@ export enum Labels {
   MachineCount = "Machine count",
 }
 
+const EphemeralSupportIcon = ({
+  supports_ephemeral,
+}: {
+  supports_ephemeral: boolean | null;
+}) => {
+  if (supports_ephemeral === true) {
+    return (
+      <TooltipButton
+        iconName="task-outstanding"
+        iconProps={{ "aria-label": "supported" }}
+        message="This image can be deployed in memory."
+      />
+    );
+  } else if (supports_ephemeral === false) {
+    return (
+      <TooltipButton
+        iconName="close"
+        iconProps={{ "aria-label": "not supported" }}
+        message="This image cannot be deployed in memory."
+      />
+    );
+  } else {
+    return (
+      <TooltipButton
+        iconName="power-unknown"
+        iconProps={{ "aria-label": "unknown" }}
+        message="It is unknown if this image can be deployed in memory."
+      />
+    );
+  }
+};
+
 /**
  * Check whether a given resource matches a form image value.
  * @param resource - the resource to check.
@@ -152,19 +184,7 @@ const generateResourceRow = ({
       { content: resource.arch, className: "arch-col" },
       { content: resource.size, className: "size-col" },
       {
-        // Icons needed: power-unknown, close, task-outstanding
-        // Aria labels: Unknown, supported, not supported
-        // Messages:
-        // - "It is unknown if this image can be deployed in memory."
-        // - "This image can be deployed in memory."
-        // - "This image cannot be deployed in memory."
-        content: (
-          <TooltipButton
-            iconName="task-outstanding"
-            iconProps={{ "aria-label": "supported" }}
-            message="This image can be deployed in memory."
-          />
-        ),
+        content: <EphemeralSupportIcon supports_ephemeral={null} />,
         className: "diskless-col",
       },
       {

--- a/src/app/images/components/ImagesTable/_index.scss
+++ b/src/app/images/components/ImagesTable/_index.scss
@@ -1,7 +1,7 @@
 @mixin ImagesTable {
   .images-table {
     .release-col {
-      @include breakpoint-widths(0.25, 0.25, 0.2, 0.2, 0.2, true);
+      @include breakpoint-widths(0.25, 0.25, 0.2, 0.2, 0.15, true);
     }
 
     .arch-col {
@@ -13,7 +13,7 @@
     }
 
     .status-col {
-      @include breakpoint-widths(0.25, 0.45, 0.3, 0.35, 0.25, true);
+      @include breakpoint-widths(0.25, 0.45, 0.3, 0.35, 0.2, true);
     }
 
     .actions-col {
@@ -26,6 +26,10 @@
 
     .last-deployed-col {
       @include breakpoint-widths(0, 0, 0.15, 0.2, 0.15, true);
+    }
+
+    .diskless-col {
+      @include breakpoint-widths(0, 0, 0, 0, 0.1, true);
     }
   }
 }

--- a/src/app/store/bootresource/types/base.ts
+++ b/src/app/store/bootresource/types/base.ts
@@ -11,6 +11,7 @@ export type BaseImageFields = {
 
 export type BootResource = Model & {
   arch: string;
+  canDeployToMemory: boolean;
   complete: boolean;
   downloading: boolean;
   icon: "in-progress" | "queued" | "succeeded" | "waiting";

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -27,6 +27,7 @@
 @include vf-p-icon-units;
 @include vf-p-icon-tag;
 @include vf-p-icon-connected;
+@include vf-p-icon-task-outstanding;
 
 // Import MAAS overrides of Vanilla patterns
 @import "./vanilla-overrides";

--- a/src/testing/factories/bootresource.ts
+++ b/src/testing/factories/bootresource.ts
@@ -36,6 +36,7 @@ export const bootResource = extend<Model, BootResource>(model, {
   numberOfNodes: 0,
   lastUpdate: "Tue, 08 Jun. 2021 02:12:47",
   lastDeployed: "Tue, 08 Jun. 2021 02:12:47",
+  canDeployToMemory: true,
 });
 
 export const bootResourceUbuntu = define<BootResourceUbuntu>({


### PR DESCRIPTION
## Done

- Added new column to images table for diskless support
- Added `canDeployToMemory` to base `BootResource` type and factory

## QA

### MAAS deployment

To run this branch you will need access to one of the following MAAS deployments:

- [Karura](/HACKING.md#karura)
- [Bolla](/HACKING.md#bolla)
- [A development MAAS](/HACKING.md#development-deployment)
- [A local snap MAAS](/HACKING.md#snap-deployment) (this will not usually have machines)

### Running the branch

You can run this branch by:

- Serving with [dotrun](/HACKING.md#maas-ui-development-setup)
- [Building in a development MAAS](/HACKING.md#running-maas-ui-from-a-development-maas)

### QA steps

- Go to /images
- Scroll down to the tables
- Ensure a new column "Deployable in memory" is shown
- Ensure a tick or a cross appears for each image
- Hover over the tick/cross
- Ensure an appropriate tooltip is displayed (e.g. "This image can be deployed in memory")

## Fixes

Fixes [MAASENG-2155](https://warthogs.atlassian.net/browse/MAASENG-2155)

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/27df498f-7616-467c-943c-37f08573af82)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/7e390336-7321-4288-8ec0-f0c170747c9b)

