### PR TITLE
feat(images): use MainToolbar on image list header MAASENG-2521

### DIFF
--- a/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -1,7 +1,7 @@
+import { MainToolbar } from "@canonical/maas-react-components";
 import { Icon, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 
-import SectionHeader from "app/base/components/SectionHeader";
 import SwitchField from "app/base/components/SwitchField";
 import TooltipButton from "app/base/components/TooltipButton";
 import { useFetchActions, useCycled } from "app/base/hooks";
@@ -55,53 +55,54 @@ const ImageListHeader = (): JSX.Element => {
   useFetchActions([configActions.fetch]);
 
   return (
-    <SectionHeader
-      buttons={
-        configLoaded
-          ? [
-              <div className="u-flex--align-baseline">
-                {configSaving && (
-                  <div className="u-nudge-left--small">
-                    <Icon className="u-animation--spin" name="spinner" />
-                  </div>
-                )}
-                <SwitchField
-                  checked={autoImport || false}
-                  className="u-nudge-right"
-                  data-testid="auto-sync-switch"
-                  id="auto-sync-switch"
-                  label={
-                    <span>
-                      <span>{Labels.AutoSyncImages}</span>
-                      <TooltipButton
-                        className="u-nudge-right--small"
-                        iconName="help"
-                        message={`Enables automatic image updates (sync). The
-                        region controller will check for new images every hour
-                        and automatically sync them, if available, from the
-                        stream configured below. Syncing at the rack controller
-                        level occurs every 5 minutes and cannot be disabled.`}
-                      />
-                    </span>
-                  }
-                  onChange={() => {
-                    dispatch(configActions.cleanup());
-                    dispatch(
-                      configActions.update({
-                        boot_images_auto_import: !autoImport,
-                      })
-                    );
-                  }}
-                  wrapperClassName="u-flex--align-center"
+    <MainToolbar>
+      <MainToolbar.Title>Images</MainToolbar.Title>
+      {configLoaded ? (
+        <div className="u-flex--align-baseline">
+          {configSaving && (
+            <div className="u-nudge-left--small">
+              <Icon className="u-animation--spin" name="spinner" />
+            </div>
+          )}
+          <SwitchField
+            checked={autoImport || false}
+            className="u-nudge-right"
+            data-testid="auto-sync-switch"
+            id="auto-sync-switch"
+            label={
+              <span>
+                <span>{Labels.AutoSyncImages}</span>
+                <TooltipButton
+                  className="u-nudge-right--small"
+                  iconName="help"
+                  message={`Enables automatic image updates (sync). The
+                            region controller will check for new images every hour
+                            and automatically sync them, if available, from the
+                            stream configured below. Syncing at the rack controller
+                            level occurs every 5 minutes and cannot be disabled.`}
                 />
-              </div>,
-            ]
-          : null
-      }
-      subtitle={generateImportStatus(rackImportRunning, regionImportRunning)}
-      subtitleLoading={polling && !hasPolled}
-      title="Images"
-    />
+              </span>
+            }
+            onChange={() => {
+              dispatch(configActions.cleanup());
+              dispatch(
+                configActions.update({
+                  boot_images_auto_import: !autoImport,
+                })
+              );
+            }}
+            wrapperClassName="u-flex--align-center"
+          />
+        </div>
+      ) : null}
+      {polling && !hasPolled ? (
+        <Spinner text="Loading..." />
+      ) : (
+        <span className="u-text--muted">
+          {generateImportStatus(rackImportRunning, regionImportRunning)}
+        </span>
+      )}
+    </MainToolbar>
   );
 };
 


### PR DESCRIPTION
## Done
- Replaced SectionHeader in image list header with MainToolbar

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to /images
- [x] Ensure the header is rendered correctly
- [x] Ensure the auto image sync switch works

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2521](https://warthogs.atlassian.net/browse/MAASENG-2521)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/53fa5874-bec2-437a-b4a5-3755b0aeab0b)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/e3be8cdd-19eb-4b58-88df-df6cb1482045)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->



[MAASENG-2521]: https://warthogs.atlassian.net/browse/MAASENG-2521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ