### PR TITLE
fix(prefs): Adding/editing API key no longer shows "Deleted" message MAASENG-2812

### DIFF
--- a/src/app/preferences/views/APIKeys/APIKeyDeleteForm/APIKeyDeleteForm.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyDeleteForm/APIKeyDeleteForm.tsx
@@ -2,6 +2,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom-v5-compat";
 
 import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { useAddMessage } from "@/app/base/hooks";
 import urls from "@/app/base/urls";
 import { actions as tokenActions } from "@/app/store/token";
 import tokenSelectors from "@/app/store/token/selectors";
@@ -11,6 +12,8 @@ const APIKeyDeleteForm = ({ id }: { id: number }) => {
   const navigate = useNavigate();
   const saved = useSelector(tokenSelectors.saved);
   const saving = useSelector(tokenSelectors.saving);
+
+  useAddMessage(saved, tokenActions.cleanup, "API key deleted successfully.");
 
   return (
     <ModelActionForm

--- a/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.tsx
@@ -2,11 +2,7 @@ import { Notification } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
 import TableActions from "@/app/base/components/TableActions";
-import {
-  useFetchActions,
-  useAddMessage,
-  useWindowTitle,
-} from "@/app/base/hooks";
+import { useFetchActions, useWindowTitle } from "@/app/base/hooks";
 import urls from "@/app/base/urls";
 import SettingsTable from "@/app/settings/components/SettingsTable";
 import { actions as tokenActions } from "@/app/store/token";
@@ -54,9 +50,6 @@ const APIKeyList = (): JSX.Element => {
   const loading = useSelector(tokenSelectors.loading);
   const loaded = useSelector(tokenSelectors.loaded);
   const tokens = useSelector(tokenSelectors.all);
-  const saved = useSelector(tokenSelectors.saved);
-
-  useAddMessage(saved, tokenActions.cleanup, "API key deleted successfully.");
 
   useFetchActions([tokenActions.fetch]);
 


### PR DESCRIPTION
## Done
- Removed line showing "Deleted" notification every time an API key update was saved
- Added line to API key delete form to show "Deleted" notification on save

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to `r/account/prefs/api-keysr/account/prefs/api-keys`
- [ ] Generate an API key
- [ ] Ensure only one notification is displayed: "API key successfully generated"
- [ ] Edit that API key
- [ ] Ensure only one notification is displayed: "API key edited successfully"
- [ ] Delete the API key 
- [ ] Ensure only one notification is displayed: "API key deleted successfully"

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2812](https://warthogs.atlassian.net/browse/MAASENG-2812)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/cf5d5fd2-6cb4-481f-ac50-6fbeeca390ed)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/2bd6427c-213b-40bf-98e8-fd6d7cc122ee)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-2812]: https://warthogs.atlassian.net/browse/MAASENG-2812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ