### PR TITLE
fix: use config bulk_update lp#1839788

### DIFF
--- a/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -95,12 +95,11 @@ describe("CommissioningForm", () => {
     expect(updateConfigAction).toEqual({
       type: "config/update",
       payload: {
-        params: [{ name: "commissioning_distro_series", value: "xenial" }],
+        params: { items: { commissioning_distro_series: "xenial" } },
       },
       meta: {
-        dispatchMultiple: true,
         model: "config",
-        method: "update",
+        method: "bulk_update",
       },
     });
   });

--- a/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx
+++ b/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.tsx
@@ -25,6 +25,7 @@ const CommissioningForm = (): JSX.Element => {
   const dispatch = useDispatch();
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
   const commissioningDistroSeries = useSelector(
     configSelectors.commissioningDistroSeries
   );
@@ -37,6 +38,8 @@ const CommissioningForm = (): JSX.Element => {
       aria-label={Labels.FormLabel}
       buttonsAlign="left"
       buttonsBordered={false}
+      cleanup={configActions.cleanup}
+      errors={errors}
       initialValues={{
         commissioning_distro_series: commissioningDistroSeries || "",
         default_min_hwe_kernel: defaultMinKernelVersion || "",

--- a/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
+++ b/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
@@ -150,13 +150,10 @@ describe("DeployFormFields", () => {
       const action = store
         .getActions()
         .find((action) => action.type === "config/update");
-      return expect(action.payload.params).toEqual(
-        expect.arrayContaining([
-          {
-            name: "hardware_sync_interval",
-            value: "30m",
-          },
-        ])
+      return expect(action.payload.params.items).toEqual(
+        expect.objectContaining({
+          hardware_sync_interval: "30m",
+        })
       );
     });
   });

--- a/src/app/settings/views/Configuration/DeployForm/DeployForm.tsx
+++ b/src/app/settings/views/Configuration/DeployForm/DeployForm.tsx
@@ -24,6 +24,7 @@ const DeployForm = (): JSX.Element => {
 
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const defaultOSystem = useSelector(configSelectors.defaultOSystem);
   const defaultDistroSeries = useSelector(configSelectors.defaultDistroSeries);
@@ -37,6 +38,8 @@ const DeployForm = (): JSX.Element => {
       aria-label="deploy configuration"
       buttonsAlign="left"
       buttonsBordered={false}
+      cleanup={configActions.cleanup}
+      errors={errors}
       initialValues={{
         default_osystem: defaultOSystem || "",
         default_distro_series: defaultDistroSeries || "",

--- a/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/GeneralForm.tsx
@@ -50,6 +50,7 @@ const GeneralForm = (): JSX.Element => {
   );
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
   const previousReleaseNotifications = useRef(releaseNotifications);
   const previousEnableAnalytics = usePrevious(analyticsEnabled);
   const { setTheme } = useThemeContext();
@@ -78,6 +79,8 @@ const GeneralForm = (): JSX.Element => {
       aria-label="Configuration - General"
       buttonsAlign="right"
       buttonsBordered={true}
+      cleanup={configActions.cleanup}
+      errors={errors}
       initialValues={{
         maas_name: maasName || "",
         theme: maasTheme || ColorValues.Default,

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
@@ -27,6 +27,7 @@ const KernelParametersForm = (): JSX.Element => {
 
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const kernelParams = useSelector(configSelectors.kernelParams);
 
@@ -35,6 +36,8 @@ const KernelParametersForm = (): JSX.Element => {
       aria-label={Labels.FormLabel}
       buttonsAlign="left"
       buttonsBordered={false}
+      cleanup={configActions.cleanup}
+      errors={errors}
       initialValues={{
         kernel_opts: kernelParams || "",
       }}

--- a/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.tsx
+++ b/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.tsx
@@ -21,6 +21,7 @@ const ThirdPartyDriversForm = (): JSX.Element => {
 
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const thirdPartyDriversEnabled = useSelector(
     configSelectors.thirdPartyDriversEnabled
@@ -31,6 +32,8 @@ const ThirdPartyDriversForm = (): JSX.Element => {
       aria-label={Labels.FormLabel}
       buttonsAlign="left"
       buttonsBordered={false}
+      cleanup={configActions.cleanup}
+      errors={errors}
       initialValues={{
         enable_third_party_drivers: thirdPartyDriversEnabled ?? false,
       }}

--- a/src/app/settings/views/Images/VMWareForm/VMWareForm.tsx
+++ b/src/app/settings/views/Images/VMWareForm/VMWareForm.tsx
@@ -24,6 +24,7 @@ export enum Labels {
 const VMWareForm = (): JSX.Element => {
   const dispatch = useDispatch();
   const updateConfig = configActions.update;
+  const errors = useSelector(configSelectors.errors);
 
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
@@ -38,6 +39,8 @@ const VMWareForm = (): JSX.Element => {
       aria-label={Labels.FormLabel}
       buttonsAlign="left"
       buttonsBordered={false}
+      cleanup={configActions.cleanup}
+      errors={errors}
       initialValues={{
         vcenter_server: vCenterServer ?? "",
         vcenter_username: vCenterUsername ?? "",

--- a/src/app/settings/views/Images/WindowsForm/WindowsForm.tsx
+++ b/src/app/settings/views/Images/WindowsForm/WindowsForm.tsx
@@ -21,6 +21,7 @@ const WindowsForm = (): JSX.Element => {
 
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const windowsKmsHost = useSelector(configSelectors.windowsKmsHost);
 
@@ -29,6 +30,8 @@ const WindowsForm = (): JSX.Element => {
       aria-label={Labels.FormLabel}
       buttonsAlign="left"
       buttonsBordered={false}
+      cleanup={configActions.cleanup}
+      errors={errors}
       initialValues={{
         windows_kms_host: windowsKmsHost ?? "",
       }}

--- a/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
+++ b/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
@@ -82,16 +82,17 @@ describe("DnsForm", () => {
       {
         type: "config/update",
         payload: {
-          params: [
-            { name: "dnssec_validation", value: "auto" },
-            { name: "dns_trusted_acl", value: "" },
-            { name: "upstream_dns", value: "0.0.0.0" },
-          ],
+          params: {
+            items: {
+              dnssec_validation: "auto",
+              dns_trusted_acl: "",
+              upstream_dns: "0.0.0.0",
+            },
+          },
         },
         meta: {
-          dispatchMultiple: true,
           model: "config",
-          method: "update",
+          method: "bulk_update",
         },
       },
     ]);

--- a/src/app/settings/views/Network/DnsForm/DnsForm.tsx
+++ b/src/app/settings/views/Network/DnsForm/DnsForm.tsx
@@ -26,6 +26,7 @@ const DnsForm = (): JSX.Element => {
   const loading = useSelector(configSelectors.loading);
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const dnssecValidation = useSelector(configSelectors.dnssecValidation);
   const dnsTrustedAcl = useSelector(configSelectors.dnsTrustedAcl);
@@ -48,6 +49,8 @@ const DnsForm = (): JSX.Element => {
           <FormikForm
             buttonsAlign="left"
             buttonsBordered={false}
+            cleanup={configActions.cleanup}
+            errors={errors}
             initialValues={{
               dnssec_validation: dnssecValidation || "",
               dns_trusted_acl: dnsTrustedAcl || "",

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
@@ -91,21 +91,16 @@ describe("NetworkDiscoveryForm", () => {
       {
         type: "config/update",
         payload: {
-          params: [
-            {
-              name: "active_discovery_interval",
-              value: "604800",
+          params: {
+            items: {
+              active_discovery_interval: "604800",
+              network_discovery: "enabled",
             },
-            {
-              name: "network_discovery",
-              value: "enabled",
-            },
-          ],
+          },
         },
         meta: {
-          dispatchMultiple: true,
           model: "config",
-          method: "update",
+          method: "bulk_update",
         },
       },
     ]);

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.tsx
@@ -26,6 +26,7 @@ const NetworkDiscoveryForm = (): JSX.Element => {
   const loading = useSelector(configSelectors.loading);
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const activeDiscoveryInterval = useSelector(
     configSelectors.activeDiscoveryInterval
@@ -48,6 +49,8 @@ const NetworkDiscoveryForm = (): JSX.Element => {
           <FormikForm<NetworkDiscoveryValues>
             buttonsAlign="left"
             buttonsBordered={false}
+            cleanup={configActions.cleanup}
+            errors={errors}
             initialValues={{
               active_discovery_interval: activeDiscoveryInterval || "",
               network_discovery: networkDiscovery || "",

--- a/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
+++ b/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
@@ -73,18 +73,16 @@ describe("NtpForm", () => {
       {
         type: "config/update",
         payload: {
-          params: [
-            {
-              name: "ntp_external_only",
-              value: false,
+          params: {
+            items: {
+              ntp_external_only: false,
+              ntp_servers: "ntp.test",
             },
-            { name: "ntp_servers", value: "ntp.test" },
-          ],
+          },
         },
         meta: {
-          dispatchMultiple: true,
           model: "config",
-          method: "update",
+          method: "bulk_update",
         },
       },
     ]);

--- a/src/app/settings/views/Network/NtpForm/NtpForm.tsx
+++ b/src/app/settings/views/Network/NtpForm/NtpForm.tsx
@@ -23,6 +23,7 @@ const NtpForm = (): JSX.Element => {
   const loading = useSelector(configSelectors.loading);
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const ntpExternalOnly = useSelector(configSelectors.ntpExternalOnly);
   const ntpServers = useSelector(configSelectors.ntpServers);
@@ -43,6 +44,8 @@ const NtpForm = (): JSX.Element => {
           <FormikForm
             buttonsAlign="left"
             buttonsBordered={false}
+            cleanup={configActions.cleanup}
+            errors={errors}
             initialValues={{
               ntp_external_only: ntpExternalOnly ?? false,
               ntp_servers: ntpServers ?? "",

--- a/src/app/settings/views/Network/ProxyForm/ProxyForm.tsx
+++ b/src/app/settings/views/Network/ProxyForm/ProxyForm.tsx
@@ -30,6 +30,7 @@ const ProxyForm = (): JSX.Element => {
   const loading = useSelector(configSelectors.loading);
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const httpProxy = useSelector(configSelectors.httpProxy);
   const proxyType = useSelector(configSelectors.proxyType);
@@ -50,6 +51,8 @@ const ProxyForm = (): JSX.Element => {
           <FormikForm<ProxyFormValues>
             buttonsAlign="left"
             buttonsBordered={false}
+            cleanup={configActions.cleanup}
+            errors={errors}
             initialValues={{
               httpProxy: httpProxy || "",
               proxyType,

--- a/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
+++ b/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
@@ -74,17 +74,11 @@ describe("SyslogForm", () => {
       {
         type: "config/update",
         payload: {
-          params: [
-            {
-              name: "remote_syslog",
-              value: "0.0.0.0",
-            },
-          ],
+          params: { items: { remote_syslog: "0.0.0.0" } },
         },
         meta: {
-          dispatchMultiple: true,
           model: "config",
-          method: "update",
+          method: "bulk_update",
         },
       },
     ]);

--- a/src/app/settings/views/Network/SyslogForm/SyslogForm.tsx
+++ b/src/app/settings/views/Network/SyslogForm/SyslogForm.tsx
@@ -22,6 +22,7 @@ const SyslogForm = (): JSX.Element => {
   const loading = useSelector(configSelectors.loading);
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const remoteSyslog = useSelector(configSelectors.remoteSyslog);
 
@@ -41,6 +42,8 @@ const SyslogForm = (): JSX.Element => {
           <FormikForm
             buttonsAlign="left"
             buttonsBordered={false}
+            cleanup={configActions.cleanup}
+            errors={errors}
             initialValues={{
               remote_syslog: remoteSyslog || "",
             }}

--- a/src/app/settings/views/Security/IpmiSettings/IpmiSettings.test.tsx
+++ b/src/app/settings/views/Security/IpmiSettings/IpmiSettings.test.tsx
@@ -66,16 +66,17 @@ describe("IpmiSettings", () => {
     expect(updateConfigAction).toEqual({
       type: "config/update",
       payload: {
-        params: [
-          { name: "maas_auto_ipmi_user", value: "maas" },
-          { name: "maas_auto_ipmi_k_g_bmc_key", value: "password" },
-          { name: "maas_auto_ipmi_user_privilege_level", value: "USER" },
-        ],
+        params: {
+          items: {
+            maas_auto_ipmi_user: "maas",
+            maas_auto_ipmi_k_g_bmc_key: "password",
+            maas_auto_ipmi_user_privilege_level: "USER",
+          },
+        },
       },
       meta: {
-        dispatchMultiple: true,
         model: "config",
-        method: "update",
+        method: "bulk_update",
       },
     });
   });

--- a/src/app/settings/views/Security/IpmiSettings/IpmiSettings.tsx
+++ b/src/app/settings/views/Security/IpmiSettings/IpmiSettings.tsx
@@ -43,6 +43,7 @@ const IpmiSettings = (): JSX.Element => {
   const configLoading = useSelector(configSelectors.loading);
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
   const ipmiUser = useSelector(configSelectors.maasAutoIpmiUser);
   const bmcKey = useSelector(configSelectors.maasAutoIpmiKGBmcKey);
   const ipmiPrivilegeLevel = useSelector(
@@ -65,6 +66,8 @@ const IpmiSettings = (): JSX.Element => {
             aria-label={Labels.FormLabel}
             buttonsAlign="left"
             buttonsBordered={false}
+            cleanup={configActions.cleanup}
+            errors={errors}
             initialValues={{
               maas_auto_ipmi_user: ipmiUser || "maas",
               maas_auto_ipmi_k_g_bmc_key: bmcKey || "",

--- a/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
@@ -75,20 +75,18 @@ describe("StorageForm", () => {
         {
           type: "config/update",
           payload: {
-            params: [
-              { name: ConfigNames.DEFAULT_STORAGE_LAYOUT, value: "bcache" },
-              { name: ConfigNames.DISK_ERASE_WITH_QUICK_ERASE, value: false },
-              { name: ConfigNames.DISK_ERASE_WITH_SECURE_ERASE, value: false },
-              {
-                name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
-                value: false,
+            params: {
+              items: {
+                [ConfigNames.DEFAULT_STORAGE_LAYOUT]: "bcache",
+                [ConfigNames.DISK_ERASE_WITH_QUICK_ERASE]: false,
+                [ConfigNames.DISK_ERASE_WITH_SECURE_ERASE]: false,
+                [ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE]: false,
               },
-            ],
+            },
           },
           meta: {
-            dispatchMultiple: true,
             model: "config",
-            method: "update",
+            method: "bulk_update",
           },
         },
       ]);

--- a/src/app/settings/views/Storage/StorageForm/StorageForm.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageForm.tsx
@@ -21,12 +21,11 @@ const StorageSchema = Yup.object().shape({
 
 const StorageForm = (): JSX.Element => {
   const dispatch = useDispatch();
-  const updateConfig = configActions.update;
-
   const loaded = useSelector(configSelectors.loaded);
   const loading = useSelector(configSelectors.loading);
   const saved = useSelector(configSelectors.saved);
   const saving = useSelector(configSelectors.saving);
+  const errors = useSelector(configSelectors.errors);
 
   const defaultStorageLayout = useSelector(
     configSelectors.defaultStorageLayout
@@ -51,6 +50,8 @@ const StorageForm = (): JSX.Element => {
           <FormikForm<StorageFormValues>
             buttonsAlign="left"
             buttonsBordered={false}
+            cleanup={configActions.cleanup}
+            errors={errors}
             initialValues={{
               default_storage_layout: defaultStorageLayout || "",
               disk_erase_with_quick_erase: diskEraseWithQuick || false,
@@ -63,7 +64,7 @@ const StorageForm = (): JSX.Element => {
               label: "Storage form",
             }}
             onSubmit={(values, { resetForm }) => {
-              dispatch(updateConfig(values));
+              dispatch(configActions.update(values));
               resetForm({ values });
             }}
             saved={saved}

--- a/src/app/store/config/actions.test.ts
+++ b/src/app/store/config/actions.test.ts
@@ -21,15 +21,11 @@ describe("config actions", () => {
     expect(actions.update(values)).toEqual({
       type: "config/update",
       payload: {
-        params: [
-          { name: "maas_name", value: "bionic-maas" },
-          { name: "enable_analytics", value: true },
-        ],
+        params: { items: { maas_name: "bionic-maas", enable_analytics: true } },
       },
       meta: {
-        dispatchMultiple: true,
         model: "config",
-        method: "update",
+        method: "bulk_update",
       },
     });
   });

--- a/src/app/store/config/slice.ts
+++ b/src/app/store/config/slice.ts
@@ -43,15 +43,13 @@ const statusSlice = createSlice({
       prepare: <V extends ConfigValues>(values: {
         [name: string]: Config<V>["value"];
       }) => {
-        const params = Object.keys(values).map((key) => ({
-          name: key,
-          value: values[key],
-        }));
+        const params = {
+          items: values,
+        };
         return {
           meta: {
-            dispatchMultiple: true,
             model: "config",
-            method: "update",
+            method: "bulk_update",
           },
           payload: {
             params,


### PR DESCRIPTION
## Summary
Refactor of the `config/slice.ts` to utilize the `bulk_update` method for updating configurations.

This improves the efficiency of updating multiple configuration values by reducing the number of websocket messages required.

## Done
- replace the "update" method with "bulk_update" in config slice
- pass config errors to child components along with cleaup prop to clear the error on component unmount

#### Note: there is significant repetition in form components, but addressing this is out of scope of this PR.

## QA

### QA steps
#### Part 1
- go to one of the settings pages
- open developer tools and inspect websocket connection
- refresh the page
- make a change to the configuration
- ensure a websocket "bulk_update" message has been sent with correct parameters

#### Part 2
- try to make an invalid configuration change (can be simulated locally by editing config/slice.ts and commenting out line 47 with `items: values`)
- submit the form and verify an error is displayed
- navigate to another settings page
- verify that error has been cleared

## Launchpad issue

[lp#1839788](https://bugs.launchpad.net/maas-ui/+bug/1839788)

## Screenshots

It could be helpful to provide some screenshots to aid in QAing the change.
