### PR TITLE
style: update tab to use bottom line

### DIFF
--- a/src/app/base/components/SectionHeader/SectionHeader.tsx
+++ b/src/app/base/components/SectionHeader/SectionHeader.tsx
@@ -127,12 +127,7 @@ const SectionHeader = <P,>({
       {actionMenuGroup ? <>{actionMenuGroup}</> : null}
       {tabLinks?.length ? (
         <div className="section-header__tabs" data-testid="section-header-tabs">
-          <hr className="u-no-margin--bottom" />
-          <Tabs
-            className="no-border"
-            links={tabLinks}
-            listClassName="u-no-margin--bottom"
-          />
+          <Tabs links={tabLinks} listClassName="u-no-margin--bottom" />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Done
- Updated tab instances to use bottom line

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Visit machine details page or controllers details (Any page with a tab implementation)
- [ ] Ensure that the tab line shows below the tabs

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-2406](https://warthogs.atlassian.net/browse/MAASENG-2406)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![image](https://github.com/canonical/maas-ui/assets/47540149/a5f6cbe2-e3ad-40a9-b623-6dff55046521)

### After
![image](https://github.com/canonical/maas-ui/assets/47540149/1f02054c-1492-44a8-9114-1ccbe7786991)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-2406]: https://warthogs.atlassian.net/browse/MAASENG-2406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ