### PR TITLE
fix(prefs): Adding SSL key no longer shows "Removed" message MAASENG-2813

### DIFF
--- a/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.tsx
+++ b/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.tsx
@@ -29,7 +29,8 @@ const generateRows = (
   hideExpanded: () => void,
   dispatch: Dispatch,
   saved: SSLKeyState["saved"],
-  saving: SSLKeyState["saving"]
+  saving: SSLKeyState["saving"],
+  setDeleting: (deleting: boolean) => void
 ) =>
   sslkeys.map(({ id, display, key }) => {
     const expanded = expandedId === id;
@@ -60,6 +61,7 @@ const generateRows = (
             modelType="SSL key"
             onClose={hideExpanded}
             onConfirm={() => {
+              setDeleting(true);
               dispatch(sslkeyActions.delete(id));
             }}
           />
@@ -82,11 +84,17 @@ const SSLKeyList = (): JSX.Element => {
   const sslkeys = useSelector(sslkeySelectors.all);
   const saved = useSelector(sslkeySelectors.saved);
   const saving = useSelector(sslkeySelectors.saving);
+  const [deleting, setDeleting] = useState(false);
   const dispatch = useDispatch();
 
   useWindowTitle(Label.Title);
 
-  useAddMessage(saved, sslkeyActions.cleanup, "SSL key removed successfully.");
+  useAddMessage(
+    saved && deleting,
+    sslkeyActions.cleanup,
+    "SSL key removed successfully.",
+    () => setDeleting(false)
+  );
 
   const hideExpanded = () => {
     setExpandedId(null);
@@ -124,7 +132,8 @@ const SSLKeyList = (): JSX.Element => {
           hideExpanded,
           dispatch,
           saved,
-          saving
+          saving,
+          setDeleting
         )}
         tableClassName="sslkey-list"
       />


### PR DESCRIPTION
## Done
- Added condition for displaying message to ensure that it is only displayed when deleting

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to `/account/prefs/ssl-keys`
- [x] Add an SSL key (you can make one [here](https://regery.com/en/security/ssl-tools/self-signed-certificate-generator))
- [x] Ensure only the "added" notification is displayed
- [x] Delete the SSL key
- [x] Ensure only one "removed" notification is displayed

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2813](https://warthogs.atlassian.net/browse/MAASENG-2813)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/47dd2e8b-0aa8-41d8-9b3d-2cce15a190e7)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/8fc90cd6-cba7-4a6d-9367-3254060d75dd)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-2813]: https://warthogs.atlassian.net/browse/MAASENG-2813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ