### PR TITLE
fix: change storage layout sidepanel MAASENG-2798

### DIFF
--- a/src/app/machines/components/MachineForms/MachineForms.tsx
+++ b/src/app/machines/components/MachineForms/MachineForms.tsx
@@ -69,7 +69,7 @@ export const MachineForms = ({
       return <AddChassisForm clearSidePanelContent={clearSidePanelContent} />;
     case MachineSidePanelViews.ADD_MACHINE:
       return <AddMachineForm clearSidePanelContent={clearSidePanelContent} />;
-    case MachineSidePanelViews.CHANGE_STORAGE_LAYOUT: {
+    case MachineSidePanelViews.APPLY_STORAGE_LAYOUT: {
       if (!systemId || !selectedLayout) {
         return null;
       }

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -38,7 +38,7 @@ export const MachineNonActionSidePanelViews = {
   ADD_MACHINE: ["machineNonActionForm", "addMachine"],
   ADD_SPECIAL_FILESYSTEM: ["machineNonActionForm", "addSpecialFilesystem"],
   ADD_VLAN: ["machineNonActionForm", "addVlan"],
-  CHANGE_STORAGE_LAYOUT: ["machineNonActionForm", "changeStorageLayout"],
+  APPLY_STORAGE_LAYOUT: ["machineNonActionForm", "applyStorageLayout"],
   CREATE_DATASTORE: ["machineNonActionForm", "createDatastore"],
   CREATE_RAID: ["machineNonActionForm", "createRaid"],
   CREATE_VOLUME_GROUP: ["machineNonActionForm", "createVolumeGroup"],

--- a/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.test.tsx
@@ -86,6 +86,7 @@ describe("ChangeStorageLayout", () => {
   });
 
   it("correctly dispatches an action to update a machine's storage layout", async () => {
+    const handleClearSidePanelContent = vi.fn();
     const state = rootStateFactory({
       machine: machineStateFactory({
         items: [machineDetailsFactory({ system_id: "abc123" })],
@@ -97,7 +98,7 @@ describe("ChangeStorageLayout", () => {
     const store = mockStore(state);
     renderWithBrowserRouter(
       <ChangeStorageLayout
-        clearSidePanelContent={vi.fn()}
+        clearSidePanelContent={handleClearSidePanelContent}
         selectedLayout={sampleStoragelayout}
         systemId="abc123"
       />,
@@ -128,5 +129,6 @@ describe("ChangeStorageLayout", () => {
       },
       type: "machine/applyStorageLayout",
     });
+    expect(handleClearSidePanelContent).toHaveBeenCalled();
   });
 });

--- a/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayout/ChangeStorageLayout.tsx
@@ -49,6 +49,7 @@ export const ChangeStorageLayout = ({
             storageLayout: selectedLayout.value,
           })
         );
+        clearSidePanelContent();
       }}
       saved={saved}
       saving={saving}

--- a/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayoutMenu/ChangeStorageLayoutMenu.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/ChangeStorageLayoutMenu/ChangeStorageLayoutMenu.tsx
@@ -52,7 +52,7 @@ const ChangeStorageLayoutMenu = ({ systemId }: Props) => {
             children: option.label,
             onClick: () =>
               setSidePanelContent({
-                view: MachineSidePanelViews.CHANGE_STORAGE_LAYOUT,
+                view: MachineSidePanelViews.APPLY_STORAGE_LAYOUT,
                 extras: {
                   systemId,
                   selectedLayout: option,

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -218,6 +218,8 @@ export const getSidePanelTitle = (
         return "Add VLAN";
       case SidePanelViews.CHANGE_SOURCE[1]:
         return "Change source";
+      case SidePanelViews.APPLY_STORAGE_LAYOUT[1]:
+        return "Change storage layout";
       case SidePanelViews.CLEAR_ALL_DISCOVERIES[1]:
         return "Clear all discoveries";
       case SidePanelViews.CREATE_DATASTORE[1]:


### PR DESCRIPTION
## Done
- fix: change storage layout sidepanel MAASENG-2798
  - close side panel on success
  - set correct panel title
  - refactor: rename constants to reflect node action

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to machine details, storage tab
- [x] Open change layout form
- [x] Verify side panel has a correct title
- [x] Verify it gets closed when action has been successful

<!-- Steps for QA. -->

## Fixes

Fixes: MAASENG-2798

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![Google Chrome screenshot 001613@2x](https://github.com/canonical/maas-ui/assets/7452681/553b1b32-f94a-4bad-92a8-ebd98508380f)

### After
![Google Chrome screenshot 001611@2x](https://github.com/canonical/maas-ui/assets/7452681/05146919-a9e8-4328-9c08-beb71b24beef)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
