### PR TITLE
fix: kvm support message for virsh only lp#2053096

### DIFF
--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -364,6 +364,41 @@ describe("DeployFormFields", () => {
     expect(screen.getByRole("radio", { name: /libvirt/ })).toBeInTheDocument();
   });
 
+  it("displays support message only when 'virsh' is selected for KVM host type", async () => {
+    if (state.general.osInfo.data) {
+      state.general.osInfo.data.default_release = "bionic";
+    }
+    const store = mockStore(state);
+    render(
+      <Provider store={store}>
+        <MemoryRouter
+          initialEntries={[{ pathname: "/machines/add", key: "testKey" }]}
+        >
+          <CompatRouter>
+            <DeployForm
+              clearSidePanelContent={vi.fn()}
+              machines={[]}
+              processingCount={0}
+              viewingDetails={false}
+            />
+          </CompatRouter>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    const SUPPORT_MESSAGE =
+      "Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially supported.";
+
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: /Register as MAAS KVM host/ })
+    );
+    await userEvent.click(screen.getByRole("radio", { name: /libvirt/ }));
+    expect(screen.getByText(SUPPORT_MESSAGE)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("radio", { name: /LXD/ }));
+    expect(screen.queryByText(SUPPORT_MESSAGE)).not.toBeInTheDocument();
+  });
+
   it("displays a warning if user has no SSH keys", () => {
     if (state.user.auth.user) {
       state.user.auth.user.sshkeys_count = 0;

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -174,7 +174,11 @@ export const DeployFormFields = (): JSX.Element => {
                 <Input
                   checked={deployVmHost}
                   disabled={!canBeKVMHost || noImages}
-                  help="Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially supported."
+                  help={
+                    values.vmHostType === PodType.VIRSH
+                      ? "Only Ubuntu 18.04 LTS and Ubuntu 20.04 LTS are officially supported."
+                      : undefined
+                  }
                   id="deployVmHost"
                   label={
                     <>


### PR DESCRIPTION
## Done
- fix: kvm support message for virsh only lp#2053096

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Open deploy form
- [ ] Select "Register as MAAS KVM host" and libvirt for KVM host type
- [ ] Verify the limited support message is displayed

<!-- Steps for QA. -->

## Fixes

Fixes: https://bugs.launchpad.net/maas-ui/+bug/2053096
Fixes: https://bugs.launchpad.net/maas-ui/+bug/2054561

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### After
![Google Chrome screenshot 001593@2x](https://github.com/canonical/maas-ui/assets/7452681/9957c4cf-27c0-4ffd-a0c3-4a8a89c80b2d)
![Google Chrome screenshot 001591@2x](https://github.com/canonical/maas-ui/assets/7452681/fe112f77-09ed-4065-ba40-a8a6a69dc4fb)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
