### PR TITLE
fix: improve intro pages a11y

### DIFF
--- a/cypress/constants.ts
+++ b/cypress/constants.ts
@@ -1,7 +1,7 @@
 export type Page = { heading: string; headingLevel?: number; url: string };
 export const pages: Page[] = [
   { heading: "Login", url: "/accounts/login" },
-  { heading: "SSH keys for admin", headingLevel: 2, url: "/intro/user" },
+  { heading: "SSH keys for admin", url: "/intro/user" },
   { heading: "Devices", url: "/devices" },
   { heading: "Controllers", url: "/controllers" },
   { heading: "Subnets", url: "/networks" },

--- a/src/app/intro/components/IntroCard/IntroCard.tsx
+++ b/src/app/intro/components/IntroCard/IntroCard.tsx
@@ -35,10 +35,10 @@ const IntroCard = ({
       title={
         <>
           <span className="u-flex--between">
-            <h2 className="p-heading--4" data-testid="section-header-title">
+            <h1 className="p-heading--4" data-testid="section-header-title">
               <Icon aria-label={icon} name={icon} />
               &ensp;{title}
-            </h2>
+            </h1>
             {titleLink ? (
               <span className="p-text--default u-text--default-size">
                 {titleLink}


### PR DESCRIPTION
## Done

This improves a11y and fixes failures on intro pages by setting the intro card title as h1 (it's the main heading for each of these pages).

- fix: improve intro pages a11y

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: https://github.com/canonical/maas-ui/issues/5271

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
