### PR TITLE
chore: bump @canonical/maas-react-components to v1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@canonical/maas-react-components": "1.5.0",
+    "@canonical/maas-react-components": "1.6.1",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "0.46.0",
     "@reduxjs/toolkit": "1.9.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,10 +2907,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@canonical/maas-react-components@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-1.5.0.tgz#3cda970c9f95a1379f22fddd37e9c94eb7e345b2"
-  integrity sha512-pef2X+mf/W+/3q3kkIBrD9gHjb0z0S+JghDkd0mlmYuCbGxb+PqXk0vzlyEfzbIsltI0H/UEJLtNhM6kVTtD9A==
+"@canonical/maas-react-components@1.6.1":
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-1.6.1.tgz#b4db2fb7635294baabde9d25d8cf30285a9a6552"
+  integrity sha512-2kZ8W0zoggV6j6zmPWN8hRFwiVeFAQq42R3driPDmGD8K+c6ViXj3RapvDL0ZY4EdB+YKtn08akqCk+a/kwaCg==
 
 "@canonical/macaroon-bakery@1.3.2":
   version "1.3.2"


### PR DESCRIPTION
## Done
- Upgraded @canonical/maas-react-components to v1.6.1

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to machine list
- [x] Hover over "Machines" in nav
- [x] Ensure cursor is a pointer and not default

<!-- Steps for QA. -->

