### PR TITLE
fix(machines): Move "Check power" to power action dropdown MAASENG-2125

### DIFF
--- a/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
+++ b/src/app/base/components/NodeActionMenu/NodeActionMenu.tsx
@@ -56,7 +56,12 @@ const actionGroups: ActionGroup[] = [
   },
   {
     name: "power",
-    actions: [NodeActions.ON, NodeActions.OFF],
+    actions: [
+      NodeActions.ON,
+      NodeActions.OFF,
+      NodeActions.SOFT_OFF,
+      NodeActions.CHECK_POWER,
+    ],
   },
   {
     name: "testing",

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
@@ -64,7 +64,7 @@ describe("NodeActionMenuGroup", () => {
       screen.queryByRole("button", { name: Labels.Lock })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: Labels.PowerCycle })
+      screen.queryByRole("button", { name: Labels.Power })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: Labels.Troubleshoot })

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
@@ -64,8 +64,8 @@ describe("NodeActionMenuGroup", () => {
       screen.queryByRole("button", { name: Labels.Lock })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: Labels.Power })
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: Labels.Power })
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: Labels.Troubleshoot })
     ).not.toBeInTheDocument();

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -40,7 +40,7 @@ type Props = {
 
 export enum Labels {
   Actions = "Actions",
-  PowerCycle = "Power cycle",
+  Power = "Power",
   Troubleshoot = "Troubleshoot",
   Categorise = "Categorise",
   Lock = "Lock",
@@ -62,8 +62,13 @@ const actionGroups: ActionGroup[] = [
   },
   {
     name: "power",
-    actions: [NodeActions.ON, NodeActions.OFF, NodeActions.SOFT_OFF],
-    title: Labels.PowerCycle,
+    actions: [
+      NodeActions.ON,
+      NodeActions.OFF,
+      NodeActions.SOFT_OFF,
+      NodeActions.CHECK_POWER,
+    ],
+    title: Labels.Power,
   },
   {
     name: "testing",

--- a/src/app/base/hooks/node.ts
+++ b/src/app/base/hooks/node.ts
@@ -25,6 +25,7 @@ export type MachineMenuAction = Exclude<
   | NodeActions.SET_ZONE
   | NodeActions.TAG
   | NodeActions.UNTAG
+  | NodeActions.CHECK_POWER
 >;
 
 /**

--- a/src/app/base/hooks/node.ts
+++ b/src/app/base/hooks/node.ts
@@ -20,12 +20,12 @@ import { kebabToCamelCase } from "app/utils";
 // without needing the user to provide any additional information.
 export type MachineMenuAction = Exclude<
   MachineActions,
+  | NodeActions.CHECK_POWER
   | NodeActions.CLONE
   | NodeActions.SET_POOL
   | NodeActions.SET_ZONE
   | NodeActions.TAG
   | NodeActions.UNTAG
-  | NodeActions.CHECK_POWER
 >;
 
 /**

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/MachineActionFormWrapper.tsx
@@ -184,6 +184,11 @@ export const MachineActionForm = ({
             {...commonNodeFormProps}
           />
         );
+      // No form should be opened for this, as it should only
+      // be available for machine details, and will be dispatched
+      // immediately on click.
+      case NodeActions.CHECK_POWER:
+        return null;
     }
   };
 

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -4,6 +4,7 @@ import { NodeActions } from "app/store/types/node";
 export const MachineActionSidePanelViews = {
   ABORT_MACHINE: ["machineActionForm", NodeActions.ABORT],
   ACQUIRE_MACHINE: ["machineActionForm", NodeActions.ACQUIRE],
+  CHECK_MACHINE_POEWR: ["machineActionForm", NodeActions.CHECK_POWER],
   CLONE_MACHINE: ["machineActionForm", NodeActions.CLONE],
   COMMISSION_MACHINE: ["machineActionForm", NodeActions.COMMISSION],
   DELETE_MACHINE: ["machineActionForm", NodeActions.DELETE],

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.test.tsx
@@ -118,9 +118,7 @@ describe("MachineHeader", () => {
         { store, route: "/machine/abc123" }
       );
 
-      await userEvent.click(
-        screen.getByRole("button", { name: /take action:/i })
-      );
+      await userEvent.click(screen.getByRole("button", { name: /Power/i }));
       await userEvent.click(
         screen.getByRole("button", { name: /check power/i })
       );

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
@@ -11,7 +11,6 @@ import NodeActionMenuGroup from "app/base/components/NodeActionMenuGroup";
 import PowerIcon from "app/base/components/PowerIcon";
 import ScriptStatus from "app/base/components/ScriptStatus";
 import SectionHeader from "app/base/components/SectionHeader";
-import TableMenu from "app/base/components/TableMenu";
 import TooltipButton from "app/base/components/TooltipButton";
 import { useSendAnalytics } from "app/base/hooks";
 import { MachineSidePanelViews } from "app/machines/constants";
@@ -53,7 +52,6 @@ const MachineHeader = ({
     useSelectedMachinesActionsDispatch({
       selectedMachines: { items: [systemId] },
     });
-  const powerMenuRef = useRef<HTMLSpanElement>(null);
   const isDetails = isMachineDetails(machine);
   useFetchMachine(systemId);
 
@@ -69,6 +67,8 @@ const MachineHeader = ({
 
     if (isImmediateAction) {
       dispatchForSelectedMachines(machineActions[action]);
+    } else if (action === NodeActions.CHECK_POWER) {
+      dispatch(machineActions.checkPower(systemId));
     } else {
       const view = Object.values(MachineSidePanelViews).find(
         ([, actionName]) => actionName === action
@@ -113,19 +113,6 @@ const MachineHeader = ({
                   ? "Checking power"
                   : `Power ${machine.power_state}`}
               </PowerIcon>
-              <TableMenu
-                className="u-nudge-right--small p-table-menu u-nudge-left--large"
-                links={[
-                  {
-                    children: "Check power",
-                    onClick: () => {
-                      dispatch(machineActions.checkPower(systemId));
-                    },
-                  },
-                ]}
-                positionNode={powerMenuRef?.current}
-                title="Take action:"
-              />
             </div>
             <div className="u-hide--medium u-hide--small">
               <NodeActionMenuGroup

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -114,7 +114,7 @@ const MachineHeader = ({
                   : `Power ${machine.power_state}`}
               </PowerIcon>
             </div>
-            <div className="u-hide--medium u-hide--small">
+            <div className="u-hide--medium u-hide--small u-nudge-right">
               <NodeActionMenuGroup
                 alwaysShowLifecycle
                 excludeActions={[NodeActions.IMPORT_IMAGES]}
@@ -127,7 +127,7 @@ const MachineHeader = ({
                 singleNode
               />
             </div>
-            <div className="u-hide--large">
+            <div className="u-hide--large u-nudge-right">
               <NodeActionMenu
                 alwaysShowLifecycle
                 className="u-hide--large"

--- a/src/app/machines/views/MachineList/MachineListControls/MachineActionMenu/MachineActionMenu.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineActionMenu/MachineActionMenu.tsx
@@ -47,7 +47,7 @@ const MachineActionMenu = ({
       <div className="u-hide--medium u-hide--small">
         <NodeActionMenuGroup
           alwaysShowLifecycle
-          excludeActions={[NodeActions.IMPORT_IMAGES]}
+          excludeActions={[NodeActions.IMPORT_IMAGES, NodeActions.CHECK_POWER]}
           getTitle={getTitle}
           hasSelection={hasSelection}
           nodeDisplay="machine"
@@ -74,7 +74,7 @@ const MachineActionMenu = ({
           alwaysShowLifecycle
           className="is-maas-select"
           constrainPanelWidth
-          excludeActions={[NodeActions.IMPORT_IMAGES]}
+          excludeActions={[NodeActions.IMPORT_IMAGES, NodeActions.CHECK_POWER]}
           getTitle={getTitle}
           hasSelection={hasSelection}
           menuPosition="left"

--- a/src/app/machines/views/MachineList/MachineListControls/MachineActionMenu/MachineActionMenu.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineActionMenu/MachineActionMenu.tsx
@@ -42,59 +42,41 @@ const MachineActionMenu = ({
     [tagsSeen]
   );
 
+  const commonProps = {
+    alwaysShowLifecycle: true,
+    excludeActions: [NodeActions.IMPORT_IMAGES, NodeActions.CHECK_POWER],
+    getTitle,
+    hasSelection,
+    nodeDisplay: "machine",
+    onActionClick: (action: NodeActions) => {
+      if (action === NodeActions.TAG && !tagsSeen) {
+        setTagsSeen(true);
+      }
+      const view = Object.values(MachineSidePanelViews).find(
+        ([, actionName]) => actionName === action
+      );
+      if (view) {
+        setSidePanelContent({ view });
+      }
+      sendAnalytics(
+        "Machine list action form",
+        getNodeActionTitle(action),
+        "Open"
+      );
+    },
+  };
+
   return (
     <>
       <div className="u-hide--medium u-hide--small">
-        <NodeActionMenuGroup
-          alwaysShowLifecycle
-          excludeActions={[NodeActions.IMPORT_IMAGES, NodeActions.CHECK_POWER]}
-          getTitle={getTitle}
-          hasSelection={hasSelection}
-          nodeDisplay="machine"
-          onActionClick={(action) => {
-            if (action === NodeActions.TAG && !tagsSeen) {
-              setTagsSeen(true);
-            }
-            const view = Object.values(MachineSidePanelViews).find(
-              ([, actionName]) => actionName === action
-            );
-            if (view) {
-              setSidePanelContent({ view });
-            }
-            sendAnalytics(
-              "Machine list action form",
-              getNodeActionTitle(action),
-              "Open"
-            );
-          }}
-        />
+        <NodeActionMenuGroup {...commonProps} />
       </div>
       <div className="u-hide--large">
         <NodeActionMenu
-          alwaysShowLifecycle
+          {...commonProps}
           className="is-maas-select"
           constrainPanelWidth
-          excludeActions={[NodeActions.IMPORT_IMAGES, NodeActions.CHECK_POWER]}
-          getTitle={getTitle}
-          hasSelection={hasSelection}
           menuPosition="left"
-          nodeDisplay="machine"
-          onActionClick={(action) => {
-            if (action === NodeActions.TAG && !tagsSeen) {
-              setTagsSeen(true);
-            }
-            const view = Object.values(MachineSidePanelViews).find(
-              ([, actionName]) => actionName === action
-            );
-            if (view) {
-              setSidePanelContent({ view });
-            }
-            sendAnalytics(
-              "Machine list action form",
-              getNodeActionTitle(action),
-              "Open"
-            );
-          }}
           toggleAppearance=""
           toggleClassName="p-action-menu"
           toggleLabel="Menu"

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
@@ -95,7 +95,7 @@ describe("MachineListControls", () => {
       screen.queryByRole("button", { name: "Actions" })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: "Power cycle" })
+      screen.queryByRole("button", { name: "Power" })
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: "Troubleshoot" })
@@ -130,9 +130,7 @@ describe("MachineListControls", () => {
     );
 
     expect(screen.getByRole("button", { name: "Actions" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Power cycle" })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Power" })).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Troubleshoot" })
     ).toBeInTheDocument();

--- a/src/app/store/types/node.ts
+++ b/src/app/store/types/node.ts
@@ -158,6 +158,7 @@ export enum FetchNodeStatus {
 export enum NodeActions {
   ABORT = "abort",
   ACQUIRE = "acquire",
+  CHECK_POWER = "check-power",
   CLONE = "clone",
   COMMISSION = "commission",
   DELETE = "delete",

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -275,8 +275,7 @@ export const canOpenActionForm = (
   }
 
   if (nodeIsMachine(node) && actionName === NodeActions.CHECK_POWER) {
-    // "Check power" should always be shown for machines, but this action
-    // won't show up in the node.actions list, so we need to return true here.
+    // "Check power" is always shown for machines, even though it's not listed in node.actions.
     return true;
   }
   return node.actions.some((nodeAction) => nodeAction === actionName);

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -52,6 +52,8 @@ export const getNodeActionTitle = (actionName: NodeActions): string => {
       return "Abort";
     case NodeActions.ACQUIRE:
       return "Allocate";
+    case NodeActions.CHECK_POWER:
+      return "Check power";
     case NodeActions.CLONE:
       return "Clone from";
     case NodeActions.COMMISSION:
@@ -109,6 +111,10 @@ export const getNodeActionLabel = (
       } actions for ${modelString}`;
     case NodeActions.ACQUIRE:
       return `${isProcessing ? "Allocating" : "Allocate"} ${modelString}`;
+    case NodeActions.CHECK_POWER:
+      return `${
+        isProcessing ? "Checking power" : "Check power"
+      } for ${modelString}`;
     case NodeActions.CLONE:
       return isProcessing ? "Cloning in progress" : `Clone to ${modelString}`;
     case NodeActions.COMMISSION:
@@ -266,6 +272,12 @@ export const canOpenActionForm = (
     // select the machine to actually perform the clone action. The destination
     // machines can only be in a subset of statuses.
     return [NodeStatus.READY, NodeStatus.FAILED_TESTING].includes(node.status);
+  }
+
+  if (nodeIsMachine(node) && actionName === NodeActions.CHECK_POWER) {
+    // "Check power" should always be shown for machines, but this action
+    // won't show up in the node.actions list, so we need to return true here.
+    return true;
   }
   return node.actions.some((nodeAction) => nodeAction === actionName);
 };


### PR DESCRIPTION
## Done
- Renamed "Power cycle" to "Power"
- Added "Check power" to power actions for machine details*
- Removed dropdown next to power icon

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to a machine's details page
- [ ] Click "Power" in the menu
- [ ] Ensure that "Check power" is present
- [ ] Click "Check power"
- [ ] Ensure the action is immediately dispatched

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2125](https://warthogs.atlassian.net/browse/MAASENG-2125)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/329a72a3-3210-467a-9c63-9423d805377e)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/775a1ce9-7243-4134-bc72-1e1ca6a1124c)
![image](https://github.com/canonical/maas-ui/assets/35104482/366620d2-dc55-474e-ace9-73f19dcf77d5)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

* "Check power" cannot be called for a selection of machines, it only takes a system ID. Therefore, "Check power" is not available in the action group in the machine list, and no changes will be seen here.

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2125]: https://warthogs.atlassian.net/browse/MAASENG-2125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ