### PR TITLE
feat(zones): use MainToolbar on zones list header MAASENG-2519

### DIFF
--- a/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListHeader/ZonesListHeader.tsx
@@ -1,9 +1,10 @@
-import { Button } from "@canonical/react-components";
+import { MainToolbar } from "@canonical/maas-react-components";
+import { Button, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import ZonesListTitle from "./ZonesListTitle";
 
-import SectionHeader from "app/base/components/SectionHeader";
+import ModelListSubtitle from "app/base/components/ModelListSubtitle";
 import { useFetchActions } from "app/base/hooks";
 import type { SetSidePanelContent } from "app/base/side-panel-context";
 import { actions } from "app/store/zone";
@@ -20,25 +21,28 @@ const ZonesListHeader = ({
 
   useFetchActions([actions.fetch]);
 
-  const buttons = [
-    <Button
-      data-testid="add-zone"
-      key="add-zone"
-      onClick={() => {
-        setSidePanelContent({ view: ZoneActionSidePanelViews.CREATE_ZONE });
-      }}
-    >
-      Add AZ
-    </Button>,
-  ];
-
   return (
-    <SectionHeader
-      buttons={buttons}
-      subtitle={`${zonesCount} AZs available`}
-      subtitleLoading={!zonesLoaded}
-      title={<ZonesListTitle />}
-    ></SectionHeader>
+    <MainToolbar>
+      <MainToolbar.Title>
+        <ZonesListTitle />
+      </MainToolbar.Title>
+      {zonesLoaded ? (
+        <ModelListSubtitle available={zonesCount} modelName="AZ" />
+      ) : (
+        <Spinner text="Loading..." />
+      )}
+      <MainToolbar.Controls>
+        <Button
+          data-testid="add-zone"
+          key="add-zone"
+          onClick={() => {
+            setSidePanelContent({ view: ZoneActionSidePanelViews.CREATE_ZONE });
+          }}
+        >
+          Add AZ
+        </Button>
+      </MainToolbar.Controls>
+    </MainToolbar>
   );
 };
 


### PR DESCRIPTION
## Done
- Replaced SectionHeader with MainToolbar on Zones list

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to /zones
- [x] Ensure the header renders correctly and the "Add AZ" button works

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2519](https://warthogs.atlassian.net/browse/MAASENG-2519)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/f4b942b5-6b14-4177-a0cb-65eef578aa6a)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/92185f81-7ac7-419c-9250-9096d16c1d16)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-2519]: https://warthogs.atlassian.net/browse/MAASENG-2519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ