### PR TITLE
feat(subnets): use MainToolbar on subnets list header MAASENG-2522

### DIFF
--- a/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsControls/SubnetsControls.tsx
@@ -1,7 +1,5 @@
 import { useState } from "react";
 
-import { Row, Col } from "@canonical/react-components";
-
 import DebounceSearchBox from "app/base/components/DebounceSearchBox";
 import type { SubnetGroupByProps } from "app/subnets/views/SubnetsList/SubnetsTable/types";
 
@@ -15,15 +13,11 @@ const SubnetsControls = ({
   const [searchText, setSearchText] = useState(initialSearchText);
 
   return (
-    <Row>
-      <Col size={12}>
-        <DebounceSearchBox
-          onDebounced={handleSearch}
-          searchText={searchText}
-          setSearchText={setSearchText}
-        />
-      </Col>
-    </Row>
+    <DebounceSearchBox
+      onDebounced={handleSearch}
+      searchText={searchText}
+      setSearchText={setSearchText}
+    />
   );
 };
 

--- a/src/app/subnets/views/SubnetsList/SubnetsList.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsList.tsx
@@ -77,7 +77,7 @@ const SubnetsList = (): JSX.Element => {
               searchText={searchText}
             />
             <GroupSelect
-              className="u-no-margin--bottom subnet-group__select"
+              className="subnet-group__select"
               groupOptions={subnetGroupingOptions}
               grouping={groupBy as GroupByKey}
               name="network-groupings"

--- a/src/app/subnets/views/SubnetsList/SubnetsList.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsList.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useCallback } from "react";
 
+import { MainToolbar } from "@canonical/maas-react-components";
 import { ContextualMenu } from "@canonical/react-components";
 import { useNavigate } from "react-router-dom-v5-compat";
 
+import SubnetsControls from "./SubnetsControls";
 import SubnetsTable from "./SubnetsTable";
 import type { GroupByKey } from "./SubnetsTable/types";
 
 import GroupSelect from "app/base/components/GroupSelect";
 import PageContent from "app/base/components/PageContent/PageContent";
-import SectionHeader from "app/base/components/SectionHeader";
 import { useWindowTitle } from "app/base/hooks";
 import { useQuery } from "app/base/hooks/urls";
 import { useSidePanel } from "app/base/side-panel-context";
@@ -67,8 +68,21 @@ const SubnetsList = (): JSX.Element => {
   return (
     <PageContent
       header={
-        <SectionHeader
-          buttons={[
+        <MainToolbar>
+          <MainToolbar.Title>Subnets</MainToolbar.Title>
+          <MainToolbar.Controls>
+            <SubnetsControls
+              groupBy={groupBy as GroupByKey}
+              handleSearch={setSearchText}
+              searchText={searchText}
+            />
+            <GroupSelect
+              className="u-no-margin--bottom subnet-group__select"
+              groupOptions={subnetGroupingOptions}
+              grouping={groupBy as GroupByKey}
+              name="network-groupings"
+              setGrouping={setGroupBy}
+            />
             <ContextualMenu
               hasToggleIcon
               links={[
@@ -86,21 +100,9 @@ const SubnetsList = (): JSX.Element => {
               position="right"
               toggleAppearance="positive"
               toggleLabel="Add"
-            />,
-          ]}
-          subtitle={
-            <div className="u-flex--wrap u-flex--align-center">
-              <GroupSelect
-                className="u-no-margin--bottom subnet-group__select"
-                groupOptions={subnetGroupingOptions}
-                grouping={groupBy as GroupByKey}
-                name="network-groupings"
-                setGrouping={setGroupBy}
-              />
-            </div>
-          }
-          title="Subnets"
-        />
+            />
+          </MainToolbar.Controls>
+        </MainToolbar>
       }
       sidePanelContent={
         activeForm ? (
@@ -113,11 +115,7 @@ const SubnetsList = (): JSX.Element => {
       sidePanelTitle={activeForm ? `Add ${activeForm}` : ""}
     >
       {hasValidGroupBy ? (
-        <SubnetsTable
-          groupBy={groupBy as GroupByKey}
-          searchText={searchText}
-          setSearchText={setSearchText}
-        />
+        <SubnetsTable groupBy={groupBy as GroupByKey} searchText={searchText} />
       ) : null}
     </PageContent>
   );

--- a/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
@@ -52,11 +52,7 @@ it("renders a single table variant at a time", () => {
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -74,11 +70,7 @@ it("renders Subnets by Fabric table when grouping by Fabric", () => {
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -97,11 +89,7 @@ it("renders Subnets by Space table when grouping by Space", () => {
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="space"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="space" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -120,11 +108,7 @@ it("displays a correct number of pages", () => {
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -158,11 +142,7 @@ it("updates the list of items correctly when navigating to another page", async 
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -205,11 +185,7 @@ it("doesn't display pagination if rows are within items per page limit", () => {
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -232,11 +208,7 @@ it("displays correctly paginated rows", async () => {
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -281,11 +253,7 @@ it("displays the last available page once the currently active has no items", as
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -317,11 +285,7 @@ it("displays the last available page once the currently active has no items", as
     <Provider store={updatedStore}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -349,11 +313,7 @@ it("remains on the same page once the data is updated and page is still availabl
     <Provider store={store}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -381,11 +341,7 @@ it("remains on the same page once the data is updated and page is still availabl
     <Provider store={updatedStore}>
       <MemoryRouter initialEntries={[{ pathname: urls.index }]}>
         <CompatRouter>
-          <SubnetsTable
-            groupBy="fabric"
-            searchText=""
-            setSearchText={jest.fn()}
-          />
+          <SubnetsTable groupBy="fabric" searchText="" />
         </CompatRouter>
       </MemoryRouter>
     </Provider>
@@ -404,10 +360,10 @@ it("displays the table group summary at the top of every page", async () => {
     numberOfFabrics,
   });
 
-  renderWithBrowserRouter(
-    <SubnetsTable groupBy="fabric" searchText="" setSearchText={jest.fn()} />,
-    { route: urls.index, state }
-  );
+  renderWithBrowserRouter(<SubnetsTable groupBy="fabric" searchText="" />, {
+    route: urls.index,
+    state,
+  });
 
   const tableBody = screen.getAllByRole("rowgroup")[1];
   expect(within(tableBody).getAllByRole("row")[0]).toHaveTextContent("network");

--- a/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.tsx
@@ -1,5 +1,3 @@
-import SubnetsControls from "../SubnetsControls";
-
 import FabricTable from "./FabricTable";
 import SpaceTable from "./SpaceTable";
 import { SubnetsColumns } from "./constants";
@@ -10,10 +8,8 @@ import type { SubnetGroupByProps } from "app/subnets/views/SubnetsList/SubnetsTa
 const SubnetsTable = ({
   groupBy,
   searchText,
-  setSearchText,
 }: Pick<SubnetGroupByProps, "groupBy"> & {
   searchText: string;
-  setSearchText: (text: string) => void;
 }): JSX.Element | null => {
   const subnetsTable = useSubnetsTable(groupBy);
   const { data, loaded } = useSubnetsTableSearch(subnetsTable, searchText);
@@ -22,12 +18,6 @@ const SubnetsTable = ({
 
   return (
     <>
-      <SubnetsControls
-        groupBy={groupBy}
-        handleSearch={setSearchText}
-        searchText={searchText}
-      />
-
       {groupBy === SubnetsColumns.FABRIC ? (
         <FabricTable data={data} emptyMsg={emptyMsg} />
       ) : (


### PR DESCRIPTION
## Done
- Replaced SectionHeader with MainToolbar in subnets list
- Moved search bar from table to header
- Removed Row/Col wrapping on search bar

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to subnets list
- [ ] Ensure header renders correctly
- [ ] Ensure all buttons and inputs work correctly

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2522](https://warthogs.atlassian.net/browse/MAASENG-2522)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/fda70dc1-a4d6-4319-aab1-3ef975083afc)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/b22bddf3-7ba9-4ca8-b48f-fc58fe93c50c)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->




[MAASENG-2522]: https://warthogs.atlassian.net/browse/MAASENG-2522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ