### PR TITLE
fix: remove synchronization status from controller list

### DIFF
--- a/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/ControllerListTable.tsx
@@ -15,7 +15,6 @@ import TooltipButton from "@/app/base/components/TooltipButton";
 import docsUrls from "@/app/base/docsUrls";
 import { useFetchActions, useTableSort } from "@/app/base/hooks";
 import { SortDirection } from "@/app/base/types";
-import ImageStatus from "@/app/controllers/components/ImageStatus";
 import { actions as controllerActions } from "@/app/store/controller";
 import controllerSelectors from "@/app/store/controller/selectors";
 import type { Controller, ControllerMeta } from "@/app/store/controller/types";
@@ -197,17 +196,6 @@ const generateRows = ({
             ? "Up-to-date"
             : controller.versions?.update?.version || null,
         },
-        {
-          "aria-label": "Last image sync",
-          className: "images-col",
-          content: (
-            <DoubleRow
-              primary={controller.last_image_sync || "Never"}
-              primaryTitle={controller.last_image_sync || "Never"}
-              secondary={<ImageStatus systemId={system_id} />}
-            />
-          ),
-        },
       ],
       "data-testid": `controller-${system_id}`,
     };
@@ -318,17 +306,6 @@ const ControllerListTable = ({
             <TableHeader data-testid="upgrade-header">
               Available upgrade
             </TableHeader>
-          ),
-        },
-        {
-          className: "images-col",
-          content: (
-            <>
-              <TableHeader data-testid="images-header">
-                Last Image Sync
-              </TableHeader>
-              <TableHeader>Images Status</TableHeader>
-            </>
           ),
         },
       ]}

--- a/src/app/controllers/views/ControllerList/ControllerListTable/_index.scss
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/_index.scss
@@ -23,9 +23,5 @@
     .upgrade-col {
       @include breakpoint-widths(0, 0, 0, 10rem, 10rem);
     }
-
-    .images-col {
-      @include breakpoint-widths(0, 0, 14rem, 14rem, 14rem);
-    }
   }
 }


### PR DESCRIPTION
## Done
- Remove Last Image Sync & Image status Column from controller list

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Navigate to `/controllers`
- [ ] Ensure that the Last image Sync column is no longer visible

<!-- Steps for QA. -->

## Fixes

Fixes: [lp#2058007](https://bugs.launchpad.net/maas-ui/+bug/2058007), [MAASENG-2896](https://warthogs.atlassian.net/browse/MAASENG-2896)


<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![image](https://github.com/canonical/maas-ui/assets/47540149/944dd806-127f-4d8b-b6ec-b5527a226cce)

### After
![image](https://github.com/canonical/maas-ui/assets/47540149/3df8c32a-eb29-4107-9fc7-f4eaae51ab61)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2896]: https://warthogs.atlassian.net/browse/MAASENG-2896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ