### PR TITLE
ci: run sitespeed on push

### DIFF
--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -1,10 +1,11 @@
 name: sitespeed.io
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches:
+      - main
+      - "3.*"
 jobs:
   run-sitespeed:
-    if: github.event.pull_request.merged == true
     name: Run sitespeed.io
     runs-on: ubuntu-22.04
     env:


### PR DESCRIPTION
## Done
This sets sitespeed.io action to be run on push to main/3.x branch instead of pull request close. This is consistent with how cypress tests are run.

- ci: run sitespeed on push

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps


<!-- Steps for QA. -->

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/5235

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
