### PR TITLE
test: fix Cypress machine list tests

### DIFF
--- a/cypress/e2e/with-users/machines/list.spec.ts
+++ b/cypress/e2e/with-users/machines/list.spec.ts
@@ -152,7 +152,7 @@ context("Machine listing", () => {
     );
     cy.findByRole("button", { name: /Delete/i }).click();
     cy.findByRole("button", { name: /Delete 3 machines/ }).click();
-    cy.findByText(/No machines match the search criteria./).should("exist");
+    cy.findByText(/No machines available./).should("exist");
   });
 
   it("can filter machine list by deployment target", () => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -39,7 +39,7 @@ Cypress.Commands.add("loginNonAdmin", () => {
 
 Cypress.Commands.add("addMachine", (hostname = generateName()) => {
   cy.visit(generateMAASURL("/machines"));
-  cy.get("[data-testid='add-hardware-dropdown'] button").click();
+  cy.findByRole("button", { name: "Add hardware" }).click();
   cy.get(".p-contextual-menu__link").contains("Machine").click();
   cy.get("input[name='hostname']").type(hostname);
   cy.get("input[name='pxe_mac']").type(generateMac());
@@ -82,7 +82,7 @@ Cypress.Commands.add("deletePool", (pool: string) => {
 
 Cypress.Commands.add("addMachines", (hostnames: string[]) => {
   cy.visit(generateMAASURL("/machines"));
-  cy.get("[data-testid='add-hardware-dropdown'] button").click();
+  cy.findByRole("button", { name: "Add hardware" }).click();
   cy.get(".p-contextual-menu__link").contains("Machine").click();
   hostnames.forEach((hostname, index) => {
     cy.get("input[name='hostname']").type(hostname);


### PR DESCRIPTION
## Done
- Fixed "can select a machine range" test
- Fixed button selector in machine add commands

This should also fix the machine actions test suite.

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Run machines/list.spec.ts
- [x] Ensure it passes

<!-- Steps for QA. -->

