### PR TITLE
fix: login error message spacing MAASENG-2885

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,7 +14,6 @@ import PageContent from "./base/components/PageContent/PageContent";
 import SectionHeader from "./base/components/SectionHeader";
 import ThemePreviewContextProvider from "./base/theme-context";
 import { MAAS_UI_ID } from "./constants";
-import { formatErrors } from "./utils";
 
 import AppSideNavigation from "@/app/base/components/AppSideNavigation";
 import Login from "@/app/base/components/Login";
@@ -74,7 +73,6 @@ export const App = (): JSX.Element => {
   const analyticsEnabled = useSelector(configSelectors.analyticsEnabled);
   const authenticated = useSelector(status.authenticated);
   const authenticating = useSelector(status.authenticating);
-  const authenticationError = useSelector(status.authenticationError);
   const authLoading = useSelector(authSelectors.loading);
   const authLoaded = useSelector(authSelectors.loaded);
   const connected = useSelector(status.connected);
@@ -134,18 +132,6 @@ export const App = (): JSX.Element => {
   } else if (hasAuthError) {
     content = (
       <PageContent sidePanelContent={null} sidePanelTitle={null}>
-        {authenticationError ? (
-          authenticationError === "Session expired" ? (
-            <Notification role="alert" severity="information">
-              Your session has expired. Plese log in again to continue using
-              MAAS.
-            </Notification>
-          ) : (
-            <Notification role="alert" severity="negative" title="Error:">
-              {formatErrors(authenticationError, "__all__")}
-            </Notification>
-          )
-        ) : null}
         <Login />
       </PageContent>
     );

--- a/src/app/base/components/Login/Login.test.tsx
+++ b/src/app/base/components/Login/Login.test.tsx
@@ -1,6 +1,3 @@
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
 import configureStore from "redux-mock-store";
 
 import Login, { Labels } from "./Login";
@@ -11,7 +8,7 @@ import {
   rootState as rootStateFactory,
   statusState as statusStateFactory,
 } from "@/testing/factories";
-import { userEvent, render, screen } from "@/testing/utils";
+import { userEvent, screen, renderWithBrowserRouter } from "@/testing/utils";
 
 const mockStore = configureStore();
 
@@ -26,17 +23,16 @@ describe("Login", () => {
     });
   });
 
+  it("can display a login error message", () => {
+    const authenticationError =
+      "Please enter a correct username and password. Note that both fields may be case-sensitive.";
+    state.status.authenticationError = authenticationError;
+    renderWithBrowserRouter(<Login />, { route: "/", state });
+    expect(screen.getByRole("alert")).toHaveTextContent(authenticationError);
+  });
+
   it("can render api login", () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
-          <CompatRouter>
-            <Login />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<Login />, { route: "/", state });
 
     expect(
       screen.getByRole("form", { name: Labels.APILoginForm })
@@ -45,16 +41,7 @@ describe("Login", () => {
 
   it("can render external login link", () => {
     state.status.externalAuthURL = "http://login.example.com";
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
-          <CompatRouter>
-            <Login />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<Login />, { route: "/", state });
 
     expect(
       screen.getByRole("link", { name: Labels.ExternalLoginButton })
@@ -63,15 +50,7 @@ describe("Login", () => {
 
   it("can login via the api", async () => {
     const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
-          <CompatRouter>
-            <Login />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<Login />, { route: "/", store });
 
     await userEvent.type(
       screen.getByRole("textbox", { name: Labels.Username }),
@@ -91,16 +70,7 @@ describe("Login", () => {
 
   it("shows a warning if no users have been added yet", () => {
     state.status.noUsers = true;
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter initialEntries={["/"]}>
-          <CompatRouter>
-            <Login />
-          </CompatRouter>
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithBrowserRouter(<Login />, { route: "/", state });
 
     expect(
       screen.getByRole("heading", { name: Labels.NoUsers })

--- a/src/app/base/components/Login/Login.tsx
+++ b/src/app/base/components/Login/Login.tsx
@@ -7,6 +7,7 @@ import {
   Col,
   Row,
   Strip,
+  Notification,
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
@@ -16,6 +17,7 @@ import FormikForm from "@/app/base/components/FormikForm";
 import { useWindowTitle } from "@/app/base/hooks";
 import { actions as statusActions } from "@/app/store/status";
 import statusSelectors from "@/app/store/status/selectors";
+import { formatErrors } from "@/app/utils";
 
 const LoginSchema = Yup.object().shape({
   username: Yup.string().required("Username is required"),
@@ -47,6 +49,8 @@ export const Login = (): JSX.Element => {
   const authenticating = useSelector(statusSelectors.authenticating);
   const externalAuthURL = useSelector(statusSelectors.externalAuthURL);
   const externalLoginURL = useSelector(statusSelectors.externalLoginURL);
+  const authenticationError = useSelector(statusSelectors.authenticationError);
+
   const noUsers = useSelector(statusSelectors.noUsers);
 
   useWindowTitle("Login");
@@ -61,6 +65,18 @@ export const Login = (): JSX.Element => {
     <Strip>
       <Row>
         <Col emptyLarge={4} size={6}>
+          {authenticationError ? (
+            authenticationError === "Session expired" ? (
+              <Notification role="alert" severity="information">
+                Your session has expired. Plese log in again to continue using
+                MAAS.
+              </Notification>
+            ) : (
+              <Notification role="alert" severity="negative" title="Error:">
+                {formatErrors(authenticationError, "__all__")}
+              </Notification>
+            )
+          ) : null}
           {noUsers && !externalAuthURL ? (
             <Card title={Labels.NoUsers}>
               <p>Use the following command to create one:</p>

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -98,7 +98,7 @@ type WrapperProps = {
   parentRoute?: string;
   routePattern?: string;
   state?: RootState;
-  store?: MockStoreEnhanced<RootState, {}>;
+  store?: MockStoreEnhanced<RootState | unknown, {}>;
   sidePanelContent?: SidePanelContent;
   sidePanelSize?: SidePanelSize;
 };


### PR DESCRIPTION
## Done
fix: login error message spacing
  - test: add login error message test
  - test: refactor Login.test.tsx to use renderWithBrowserRouter


<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Use incorrect credentials to login
- [x] Press login
- [x] Verify that the error message is displayed in the center with a correct padding

<!-- Steps for QA. -->

## Fixes

Fixes: MAASENG-2885

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![Google Chrome screenshot 001675@2x](https://github.com/canonical/maas-ui/assets/7452681/993d205d-3705-41a2-9e22-c33d902a8baf)


### After
![Google Chrome screenshot 001673@2x](https://github.com/canonical/maas-ui/assets/7452681/f058a23b-de89-4c17-b81d-c35bca29372f)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
