### PR TITLE
fix(machines): Remove typo on empty network table MAASENG-2889

### DIFF
--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.tsx
@@ -63,7 +63,7 @@ export enum Label {
   Actions = "Actions",
   ActionsMenu = "Interface actions",
   DHCP = "DHCP",
-  EmptyList = "No interfaces availaable",
+  EmptyList = "No interfaces available",
   Fabric = "Fabric",
   IP = "IP Address",
   MAC = "MAC",


### PR DESCRIPTION
## Done
- Changed "availaable" to "available" on empty machine network table

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to "New" machine's details (e.g. `jcc0q900003` on UI demo maas)
- [ ] Go to "Network" tab
- [ ] Verify that empty interface table says "No interfaces available" instead of "No interfaces availaable"

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2889](https://warthogs.atlassian.net/browse/MAASENG-2889)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/ebe78a75-2dac-4170-a868-2f323dd3b44e)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/cbed8625-11fa-45e5-b655-0fa4863ed583)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-2889]: https://warthogs.atlassian.net/browse/MAASENG-2889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ