### PR TITLE
ci: fix sitespeed workflow MAASENG-2671

### DIFF
--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -4,32 +4,24 @@ on:
     branches:
       - main
       - "3.*"
+      - "*sitespeed*"
 jobs:
   run-sitespeed:
     name: Run sitespeed.io
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
     env:
       MAAS_DOMAIN: localhost
+      MAAS_URL: http://localhost:5240
     steps:
       - uses: actions/checkout@main
-      - name: Install MAAS
-        run: |
-          sudo systemctl enable snapd
-          sudo snap install maas-test-db --channel=latest/edge
-          sudo snap install maas --channel=latest/edge
-      - name: Fetch database dump
-        uses: wei/wget@v1
+      - name: Setup MAAS
+        uses: canonical/setup-maas@main
         with:
-          args: -O maasdb.dump https://github.com/canonical/maas-ui-testing/raw/main/db/maasdb-22.04-master-1000.dump
-      - name: Set up MAAS with database dump
-        run: |
-          sudo sed -i "s/dynamic_shared_memory_type = posix/dynamic_shared_memory_type = sysv/" /var/snap/maas-test-db/common/postgres/data/postgresql.conf
-          sudo snap restart maas-test-db
-          sudo mv maasdb.dump /var/snap/maas-test-db/common/maasdb.dump
-          sudo snap run --shell maas-test-db.psql -c 'db-dump restore /var/snap/maas-test-db/common/maasdb.dump maassampledata'
-          sudo maas init region+rack --maas-url=http://${{env.MAAS_DOMAIN}}:5240/MAAS --database-uri maas-test-db:///
-          sudo sed -i "s/database_name: maasdb/database_name: maassampledata/" /var/snap/maas/current/regiond.conf
-          sudo snap restart maas
+          maas-url: ${{ env.MAAS_URL }}/MAAS
+          use-maasdb-dump: true
+          maasdb-dump-url: https://github.com/canonical/maas-ui-testing/raw/main/db/maasdb-22.04-master-1000.dump
       - name: Create MAAS admin
         run: sudo maas createadmin --username=admin --password=test --email=fake@example.org
       - name: Wait for MAAS
@@ -39,8 +31,24 @@ jobs:
           responseCode: 200
           timeout: 200000
           interval: 500
+      - name: Login MAAS admin
+        run: |
+          for i in {1..5}; do
+            export API_KEY=`sudo maas apikey --username=admin`
+            maas login admin http://localhost:5240/MAAS $API_KEY && break || sleep 10
+          done
+      - name: Wait for MAAS boot resources
+        shell: bash
+        run: while [ $(maas admin boot-resources is-importing | cat) == "true" ]; do sleep 10; done; echo "syncing finished"
       - name: Run sitespeed.io tests
-        run: yarn sitespeed:ci --browsertime.domain=${{env.MAAS_DOMAIN}}
+        run: |
+          yarn sitespeed:ci --browsertime.domain=${{env.MAAS_DOMAIN}} \
+            --browsertime.timeouts.pageLoad=300000 \
+            --browsertime.timeouts.script=300000 \
+            --browsertime.visualMetrics=true \
+            --browsertime.video=true \
+            --browsertime.screenshot=true
+        continue-on-error: true
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - "3.*"
-      - "*sitespeed*"
 jobs:
   run-sitespeed:
     name: Run sitespeed.io

--- a/.github/workflows/sitespeed.yml
+++ b/.github/workflows/sitespeed.yml
@@ -41,14 +41,7 @@ jobs:
         shell: bash
         run: while [ $(maas admin boot-resources is-importing | cat) == "true" ]; do sleep 10; done; echo "syncing finished"
       - name: Run sitespeed.io tests
-        run: |
-          yarn sitespeed:ci --browsertime.domain=${{env.MAAS_DOMAIN}} \
-            --browsertime.timeouts.pageLoad=300000 \
-            --browsertime.timeouts.script=300000 \
-            --browsertime.visualMetrics=true \
-            --browsertime.video=true \
-            --browsertime.screenshot=true
-        continue-on-error: true
+        run: yarn sitespeed:ci --browsertime.domain=${{env.MAAS_DOMAIN}}
       - name: Upload results
         uses: actions/upload-artifact@v4
         with:

--- a/sitespeed.io/login.js
+++ b/sitespeed.io/login.js
@@ -13,7 +13,7 @@ module.exports = async function (context, commands) {
     name: "skipintro",
     value: "true",
   });
-  await commands.navigate(constructURL(context, "/network-discovery"));
+  await commands.navigate(constructURL(context, "/"));
   await commands.wait.bySelector("input[name='username']", TIMEOUT);
   await commands.addText.byName("admin", "username");
   await commands.addText.byName("test", "password");

--- a/sitespeed.io/scripts/machines.js
+++ b/sitespeed.io/scripts/machines.js
@@ -5,7 +5,7 @@ const TIMEOUT = 120000;
 const waitForMachines = async (context, commands, pageSize = 50) => {
   context.log.info("waiting for machine list count");
   await commands.wait.byCondition(
-    `document.querySelector('[data-testid="section-header-title"]').textContent.includes("1000 machines")`,
+    `document.querySelector('[data-testid="main-toolbar-heading"]').textContent.includes("1000 machines")`,
     TIMEOUT
   );
   context.log.info(`waiting for ${pageSize} machine list rows`);


### PR DESCRIPTION
## Done
- ci: fix sitespeed workflow MAASENG-2671

#### sitespeed.yml 
  - Replaced the manual MAAS installation and database setup steps with the canonical/setup-maas action
  - Added steps to log in the MAAS admin user and wait for MAAS boot resources to finish importing.
  - Removed the manual database dump download and restoration steps, as the setup-maas action handles this automatically.

#### login.js 
- Updated the initial navigation URL from `/network-discovery` to `/`.

#### machines.js
- Updated the selector used to check for the presence of 1000 machines in the machine list. The new selector ([data-testid="main-toolbar-heading"]) is likely a more robust way to locate the machine count element.

### db-dumps
On top of this, [maas-ui-testing db-dumps](https://github.com/canonical/maas-ui-testing/tree/main) have been updated from maas-sampledata-dumper.

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Verify that the sitespeed action for a commit prior to disabling it for non-release branches was successful - https://github.com/canonical/maas-ui/actions/runs/8266888660

<!-- Steps for QA. -->

## Fixes

Fixes: MAASENG-2671

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
