### PR TITLE
fix(users): Adding/editing user no longer shows "Deleted" message MAASENG-2797

### DIFF
--- a/src/app/settings/views/Users/UserDelete/UserDelete.test.tsx
+++ b/src/app/settings/views/Users/UserDelete/UserDelete.test.tsx
@@ -1,3 +1,5 @@
+import configureStore from "redux-mock-store";
+
 import UserDelete from "./UserDelete";
 
 import type { RootState } from "@/app/store/root/types";
@@ -10,6 +12,8 @@ import {
 import { renderWithBrowserRouter, screen } from "@/testing/utils";
 
 let state: RootState;
+
+const mockStore = configureStore<RootState>();
 
 beforeEach(() => {
   state = rootStateFactory({
@@ -40,4 +44,17 @@ it("renders", () => {
     routePattern: "/settings/users/:id/edit",
   });
   expect(screen.getByRole("form", { name: "Delete user" }));
+});
+
+it("can add a message when a user is deleted", () => {
+  state.user.saved = true;
+  const store = mockStore(state);
+  renderWithBrowserRouter(<UserDelete />, {
+    store,
+    route: "/settings/users/1/edit",
+    routePattern: "/settings/users/:id/edit",
+  });
+  const actions = store.getActions();
+  expect(actions.some((action) => action.type === "user/cleanup")).toBe(true);
+  expect(actions.some((action) => action.type === "message/add")).toBe(true);
 });

--- a/src/app/settings/views/Users/UserDeleteForm/UserDeleteForm.tsx
+++ b/src/app/settings/views/Users/UserDeleteForm/UserDeleteForm.tsx
@@ -27,7 +27,7 @@ const UserDeleteForm = ({ user }: UserDeleteProps) => {
   useAddMessage(
     saved && !errors,
     userActions.cleanup,
-    `Deleted ${deletedUser} from list`
+    `${deletedUser} removed successfully`
   );
 
   return (

--- a/src/app/settings/views/Users/UsersList/UsersList.test.tsx
+++ b/src/app/settings/views/Users/UsersList/UsersList.test.tsx
@@ -98,25 +98,6 @@ describe("UsersList", () => {
     );
   });
 
-  it("can add a message when a user is deleted", () => {
-    state.user.saved = true;
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter
-          initialEntries={[{ pathname: "/settings/users", key: "testKey" }]}
-        >
-          <CompatRouter>
-            <UsersList />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
-    const actions = store.getActions();
-    expect(actions.some((action) => action.type === "user/cleanup")).toBe(true);
-    expect(actions.some((action) => action.type === "message/add")).toBe(true);
-  });
-
   it("can filter users", async () => {
     const store = mockStore(state);
     const { rerender } = render(

--- a/src/app/settings/views/Users/UsersList/UsersList.tsx
+++ b/src/app/settings/views/Users/UsersList/UsersList.tsx
@@ -9,7 +9,6 @@ import TableActions from "@/app/base/components/TableActions";
 import TableHeader from "@/app/base/components/TableHeader";
 import {
   useFetchActions,
-  useAddMessage,
   useTableSort,
   useWindowTitle,
 } from "@/app/base/hooks";
@@ -101,14 +100,12 @@ const getSortValue = (sortKey: SortKey, user: User) => {
 const UsersList = (): JSX.Element => {
   const [searchText, setSearchText] = useState("");
   const [displayUsername, setDisplayUsername] = useState(true);
-  const [deletingUser, setDeleting] = useState<User["username"] | null>(null);
   const users = useSelector((state: RootState) =>
     userSelectors.search(state, searchText)
   );
   const loading = useSelector(userSelectors.loading);
   const loaded = useSelector(userSelectors.loaded);
   const authUser = useSelector(authSelectors.get);
-  const saved = useSelector(userSelectors.saved);
   const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
   const dispatch = useDispatch();
 
@@ -123,13 +120,6 @@ const UsersList = (): JSX.Element => {
   const sortedUsers = sortRows(users);
 
   useWindowTitle("Users");
-
-  useAddMessage(
-    saved,
-    userActions.cleanup,
-    `${deletingUser} removed successfully.`,
-    () => setDeleting(null)
-  );
 
   useFetchActions([userActions.fetch]);
 


### PR DESCRIPTION
## Done
- Removed `useAddMessage` call in user list
- Changed deletion message in UserDeleteForm

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to `/settings/users`
- [x] Add a user
- [x] Ensure only the "created" notification is displayed
- [x] Edit the user
- [x] Ensure only the "edited" notification is displayed
- [x] Delete the user
- [x] Ensure only one "deleted" notification is displayed

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2797](https://warthogs.atlassian.net/browse/MAASENG-2797)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/35ac270e-90ef-4999-b047-866ab05d11a6)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/875b7ba5-488e-4d3f-8f70-a4575495f73b)


[MAASENG-2797]: https://warthogs.atlassian.net/browse/MAASENG-2797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ