### PR TITLE
feat: move file system forms to side panel

### DIFF
--- a/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteFilesystem/DeleteFilesystem.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteFilesystem/DeleteFilesystem.test.tsx
@@ -1,0 +1,60 @@
+import configureStore from "redux-mock-store";
+
+import DeleteFilesystem from "./DeleteFilesystem";
+
+import { actions as machineActions } from "@/app/store/machine";
+import type { RootState } from "@/app/store/root/types";
+import * as factory from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const mockStore = configureStore<RootState>();
+const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
+const disk = factory.nodeDisk({ filesystem, partitions: [] });
+const machine = factory.machineDetails({
+  disks: [disk],
+  system_id: "abc123",
+});
+const state = factory.rootState({
+  machine: factory.machineState({
+    items: [machine],
+    statuses: factory.machineStatuses({
+      abc123: factory.machineStatus(),
+    }),
+  }),
+});
+
+it("renders a delete confirmation form", () => {
+  renderWithBrowserRouter(
+    <DeleteFilesystem close={vi.fn()} storageDevice={disk} systemId="abc123" />,
+    { state }
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Delete filesystem" })
+  ).toBeInTheDocument();
+});
+
+it("can remove a disk's filesystem", async () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(
+    <DeleteFilesystem close={vi.fn()} storageDevice={disk} systemId="abc123" />,
+    { store }
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Delete filesystem" })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("Are you sure you want to remove this filesystem?")
+  ).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+  const expectedAction = machineActions.deleteFilesystem({
+    blockDeviceId: disk.id,
+    filesystemId: filesystem.id,
+    systemId: machine.system_id,
+  });
+
+  expect(
+    store.getActions().find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
+});

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteFilesystem/DeleteFilesystem.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteFilesystem/DeleteFilesystem.tsx
@@ -1,0 +1,59 @@
+import { useDispatch } from "react-redux";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { actions as machineActions } from "@/app/store/machine";
+import type { Machine } from "@/app/store/machine/types";
+import type { Disk, Partition } from "@/app/store/types/node";
+import { isDisk, isMounted } from "@/app/store/utils";
+
+type Props = {
+  close: () => void;
+  systemId: Machine["system_id"];
+  storageDevice: Disk | Partition;
+};
+
+const DeleteFilesystem = ({ close, systemId, storageDevice }: Props) => {
+  const dispatch = useDispatch();
+  const deviceIsDisk = isDisk(storageDevice);
+  const storageFs = storageDevice.filesystem;
+  const isDiskFsDelete = deviceIsDisk && isMounted(storageFs);
+
+  return (
+    <ModelActionForm
+      aria-label="Delete filesystem"
+      initialValues={{}}
+      message={<>Are you sure you want to remove this filesystem?</>}
+      modelType="filesystem"
+      onCancel={close}
+      onSaveAnalytics={{
+        action: `Delete ${isDiskFsDelete ? "disk" : "partition"} filesystem`,
+        category: "Machine storage",
+        label: "Remove",
+      }}
+      onSubmit={() => {
+        dispatch(machineActions.cleanup());
+        if (isDiskFsDelete) {
+          dispatch(
+            machineActions.deleteFilesystem({
+              blockDeviceId: storageDevice.id,
+              filesystemId: storageFs.id,
+              systemId,
+            })
+          );
+        } else {
+          dispatch(
+            machineActions.deletePartition({
+              partitionId: storageDevice.id,
+              systemId,
+            })
+          );
+        }
+        close();
+      }}
+      submitAppearance="negative"
+      submitLabel="Remove"
+    />
+  );
+};
+
+export default DeleteFilesystem;

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteFilesystem/index.ts
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteFilesystem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteFilesystem";

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteSpecialFilesystem/DeleteSpecialFilesystem.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteSpecialFilesystem/DeleteSpecialFilesystem.test.tsx
@@ -1,0 +1,67 @@
+import configureStore from "redux-mock-store";
+
+import DeleteSpecialFilesystem from "./DeleteSpecialFilesystem";
+
+import { actions as machineActions } from "@/app/store/machine";
+import type { RootState } from "@/app/store/root/types";
+import * as factory from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const mockStore = configureStore<RootState>();
+const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
+const disk = factory.nodeDisk({ filesystem, partitions: [] });
+const machine = factory.machineDetails({
+  disks: [disk],
+  system_id: "abc123",
+});
+const state = factory.rootState({
+  machine: factory.machineState({
+    items: [machine],
+    statuses: factory.machineStatuses({
+      abc123: factory.machineStatus(),
+    }),
+  }),
+});
+
+it("renders a delete confirmation form", () => {
+  renderWithBrowserRouter(
+    <DeleteSpecialFilesystem
+      close={vi.fn()}
+      mountPoint={filesystem.mount_point}
+      systemId="abc123"
+    />,
+    { state }
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Delete special filesystem" })
+  ).toBeInTheDocument();
+});
+
+it("can remove a special filesystem", async () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(
+    <DeleteSpecialFilesystem
+      close={vi.fn()}
+      mountPoint={filesystem.mount_point}
+      systemId="abc123"
+    />,
+    { store }
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Delete special filesystem" })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("Are you sure you want to remove this special filesystem?")
+  ).toBeInTheDocument();
+  await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+  const expectedAction = machineActions.unmountSpecial({
+    mountPoint: filesystem.mount_point,
+    systemId: machine.system_id,
+  });
+
+  expect(
+    store.getActions().find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
+});

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteSpecialFilesystem/DeleteSpecialFilesystem.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteSpecialFilesystem/DeleteSpecialFilesystem.tsx
@@ -1,0 +1,45 @@
+import { useDispatch } from "react-redux";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { actions as machineActions } from "@/app/store/machine";
+import type { Machine } from "@/app/store/machine/types";
+import type { Filesystem } from "@/app/store/types/node";
+
+type Props = {
+  close: () => void;
+  mountPoint: Filesystem["mount_point"];
+  systemId: Machine["system_id"];
+};
+
+const DeleteSpecialFilesystem = ({ close, systemId, mountPoint }: Props) => {
+  const dispatch = useDispatch();
+
+  return (
+    <ModelActionForm
+      aria-label="Delete special filesystem"
+      initialValues={{}}
+      message={<>Are you sure you want to remove this special filesystem?</>}
+      modelType="special filesystem"
+      onCancel={close}
+      onSaveAnalytics={{
+        action: "Unmount special filesystem",
+        category: "Machine storage",
+        label: "Remove",
+      }}
+      onSubmit={() => {
+        dispatch(machineActions.cleanup());
+        dispatch(
+          machineActions.unmountSpecial({
+            mountPoint,
+            systemId,
+          })
+        );
+        close();
+      }}
+      submitAppearance="negative"
+      submitLabel="Remove"
+    />
+  );
+};
+
+export default DeleteSpecialFilesystem;

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteSpecialFilesystem/index.ts
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/DeleteSpecialFilesystem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteSpecialFilesystem";

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
@@ -5,11 +5,24 @@ import configureStore from "redux-mock-store";
 
 import FilesystemsTable from "./FilesystemsTable";
 
-import { actions as machineActions } from "@/app/store/machine";
+import * as sidePanelHooks from "@/app/base/side-panel-context";
+import { MachineSidePanelViews } from "@/app/machines/constants";
 import * as factory from "@/testing/factories";
 import { userEvent, render, screen } from "@/testing/utils";
 
 const mockStore = configureStore();
+const setSidePanelContent = vi.fn();
+beforeEach(() => {
+  vi.spyOn(sidePanelHooks, "useSidePanel").mockReturnValue({
+    setSidePanelContent,
+    sidePanelContent: null,
+    setSidePanelSize: vi.fn(),
+    sidePanelSize: "regular",
+  });
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 it("can show an empty message", () => {
   const machine = factory.machineDetails({
@@ -263,19 +276,9 @@ it("can remove a disk's filesystem if node is a machine", async () => {
   await userEvent.click(
     screen.getByRole("button", { name: "Remove filesystem..." })
   );
-  await userEvent.click(screen.getByRole("button", { name: "Remove" }));
-
-  const expectedAction = machineActions.deleteFilesystem({
-    blockDeviceId: disk.id,
-    filesystemId: filesystem.id,
-    systemId: machine.system_id,
-  });
-  expect(
-    screen.getByText("Are you sure you want to remove this filesystem?")
-  ).toBeInTheDocument();
-  expect(
-    store.getActions().find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+  expect(setSidePanelContent).toHaveBeenCalledWith(
+    expect.objectContaining({ view: MachineSidePanelViews.DELETE_FILESYSTEM })
+  );
 });
 
 it("can remove a partition's filesystem if node is a machine", async () => {
@@ -309,18 +312,9 @@ it("can remove a partition's filesystem if node is a machine", async () => {
   await userEvent.click(
     screen.getByRole("button", { name: "Remove filesystem..." })
   );
-  await userEvent.click(screen.getByRole("button", { name: "Remove" }));
-
-  const expectedAction = machineActions.deletePartition({
-    partitionId: partition.id,
-    systemId: machine.system_id,
-  });
-  expect(
-    screen.getByText("Are you sure you want to remove this filesystem?")
-  ).toBeInTheDocument();
-  expect(
-    store.getActions().find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+  expect(setSidePanelContent).toHaveBeenCalledWith(
+    expect.objectContaining({ view: MachineSidePanelViews.DELETE_FILESYSTEM })
+  );
 });
 
 it("can remove a special filesystem if node is a machine", async () => {
@@ -356,18 +350,11 @@ it("can remove a special filesystem if node is a machine", async () => {
   await userEvent.click(
     screen.getByRole("button", { name: "Remove filesystem..." })
   );
-  await userEvent.click(screen.getByRole("button", { name: "Remove" }));
-
-  const expectedAction = machineActions.unmountSpecial({
-    mountPoint: filesystem.mount_point,
-    systemId: machine.system_id,
-  });
-  expect(
-    screen.getByText("Are you sure you want to remove this special filesystem?")
-  ).toBeInTheDocument();
-  expect(
-    store.getActions().find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+  expect(setSidePanelContent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      view: MachineSidePanelViews.DELETE_SPECIAL_FILESYSTEM,
+    })
+  );
 });
 
 it("can unmount a disk's filesystem if node is a machine", async () => {
@@ -400,20 +387,9 @@ it("can unmount a disk's filesystem if node is a machine", async () => {
   await userEvent.click(
     screen.getByRole("button", { name: "Unmount filesystem..." })
   );
-  await userEvent.click(screen.getByRole("button", { name: "Unmount" }));
-
-  const expectedAction = machineActions.updateFilesystem({
-    blockId: disk.id,
-    mountOptions: "",
-    mountPoint: "",
-    systemId: machine.system_id,
-  });
-  expect(
-    screen.getByText("Are you sure you want to unmount this filesystem?")
-  ).toBeInTheDocument();
-  expect(
-    store.getActions().find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+  expect(setSidePanelContent).toHaveBeenCalledWith(
+    expect.objectContaining({ view: MachineSidePanelViews.UNMOUNT_FILESYSTEM })
+  );
 });
 
 it("can unmount a partition's filesystem if node is a machine", async () => {
@@ -447,18 +423,7 @@ it("can unmount a partition's filesystem if node is a machine", async () => {
   await userEvent.click(
     screen.getByRole("button", { name: "Unmount filesystem..." })
   );
-  await userEvent.click(screen.getByRole("button", { name: "Unmount" }));
-
-  const expectedAction = machineActions.updateFilesystem({
-    mountOptions: "",
-    mountPoint: "",
-    partitionId: partition.id,
-    systemId: machine.system_id,
-  });
-  expect(
-    screen.getByText("Are you sure you want to unmount this filesystem?")
-  ).toBeInTheDocument();
-  expect(
-    store.getActions().find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
+  expect(setSidePanelContent).toHaveBeenCalledWith(
+    expect.objectContaining({ view: MachineSidePanelViews.UNMOUNT_FILESYSTEM })
+  );
 });

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/UnmountFilesystem/UnmountFilesystem.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/UnmountFilesystem/UnmountFilesystem.test.tsx
@@ -1,0 +1,67 @@
+import configureStore from "redux-mock-store";
+
+import UnmountFilesystem from "./UnmountFilesystem";
+
+import { actions as machineActions } from "@/app/store/machine";
+import type { RootState } from "@/app/store/root/types";
+import * as factory from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const mockStore = configureStore<RootState>();
+const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
+const disk = factory.nodeDisk({ filesystem, partitions: [] });
+const machine = factory.machineDetails({
+  disks: [disk],
+  system_id: "abc123",
+});
+const state = factory.rootState({
+  machine: factory.machineState({
+    items: [machine],
+    statuses: factory.machineStatuses({
+      abc123: factory.machineStatus(),
+    }),
+  }),
+});
+
+it("renders a delete confirmation form", () => {
+  renderWithBrowserRouter(
+    <UnmountFilesystem
+      close={vi.fn()}
+      storageDevice={disk}
+      systemId="abc123"
+    />,
+
+    { state }
+  );
+
+  expect(
+    screen.getByRole("form", { name: "Unmount filesystem" })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByText("Are you sure you want to unmount this filesystem?")
+  ).toBeInTheDocument();
+});
+
+it("can remove a special filesystem", async () => {
+  const store = mockStore(state);
+  renderWithBrowserRouter(
+    <UnmountFilesystem
+      close={vi.fn()}
+      storageDevice={disk}
+      systemId="abc123"
+    />,
+    { store }
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+  const expectedAction = machineActions.updateFilesystem({
+    blockId: disk.id,
+    mountOptions: "",
+    mountPoint: "",
+    systemId: "abc123",
+  });
+
+  expect(
+    store.getActions().find((action) => action.type === expectedAction.type)
+  ).toStrictEqual(expectedAction);
+});

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/UnmountFilesystem/UnmountFilesystem.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/UnmountFilesystem/UnmountFilesystem.tsx
@@ -1,0 +1,62 @@
+import { useDispatch } from "react-redux";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { actions as machineActions } from "@/app/store/machine";
+import type { Machine } from "@/app/store/machine/types";
+import type { Disk, Partition } from "@/app/store/types/node";
+import { isDisk, isMounted } from "@/app/store/utils";
+
+type Props = {
+  close: () => void;
+  systemId: Machine["system_id"];
+  storageDevice: Disk | Partition;
+};
+
+const UnmountFilesystem = ({ close, systemId, storageDevice }: Props) => {
+  const dispatch = useDispatch();
+  const deviceIsDisk = isDisk(storageDevice);
+  const storageFs = storageDevice.filesystem;
+  const isDiskFsUnmount = deviceIsDisk && isMounted(storageFs);
+
+  return (
+    <ModelActionForm
+      aria-label="Unmount filesystem"
+      initialValues={{}}
+      message={<>Are you sure you want to unmount this filesystem?</>}
+      modelType="filesystem"
+      onCancel={close}
+      onSaveAnalytics={{
+        action: `Unmount ${isDiskFsUnmount ? "disk" : "partition"} filesystem`,
+        category: "Machine storage",
+        label: "Unmount",
+      }}
+      onSubmit={() => {
+        dispatch(machineActions.cleanup());
+        if (isDiskFsUnmount) {
+          dispatch(
+            machineActions.updateFilesystem({
+              blockId: storageDevice.id,
+              mountOptions: "",
+              mountPoint: "",
+              systemId,
+            })
+          );
+        } else {
+          dispatch(
+            machineActions.updateFilesystem({
+              mountOptions: "",
+              mountPoint: "",
+              partitionId: storageDevice.id,
+              systemId,
+            })
+          );
+        }
+        close();
+      }}
+      submitAppearance="negative"
+      submitLabel="Remove"
+    />
+  );
+};
+
+export default UnmountFilesystem;

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/UnmountFilesystem/index.ts
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/UnmountFilesystem/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./UnmountFilesystem";

--- a/src/app/machines/components/MachineForms/MachineForms.tsx
+++ b/src/app/machines/components/MachineForms/MachineForms.tsx
@@ -25,6 +25,9 @@ import EditDisk from "@/app/base/components/node/StorageTables/AvailableStorageT
 import EditPartition from "@/app/base/components/node/StorageTables/AvailableStorageTable/EditPartition";
 import SetBootDisk from "@/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk";
 import AddSpecialFilesystem from "@/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem";
+import DeleteFilesystem from "@/app/base/components/node/StorageTables/FilesystemsTable/DeleteFilesystem";
+import DeleteSpecialFilesystem from "@/app/base/components/node/StorageTables/FilesystemsTable/DeleteSpecialFilesystem";
+import UnmountFilesystem from "@/app/base/components/node/StorageTables/FilesystemsTable/UnmountFilesystem";
 import type { SidePanelContentTypes } from "@/app/base/side-panel-context";
 import type { SetSearchFilter } from "@/app/base/types";
 import type { MachineActionSidePanelViews } from "@/app/machines/constants";
@@ -84,6 +87,10 @@ export const MachineForms = ({
   const disk = extras && "disk" in extras ? extras.disk : undefined;
   const partition =
     extras && "partition" in extras ? extras.partition : undefined;
+  const storageDevice =
+    extras && "storageDevice" in extras ? extras.storageDevice : undefined;
+  const mountPoint =
+    extras && "mountPoint" in extras ? extras.mountPoint : undefined;
 
   switch (sidePanelContent.view) {
     case MachineSidePanelViews.ADD_CHASSIS:
@@ -240,6 +247,26 @@ export const MachineForms = ({
         />
       );
     }
+    case MachineSidePanelViews.DELETE_FILESYSTEM: {
+      if (!storageDevice || !systemId) return null;
+      return (
+        <DeleteFilesystem
+          close={clearSidePanelContent}
+          storageDevice={storageDevice}
+          systemId={systemId}
+        />
+      );
+    }
+    case MachineSidePanelViews.DELETE_SPECIAL_FILESYSTEM: {
+      if (!mountPoint || !systemId) return null;
+      return (
+        <DeleteSpecialFilesystem
+          close={clearSidePanelContent}
+          mountPoint={mountPoint}
+          systemId={systemId}
+        />
+      );
+    }
     case MachineSidePanelViews.DELETE_VOLUME_GROUP: {
       if (!disk || !systemId) return null;
       return (
@@ -335,6 +362,16 @@ export const MachineForms = ({
         <SetBootDisk
           close={clearSidePanelContent}
           diskId={disk.id}
+          systemId={systemId}
+        />
+      );
+    }
+    case MachineSidePanelViews.UNMOUNT_FILESYSTEM: {
+      if (!storageDevice || !systemId) return null;
+      return (
+        <UnmountFilesystem
+          close={clearSidePanelContent}
+          storageDevice={storageDevice}
           systemId={systemId}
         />
       );

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -47,6 +47,11 @@ export const MachineNonActionSidePanelViews = {
   CREATE_RAID: ["machineNonActionForm", "createRaid"],
   CREATE_VOLUME_GROUP: ["machineNonActionForm", "createVolumeGroup"],
   DELETE_DISK: ["machineNonActionForm", "deleteDisk"],
+  DELETE_FILESYSTEM: ["machineNonActionForm", "deleteFilesystem"],
+  DELETE_SPECIAL_FILESYSTEM: [
+    "machineNonActionForm",
+    "deleteSpecialFilesystem",
+  ],
   DELETE_VOLUME_GROUP: ["machineNonActionForm", "deleteVolumeGroup"],
   EDIT_DISK: ["machineNonActionForm", "editDisk"],
   EDIT_PARTITION: ["machineNonActionForm", "editPartition"],
@@ -56,6 +61,7 @@ export const MachineNonActionSidePanelViews = {
   REMOVE_PARTITION: ["machineNonActionForm", "removePartition"],
   REMOVE_PHYSICAL: ["machineNonActionForm", "removePhysical"],
   SET_BOOT_DISK: ["machineNonActionForm", "setBootDisk"],
+  UNMOUNT_FILESYSTEM: ["machineNonActionForm", "unmountFilesystem"],
   UPDATE_DATASTORE: ["machineNonActionForm", "updateDatastore"],
 } as const;
 

--- a/src/app/machines/types.ts
+++ b/src/app/machines/types.ts
@@ -22,6 +22,7 @@ import type {
 import type { Script } from "@/app/store/script/types";
 import type {
   Disk,
+  Filesystem,
   NetworkInterface,
   NetworkLink,
   Partition,
@@ -94,6 +95,20 @@ export type MachineSidePanelContent =
         systemId?: Machine["system_id"];
         disk?: Disk;
         partition?: Partition;
+      }
+    >
+  | SidePanelContent<
+      ValueOf<typeof MachineSidePanelViews>,
+      {
+        systemId?: Machine["system_id"];
+        storageDevice: Disk | Partition | null;
+      }
+    >
+  | SidePanelContent<
+      ValueOf<typeof MachineSidePanelViews>,
+      {
+        systemId?: Machine["system_id"];
+        mountPoint: Filesystem["mount_point"];
       }
     >;
 

--- a/src/app/store/utils/node/base.ts
+++ b/src/app/store/utils/node/base.ts
@@ -240,6 +240,10 @@ export const getSidePanelTitle = (
         return "Delete discovery";
       case SidePanelViews.DELETE_DISK[1]:
         return "Delete disk";
+      case SidePanelViews.DELETE_FILESYSTEM[1]:
+        return "Delete filesystem";
+      case SidePanelViews.DELETE_SPECIAL_FILESYSTEM[1]:
+        return "Delete special filesystem";
       case SidePanelViews.DeleteTag[1]:
         return "Delete tag";
       case SidePanelViews.DELETE_VOLUME_GROUP[1]:
@@ -274,6 +278,8 @@ export const getSidePanelTitle = (
         return "Set boot disk";
       case SidePanelViews.SET_DEFAULT[1]:
         return "Set default";
+      case SidePanelViews.UNMOUNT_FILESYSTEM[1]:
+        return "Unmount filesystem";
       case SidePanelViews.UPDATE_DATASTORE[1]:
         return "Update datastore";
       case SidePanelViews.UpdateTag[1]:


### PR DESCRIPTION
## Done
Moved File system table forms to side panel
- Delete Filesystem
- Unmount Filesystem
- Delete special filesystem

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Visit the storage tab of a ready state machine
- [ ] In the file systems table, click the action dropdown for a file system
- [ ] Ensure all actions open in a side panel
- [ ] Click the Add special filesystem button to add a special file sysem
- [ ] Ensure that the actions for that file system also open up in a side panel
- [ ] Ensure that the side panel forms work as expected

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-2874](https://warthogs.atlassian.net/browse/MAASENG-2874)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![image](https://github.com/canonical/maas-ui/assets/47540149/ed68dc89-0609-4473-9ed7-b41d1751614e)

### After
![image](https://github.com/canonical/maas-ui/assets/47540149/ccdb8fee-e5b1-4cf3-a182-aa0742d92085)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2874]: https://warthogs.atlassian.net/browse/MAASENG-2874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ