### PR TITLE
fix: improve boot source keyring data placeholder

### DIFF
--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.tsx
@@ -82,7 +82,7 @@ const FetchImagesFormFields = (): JSX.Element => {
                 help="Contents on the keyring to validate the mirror path."
                 label={Labels.KeyringData}
                 name="keyring_data"
-                placeholder="Contents of GPG key"
+                placeholder="Contents of GPG key (base64 encoded)"
               />
             </ShowAdvanced>
           </>


### PR DESCRIPTION
## Done
- In the boot source page, the user has to base64 encode the content of the keyring data and submit the string. This PR aims to improve the placeholder text for that field. 

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
