### PR TITLE
feat: move SSH Key delete form to sidepanel

### DIFF
--- a/src/app/base/side-panel-context.tsx
+++ b/src/app/base/side-panel-context.tsx
@@ -23,6 +23,8 @@ import {
   NetworkDiscoverySidePanelViews,
   type NetworkDiscoverySidePanelContent,
 } from "@/app/networkDiscovery/views/constants";
+import { PreferenceSidePanelViews } from "@/app/preferences/constants";
+import type { PreferenceSidePanelContent } from "@/app/preferences/types";
 import {
   SubnetSidePanelViews,
   type SubnetSidePanelContent,
@@ -64,6 +66,7 @@ export type SidePanelContent =
   | VLANDetailsSidePanelContent
   | FabricDetailsSidePanelContent
   | ImageSidePanelContent
+  | PreferenceSidePanelContent
   | SubnetDetailsSidePanelContent
   | SpaceDetailsSidePanelContent
   | null;
@@ -93,6 +96,7 @@ export const SidePanelViews = {
   ...VLANDetailsSidePanelViews,
   ...FabricDetailsSidePanelViews,
   ...ImageSidePanelViews,
+  ...PreferenceSidePanelViews,
   ...SubnetDetailsSidePanelViews,
   ...SpaceDetailsSidePanelViews,
 } as const;

--- a/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -55,7 +55,7 @@ const UserIntro = (): JSX.Element => {
           Add multiple keys from Launchpad and Github or enter them manually.
         </p>
         <h4>Keys</h4>
-        {hasSSHKeys ? <SSHKeyList sidebar={false} /> : null}
+        {hasSSHKeys ? <SSHKeyList /> : null}
         <SSHKeyForm
           onSaveAnalytics={{
             action: "Import",

--- a/src/app/preferences/components/Routes/Routes.tsx
+++ b/src/app/preferences/components/Routes/Routes.tsx
@@ -1,6 +1,8 @@
 import { Redirect } from "react-router";
 import { Route, Routes as ReactRouterRoutes } from "react-router-dom-v5-compat";
 
+import DeleteSSHKey from "../../views/SSHKeys/DeleteSSHKey";
+
 import PageContent from "@/app/base/components/PageContent";
 import urls from "@/app/base/urls";
 import NotFound from "@/app/base/views/NotFound";
@@ -92,6 +94,17 @@ const Routes = (): JSX.Element => {
           </PageContent>
         }
         path={getRelativeRoute(urls.preferences.sshKeys.add, base)}
+      />
+      <Route
+        element={
+          <PageContent
+            sidePanelContent={<DeleteSSHKey />}
+            sidePanelTitle="Delete SSH key"
+          >
+            <SSHKeyList />
+          </PageContent>
+        }
+        path={getRelativeRoute(urls.preferences.sshKeys.delete, base)}
       />
       <Route
         element={

--- a/src/app/preferences/constants.ts
+++ b/src/app/preferences/constants.ts
@@ -19,3 +19,7 @@ export const preferencesNavItems: NavItem[] = [
     label: "SSL keys",
   },
 ];
+
+export const PreferenceSidePanelViews = {
+  DELETE_SSH_KEYS: ["", "deleteSSHKeys"],
+} as const;

--- a/src/app/preferences/types.ts
+++ b/src/app/preferences/types.ts
@@ -1,0 +1,17 @@
+import type { ValueOf } from "@canonical/react-components";
+
+import type { PreferenceSidePanelViews } from "./constants";
+
+import type { SidePanelContent, SetSidePanelContent } from "@/app/base/types";
+import type { SSHKey } from "@/app/store/sshkey/types";
+
+type SSHKeyGroup = {
+  keys: SSHKey[];
+};
+export type PreferenceSidePanelContent = SidePanelContent<
+  ValueOf<typeof PreferenceSidePanelViews>,
+  { group?: SSHKeyGroup }
+>;
+
+export type PreferenceSetSidePanelContent =
+  SetSidePanelContent<PreferenceSidePanelContent>;

--- a/src/app/preferences/urls.ts
+++ b/src/app/preferences/urls.ts
@@ -12,6 +12,7 @@ const urls = {
   index: "/account/prefs",
   sshKeys: {
     add: "/account/prefs/ssh-keys/add",
+    delete: "/account/prefs/ssh-keys/delete",
     index: "/account/prefs/ssh-keys",
   },
   sslKeys: {

--- a/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.test.tsx
@@ -1,0 +1,99 @@
+import configureStore from "redux-mock-store";
+
+import DeleteSSHKey from "./DeleteSSHKey";
+
+import * as sidePanelHooks from "@/app/base/side-panel-context";
+import { PreferenceSidePanelViews } from "@/app/preferences/constants";
+import type { RootState } from "@/app/store/root/types";
+import {
+  sshKey as sshKeyFactory,
+  sshKeyState as sshKeyStateFactory,
+  rootState as rootStateFactory,
+} from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+let state: RootState;
+const mockStore = configureStore<RootState>();
+
+beforeEach(() => {
+  const keys = [
+    sshKeyFactory({
+      id: 1,
+      key: "ssh-rsa aabb",
+      keysource: { protocol: "lp", auth_id: "koalaparty" },
+    }),
+    sshKeyFactory({
+      id: 2,
+      key: "ssh-rsa ccdd",
+      keysource: { protocol: "gh", auth_id: "koalaparty" },
+    }),
+    sshKeyFactory({
+      id: 3,
+      key: "ssh-rsa eeff",
+      keysource: { protocol: "lp", auth_id: "maaate" },
+    }),
+    sshKeyFactory({
+      id: 4,
+      key: "ssh-rsa gghh",
+      keysource: { protocol: "gh", auth_id: "koalaparty" },
+    }),
+    sshKeyFactory({ id: 5, key: "ssh-rsa gghh" }),
+  ];
+  vi.spyOn(sidePanelHooks, "useSidePanel").mockReturnValue({
+    setSidePanelContent: vi.fn(),
+    sidePanelContent: {
+      view: PreferenceSidePanelViews.DELETE_SSH_KEYS,
+      extras: { group: { keys } },
+    },
+    setSidePanelSize: vi.fn(),
+    sidePanelSize: "regular",
+  });
+  state = rootStateFactory({
+    sshkey: sshKeyStateFactory({
+      loading: false,
+      loaded: true,
+      items: keys,
+    }),
+  });
+});
+
+it("renders", () => {
+  renderWithBrowserRouter(<DeleteSSHKey />, {
+    state,
+    route: "/account/prefs/ssh-keys/delete?ids=2,3",
+  });
+  expect(
+    screen.getByRole("form", { name: "Delete SSH key confirmation" })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("Are you sure you want to delete these SSH keys?")
+  ).toBeInTheDocument();
+});
+
+it("can delete a group of SSH keys", async () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(<DeleteSSHKey />, {
+    route: "/account/prefs/ssh-keys/delete?ids=2,3",
+    store,
+  });
+  await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+  expect(
+    store.getActions().some((action) => action.type === "sshkey/delete")
+  ).toBe(true);
+});
+
+it("can add a message when a SSH key is deleted", async () => {
+  state.sshkey.saved = true;
+  const store = mockStore(state);
+  renderWithBrowserRouter(<DeleteSSHKey />, {
+    route: "/account/prefs/ssh-keys/delete?ids=2,3",
+    store,
+  });
+  // Click on the delete button:
+  await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+  const actions = store.getActions();
+  expect(actions.some((action) => action.type === "sshkey/cleanup")).toBe(true);
+  expect(actions.some((action) => action.type === "message/add")).toBe(true);
+});

--- a/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+
+import { useOnEscapePressed } from "@canonical/react-components";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate, useSearchParams } from "react-router-dom-v5-compat";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { useAddMessage } from "@/app/base/hooks";
+import urls from "@/app/preferences/urls";
+import { actions as sshkeyActions } from "@/app/store/sshkey";
+import sshkeySelectors from "@/app/store/sshkey/selectors";
+import type { SSHKey, SSHKeyMeta } from "@/app/store/sshkey/types";
+
+const DeleteSSHKey = () => {
+  const [deleting, setDeleting] = useState<SSHKey[SSHKeyMeta.PK][]>([]);
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const saved = useSelector(sshkeySelectors.saved);
+  const saving = useSelector(sshkeySelectors.saving);
+  const sshkeys = useSelector(sshkeySelectors.all);
+  const dispatch = useDispatch();
+  const onClose = () => navigate({ pathname: urls.sshKeys.index });
+  useOnEscapePressed(() => onClose());
+  const sshKeysDeleted =
+    deleting.length > 0 &&
+    !deleting.some((id) => !sshkeys.find((key) => key.id === id));
+  useAddMessage(
+    saved && sshKeysDeleted,
+    sshkeyActions.cleanup,
+    "SSH key removed successfully.",
+    () => setDeleting([])
+  );
+
+  const ids = searchParams
+    .get("ids")
+    ?.split(",")
+    .map((id) => Number(id));
+
+  if (!ids || ids?.length === 0) {
+    return <h4>SSH key not found</h4>;
+  }
+
+  return (
+    <ModelActionForm
+      aria-label="Delete SSH key confirmation"
+      initialValues={{}}
+      message={`Are you sure you want to delete ${
+        ids.length > 1 ? "these SSH keys" : "this SSH key"
+      }?`}
+      modelType="SSH key"
+      onCancel={onClose}
+      onSubmit={() => {
+        ids.forEach((id) => {
+          dispatch(sshkeyActions.delete(id));
+        });
+        setDeleting(ids);
+      }}
+      onSuccess={() => {
+        dispatch(sshkeyActions.cleanup());
+        onClose();
+      }}
+      saved={saved}
+      saving={saving}
+    />
+  );
+};
+
+export default DeleteSSHKey;

--- a/src/app/preferences/views/SSHKeys/DeleteSSHKey/index.ts
+++ b/src/app/preferences/views/SSHKeys/DeleteSSHKey/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteSSHKey";


### PR DESCRIPTION
## Done
- moved SSH Key delete form to sidepanel

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] visit /account/prefs/ssh-keys
- [x] If you don't have an SSH key added already, add one
- [x] Click on the delete button on the table row
- [x] ensure the side panel opens up to delete the SSH key
- [x] ensure deletion works

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-2576](https://warthogs.atlassian.net/browse/MAASENG-2576)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![image](https://github.com/canonical/maas-ui/assets/47540149/02b60413-c572-48ec-ac6c-8ee128f13df0)

### After
![image](https://github.com/canonical/maas-ui/assets/47540149/7d91f835-64f3-4973-a045-70706bcbcc46)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2576]: https://warthogs.atlassian.net/browse/MAASENG-2576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ