### PR TITLE
feat(domains): use MainToolbar on domains list header MAASENG-2523

### DIFF
--- a/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeader/DomainListHeader.tsx
@@ -1,10 +1,10 @@
-import { Button } from "@canonical/react-components";
-import pluralize from "pluralize";
+import { MainToolbar } from "@canonical/maas-react-components";
+import { Button, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import { DomainListSidePanelViews } from "../constants";
 
-import SectionHeader from "app/base/components/SectionHeader";
+import ModelListSubtitle from "app/base/components/ModelListSubtitle";
 import { useFetchActions } from "app/base/hooks";
 import type { SetSidePanelContent } from "app/base/side-panel-context";
 import { actions as domainActions } from "app/store/domain";
@@ -24,25 +24,26 @@ const DomainListHeader = ({
 
   useFetchActions([domainActions.fetch]);
 
-  let buttons: JSX.Element[] | null = [
-    <Button
-      data-testid="add-domain"
-      key="add-domain"
-      onClick={() =>
-        setSidePanelContent({ view: DomainListSidePanelViews.ADD_DOMAIN })
-      }
-    >
-      {Labels.AddDomains}
-    </Button>,
-  ];
-
   return (
-    <SectionHeader
-      buttons={buttons}
-      subtitle={`${pluralize("domain", domainCount, true)} available`}
-      subtitleLoading={!domainsLoaded}
-      title="DNS"
-    />
+    <MainToolbar>
+      <MainToolbar.Title>DNS</MainToolbar.Title>
+      {domainsLoaded ? (
+        <ModelListSubtitle available={domainCount} modelName="domain" />
+      ) : (
+        <Spinner text="Loading..." />
+      )}
+      <MainToolbar.Controls>
+        <Button
+          data-testid="add-domain"
+          key="add-domain"
+          onClick={() =>
+            setSidePanelContent({ view: DomainListSidePanelViews.ADD_DOMAIN })
+          }
+        >
+          {Labels.AddDomains}
+        </Button>
+      </MainToolbar.Controls>
+    </MainToolbar>
   );
 };
 


### PR DESCRIPTION
## Done
- Replaced SectionHeader with MainToolbar on domains list header

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to `/domains`
- [ ] Ensure the header renders correctly
- [ ] Ensure the "Add domains" button works

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2523](https://warthogs.atlassian.net/browse/MAASENG-2523)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/3618eedb-636e-4e6c-a9ec-9db92ef15e5a)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/7dd2f70e-6bc7-4e12-8694-9232cf7566a4)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->



[MAASENG-2523]: https://warthogs.atlassian.net/browse/MAASENG-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ