### PR TITLE
feat(kvm): use MainToolbar on KVM list header MAASENG-2516

### DIFF
--- a/src/app/kvm/views/KVMList/KVMList.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMList.test.tsx
@@ -162,7 +162,7 @@ describe("KVMList", () => {
     });
 
     expect(screen.queryByTestId("no-hosts")).not.toBeInTheDocument();
-    expect(screen.getAllByText(/Loading.../i)).toHaveLength(2);
+    expect(screen.getAllByText(/Loading/i)).toHaveLength(2);
     expect(
       screen.queryByText(/No LXD hosts available/i)
     ).not.toBeInTheDocument();

--- a/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -61,9 +61,7 @@ describe("KVMListHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(screen.getByTestId("section-header-subtitle")).toHaveTextContent(
-      "2 KVM hosts available"
-    );
+    expect(screen.getByText("2 KVM hosts available")).toBeInTheDocument();
   });
 
   it("can open the add LXD form at the LXD URL", async () => {
@@ -83,8 +81,13 @@ describe("KVMListHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(screen.getByTestId("add-kvm")).toHaveTextContent("Add LXD host");
-    await userEvent.click(screen.getByTestId("add-kvm"));
+    expect(
+      screen.getByRole("button", { name: "Add LXD host" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add Virsh host" })
+    ).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Add LXD host" }));
     expect(setSidePanelContent).toHaveBeenCalledWith({
       view: KVMSidePanelViews.ADD_LXD_HOST,
     });
@@ -107,8 +110,15 @@ describe("KVMListHeader", () => {
         </MemoryRouter>
       </Provider>
     );
-    expect(screen.getByTestId("add-kvm")).toHaveTextContent("Add Virsh host");
-    await userEvent.click(screen.getByTestId("add-kvm"));
+    expect(
+      screen.getByRole("button", { name: "Add Virsh host" })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Add LXD host" })
+    ).not.toBeInTheDocument();
+    await userEvent.click(
+      screen.getByRole("button", { name: "Add Virsh host" })
+    );
     expect(setSidePanelContent).toHaveBeenCalledWith({
       view: KVMSidePanelViews.ADD_VIRSH_HOST,
     });

--- a/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
+++ b/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.tsx
@@ -1,10 +1,10 @@
-import { Button } from "@canonical/react-components";
-import pluralize from "pluralize";
+import { MainToolbar } from "@canonical/maas-react-components";
+import { Button, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
 
+import ModelListSubtitle from "app/base/components/ModelListSubtitle";
 import type { SectionHeaderProps } from "app/base/components/SectionHeader";
-import SectionHeader from "app/base/components/SectionHeader";
 import { useFetchActions } from "app/base/hooks";
 import urls from "app/base/urls";
 import { KVMSidePanelViews } from "app/kvm/constants";
@@ -25,8 +25,14 @@ const KVMListHeader = ({ setSidePanelContent, title }: Props): JSX.Element => {
   useFetchActions([podActions.fetch]);
 
   return (
-    <SectionHeader
-      buttons={[
+    <MainToolbar>
+      <MainToolbar.Title>{title}</MainToolbar.Title>
+      {podsLoaded ? (
+        <ModelListSubtitle available={kvms.length} modelName="KVM host" />
+      ) : (
+        <Spinner text="Loading" />
+      )}
+      <MainToolbar.Controls>
         <Button
           appearance="positive"
           data-testid="add-kvm"
@@ -40,12 +46,9 @@ const KVMListHeader = ({ setSidePanelContent, title }: Props): JSX.Element => {
           }
         >
           Add {lxdTabActive ? "LXD" : "Virsh"} host
-        </Button>,
-      ]}
-      subtitle={`${pluralize("KVM host", kvms.length, true)} available`}
-      subtitleLoading={!podsLoaded}
-      title={title}
-    />
+        </Button>
+      </MainToolbar.Controls>
+    </MainToolbar>
   );
 };
 


### PR DESCRIPTION
## Done
- Replaced SectionHeader with MainToolbar in KVM list header

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to /kvm/lxd
- [ ] Ensure the header renders correctly and the "Add LXD host" button works
- [ ] Go to /kvm/virsh
- [ ] Ensure the header renders correctly and the "Add Virsh host" button works

<!-- Steps for QA. -->

## Fixes

- Fixes [MAASENG-2516](https://warthogs.atlassian.net/browse/MAASENG-2516)
- Fixes [MAASENG-2517](https://warthogs.atlassian.net/browse/MAASENG-2517)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
LXD
![image](https://github.com/canonical/maas-ui/assets/35104482/269255ff-dc0d-437c-a89c-20da8be64b63)

Virsh
![image](https://github.com/canonical/maas-ui/assets/35104482/0bc7e6ab-3417-4603-88ab-842476f3b619)

### After
LXD
![image](https://github.com/canonical/maas-ui/assets/35104482/c23fc1eb-df64-4fd6-be6f-bc293e02327f)

Virsh
![image](https://github.com/canonical/maas-ui/assets/35104482/5c533662-9ecf-4242-9402-65914557c898)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2516]: https://warthogs.atlassian.net/browse/MAASENG-2516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAASENG-2517]: https://warthogs.atlassian.net/browse/MAASENG-2517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ