### PR TITLE
fix: side panel fieldless forms spacing

### DIFF
--- a/src/app/base/components/AppSidePanel/AppSidePanel.tsx
+++ b/src/app/base/components/AppSidePanel/AppSidePanel.tsx
@@ -68,7 +68,6 @@ const AppSidePanelContent = ({
                 <h3 className="section-header__title u-flex--no-shrink p-heading--4">
                   {title}
                 </h3>
-                <hr />
               </div>
             </div>
           ) : null}

--- a/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -173,7 +173,8 @@ const FormikFormContent = <V extends object, E = null>({
       inline={inline}
       onSubmit={handleSubmit}
     >
-      <ContentSection>
+      {/* collapse content section when there's no content */}
+      <ContentSection className={!children ? "u-no-padding--top" : undefined}>
         <ContentSection.Content>
           {!!nonFieldError && (
             <Notification severity="negative" title="Error:">
@@ -184,7 +185,9 @@ const FormikFormContent = <V extends object, E = null>({
             ? children({ ...formikContext })
             : children}
         </ContentSection.Content>
-        <ContentSection.Footer>
+        <ContentSection.Footer
+          className={!children ? "u-no-margin--top" : undefined}
+        >
           {editable && (
             <FormikFormButtons
               {...buttonsProps}


### PR DESCRIPTION

## Done
- fix: side panel fieldless forms spacing
  - collapse content section when there's no content

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to machine list and open bulk actions (e.g. tag, soft power off) and verify it matches the design

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before

![Google Chrome screenshot 001228@2x](https://github.com/canonical/maas-ui/assets/7452681/d072e854-5d3f-4e93-bed3-4ae5450df34e)
### After

![Google Chrome screenshot 001226@2x](https://github.com/canonical/maas-ui/assets/7452681/33eee936-6f34-4bbe-96c0-7e80b18c29b6)
![Google Chrome screenshot 001230@2x](https://github.com/canonical/maas-ui/assets/7452681/ec36e88b-d1d6-4f94-be0e-7436db309d98)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
