### PR TITLE
fix: settings top padding

### DIFF
--- a/src/app/base/components/MainContentSection/MainContentSection.test.tsx
+++ b/src/app/base/components/MainContentSection/MainContentSection.test.tsx
@@ -2,16 +2,7 @@ import MainContentSection from "./MainContentSection";
 
 import { renderWithMockStore, screen, within } from "@/testing/utils";
 
-it("renders sidebar", () => {
-  renderWithMockStore(
-    <MainContentSection header="Settings" sidebar={<div>Sidebar</div>}>
-      content
-    </MainContentSection>
-  );
-  expect(screen.getByRole("complementary")).toBeInTheDocument();
-});
-
-it("renders without a sidebar", () => {
+it("renders", () => {
   renderWithMockStore(
     <MainContentSection header="Settings">content</MainContentSection>
   );

--- a/src/app/base/components/MainContentSection/MainContentSection.tsx
+++ b/src/app/base/components/MainContentSection/MainContentSection.tsx
@@ -1,11 +1,8 @@
 import type { HTMLProps, ReactNode } from "react";
 
 import { Col, Row } from "@canonical/react-components";
-import type { ColSize } from "@canonical/react-components";
-import classNames from "classnames";
 
 import NotificationList from "@/app/base/components/NotificationList";
-import { COL_SIZES } from "@/app/base/constants";
 
 export type Props = {
   children?: ReactNode;
@@ -19,11 +16,8 @@ export const MAIN_CONTENT_SECTION_ID = "main-content-section";
 const MainContentSection = ({
   children,
   header,
-  sidebar,
-  isNotificationListHidden = false,
   ...props
 }: Props): JSX.Element => {
-  const { SIDEBAR, TOTAL } = COL_SIZES;
   return (
     <div {...props} id={MAIN_CONTENT_SECTION_ID}>
       <div>
@@ -33,18 +27,8 @@ const MainContentSection = ({
           </header>
         ) : null}
         <Row>
-          {sidebar && (
-            <Col className="section__sidebar" element="aside" size={SIDEBAR}>
-              {sidebar}
-            </Col>
-          )}
-          <Col
-            className={classNames({
-              "u-nudge-down": !isNotificationListHidden,
-            })}
-            size={(sidebar ? TOTAL - SIDEBAR : TOTAL) as ColSize}
-          >
-            {!isNotificationListHidden && <NotificationList />}
+          <Col size={12}>
+            <NotificationList />
             {children}
           </Col>
         </Row>

--- a/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -208,4 +208,26 @@ describe("NotificationList", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId("notification-count")).not.toBeInTheDocument();
   });
+
+  it("applies the correct className when has content", () => {
+    const notificationsWithContent = [
+      notificationFactory({
+        id: 1,
+        category: NotificationCategory.INFO,
+        message: "Informational message",
+      }),
+    ];
+    const stateWithContent = rootStateFactory({
+      notification: notificationStateFactory({
+        items: notificationsWithContent,
+      }),
+    });
+
+    const store = mockStore(stateWithContent);
+    const { container } = renderWithBrowserRouter(<NotificationList />, {
+      route: "/machines",
+      store,
+    });
+    expect(container.firstChild).toHaveClass("u-nudge-down");
+  });
 });

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -29,7 +29,6 @@ const PageContent = ({
   children,
   header,
   sidebar,
-  isNotificationListHidden = false,
   sidePanelContent,
   sidePanelTitle,
   ...props
@@ -70,11 +69,7 @@ const PageContent = ({
           </div>
         ) : null}
         <div className="l-main__content" id="main-content">
-          <MainContentSection
-            header={header}
-            isNotificationListHidden={isNotificationListHidden}
-            {...props}
-          >
+          <MainContentSection header={header} {...props}>
             <ErrorBoundary>{children}</ErrorBoundary>
           </MainContentSection>
         </div>

--- a/src/app/store/message/selectors.test.ts
+++ b/src/app/store/message/selectors.test.ts
@@ -21,4 +21,18 @@ describe("messages", () => {
     expect(items.length).toEqual(1);
     expect(items[0].message).toEqual("User added");
   });
+
+  it("can get the count of messages", () => {
+    const state = rootStateFactory({
+      message: messageStateFactory({
+        items: [
+          messageFactory({
+            message: "User added",
+          }),
+        ],
+      }),
+    });
+    const count = messages.count(state);
+    expect(count).toEqual(1);
+  });
 });

--- a/src/app/store/message/selectors.ts
+++ b/src/app/store/message/selectors.ts
@@ -8,6 +8,8 @@ import type { RootState } from "@/app/store/root/types";
  */
 const all = (state: RootState): Message[] => state.message.items;
 
-const messages = { all };
+const count = (state: RootState): number => state.message.items.length;
+
+const messages = { all, count };
 
 export default messages;


### PR DESCRIPTION
## Done
- fix: settings preferences pages top padding
  - refactor: remove redundant sidebar, isNotificationListHidden props
  - refactor NotificationList
  - add count selector to messages

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to settings page with no notifications active and verify that the page title is in line with secondary navigation title

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before 
![Google Chrome screenshot 001569@2x](https://github.com/canonical/maas-ui/assets/7452681/a5e2921e-f634-4d61-8d13-62fcc9b0d8f3)

### After
![Google Chrome screenshot 001571@2x](https://github.com/canonical/maas-ui/assets/7452681/3b81d494-7f0f-4da9-a607-25723d54bfa7)

![Google Chrome screenshot 001567@2x](https://github.com/canonical/maas-ui/assets/7452681/56829e1b-1e12-4e2b-b1d4-17814e2f227f)

![Google Chrome screenshot 001565@2x](https://github.com/canonical/maas-ui/assets/7452681/73b50aaa-ab96-4f62-91b1-9f40e856d6f3)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
