### PR TITLE
feat: move network discovery forms to sidepanel

### DIFF
--- a/src/app/networkDiscovery/components/NetworkForm/NetworkForm.test.tsx
+++ b/src/app/networkDiscovery/components/NetworkForm/NetworkForm.test.tsx
@@ -1,0 +1,163 @@
+import configureStore from "redux-mock-store";
+
+import type { NetworkDiscoverySidePanelContent } from "../../views/constants";
+import { NetworkDiscoverySidePanelViews } from "../../views/constants";
+
+import NetworkForm from "./NetworkForm";
+
+import type { Discovery } from "@/app/store/discovery/types";
+import type { RootState } from "@/app/store/root/types";
+import {
+  NodeStatus,
+  NodeStatusCode,
+  TestStatusStatus,
+} from "@/app/store/types/node";
+import { callId, enableCallIdMocks } from "@/testing/callId-mock";
+import {
+  discovery as discoveryFactory,
+  domain as domainFactory,
+  device as deviceFactory,
+  machine as machineFactory,
+  testStatus as testStatusFactory,
+  modelRef as modelRefFactory,
+  discoveryState as discoveryStateFactory,
+  deviceState as deviceStateFactory,
+  domainState as domainStateFactory,
+  machineState as machineStateFactory,
+  subnetState as subnetStateFactory,
+  vlanState as vlanStateFactory,
+  rootState as rootStateFactory,
+  machineStateList as machineStateListFactory,
+  machineStateListGroup as machineStateListGroupFactory,
+} from "@/testing/factories";
+import { renderWithBrowserRouter, screen } from "@/testing/utils";
+
+const mockStore = configureStore<RootState, {}>();
+enableCallIdMocks();
+
+let state: RootState;
+let discovery: Discovery;
+
+beforeEach(() => {
+  const machines = [
+    machineFactory({
+      actions: [],
+      architecture: "amd64/generic",
+      cpu_count: 4,
+      cpu_test_status: testStatusFactory({
+        status: TestStatusStatus.RUNNING,
+      }),
+      distro_series: "bionic",
+      domain: modelRefFactory({
+        name: "example",
+      }),
+      extra_macs: [],
+      fqdn: "koala.example",
+      hostname: "koala",
+      ip_addresses: [],
+      memory: 8,
+      memory_test_status: testStatusFactory({
+        status: TestStatusStatus.PASSED,
+      }),
+      network_test_status: testStatusFactory({
+        status: TestStatusStatus.PASSED,
+      }),
+      osystem: "ubuntu",
+      owner: "admin",
+      permissions: ["edit", "delete"],
+      physical_disk_count: 1,
+      pool: modelRefFactory(),
+      pxe_mac: "00:11:22:33:44:55",
+      spaces: [],
+      status: NodeStatus.DEPLOYED,
+      status_code: NodeStatusCode.DEPLOYED,
+      status_message: "",
+      storage: 8,
+      storage_test_status: testStatusFactory({
+        status: TestStatusStatus.PASSED,
+      }),
+      testing_status: TestStatusStatus.PASSED,
+      system_id: "abc123",
+      zone: modelRefFactory(),
+    }),
+  ];
+  discovery = discoveryFactory({
+    ip: "1.2.3.4",
+    mac_address: "aa:bb:cc",
+    subnet: 9,
+    vlan: 8,
+  });
+  state = rootStateFactory({
+    device: deviceStateFactory({
+      loaded: true,
+      items: [deviceFactory({ system_id: "abc123", fqdn: "abc123.example" })],
+    }),
+    discovery: discoveryStateFactory({
+      loaded: true,
+      items: [discovery],
+    }),
+    domain: domainStateFactory({
+      loaded: true,
+      items: [domainFactory({ name: "local" })],
+    }),
+    machine: machineStateFactory({
+      loaded: true,
+      items: machines,
+      lists: {
+        [callId]: machineStateListFactory({
+          loaded: true,
+          groups: [
+            machineStateListGroupFactory({
+              items: [machines[0].system_id],
+              name: "Deployed",
+            }),
+          ],
+        }),
+      },
+    }),
+    subnet: subnetStateFactory({ loaded: true }),
+    vlan: vlanStateFactory({ loaded: true }),
+  });
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+it("renders the clear discovery form when the sidepanel view is provided", () => {
+  const sidePanelContent: NetworkDiscoverySidePanelContent = {
+    view: NetworkDiscoverySidePanelViews.CLEAR_ALL_DISCOVERIES,
+  };
+  renderWithBrowserRouter(
+    <NetworkForm
+      setSidePanelContent={vi.fn()}
+      sidePanelContent={sidePanelContent}
+    />
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Clear all discoveries" })
+  ).toBeInTheDocument();
+});
+
+it("renders the add discovery form given the sidepanel view", () => {
+  const store = mockStore(state);
+  const sidePanelContent: NetworkDiscoverySidePanelContent = {
+    view: NetworkDiscoverySidePanelViews.ADD_DISCOVERY,
+    extras: {
+      discovery,
+    },
+  };
+
+  renderWithBrowserRouter(
+    <NetworkForm
+      setSidePanelContent={vi.fn()}
+      sidePanelContent={sidePanelContent}
+    />,
+    { store }
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Add discovery" })
+  ).toBeInTheDocument();
+});

--- a/src/app/networkDiscovery/components/NetworkForm/NetworkForm.tsx
+++ b/src/app/networkDiscovery/components/NetworkForm/NetworkForm.tsx
@@ -1,0 +1,49 @@
+import { useCallback } from "react";
+
+import type { SidePanelContentTypes } from "@/app/base/side-panel-context";
+import DiscoveryAddForm from "@/app/networkDiscovery/views/DiscoveryAddForm";
+import DiscoveryDeleteForm from "@/app/networkDiscovery/views/DiscoveryDeleteForm";
+import ClearAllForm from "@/app/networkDiscovery/views/NetworkDiscoveryHeader/ClearAllForm";
+import { NetworkDiscoverySidePanelViews } from "@/app/networkDiscovery/views/constants";
+
+type Props = SidePanelContentTypes & {};
+
+const NetworkForm = ({ sidePanelContent, setSidePanelContent }: Props) => {
+  const clearSidePanelContent = useCallback(
+    () => setSidePanelContent(null),
+    [setSidePanelContent]
+  );
+
+  if (!sidePanelContent) return null;
+  const discovery =
+    sidePanelContent.extras && "discovery" in sidePanelContent.extras
+      ? sidePanelContent.extras.discovery
+      : null;
+
+  switch (sidePanelContent.view) {
+    case NetworkDiscoverySidePanelViews.ADD_DISCOVERY: {
+      if (!discovery) return null;
+      return (
+        <DiscoveryAddForm
+          discovery={discovery}
+          onClose={clearSidePanelContent}
+        />
+      );
+    }
+    case NetworkDiscoverySidePanelViews.CLEAR_ALL_DISCOVERIES:
+      return <ClearAllForm closeForm={clearSidePanelContent} />;
+    case NetworkDiscoverySidePanelViews.DELETE_DISCOVERY: {
+      if (!discovery) return null;
+      return (
+        <DiscoveryDeleteForm
+          discovery={discovery}
+          onClose={clearSidePanelContent}
+        />
+      );
+    }
+    default:
+      return null;
+  }
+};
+
+export default NetworkForm;

--- a/src/app/networkDiscovery/components/NetworkForm/index.ts
+++ b/src/app/networkDiscovery/components/NetworkForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./NetworkForm";

--- a/src/app/networkDiscovery/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/src/app/networkDiscovery/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -71,7 +71,7 @@ const DiscoveryAddFormFields = ({
   return (
     <>
       <Row>
-        <Col size={6}>
+        <Col size={12}>
           <FormikField
             component={Select}
             label={Labels.Type}
@@ -148,7 +148,7 @@ const DiscoveryAddFormFields = ({
             />
           )}
         </Col>
-        <Col size={6}>
+        <Col size={12}>
           <IpAssignmentSelect
             includeStatic={includeStatic}
             name="ip_assignment"

--- a/src/app/networkDiscovery/views/DiscoveryDeleteForm/DiscoveryDeleteForm.test.tsx
+++ b/src/app/networkDiscovery/views/DiscoveryDeleteForm/DiscoveryDeleteForm.test.tsx
@@ -1,0 +1,147 @@
+import configureStore from "redux-mock-store";
+
+import DiscoveryDeleteForm from "./DiscoveryDeleteForm";
+
+import { actions as discoveryActions } from "@/app/store/discovery";
+import type { Discovery } from "@/app/store/discovery/types";
+import type { RootState } from "@/app/store/root/types";
+import {
+  NodeStatus,
+  NodeStatusCode,
+  TestStatusStatus,
+} from "@/app/store/types/node";
+import { callId, enableCallIdMocks } from "@/testing/callId-mock";
+import {
+  discovery as discoveryFactory,
+  domain as domainFactory,
+  device as deviceFactory,
+  machine as machineFactory,
+  testStatus as testStatusFactory,
+  modelRef as modelRefFactory,
+  discoveryState as discoveryStateFactory,
+  deviceState as deviceStateFactory,
+  domainState as domainStateFactory,
+  machineState as machineStateFactory,
+  subnetState as subnetStateFactory,
+  vlanState as vlanStateFactory,
+  rootState as rootStateFactory,
+  machineStateList as machineStateListFactory,
+  machineStateListGroup as machineStateListGroupFactory,
+} from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const mockStore = configureStore<RootState, {}>();
+enableCallIdMocks();
+
+let state: RootState;
+let discovery: Discovery;
+
+beforeEach(() => {
+  const machines = [
+    machineFactory({
+      actions: [],
+      architecture: "amd64/generic",
+      cpu_count: 4,
+      cpu_test_status: testStatusFactory({
+        status: TestStatusStatus.RUNNING,
+      }),
+      distro_series: "bionic",
+      domain: modelRefFactory({
+        name: "example",
+      }),
+      extra_macs: [],
+      fqdn: "koala.example",
+      hostname: "koala",
+      ip_addresses: [],
+      memory: 8,
+      memory_test_status: testStatusFactory({
+        status: TestStatusStatus.PASSED,
+      }),
+      network_test_status: testStatusFactory({
+        status: TestStatusStatus.PASSED,
+      }),
+      osystem: "ubuntu",
+      owner: "admin",
+      permissions: ["edit", "delete"],
+      physical_disk_count: 1,
+      pool: modelRefFactory(),
+      pxe_mac: "00:11:22:33:44:55",
+      spaces: [],
+      status: NodeStatus.DEPLOYED,
+      status_code: NodeStatusCode.DEPLOYED,
+      status_message: "",
+      storage: 8,
+      storage_test_status: testStatusFactory({
+        status: TestStatusStatus.PASSED,
+      }),
+      testing_status: TestStatusStatus.PASSED,
+      system_id: "abc123",
+      zone: modelRefFactory(),
+    }),
+  ];
+  discovery = discoveryFactory({
+    ip: "1.2.3.4",
+    mac_address: "aa:bb:cc",
+    subnet: 9,
+    vlan: 8,
+  });
+  state = rootStateFactory({
+    device: deviceStateFactory({
+      loaded: true,
+      items: [deviceFactory({ system_id: "abc123", fqdn: "abc123.example" })],
+    }),
+    discovery: discoveryStateFactory({
+      loaded: true,
+      items: [discovery],
+    }),
+    domain: domainStateFactory({
+      loaded: true,
+      items: [domainFactory({ name: "local" })],
+    }),
+    machine: machineStateFactory({
+      loaded: true,
+      items: machines,
+      lists: {
+        [callId]: machineStateListFactory({
+          loaded: true,
+          groups: [
+            machineStateListGroupFactory({
+              items: [machines[0].system_id],
+              name: "Deployed",
+            }),
+          ],
+        }),
+      },
+    }),
+    subnet: subnetStateFactory({ loaded: true }),
+    vlan: vlanStateFactory({ loaded: true }),
+  });
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+it("renders", () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(
+    <DiscoveryDeleteForm discovery={discovery} onClose={vi.fn()} />,
+    { store }
+  );
+});
+
+it("can dispatch an action to delete a discovery", async () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(
+    <DiscoveryDeleteForm discovery={discovery} onClose={vi.fn()} />,
+    { store }
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+  expect(
+    store.getActions().find((action) => action.type === "discovery/delete")
+  ).toStrictEqual(
+    discoveryActions.delete({ ip: discovery.ip, mac: discovery.mac_address })
+  );
+});

--- a/src/app/networkDiscovery/views/DiscoveryDeleteForm/DiscoveryDeleteForm.tsx
+++ b/src/app/networkDiscovery/views/DiscoveryDeleteForm/DiscoveryDeleteForm.tsx
@@ -1,0 +1,40 @@
+import { useDispatch, useSelector } from "react-redux";
+
+import ModelDeleteForm from "@/app/base/components/ModelDeleteForm";
+import { actions as discoveryActions } from "@/app/store/discovery";
+import discoverySelectors from "@/app/store/discovery/selectors";
+import type { Discovery } from "@/app/store/discovery/types";
+
+type Props = {
+  discovery: Discovery;
+  onClose: () => void;
+};
+
+const DiscoveryDeleteForm = ({ discovery, onClose }: Props) => {
+  const dispatch = useDispatch();
+  const saving = useSelector(discoverySelectors.saving);
+  const saved = useSelector(discoverySelectors.saved);
+  return (
+    <ModelDeleteForm
+      aria-label="Delete discovery"
+      initialValues={{}}
+      message={`Are you sure you want to delete discovery "${
+        discovery.hostname || "Unknown"
+      }"?`}
+      modelType="discovery"
+      onCancel={onClose}
+      onSubmit={() => {
+        dispatch(
+          discoveryActions.delete({
+            ip: discovery.ip,
+            mac: discovery.mac_address,
+          })
+        );
+      }}
+      saved={saved}
+      saving={saving}
+    />
+  );
+};
+
+export default DiscoveryDeleteForm;

--- a/src/app/networkDiscovery/views/DiscoveryDeleteForm/index.ts
+++ b/src/app/networkDiscovery/views/DiscoveryDeleteForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DiscoveryDeleteForm";

--- a/src/app/networkDiscovery/views/NetworkDiscovery.tsx
+++ b/src/app/networkDiscovery/views/NetworkDiscovery.tsx
@@ -2,11 +2,11 @@ import { Notification } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { Route, Routes } from "react-router-dom-v5-compat";
 
+import NetworkForm from "../components/NetworkForm";
+
 import DiscoveriesList from "./DiscoveriesList";
 import NetworkDiscoveryConfigurationForm from "./NetworkDiscoveryConfigurationForm";
 import NetworkDiscoveryHeader from "./NetworkDiscoveryHeader";
-import ClearAllForm from "./NetworkDiscoveryHeader/ClearAllForm";
-import { NetworkDiscoverySidePanelViews } from "./constants";
 
 import PageContent from "@/app/base/components/PageContent";
 import SectionHeader from "@/app/base/components/SectionHeader";
@@ -15,6 +15,7 @@ import urls from "@/app/base/urls";
 import NotFound from "@/app/base/views/NotFound";
 import authSelectors from "@/app/store/auth/selectors";
 import configSelectors from "@/app/store/config/selectors";
+import { getSidePanelTitle } from "@/app/store/utils/node/base";
 import { getRelativeRoute } from "@/app/utils";
 
 export enum Label {
@@ -37,29 +38,21 @@ const NetworkDiscovery = (): JSX.Element => {
     );
   }
 
-  let content: JSX.Element | null = null;
-
-  if (
-    sidePanelContent?.view ===
-    NetworkDiscoverySidePanelViews.CLEAR_ALL_DISCOVERIES
-  ) {
-    content = (
-      <ClearAllForm
-        closeForm={() => {
-          setSidePanelContent(null);
-        }}
-      />
-    );
-  }
-
   const base = urls.networkDiscovery.index;
   return (
     <PageContent
       header={
         <NetworkDiscoveryHeader setSidePanelContent={setSidePanelContent} />
       }
-      sidePanelContent={content}
-      sidePanelTitle="Clear all discoveries"
+      sidePanelContent={
+        sidePanelContent && (
+          <NetworkForm
+            setSidePanelContent={setSidePanelContent}
+            sidePanelContent={sidePanelContent}
+          />
+        )
+      }
+      sidePanelTitle={getSidePanelTitle("Network discovery", sidePanelContent)} // "Clear all discoveries"
     >
       {networkDiscovery === "disabled" && (
         <Notification severity="caution">{Label.Disabled}</Notification>

--- a/src/app/networkDiscovery/views/NetworkDiscoveryHeader/ClearAllForm/ClearAllForm.tsx
+++ b/src/app/networkDiscovery/views/NetworkDiscoveryHeader/ClearAllForm/ClearAllForm.tsx
@@ -63,6 +63,7 @@ const ClearAllForm = ({ closeForm }: Props): JSX.Element => {
   }
   return (
     <FormikForm<EmptyObject>
+      aria-label="Clear all discoveries"
       cleanup={cleanup}
       errors={errors}
       initialValues={{}}

--- a/src/app/networkDiscovery/views/constants.ts
+++ b/src/app/networkDiscovery/views/constants.ts
@@ -1,11 +1,15 @@
 import type { ValueOf } from "@canonical/react-components";
 
 import type { SidePanelContent } from "@/app/base/types";
+import type { Discovery } from "@/app/store/discovery/types";
 
 export const NetworkDiscoverySidePanelViews = {
+  ADD_DISCOVERY: ["", "addDiscovery"],
   CLEAR_ALL_DISCOVERIES: ["", "clearAllDiscoveries"],
+  DELETE_DISCOVERY: ["", "deleteDiscovery"],
 } as const;
 
 export type NetworkDiscoverySidePanelContent = SidePanelContent<
-  ValueOf<typeof NetworkDiscoverySidePanelViews>
+  ValueOf<typeof NetworkDiscoverySidePanelViews>,
+  { discovery?: Discovery }
 >;

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -200,6 +200,8 @@ export const getSidePanelTitle = (
         return "Add controller";
       case SidePanelViews.ADD_CHASSIS[1]:
         return "Add chassis";
+      case SidePanelViews.ADD_DISCOVERY[1]:
+        return "Add discovery";
       case SidePanelViews.ADD_INTERFACE[1]:
         return "Add interface";
       case SidePanelViews.ADD_MACHINE[1]:
@@ -214,12 +216,16 @@ export const getSidePanelTitle = (
         return "Add VLAN";
       case SidePanelViews.CHANGE_SOURCE[1]:
         return "Change source";
+      case SidePanelViews.CLEAR_ALL_DISCOVERIES[1]:
+        return "Clear all discoveries";
       case SidePanelViews.CREATE_DATASTORE[1]:
         return "Create datastore";
       case SidePanelViews.CREATE_RAID[1]:
         return "Create raid";
       case SidePanelViews.CREATE_VOLUME_GROUP[1]:
         return "Create volume group";
+      case SidePanelViews.DELETE_DISCOVERY[1]:
+        return "Delete discovery";
       case SidePanelViews.DeleteTag[1]:
         return "Delete tag";
       case SidePanelViews.EDIT_INTERFACE[1]:


### PR DESCRIPTION
## Done
- Moved add/delete discovery forms to sidepanel

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Visit `/network-discovery`
- [ ] Try adding or deleting a discovery
- [ ] Ensure that both forms display in a sidepanel

<!-- Steps for QA. -->

## Fixes

Fixes: [Move Network Discovery forms to side panel](https://warthogs.atlassian.net/browse/MAASENG-2572)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
###. Before
![image](https://github.com/canonical/maas-ui/assets/47540149/d79846ce-3e1c-4ea0-8eec-ff94b6573a90)
![image](https://github.com/canonical/maas-ui/assets/47540149/bd98be0f-1318-4e0c-8a02-4820ee9c1172)


### After
<img width="896" alt="image" src="https://github.com/canonical/maas-ui/assets/47540149/1b6b9caf-54a4-4cdf-9a07-9a92f0b8cc40">
<img width="811" alt="image" src="https://github.com/canonical/maas-ui/assets/47540149/10b51e96-2eff-4bd2-af5e-5d19388d763d">

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
