### PR TITLE
fix(LXD): Link to VMs tab for single LXD hosts MAASENG-2412

### DIFF
--- a/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -2,7 +2,7 @@ import configureStore from "redux-mock-store";
 
 import KVMResourcesCard from "./KVMResourcesCard";
 
-import { actions as machineActions } from "app/store/machine";
+import urls from "app/base/urls";
 import { PodType } from "app/store/pod/constants";
 import type { RootState } from "app/store/root/types";
 import {
@@ -19,25 +19,6 @@ describe("KVMResourcesCard", () => {
     jest.restoreAllMocks();
   });
 
-  it("fetches machines on load", () => {
-    const state = rootStateFactory({
-      pod: podStateFactory({
-        items: [podFactory({ id: 1, type: PodType.LXD })],
-        loaded: true,
-      }),
-    });
-    const store = mockStore(state);
-    renderWithBrowserRouter(<KVMResourcesCard id={1} />, {
-      store,
-      route: "/kvm/1/project",
-    });
-
-    const expectedAction = machineActions.fetch("mocked-nanoid");
-    expect(
-      store.getActions().some((action) => action.type === expectedAction.type)
-    ).toBe(true);
-  });
-
   it("shows a spinner if pods have not loaded yet", () => {
     const state = rootStateFactory({
       pod: podStateFactory({
@@ -51,5 +32,42 @@ describe("KVMResourcesCard", () => {
     });
 
     expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+  });
+
+  it("links to the VMs tab for a LXD pod", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [podFactory({ id: 1, type: PodType.LXD })],
+        loaded: true,
+      }),
+    });
+
+    renderWithBrowserRouter(<KVMResourcesCard id={1} />, {
+      state,
+      route: "/kvm/1/project",
+    });
+
+    expect(screen.getByRole("link", { name: /Total VMs/ })).toHaveAttribute(
+      "href",
+      urls.kvm.lxd.single.vms({ id: 1 })
+    );
+  });
+
+  it("displays VmResources for a Virsh pod", () => {
+    const state = rootStateFactory({
+      pod: podStateFactory({
+        items: [podFactory({ id: 1, type: PodType.VIRSH })],
+        loaded: true,
+      }),
+    });
+
+    renderWithBrowserRouter(<KVMResourcesCard id={1} />, {
+      state,
+      route: "/kvm/1/project",
+    });
+
+    expect(
+      screen.getByRole("button", { name: /Resource VMs/ })
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
+++ b/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.test.tsx
@@ -1,18 +1,13 @@
-import configureStore from "redux-mock-store";
-
 import KVMResourcesCard from "./KVMResourcesCard";
 
 import urls from "app/base/urls";
 import { PodType } from "app/store/pod/constants";
-import type { RootState } from "app/store/root/types";
 import {
   podState as podStateFactory,
   rootState as rootStateFactory,
   pod as podFactory,
 } from "testing/factories";
 import { renderWithBrowserRouter, screen } from "testing/utils";
-
-const mockStore = configureStore<RootState>();
 
 describe("KVMResourcesCard", () => {
   afterEach(() => {

--- a/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
+++ b/src/app/kvm/components/KVMResourcesCard/KVMResourcesCard.tsx
@@ -1,11 +1,16 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
+import { Link } from "react-router-dom";
 
 import CoreResources from "../CoreResources";
 import RamResources from "../RamResources";
 import VfResources from "../VfResources";
 import VmResources from "../VmResources";
 
+import urls from "app/base/urls";
+import { FilterGroupKey } from "app/store/machine/types";
+import { useFetchMachineCount } from "app/store/machine/utils/hooks";
+import { PodType } from "app/store/pod/constants";
 import podSelectors from "app/store/pod/selectors";
 import type { Pod } from "app/store/pod/types";
 import { resourceWithOverCommit } from "app/store/pod/utils";
@@ -17,6 +22,10 @@ const KVMResourcesCard = ({ id }: Props): JSX.Element => {
   const pod = useSelector((state: RootState) =>
     podSelectors.getById(state, id)
   );
+
+  const { machineCount } = useFetchMachineCount({
+    [FilterGroupKey.Pod]: pod ? [pod.name] : [],
+  });
 
   if (pod) {
     const {
@@ -33,6 +42,7 @@ const KVMResourcesCard = ({ id }: Props): JSX.Element => {
       general,
       memory_over_commit_ratio
     );
+
     return (
       <>
         <div className="kvm-resources-card">
@@ -53,7 +63,15 @@ const KVMResourcesCard = ({ id }: Props): JSX.Element => {
           />
           <VfResources dynamicLayout interfaces={interfaces} />
         </div>
-        <VmResources podId={id} />
+        {pod.type === PodType.LXD ? (
+          <div className="vms-link">
+            <Link to={urls.kvm.lxd.single.vms({ id })}>
+              Total VMs: {machineCount ?? 0}
+            </Link>
+          </div>
+        ) : (
+          <VmResources podId={id} />
+        )}
       </>
     );
   }

--- a/src/app/kvm/components/KVMResourcesCard/_index.scss
+++ b/src/app/kvm/components/KVMResourcesCard/_index.scss
@@ -43,4 +43,8 @@
       }
     }
   }
+
+  .vms-link {
+    padding: $spv--large;
+  }
 }


### PR DESCRIPTION
## Done

- For LXD resources, replace machine table contextual menu with link to VMs tab
- Remove test checking for machine fetch on KVM resources

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

Using polong-ng as a backend:
- [x] Go to `/kvm/lxd/2/resources`
- [x] Click the link beneath the resources card, titled "Total VMs: XX"
- [x] Ensure you are redirected to the VMs tab for that host
- [x] Go to `/kvm/virsh/3/resources`
- [x] Click the same link
- [x] Ensure the mini machine list is displayed

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2412](https://warthogs.atlassian.net/browse/MAASENG-2412)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->


[MAASENG-2412]: https://warthogs.atlassian.net/browse/MAASENG-2412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ