### PR TITLE
fix: composing machine does not update list lp#1842524

### DIFF
--- a/src/app/kvm/components/KVMForms/ComposeForm/ComposeForm.tsx
+++ b/src/app/kvm/components/KVMForms/ComposeForm/ComposeForm.tsx
@@ -24,6 +24,7 @@ import { actions as fabricActions } from "@/app/store/fabric";
 import fabricSelectors from "@/app/store/fabric/selectors";
 import { actions as generalActions } from "@/app/store/general";
 import { powerTypes as powerTypesSelectors } from "@/app/store/general/selectors";
+import { actions as machineActions } from "@/app/store/machine";
 import { actions as messageActions } from "@/app/store/message";
 import { actions as podActions } from "@/app/store/pod";
 import podSelectors from "@/app/store/pod/selectors";
@@ -498,10 +499,12 @@ const ComposeForm = ({ clearSidePanelContent, hostId }: Props): JSX.Element => {
               NotificationSeverity.INFORMATION
             )
           );
+          dispatch(machineActions.invalidateQueries());
           clearSidePanelContent();
         }}
         processingCount={composingPods.length}
         selectedCount={1}
+        showProcessingCount={false}
         validateOnMount
         validationSchema={ComposeFormSchema}
       >

--- a/src/app/store/machine/reducers.test.ts
+++ b/src/app/store/machine/reducers.test.ts
@@ -418,6 +418,59 @@ describe("machine reducer", () => {
     );
   });
 
+  it("resets stale status on fetchSuccess", () => {
+    const initialState = machineStateFactory({
+      loading: false,
+      lists: {
+        [callId]: machineStateListFactory({ loaded: true, stale: true }),
+      },
+    });
+    const groups = [
+      { collapsed: true, count: 0, items: [], name: "admin", value: "admin1" },
+    ];
+    const fetchSuccessPayload = { count: 1, cur_page: 2, groups, num_pages: 3 };
+    const expectedState = {
+      lists: {
+        [callId]: {
+          ...machineStateListFactory(),
+          ...fetchSuccessPayload,
+          loaded: true,
+          loading: false,
+          stale: false,
+        },
+      },
+    };
+
+    expect(
+      reducers(initialState, actions.fetchSuccess(callId, fetchSuccessPayload))
+    ).toEqual(machineStateFactory(expectedState));
+  });
+
+  it("resets stale status on countSuccess", () => {
+    const initialState = machineStateFactory({
+      loading: false,
+      counts: {
+        [callId]: machineStateCountFactory({
+          loaded: true,
+          stale: true,
+        }),
+      },
+    });
+    expect(
+      reducers(initialState, actions.countSuccess(callId, { count: 1 }))
+    ).toEqual(
+      machineStateFactory({
+        counts: {
+          [callId]: machineStateCountFactory({
+            loaded: true,
+            stale: false,
+            count: 1,
+          }),
+        },
+      })
+    );
+  });
+
   it("updates selected machines on delete notify", () => {
     const initialState = machineStateFactory({
       selected: { items: ["abc123"] },

--- a/src/app/store/machine/slice.ts
+++ b/src/app/store/machine/slice.ts
@@ -474,6 +474,7 @@ const machineSlice = createSlice({
             ...(action.meta.callId in state.counts
               ? state.counts[action.meta.callId]
               : DEFAULT_COUNT_STATE),
+            stale: false,
             count: action.payload.count,
             loading: false,
             loaded: true,
@@ -979,6 +980,7 @@ const machineSlice = createSlice({
             });
           });
           const { payload } = action;
+          state.lists[callId].stale = false;
           state.lists[callId].count = payload.count;
           state.lists[callId].cur_page = payload.cur_page;
           state.lists[callId].groups = payload.groups.map((group) => ({


### PR DESCRIPTION
## Done
This ensures we refetch machine list on compose success via `dispatch(machineActions.invalidateQueries());` and update the list immediately. It also adds `stale: false` to success actions to ensure consistent behaviour.

- fix: composing machine does not update list

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to KVM
- [ ] Add a new machine using "Add VM" button
- [ ] Ensure that it's displayed on the list immediately when operation is successful

<!-- Steps for QA. -->

## Fixes

Fixes: lp#1842524

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
