### PR TITLE
ci: use node-version-file in playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: yarn
       - name: Install Playwright Browsers


### PR DESCRIPTION
## Done
- ci: use node-version-file in playwright workflow

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: https://github.com/canonical/maas-ui/actions/runs/7528576197/job/20491068356

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
