### PR TITLE
chore: update renovate configuration with groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,48 @@
 {
   "extends": ["config:base", "group:allNonMajor", "schedule:weekly"],
   "labels": ["Maintenance 🔨"],
+  "timezone": "Europe/London",
   "packageRules": [
     {
       "groupName": "internal dependencies",
       "groupSlug": "internal",
-      "matchPackagePatterns": [
-        "^@canonical",
-        "^canonicalwebteam",
-        "^vanilla-framework",
-        "^jquery",
-        "^prettier"
-      ],
+      "matchPackagePatterns": ["^@canonical", "^vanilla-framework"],
       "schedule": ["at any time"]
     },
     {
       "matchPackagePatterns": ["^@sentry"],
       "enabled": false
+    },
+    {
+      "groupName": "React ecosystem",
+      "groupSlug": "react-ecosystem",
+      "matchPackagePatterns": ["^react", "^@types/react"],
+      "schedule": ["before 5am on monday"]
+    },
+    {
+      "groupName": "Testing libraries",
+      "groupSlug": "testing-libraries",
+      "matchPackagePatterns": [
+        "^@testing-library",
+        "^jest",
+        "^cypress",
+        "^@cypress",
+        "^@percy"
+      ],
+      "schedule": ["before 5am on tuesday"]
+    },
+    {
+      "groupName": "Redux ecosystem",
+      "groupSlug": "redux-ecosystem",
+      "matchPackagePatterns": ["^redux", "^@reduxjs/toolkit", "^react-redux"],
+      "schedule": ["before 5am on wednesday"]
+    },
+    {
+      "groupName": "Development tools",
+      "groupSlug": "dev-tools",
+      "matchPackageNames": ["typescript", "eslint", "prettier", "nodemon"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "schedule": ["before 5am on thursday"]
     }
   ]
 }


### PR DESCRIPTION
## Done
This PR configures renovate to group updates into categories, reducing the number of pull requests and making updates more manageable.
- chore: update renovate configuration with groups

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
