### PR TITLE
fix: route logo link to machine list page

### DIFF
--- a/cypress/e2e/with-users/base/navigation.spec.ts
+++ b/cypress/e2e/with-users/base/navigation.spec.ts
@@ -119,12 +119,12 @@ context("Navigation - admin", () => {
     { destinationUrl: "/zones", linkLabel: "AZs" },
   ];
 
-  it("navigates to /dashboard when clicking on the logo", () => {
+  it("navigates to machines when clicking on the logo", () => {
     cy.waitForPageToLoad();
     cy.getMainNavigation().within(() =>
       cy.findByRole("link", { name: "Homepage" }).click()
     );
-    cy.location("pathname").should("eq", generateMAASURL("/dashboard"));
+    cy.location("pathname").should("eq", generateMAASURL("/machines"));
   });
 
   expected.forEach(({ destinationUrl, linkLabel }) => {

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -162,8 +162,11 @@ describe("GlobalSideNav", () => {
       state,
     });
 
-    // In this case the second link is taken because the logo also points to the machine list page
-    const currentMenuItem = screen.getAllByRole("link", { current: "page" })[1];
+    // Ensure that machine link is selected from within the nav
+    const sideNavigation = screen.getAllByRole("navigation")[0];
+    const currentMenuItem = within(sideNavigation).getAllByRole("link", {
+      current: "page",
+    })[0];
     expect(currentMenuItem).toBeInTheDocument();
     expect(currentMenuItem).toHaveTextContent("Machines");
   });

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -162,7 +162,8 @@ describe("GlobalSideNav", () => {
       state,
     });
 
-    const currentMenuItem = screen.getAllByRole("link", { current: "page" })[0];
+    // In this case the second link is taken because the logo also points to the machine list page
+    const currentMenuItem = screen.getAllByRole("link", { current: "page" })[1];
     expect(currentMenuItem).toBeInTheDocument();
     expect(currentMenuItem).toHaveTextContent("Machines");
   });
@@ -265,7 +266,7 @@ describe("GlobalSideNav", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("links from the logo to the dashboard for admins", () => {
+  it("links from the logo to machine list page for admins", () => {
     state.user.auth.user = userFactory({ is_superuser: true });
     renderWithBrowserRouter(<AppSideNavigation />, {
       route: "/machine/abc123",
@@ -278,15 +279,7 @@ describe("GlobalSideNav", () => {
           name: "Homepage",
         }
       )
-    ).toHaveAttribute("href", "/dashboard");
-    expect(
-      within(screen.getByRole("banner", { name: "main navigation" })).getByRole(
-        "link",
-        {
-          name: "Homepage",
-        }
-      )
-    ).toHaveAttribute("href", "/dashboard");
+    ).toHaveAttribute("href", "/machines");
   });
 
   it("links from the logo to the machine list for non admins", () => {

--- a/src/app/base/components/AppSideNavigation/NavigationBanner/NavigationBanner.tsx
+++ b/src/app/base/components/AppSideNavigation/NavigationBanner/NavigationBanner.tsx
@@ -1,23 +1,18 @@
 import { Navigation } from "@canonical/maas-react-components";
-import { useSelector } from "react-redux";
 import { Link, useLocation } from "react-router-dom-v5-compat";
 
 import { isSelected } from "../utils";
 
 import urls from "app/base/urls";
-import authSelectors from "app/store/auth/selectors";
 
 const NavigationBanner = ({
   children,
 }: {
   children?: React.ReactNode;
 }): JSX.Element => {
-  const isAdmin = useSelector(authSelectors.isAdmin);
   const location = useLocation();
 
-  const homepageLink = isAdmin
-    ? { url: urls.dashboard.index, label: "Homepage" }
-    : { url: urls.machines.index, label: "Homepage" };
+  const homepageLink = { url: urls.machines.index, label: "Homepage" };
   return (
     <Navigation.Banner>
       <Navigation.Logo


### PR DESCRIPTION
## Done
- Routed logo link to machine list page regardless of user type

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Visit MAAS UI url
- [x] Navigate to any page besides the machine list page
- [x] Click on the MAAS logo on the side navigation
- [x] Ensure that you're taken to the machine list page

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-2408](https://warthogs.atlassian.net/browse/MAASENG-2408)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2408]: https://warthogs.atlassian.net/browse/MAASENG-2408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ