### PR TITLE
fix(kvm): KVM CPU resources label positioning MAASENG-2381

### DIFF
--- a/src/app/kvm/components/CoreResources/_index.scss
+++ b/src/app/kvm/components/CoreResources/_index.scss
@@ -9,8 +9,6 @@
   // viewport size. Otherwise, the component keeps the "mobile" styling.
   .core-resources--dynamic-layout {
     @media only screen and (min-width: $breakpoint-small) {
-      // flex-direction: row;
-
       .core-resources__header {
         flex: 1;
         margin-right: $sph--large;

--- a/src/app/kvm/components/CoreResources/_index.scss
+++ b/src/app/kvm/components/CoreResources/_index.scss
@@ -9,7 +9,7 @@
   // viewport size. Otherwise, the component keeps the "mobile" styling.
   .core-resources--dynamic-layout {
     @media only screen and (min-width: $breakpoint-small) {
-      flex-direction: row;
+      // flex-direction: row;
 
       .core-resources__header {
         flex: 1;


### PR DESCRIPTION
## Done
- Fixed positioning of "CPU Cores" text in KVM resources cards

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to kvm list and click a host
- [x] Shrink your window width to < 1300px
- [ ] Ensure that "CPU Cores" is displayed above the meter key (the text that says "Allocated")

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2381](https://warthogs.atlassian.net/browse/MAASENG-2381)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/74372203-edab-4f4d-bf31-ea3f64a922ca)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/6ab686c5-accb-4d71-b64b-3decc1b00ea8)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-2381]: https://warthogs.atlassian.net/browse/MAASENG-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ