### PR TITLE
feat(pools): use MainToolbar on pools list header MAASENG-2520

### DIFF
--- a/src/app/pools/views/Pools.tsx
+++ b/src/app/pools/views/Pools.tsx
@@ -1,3 +1,4 @@
+import { MainToolbar } from "@canonical/maas-react-components";
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
@@ -6,7 +7,6 @@ import { Link, Route, Routes } from "react-router-dom-v5-compat";
 import PoolList from "./PoolList";
 
 import PageContent from "app/base/components/PageContent";
-import MachinesHeader from "app/base/components/node/MachinesHeader";
 import { useFetchActions } from "app/base/hooks";
 import urls from "app/base/urls";
 import NotFound from "app/base/views/NotFound";
@@ -29,20 +29,17 @@ const Pools = (): JSX.Element => {
   return (
     <PageContent
       header={
-        <MachinesHeader
-          buttons={[
+        <MainToolbar>
+          <MainToolbar.Title>
+            <Link to={urls.machines.index}>{machineCount} machines </Link>
+            in {resourcePoolsCount} {pluralize("pool", resourcePoolsCount)}
+          </MainToolbar.Title>
+          <MainToolbar.Controls>
             <Button data-testid="add-pool" element={Link} to={urls.pools.add}>
               Add pool
-            </Button>,
-          ]}
-          machineCount={machineCount}
-          title={
-            <>
-              <Link to={urls.machines.index}>{machineCount} machines </Link>
-              in {resourcePoolsCount} {pluralize("pool", resourcePoolsCount)}
-            </>
-          }
-        />
+            </Button>
+          </MainToolbar.Controls>
+        </MainToolbar>
       }
       sidePanelContent={null}
       sidePanelTitle={null}


### PR DESCRIPTION
## Done
- Replace MachineHeader with MainToolbar in pools list header

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to /pools
- [ ] Ensure the header renders correctly and the "Add pool" button works

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2520](https://warthogs.atlassian.net/browse/MAASENG-2520)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/b1c912a7-feda-46e0-a275-d90d2fe2f7fa)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/618999b7-539d-497c-a3bc-d007cb424a09)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->



[MAASENG-2520]: https://warthogs.atlassian.net/browse/MAASENG-2520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ