### PR TITLE
feat: move non-partition collapsible forms to side panel

### DIFF
--- a/src/app/base/components/TableActionsDropdown/TableActionsDropdown.test.tsx
+++ b/src/app/base/components/TableActionsDropdown/TableActionsDropdown.test.tsx
@@ -59,6 +59,6 @@ describe("TableActionsDropdown", () => {
     // Open menu and click the actions
     await userEvent.click(screen.getByRole("button"));
     await userEvent.click(screen.getByRole("button", { name: "Action 1" }));
-    expect(onActionClick).toHaveBeenCalledWith("action-1");
+    expect(onActionClick).toHaveBeenCalledWith("action-1", undefined);
   });
 });

--- a/src/app/base/components/TableActionsDropdown/TableActionsDropdown.tsx
+++ b/src/app/base/components/TableActionsDropdown/TableActionsDropdown.tsx
@@ -1,12 +1,14 @@
-import type { ButtonProps } from "@canonical/react-components";
+import type { ButtonProps, ValueOf } from "@canonical/react-components";
 
 import TableMenu from "@/app/base/components/TableMenu";
 import type { DataTestElement } from "@/app/base/types";
+import type { MachineSidePanelViews } from "@/app/machines/constants";
 
 export type TableAction<A> = {
   label: string;
   show?: boolean;
   type: A;
+  view?: ValueOf<typeof MachineSidePanelViews>;
 };
 
 // This allows the "data-testid" attribute to be used for the action links, which
@@ -16,7 +18,7 @@ type TableActionsLink = DataTestElement<ButtonProps>;
 type Props<A> = {
   actions: TableAction<A>[];
   disabled?: boolean;
-  onActionClick: (action: A) => void;
+  onActionClick: (action: A, view?: TableAction<A>["view"]) => void;
 };
 
 const TableActionsDropdown = <A extends string>({
@@ -30,7 +32,7 @@ const TableActionsDropdown = <A extends string>({
       links.push({
         children: action.label,
         "data-testid": action.type,
-        onClick: () => onActionClick(action.type),
+        onClick: () => onActionClick(action.type, action?.view),
       });
     }
     return links;

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/AddPartition/AddPartitionFields/AddPartitionFields.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/AddPartition/AddPartitionFields/AddPartitionFields.tsx
@@ -21,7 +21,7 @@ export const AddPartitionFields = ({
 
   return (
     <Row>
-      <Col size={5}>
+      <Col size={12}>
         <Input
           aria-label="Name"
           disabled
@@ -67,7 +67,7 @@ export const AddPartitionFields = ({
           ]}
         />
       </Col>
-      <Col emptyLarge={7} size={5}>
+      <Col size={12}>
         <FilesystemFields systemId={systemId} />
       </Col>
     </Row>

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.tsx
@@ -20,6 +20,7 @@ import ActionConfirm from "@/app/base/components/node/ActionConfirm";
 import DiskBootStatus from "@/app/base/components/node/DiskBootStatus";
 import DiskNumaNodes from "@/app/base/components/node/DiskNumaNodes";
 import DiskTestStatus from "@/app/base/components/node/DiskTestStatus";
+import type { SetSidePanelContent } from "@/app/base/side-panel-context";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import urls from "@/app/base/urls";
 import type { ControllerDetails } from "@/app/store/controller/types";
@@ -131,7 +132,8 @@ const normaliseRowData = (
   expanded: Expanded | null,
   setExpanded: (expanded: Expanded | null) => void,
   selected: (Disk | Partition)[],
-  handleRowCheckbox: (storageDevice: Disk | Partition) => void
+  handleRowCheckbox: (storageDevice: Disk | Partition) => void,
+  setSidePanelContent: SetSidePanelContent
 ) => {
   const rowId = uniqueId(storageDevice);
   const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
@@ -264,9 +266,21 @@ const normaliseRowData = (
               content: (
                 <StorageDeviceActions
                   disabled={actionsDisabled}
-                  onActionClick={(action: StorageDeviceAction) =>
-                    setExpanded({ content: action, id: rowId })
-                  }
+                  onActionClick={(action: StorageDeviceAction, view) => {
+                    if (view) {
+                      setSidePanelContent({
+                        view,
+                        extras: {
+                          systemId,
+                          disk: isDisk(storageDevice)
+                            ? storageDevice
+                            : undefined,
+                        },
+                      });
+                    } else {
+                      setExpanded({ content: action, id: rowId });
+                    }
+                  }}
                   storageDevice={storageDevice}
                   systemId={systemId}
                 />
@@ -288,7 +302,7 @@ const AvailableStorageTable = ({
   const [expanded, setExpanded] = useState<Expanded | null>(null);
   const [selected, setSelected] = useState<(Disk | Partition)[]>([]);
   const isMachine = nodeIsMachine(node);
-  const { sidePanelContent } = useSidePanel();
+  const { sidePanelContent, setSidePanelContent } = useSidePanel();
 
   const closeExpanded = () => setExpanded(null);
   const handleRowCheckbox = (storageDevice: Disk | Partition) => {
@@ -358,7 +372,8 @@ const AvailableStorageTable = ({
           expanded,
           setExpanded,
           selected,
-          handleRowCheckbox
+          handleRowCheckbox,
+          setSidePanelContent
         ),
         expandedContent: isMachine ? (
           <div className="u-flex--grow">
@@ -504,7 +519,8 @@ const AvailableStorageTable = ({
               expanded,
               setExpanded,
               selected,
-              handleRowCheckbox
+              handleRowCheckbox,
+              setSidePanelContent
             ),
             expandedContent: isMachine ? (
               <div className="u-flex--grow">

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/CreateCacheSet/CreateCacheSet.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/CreateCacheSet/CreateCacheSet.test.tsx
@@ -1,0 +1,60 @@
+import configureStore from "redux-mock-store";
+
+import CreateCacheSet from "./CreateCacheSet";
+
+import type { RootState } from "@/app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  nodeDisk as diskFactory,
+  nodePartition as partitionFactory,
+  rootState as rootStateFactory,
+} from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const mockStore = configureStore<RootState>();
+const disk = diskFactory({
+  id: 1,
+  name: "floppy-disk",
+  partitions: [partitionFactory(), partitionFactory()],
+});
+
+const state = rootStateFactory({
+  machine: machineStateFactory({
+    items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+    statuses: machineStatusesFactory({
+      abc123: machineStatusFactory(),
+    }),
+  }),
+});
+
+it("should render the form", () => {
+  renderWithBrowserRouter(
+    <CreateCacheSet close={vi.fn()} diskId={disk.id} systemId="abc123" />,
+    { state }
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Create cache set" })
+  ).toBeInTheDocument();
+});
+
+it("should fire an action to create cache set", async () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(
+    <CreateCacheSet close={vi.fn()} diskId={disk.id} systemId="abc123" />,
+    { store }
+  );
+
+  await userEvent.click(
+    screen.getByRole("button", { name: "Create cache set" })
+  );
+
+  expect(
+    store
+      .getActions()
+      .some((action) => action.type === "machine/createCacheSet")
+  ).toBe(true);
+});

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/CreateCacheSet/CreateCacheSet.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/CreateCacheSet/CreateCacheSet.tsx
@@ -1,0 +1,44 @@
+import { useDispatch } from "react-redux";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { actions as machineActions } from "@/app/store/machine";
+import type { Machine } from "@/app/store/machine/types";
+import type { Disk } from "@/app/store/types/node";
+
+type Props = {
+  close: () => void;
+  systemId: Machine["system_id"];
+  diskId: Disk["id"];
+};
+
+const CreateCacheSet = ({ systemId, diskId, close }: Props) => {
+  const dispatch = useDispatch();
+  return (
+    <ModelActionForm
+      aria-label="Create cache set"
+      initialValues={{}}
+      message={<>Are you sure you want to create a cache set?</>}
+      modelType="cache set"
+      onCancel={close}
+      onSaveAnalytics={{
+        action: "Create cache set from disk",
+        category: "Machine storage",
+        label: "Create cache set",
+      }}
+      onSubmit={() => {
+        dispatch(machineActions.cleanup());
+        dispatch(
+          machineActions.createCacheSet({
+            blockId: diskId,
+            systemId: systemId,
+          })
+        );
+        close();
+      }}
+      submitAppearance="positive"
+      submitLabel="Create cache set"
+    />
+  );
+};
+
+export default CreateCacheSet;

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/CreateCacheSet/index.ts
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/CreateCacheSet/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CreateCacheSet";

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteDisk/DeleteDisk.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteDisk/DeleteDisk.test.tsx
@@ -1,0 +1,56 @@
+import configureStore from "redux-mock-store";
+
+import DeleteDisk from "./DeleteDisk";
+
+import type { RootState } from "@/app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  nodeDisk as diskFactory,
+  nodePartition as partitionFactory,
+  rootState as rootStateFactory,
+} from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const mockStore = configureStore<RootState>();
+const disk = diskFactory({
+  id: 1,
+  name: "floppy-disk",
+  partitions: [partitionFactory(), partitionFactory()],
+});
+
+const state = rootStateFactory({
+  machine: machineStateFactory({
+    items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+    statuses: machineStatusesFactory({
+      abc123: machineStatusFactory(),
+    }),
+  }),
+});
+
+it("should render the form", () => {
+  renderWithBrowserRouter(
+    <DeleteDisk close={vi.fn()} disk={disk} systemId="abc123" />,
+    { state }
+  );
+
+  expect(screen.getByRole("form", { name: "Delete disk" })).toBeInTheDocument();
+});
+
+it("should fire an action to delete a disk", async () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(
+    <DeleteDisk close={vi.fn()} disk={disk} systemId="abc123" />,
+    { store }
+  );
+
+  await userEvent.click(
+    screen.getByRole("button", { name: "Remove physical disk" })
+  );
+
+  expect(
+    store.getActions().some((action) => action.type === "machine/deleteDisk")
+  ).toBe(true);
+});

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteDisk/DeleteDisk.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteDisk/DeleteDisk.tsx
@@ -1,0 +1,46 @@
+import { useDispatch } from "react-redux";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { actions as machineActions } from "@/app/store/machine";
+import type { Machine } from "@/app/store/machine/types";
+import type { Disk } from "@/app/store/types/node";
+import { formatType } from "@/app/store/utils";
+
+type Props = {
+  close: () => void;
+  systemId: Machine["system_id"];
+  disk: Disk;
+};
+
+const DeleteDisk = ({ systemId, disk, close }: Props) => {
+  const dispatch = useDispatch();
+  const diskType = formatType(disk, true);
+  return (
+    <ModelActionForm
+      aria-label="Delete disk"
+      initialValues={{}}
+      message={<>Are you sure you want to remove this {diskType}?</>}
+      modelType={diskType}
+      onCancel={close}
+      onSaveAnalytics={{
+        action: `Delete ${diskType}`,
+        category: "Machine storage",
+        label: `Remove ${diskType}`,
+      }}
+      onSubmit={() => {
+        dispatch(machineActions.cleanup());
+        dispatch(
+          machineActions.deleteDisk({
+            blockId: disk.id,
+            systemId: systemId,
+          })
+        );
+        close();
+      }}
+      submitAppearance="negative"
+      submitLabel={`Remove ${diskType}`}
+    />
+  );
+};
+
+export default DeleteDisk;

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteDisk/index.ts
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteDisk/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteDisk";

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/EditDisk/EditDiskFields/EditDiskFields.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/EditDisk/EditDiskFields/EditDiskFields.tsx
@@ -15,7 +15,7 @@ type Props = {
 export const EditDiskFields = ({ disk, systemId }: Props): JSX.Element => {
   return (
     <Row>
-      <Col size={5}>
+      <Col size={12}>
         <Input
           aria-label="Name"
           disabled
@@ -38,7 +38,7 @@ export const EditDiskFields = ({ disk, systemId }: Props): JSX.Element => {
           value={formatSize(disk.size)}
         />
       </Col>
-      <Col emptyLarge={7} size={5}>
+      <Col size={12}>
         {disk.is_boot === false && <FilesystemFields systemId={systemId} />}
         <TagNameField />
       </Col>

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk/SetBootDisk.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk/SetBootDisk.test.tsx
@@ -1,0 +1,56 @@
+import configureStore from "redux-mock-store";
+
+import SetBootDisk from "./SetBootDisk";
+
+import type { RootState } from "@/app/store/root/types";
+import {
+  machineDetails as machineDetailsFactory,
+  machineState as machineStateFactory,
+  machineStatus as machineStatusFactory,
+  machineStatuses as machineStatusesFactory,
+  nodeDisk as diskFactory,
+  nodePartition as partitionFactory,
+  rootState as rootStateFactory,
+} from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const mockStore = configureStore<RootState>();
+const disk = diskFactory({
+  id: 1,
+  name: "floppy-disk",
+  partitions: [partitionFactory(), partitionFactory()],
+});
+
+const state = rootStateFactory({
+  machine: machineStateFactory({
+    items: [machineDetailsFactory({ disks: [disk], system_id: "abc123" })],
+    statuses: machineStatusesFactory({
+      abc123: machineStatusFactory(),
+    }),
+  }),
+});
+
+it("should render the form", () => {
+  renderWithBrowserRouter(
+    <SetBootDisk close={vi.fn()} diskId={disk.id} systemId="abc123" />,
+    { state }
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Set boot disk" })
+  ).toBeInTheDocument();
+});
+
+it("should fire an action to set boot disk", async () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(
+    <SetBootDisk close={vi.fn()} diskId={disk.id} systemId="abc123" />,
+    { store }
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: "Set boot disk" }));
+
+  expect(
+    store.getActions().some((action) => action.type === "machine/setBootDisk")
+  ).toBe(true);
+});

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk/SetBootDisk.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk/SetBootDisk.tsx
@@ -1,0 +1,44 @@
+import { useDispatch } from "react-redux";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { actions as machineActions } from "@/app/store/machine";
+import type { Machine } from "@/app/store/machine/types";
+import type { Disk } from "@/app/store/types/node";
+
+type Props = {
+  close: () => void;
+  systemId: Machine["system_id"];
+  diskId: Disk["id"];
+};
+
+const SetBootDisk = ({ systemId, diskId, close }: Props) => {
+  const dispatch = useDispatch();
+  return (
+    <ModelActionForm
+      aria-label="Set boot disk"
+      initialValues={{}}
+      message={<>Are you sure you want to set boot disk?</>}
+      modelType="boot disk"
+      onCancel={close}
+      onSaveAnalytics={{
+        action: "Set boot disk",
+        category: "Machine storage",
+        label: "Set boot disk",
+      }}
+      onSubmit={() => {
+        dispatch(machineActions.cleanup());
+        dispatch(
+          machineActions.setBootDisk({
+            blockId: diskId,
+            systemId: systemId,
+          })
+        );
+        close();
+      }}
+      submitAppearance="positive"
+      submitLabel="Set boot disk"
+    />
+  );
+};
+
+export default SetBootDisk;

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk/index.ts
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SetBootDisk";

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/StorageDeviceActions/StorageDeviceActions.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/StorageDeviceActions/StorageDeviceActions.tsx
@@ -4,6 +4,7 @@ import { StorageDeviceAction } from "../AvailableStorageTable";
 
 import TableActionsDropdown from "@/app/base/components/TableActionsDropdown";
 import type { TableAction } from "@/app/base/components/TableActionsDropdown";
+import { MachineSidePanelViews } from "@/app/machines/constants";
 import machineSelectors from "@/app/store/machine/selectors";
 import type { MachineDetails } from "@/app/store/machine/types";
 import { isMachineDetails } from "@/app/store/machine/utils";
@@ -25,7 +26,10 @@ import {
 type Props = {
   disabled: boolean;
   storageDevice: Disk | Partition;
-  onActionClick: (rowAction: StorageDeviceAction) => void;
+  onActionClick: (
+    rowAction: StorageDeviceAction,
+    view?: TableAction<StorageDeviceAction>["view"]
+  ) => void;
   systemId: MachineDetails["system_id"];
 };
 
@@ -52,6 +56,7 @@ const StorageDeviceActions = ({
           label: "Add partition...",
           show: canBePartitioned(storageDevice),
           type: StorageDeviceAction.CREATE_PARTITION,
+          view: MachineSidePanelViews.CREATE_PARTITION,
         },
         {
           label: "Create bcache...",
@@ -62,16 +67,19 @@ const StorageDeviceActions = ({
           label: "Create cache set...",
           show: canCreateCacheSet(storageDevice),
           type: StorageDeviceAction.CREATE_CACHE_SET,
+          view: MachineSidePanelViews.CREATE_CACHE_SET,
         },
         {
           label: "Set boot disk...",
           show: canSetBootDisk(machine.detected_storage_layout, storageDevice),
           type: StorageDeviceAction.SET_BOOT_DISK,
+          view: MachineSidePanelViews.SET_BOOT_DISK,
         },
         {
           label: `Edit ${formatType(storageDevice, true)}...`,
           show: !isVolumeGroup(storageDevice),
           type: StorageDeviceAction.EDIT_DISK,
+          view: MachineSidePanelViews.EDIT_DISK,
         },
         {
           label: "Remove volume group...",
@@ -82,6 +90,7 @@ const StorageDeviceActions = ({
           label: `Remove ${formatType(storageDevice, true)}...`,
           show: canBeDeleted(storageDevice) && !isVolumeGroup(storageDevice),
           type: StorageDeviceAction.DELETE_DISK,
+          view: MachineSidePanelViews.DELETE_DISK,
         },
       ];
     }

--- a/src/app/machines/components/MachineForms/MachineForms.tsx
+++ b/src/app/machines/components/MachineForms/MachineForms.tsx
@@ -10,10 +10,15 @@ import AddChassisForm from "./AddChassis/AddChassisForm";
 import AddMachineForm from "./AddMachine/AddMachineForm";
 import MachineActionFormWrapper from "./MachineActionFormWrapper";
 
+import AddPartition from "@/app/base/components/node/StorageTables/AvailableStorageTable/AddPartition";
 import CreateDatastore from "@/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateDatastore";
 import CreateRaid from "@/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateRaid";
 import CreateVolumeGroup from "@/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/CreateVolumeGroup";
 import UpdateDatastore from "@/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/UpdateDatastore";
+import CreateCacheSet from "@/app/base/components/node/StorageTables/AvailableStorageTable/CreateCacheSet";
+import DeleteDisk from "@/app/base/components/node/StorageTables/AvailableStorageTable/DeleteDisk";
+import EditDisk from "@/app/base/components/node/StorageTables/AvailableStorageTable/EditDisk";
+import SetBootDisk from "@/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk";
 import AddSpecialFilesystem from "@/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem";
 import type { SidePanelContentTypes } from "@/app/base/side-panel-context";
 import type { SetSearchFilter } from "@/app/base/types";
@@ -71,6 +76,7 @@ export const MachineForms = ({
   const node = extras && "node" in extras ? extras.node : undefined;
   const linkId = extras && "linkId" in extras ? extras.linkId : undefined;
   const nicId = extras && "nicId" in extras ? extras.nicId : undefined;
+  const disk = extras && "disk" in extras ? extras.disk : undefined;
 
   switch (sidePanelContent.view) {
     case MachineSidePanelViews.ADD_CHASSIS:
@@ -146,12 +152,32 @@ export const MachineForms = ({
         />
       );
     }
+    case MachineSidePanelViews.CREATE_CACHE_SET: {
+      if (!systemId || !disk) return null;
+      return (
+        <CreateCacheSet
+          close={clearSidePanelContent}
+          diskId={disk.id}
+          systemId={systemId}
+        />
+      );
+    }
     case MachineSidePanelViews.CREATE_DATASTORE: {
       if (!bulkActionSelected || !systemId) return null;
       return (
         <CreateDatastore
           closeForm={clearSidePanelContent}
           selected={bulkActionSelected}
+          systemId={systemId}
+        />
+      );
+    }
+    case MachineSidePanelViews.CREATE_PARTITION: {
+      if (!systemId || !disk) return null;
+      return (
+        <AddPartition
+          closeExpanded={clearSidePanelContent}
+          disk={disk}
           systemId={systemId}
         />
       );
@@ -172,6 +198,26 @@ export const MachineForms = ({
         <CreateVolumeGroup
           closeForm={clearSidePanelContent}
           selected={bulkActionSelected}
+          systemId={systemId}
+        />
+      );
+    }
+    case MachineSidePanelViews.DELETE_DISK: {
+      if (!disk || !systemId) return null;
+      return (
+        <DeleteDisk
+          close={clearSidePanelContent}
+          disk={disk}
+          systemId={systemId}
+        />
+      );
+    }
+    case MachineSidePanelViews.EDIT_DISK: {
+      if (!disk || !systemId) return null;
+      return (
+        <EditDisk
+          closeExpanded={clearSidePanelContent}
+          disk={disk}
           systemId={systemId}
         />
       );
@@ -220,6 +266,16 @@ export const MachineForms = ({
           close={clearSidePanelContent}
           link={link}
           nic={nic}
+          systemId={systemId}
+        />
+      );
+    }
+    case MachineSidePanelViews.SET_BOOT_DISK: {
+      if (!systemId || !disk) return null;
+      return (
+        <SetBootDisk
+          close={clearSidePanelContent}
+          diskId={disk.id}
           systemId={systemId}
         />
       );

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -39,13 +39,18 @@ export const MachineNonActionSidePanelViews = {
   ADD_SPECIAL_FILESYSTEM: ["machineNonActionForm", "addSpecialFilesystem"],
   ADD_VLAN: ["machineNonActionForm", "addVlan"],
   APPLY_STORAGE_LAYOUT: ["machineNonActionForm", "applyStorageLayout"],
+  CREATE_CACHE_SET: ["machineNonActionForm", "createCacheSet"],
   CREATE_DATASTORE: ["machineNonActionForm", "createDatastore"],
+  CREATE_PARTITION: ["machineNonActionForm", "createPartition"],
   CREATE_RAID: ["machineNonActionForm", "createRaid"],
   CREATE_VOLUME_GROUP: ["machineNonActionForm", "createVolumeGroup"],
+  DELETE_DISK: ["machineNonActionForm", "deleteDisk"],
+  EDIT_DISK: ["machineNonActionForm", "editDisk"],
   EDIT_PHYSICAL: ["machineNonActionForm", "editPhysical"],
   MARK_CONNECTED: ["machineNonActionForm", "markConnected"],
   MARK_DISCONNECTED: ["machineNonActionForm", "markDisconnected"],
   REMOVE_PHYSICAL: ["machineNonActionForm", "removePhysical"],
+  SET_BOOT_DISK: ["machineNonActionForm", "setBootDisk"],
   UPDATE_DATASTORE: ["machineNonActionForm", "updateDatastore"],
 } as const;
 

--- a/src/app/machines/types.ts
+++ b/src/app/machines/types.ts
@@ -87,6 +87,13 @@ export type MachineSidePanelContent =
         linkId?: NetworkLink["id"];
         nicId?: NetworkInterface["id"];
       }
+    >
+  | SidePanelContent<
+      ValueOf<typeof MachineSidePanelViews>,
+      {
+        systemId?: Machine["system_id"];
+        disk?: Disk;
+      }
     >;
 
 export type MachineSetSidePanelContent =

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -222,20 +222,28 @@ export const getSidePanelTitle = (
         return "Change storage layout";
       case SidePanelViews.CLEAR_ALL_DISCOVERIES[1]:
         return "Clear all discoveries";
+      case SidePanelViews.CREATE_CACHE_SET[1]:
+        return "Create cache set";
       case SidePanelViews.CREATE_DATASTORE[1]:
         return "Create datastore";
+      case SidePanelViews.CREATE_PARTITION[1]:
+        return "Create partition";
       case SidePanelViews.CREATE_RAID[1]:
         return "Create raid";
       case SidePanelViews.CREATE_VOLUME_GROUP[1]:
         return "Create volume group";
       case SidePanelViews.DELETE_DISCOVERY[1]:
         return "Delete discovery";
+      case SidePanelViews.DELETE_DISK[1]:
+        return "Delete disk";
       case SidePanelViews.DeleteTag[1]:
         return "Delete tag";
       case SidePanelViews.EDIT_INTERFACE[1]:
         return "Edit interface";
       case SidePanelViews.CREATE_ZONE[1]:
         return "Add AZ";
+      case SidePanelViews.EDIT_DISK[1]:
+        return "Edit disk";
       case SidePanelViews.EDIT_PHYSICAL[1]:
         return "Edit physical";
       case SidePanelViews.DELETE_IMAGE[1]:
@@ -252,6 +260,8 @@ export const getSidePanelTitle = (
         return "Remove interface";
       case SidePanelViews.REMOVE_PHYSICAL[1]:
         return "Remove physical";
+      case SidePanelViews.SET_BOOT_DISK[1]:
+        return "Set boot disk";
       case SidePanelViews.SET_DEFAULT[1]:
         return "Set default";
       case SidePanelViews.UPDATE_DATASTORE[1]:


### PR DESCRIPTION
## Done
- Add Partition
- Create cache set
- Set boot disk
- Edit physical disk
- Remove physical disk
All moved to side panels

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to the storage tab of a machine in ready state
- [ ] Under "Available disks and partitions" table, click on the actions dropdown
- [ ] Ensure that the forms listed above all open in sidepanels and work as expected

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-2856](https://warthogs.atlassian.net/browse/MAASENG-2856)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![image](https://github.com/canonical/maas-ui/assets/47540149/329dc2b2-71fd-4d1a-b837-df08c5c9e454)
![image](https://github.com/canonical/maas-ui/assets/47540149/c9b35bf9-5925-43bb-a10a-5c39c0a6c8e7)

### After
![image](https://github.com/canonical/maas-ui/assets/47540149/64eb5459-bcf6-4b9a-9f24-19e4b6b2843c)
![image](https://github.com/canonical/maas-ui/assets/47540149/84591818-05db-42ad-a60d-343eeb45b63c)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes
Inline forms that carry out operations on partitions instead of disks will be handled in a separate PR
<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2856]: https://warthogs.atlassian.net/browse/MAASENG-2856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ