### PR TITLE
build: optimize js bundle

### DIFF
--- a/src/app/base/sagas/http.ts
+++ b/src/app/base/sagas/http.ts
@@ -10,7 +10,6 @@ import type { Script } from "@/app/store/script/types";
 import { ScriptResultNames } from "@/app/store/scriptresult/types";
 import type { SimpleNode } from "@/app/store/types/node";
 import { getCookie } from "@/app/utils";
-import bakery from "@/bakery";
 
 type CSRFToken = string;
 
@@ -102,17 +101,19 @@ export const api = {
     },
     externalLogin: (): Promise<XMLHttpRequest["response"]> => {
       return new Promise((resolve, reject) => {
-        bakery.get(
-          BAKERY_LOGIN_API,
-          DEFAULT_HEADERS,
-          (_: unknown, response: XMLHttpRequest["response"]) => {
-            if (response.currentTarget.status !== 200) {
-              localStorage.clear();
-              reject(Error(response.currentTarget.responseText));
-            } else {
-              resolve({ response });
+        import("@/bakery").then(({ default: bakery }) =>
+          bakery.get(
+            BAKERY_LOGIN_API,
+            DEFAULT_HEADERS,
+            (_: unknown, response: XMLHttpRequest["response"]) => {
+              if (response.currentTarget.status !== 200) {
+                localStorage.clear();
+                reject(Error(response.currentTarget.responseText));
+              } else {
+                resolve({ response });
+              }
             }
-          }
+          )
         );
       });
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,13 @@ import react from "@vitejs/plugin-react-swc";
 import * as path from "path";
 import eslint from "vite-plugin-eslint";
 
+const manualChunks = [
+  "@canonical/react-components",
+  "@canonical/maas-react-components",
+  "@canonical/macaroon-bakery",
+  "@/app/store/machine/slice",
+];
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, "./");
@@ -20,6 +27,18 @@ export default defineConfig(({ mode }) => {
       rollupOptions: {
         output: {
           sanitizeFileName: false,
+          // Creates an object with sanitized camel-cased module names as keys and original module names as values.
+          // e.g.: { "canonicalReactComponents": ["@canonical/react-components"] }.
+          manualChunks: manualChunks.reduce((chunks, module) => {
+            const sanitizedModule = module
+              .replace(/(^|[-\/])(.)/g, (_, _separator, letter) =>
+                letter.toUpperCase()
+              )
+              .replace(/[^a-zA-Z0-9]/g, "")
+              .replace(/^./, (firstChar) => firstChar.toLowerCase());
+            chunks[sanitizedModule] = [module];
+            return chunks;
+          }, {}),
         },
       },
       sourcemap: true,


### PR DESCRIPTION
This moves external login to separate module.
It reduces the bundle size for users that use local authentication by ` 505.47 kB` 

`build/assets/canonicalMacaroonBakery-yGIenEOq.js                             505.47 kB │ gzip: 159.98 kB`

## Done
- build: optimize js bundle
  - use dynamic import for @canonical/macaroon-bakery

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps
- [x] Check out the repository locally
- [x] Make sure you're able to login and machine list page works as expected
- [x] Open your browser's developer tools and network tab
- [x] Make sure bakery module has not been requested (you can use filter input field and type in bakery)
- [x] Logout
- [x] Go to `status/slice.ts` file and replace line `45` with below:
```
      state.externalAuthURL = "http://localhost:5240/login";
      state.externalAuthURL = "http://localhost:5240/login";
```
- [x] Refresh the page
- [x] Ensure "Go to login page" login button is displayed
- [x] Open your browser's developer tools and network tab
- [x] Make sure bakery module has been requested


<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
```
build/index.html                                                               2.63 kB │ gzip:   0.88 kB
build/assets/d5fc1819-UbuntuMono[wght]-latin-v0.869-dm70xBn2.woff2            31.24 kB
build/asset-manifest.json                                                     53.65 kB │ gzip:   4.77 kB
build/assets/90b59210-Ubuntu-Italic[wdth,wght]-latin-v0.896a-NHXK-QrM.woff2   75.84 kB
build/assets/f1ea362b-Ubuntu[wdth,wght]-latin-v0.896a-b_Xgw9oJ.woff2          95.13 kB
build/assets/index-rpGP_V-a.css                                              613.47 kB │ gzip:  86.38 kB
build/assets/VisuallyHidden-okxiFOln.js                                        0.16 kB │ gzip:   0.16 kB
build/assets/utils-urBu1ZtY.js                                                 0.17 kB │ gzip:   0.14 kB
build/assets/MacAddressDisplay-Peu6a5Ca.js                                     0.25 kB │ gzip:   0.19 kB
build/assets/selectors-bBVOWYzS.js                                             0.26 kB │ gzip:   0.21 kB
build/assets/selectors-uRDj-Ixz.js                                             0.39 kB │ gzip:   0.29 kB
build/assets/SearchBox-FFmbz7Fj.js                                             0.39 kB │ gzip:   0.29 kB
build/assets/MacAddressField-r9Ys7ODR.js                                       0.41 kB │ gzip:   0.29 kB
build/assets/selectors-kZcfCVue.js                                             0.41 kB │ gzip:   0.29 kB
build/assets/GroupSelect-E695IR_L.js                                           0.42 kB │ gzip:   0.30 kB
build/assets/ErrorsNotification-wYKU2fGv.js                                    0.44 kB │ gzip:   0.32 kB
build/assets/bakery-1tVOQ65w.js                                                0.45 kB │ gzip:   0.32 kB
build/assets/CertificateMetadata-eJoCn0gz.js                                   0.46 kB │ gzip:   0.29 kB
build/assets/TableHeader-xgsDLS24.js                                           0.50 kB │ gzip:   0.33 kB
build/assets/IpAssignmentSelect-Rd2N3kVO.js                                    0.53 kB │ gzip:   0.33 kB
build/assets/VLANLink-718nYZHh.js                                              0.53 kB │ gzip:   0.36 kB
build/assets/Definition-M7QwtFK7.js                                            0.54 kB │ gzip:   0.34 kB
build/assets/LabelledList-XmUJxMH4.js                                          0.55 kB │ gzip:   0.33 kB
build/assets/SubnetLink-G8QMM7WB.js                                            0.56 kB │ gzip:   0.36 kB
build/assets/RowCheckbox-24ixWpk-.js                                           0.57 kB │ gzip:   0.36 kB
build/assets/ModelActionForm-3PKW0oSt.js                                       0.57 kB │ gzip:   0.36 kB
build/assets/SpaceLink-eC05fLtK.js                                             0.57 kB │ gzip:   0.37 kB
build/assets/FabricLink-J97_UWy9.js                                            0.57 kB │ gzip:   0.37 kB
build/assets/ControllerLink-98uI1Dzm.js                                        0.57 kB │ gzip:   0.37 kB
build/assets/DomainSelect-Z4ArZiNt.js                                          0.59 kB │ gzip:   0.37 kB
build/assets/TooltipButton-Rrxs07lA.js                                         0.63 kB │ gzip:   0.39 kB
build/assets/selectors-1adI0GaJ.js                                             0.64 kB │ gzip:   0.35 kB
build/assets/SpaceSelect-KyszdKMC.js                                           0.64 kB │ gzip:   0.40 kB
build/assets/ModelListSubtitle-N6fYpOjA.js                                     0.66 kB │ gzip:   0.41 kB
build/assets/SwitchField-sFbeTNPm.js                                           0.68 kB │ gzip:   0.36 kB
build/assets/ModelNotFound-N2Mxhlys.js                                         0.68 kB │ gzip:   0.44 kB
build/assets/NodeActionFormWrapper-I1MXIQeT.js                                 0.68 kB │ gzip:   0.44 kB
build/assets/ShowAdvanced-e7-Zb33L.js                                          0.71 kB │ gzip:   0.40 kB
build/assets/selectors-X494NxA7.js                                             0.71 kB │ gzip:   0.41 kB
build/assets/utils-Qb-RNJI7.js                                                 0.74 kB │ gzip:   0.44 kB
build/assets/GroupCheckbox-R2KcnQN_.js                                         0.75 kB │ gzip:   0.46 kB
build/assets/FormCard-5N_GdIOm.js                                              0.76 kB │ gzip:   0.47 kB
build/assets/DynamicSelect-Z7Aope-j.js                                         0.78 kB │ gzip:   0.48 kB
build/assets/SubnetSelect-mCUjJf0p.js                                          0.79 kB │ gzip:   0.48 kB
build/assets/DebounceSearchBox-Ykaubzzs.js                                     0.86 kB │ gzip:   0.52 kB
build/assets/selectors-PNvqOKqR.js                                             0.94 kB │ gzip:   0.52 kB
build/assets/ArrowPagination-lMmNhUgl.js                                       1.04 kB │ gzip:   0.54 kB
build/assets/utils-6k3s5PYa.js                                                 1.09 kB │ gzip:   0.63 kB
build/assets/VaultNotification-GF9cjbKD.js                                     1.19 kB │ gzip:   0.51 kB
build/assets/selectors-kZNJht0O.js                                             1.23 kB │ gzip:   0.60 kB
build/assets/hooks-A88n6c5v.js                                                 1.36 kB │ gzip:   0.76 kB
build/assets/KernelOptionsField-7NmkPnSf.js                                    1.39 kB │ gzip:   0.78 kB
build/assets/selectors-L57AwkQr.js                                             1.48 kB │ gzip:   0.75 kB
build/assets/EditableSection-nkA_9JLK.js                                       1.49 kB │ gzip:   0.70 kB
build/assets/docsUrls-Ybdb_5H7.js                                              1.67 kB │ gzip:   0.56 kB
build/assets/VLANSelect-PRlCZfAn.js                                            1.69 kB │ gzip:   0.91 kB
build/assets/FilterAccordion-RioYq51H.js                                       1.72 kB │ gzip:   0.95 kB
build/assets/DoubleRow-dJwzVXW8.js                                             1.74 kB │ gzip:   0.74 kB
build/assets/selectors-ae0UFlYm.js                                             1.76 kB │ gzip:   0.80 kB
build/assets/TableActions-ijz4RzrN.js                                          1.89 kB │ gzip:   0.74 kB
build/assets/MachineListPagination-x9rF330d.js                                 1.94 kB │ gzip:   0.87 kB
build/assets/CertificateDetails-4ND6q0gx.js                                    1.95 kB │ gzip:   0.99 kB
build/assets/NetworkDiscoveryForm-ZUCYvIsF.js                                  1.98 kB │ gzip:   0.97 kB
build/assets/MachineSelectTable-RCunBOq-.js                                    2.01 kB │ gzip:   0.96 kB
build/assets/SettingsTable-_1uld7LT.js                                         2.22 kB │ gzip:   1.07 kB
build/assets/MachineSelect-W1gAevvr.js                                         2.36 kB │ gzip:   1.14 kB
build/assets/NodeActionMenuGroup-r1Ha9sEH.js                                   2.36 kB │ gzip:   1.23 kB
build/assets/DHCPTable-E8C7VJ94.js                                             2.71 kB │ gzip:   1.38 kB
build/assets/NodeName-OsHz3SUf.js                                              2.79 kB │ gzip:   1.24 kB
build/assets/PowerIcon-JZY6XCpY.js                                             2.85 kB │ gzip:   1.22 kB
build/assets/TagNameField-xM-SyqSh.js                                          3.25 kB │ gzip:   1.67 kB
build/assets/index-ZhD8fIZ2.js                                                 3.30 kB │ gzip:   1.46 kB
build/assets/ReservedRanges-X-qOUmqr.js                                        3.38 kB │ gzip:   1.48 kB
build/assets/index--WpLnsuO.js                                                 3.38 kB │ gzip:   1.58 kB
build/assets/TableDeleteConfirm-_FFchinC.js                                    3.39 kB │ gzip:   1.52 kB
build/assets/TagSelector-H6ciDvOL.js                                           3.41 kB │ gzip:   1.39 kB
build/assets/ControllerForms-RVynJtLl.js                                       3.63 kB │ gzip:   1.67 kB
build/assets/TestForm-hlqlIUhI.js                                              3.77 kB │ gzip:   1.80 kB
build/assets/SSHKeyList-H0PaJ7Xu.js                                            4.06 kB │ gzip:   1.93 kB
build/assets/index-NxZ2U6sW.js                                                 4.33 kB │ gzip:   1.95 kB
build/assets/index-n4Cf8njv.js                                                 4.66 kB │ gzip:   1.98 kB
build/assets/NodeConfigurationFields-unfL0NfL.js                               4.94 kB │ gzip:   1.78 kB
build/assets/NodeSummaryNetworkCard-WuBA9Lod.js                                5.15 kB │ gzip:   1.97 kB
build/assets/Pools-PApTX_ab.js                                                 5.22 kB │ gzip:   2.06 kB
build/assets/DhcpSnippetType-zZ_CcQaF.js                                       5.30 kB │ gzip:   2.35 kB
build/assets/DeviceHeaderForms-3MtxMLHP.js                                     5.54 kB │ gzip:   2.35 kB
build/assets/index-mIDBofo0.js                                                 5.68 kB │ gzip:   2.39 kB
build/assets/SetZoneForm-5Zii8JEr.js                                           6.20 kB │ gzip:   2.66 kB
build/assets/index--RTR0tAT.js                                                 6.32 kB │ gzip:   2.61 kB
build/assets/index-OwvDtjgc.js                                                 8.22 kB │ gzip:   3.18 kB
build/assets/Intro-J2p7M-dc.js                                                 9.54 kB │ gzip:   3.64 kB
build/assets/Preferences--xbo0heX.js                                           9.91 kB │ gzip:   3.43 kB
build/assets/index-s3wSK5GM.js                                                10.32 kB │ gzip:   3.70 kB
build/assets/index-NXx5CyBA.js                                                10.43 kB │ gzip:   3.77 kB
build/assets/Machines-W9LegFMC.js                                             10.72 kB │ gzip:   4.14 kB
build/assets/NetworkDiscovery-eFIoeYkb.js                                     14.23 kB │ gzip:   5.43 kB
build/assets/index-psOizz2n.js                                                14.54 kB │ gzip:   4.42 kB
build/assets/index-buPXONi8.js                                                15.02 kB │ gzip:   5.19 kB
build/assets/SyncedImages-MPz1aqd9.js                                         15.38 kB │ gzip:   4.91 kB
build/assets/Tags-PJoT_jTj.js                                                 15.55 kB │ gzip:   5.52 kB
build/assets/index-XsPRHjHb.js                                                16.44 kB │ gzip:   5.68 kB
build/assets/index-3ZTapsuA.js                                                17.16 kB │ gzip:   5.56 kB
build/assets/index--8NmqWGy.js                                                21.69 kB │ gzip:   6.85 kB
build/assets/index-SRil-khk.js                                                22.41 kB │ gzip:   7.46 kB
build/assets/DiskNumaNodes-2eZ6GFo2.js                                        27.66 kB │ gzip:   9.91 kB
build/assets/constants-yeIZjUZv.js                                            31.58 kB │ gzip:   9.64 kB
build/assets/canonicalMaasReactComponents-ut7N3heH.js                         32.97 kB │ gzip:  11.18 kB
build/assets/index-T5n8B6Te.js                                                39.27 kB │ gzip:  12.28 kB
build/assets/Settings-sBexA3nQ.js                                             62.71 kB │ gzip:  16.84 kB
build/assets/NodeTestDetails-M2_NSNz8.js                                      69.24 kB │ gzip:  18.07 kB
build/assets/MachineForms-t_qFIGRk.js                                         76.19 kB │ gzip:  21.86 kB
build/assets/KVM-9-oLbmxz.js                                                 111.11 kB │ gzip:  29.45 kB
build/assets/index-dm6MAOdU.js                                               225.85 kB │ gzip:  67.31 kB
build/assets/appStoreMachineSlice-cZAHVg1H.js                                406.33 kB │ gzip: 113.65 kB
build/assets/canonicalReactComponents-zzdJG53E.js                            466.56 kB │ gzip: 128.03 kB
build/assets/canonicalMacaroonBakery-yGIenEOq.js                             505.47 kB │ gzip: 159.98 kB
```
