### PR TITLE
fix(machines): default to ascending sort

### DIFF
--- a/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
+++ b/src/app/kvm/components/LXDVMsTable/LXDVMsTable.test.tsx
@@ -42,7 +42,7 @@ describe("LXDVMsTable", () => {
       group_key: null,
       page_number: 1,
       page_size: 10,
-      sort_direction: FetchSortDirection.Descending,
+      sort_direction: FetchSortDirection.Ascending,
       sort_key: FetchGroupKey.Hostname,
     };
     const expectedAction = machineActions.fetch(generateCallId(options), {
@@ -51,7 +51,7 @@ describe("LXDVMsTable", () => {
       group_key: null,
       page_number: 1,
       page_size: 10,
-      sort_direction: FetchSortDirection.Descending,
+      sort_direction: FetchSortDirection.Ascending,
       sort_key: FetchGroupKey.Hostname,
     });
     expect(

--- a/src/app/machines/views/MachineList/MachineListTable/constants.ts
+++ b/src/app/machines/views/MachineList/MachineListTable/constants.ts
@@ -2,7 +2,7 @@ import { SortDirection } from "app/base/types";
 import { FetchGroupKey } from "app/store/machine/types";
 export const DEFAULTS = {
   pageSize: 50,
-  sortDirection: SortDirection.DESCENDING,
+  sortDirection: SortDirection.ASCENDING,
   // TODO: change this to fqdn when the API supports it:
   // https://github.com/canonical/app-tribe/issues/1268
   sortKey: FetchGroupKey.Hostname,

--- a/src/app/tags/views/TagMachines/TagMachines.test.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.test.tsx
@@ -96,7 +96,7 @@ it("dispatches actions to fetch necessary data", () => {
       group_key: null,
       page_number: 1,
       page_size: 50,
-      sort_direction: FetchSortDirection.Descending,
+      sort_direction: FetchSortDirection.Ascending,
       sort_key: FetchGroupKey.Hostname,
     }),
     tagActions.fetch(),


### PR DESCRIPTION
## Done
- set machine listing table to default to ascending sort direction

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Open your browser in incognito mode
- [x] Go to machine list
- [x] Verify that machines table  sort direction is set to ascending

<!-- Steps for QA. -->

## Fixes

Fixes:  [lp#2042847](https://bugs.launchpad.net/maas/+bug/2042847)
<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
