### PR TITLE
ci: run tests on *cypress* branches

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - "3.*"
+      - "*cypress*"
 jobs:
   cypress:
     name: Cypress


### PR DESCRIPTION
This will allow testing changes to cypress workflow outside of main branches by using *cypress* branch name.

## Done
- ci: set cypress to run *cypress* branches

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
