### PR TITLE
chore: remove react-router-dom-v5-compat imports

### DIFF
--- a/src/app/Routes.tsx
+++ b/src/app/Routes.tsx
@@ -1,7 +1,6 @@
 import { lazy } from "react";
 
-import { Redirect } from "react-router-dom";
-import { Route, Routes as ReactRouterRoutes } from "react-router-dom-v5-compat";
+import { Redirect, Route, Routes as ReactRouterRoutes } from "react-router-dom";
 
 import ErrorBoundary from "@/app/base/components/ErrorBoundary";
 import urls from "@/app/base/urls";

--- a/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavItem/AppSideNavItem.tsx
@@ -2,7 +2,7 @@ import type { MouseEvent, ReactNode } from "react";
 
 import { Navigation } from "@canonical/maas-react-components";
 import classNames from "classnames";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import type { SideNavigationProps } from "../AppSideNavigation";
 import type { NavItem } from "../types";

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -1,7 +1,12 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
-import { BrowserRouter, Router } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import {
+  BrowserRouter,
+  Router,
+  CompatRouter,
+  Route,
+  Routes,
+} from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AppSideNavigation from "./AppSideNavigation";
@@ -21,8 +26,8 @@ import {
 } from "@/testing/utils";
 
 const mockUseNavigate = vi.fn();
-vi.mock("react-router-dom-v5-compat", async () => {
-  const actual: object = await vi.importActual("react-router-dom-v5-compat");
+vi.mock("react-router-dom", async () => {
+  const actual: object = await vi.importActual("react-router-dom");
   return {
     ...actual,
     useNavigate: () => mockUseNavigate,

--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo } from "react";
 
 import { Navigation, NavigationBar } from "@canonical/maas-react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate, useLocation, useMatch } from "react-router-dom-v5-compat";
+import { useNavigate, useLocation, useMatch } from "react-router-dom";
 import { useStorageState } from "react-storage-hooks";
 
 import AppSideNavItems from "./AppSideNavItems";

--- a/src/app/base/components/AppSideNavigation/NavigationBanner/NavigationBanner.tsx
+++ b/src/app/base/components/AppSideNavigation/NavigationBanner/NavigationBanner.tsx
@@ -1,5 +1,5 @@
 import { Navigation } from "@canonical/maas-react-components";
-import { Link, useLocation } from "react-router-dom-v5-compat";
+import { Link, useLocation } from "react-router-dom";
 
 import { isSelected } from "../utils";
 

--- a/src/app/base/components/AppSideNavigation/utils.ts
+++ b/src/app/base/components/AppSideNavigation/utils.ts
@@ -1,4 +1,4 @@
-import { matchPath } from "react-router-dom-v5-compat";
+import { matchPath } from "react-router-dom";
 
 import type { NavItem } from "./types";
 

--- a/src/app/base/components/ControllerLink/ControllerLink.test.tsx
+++ b/src/app/base/components/ControllerLink/ControllerLink.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ControllerLink, { Labels } from "./ControllerLink";

--- a/src/app/base/components/ControllerLink/ControllerLink.tsx
+++ b/src/app/base/components/ControllerLink/ControllerLink.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/base/components/DHCPTable/DHCPTable.test.tsx
+++ b/src/app/base/components/DHCPTable/DHCPTable.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DHCPTable, { TestIds } from "./DHCPTable";

--- a/src/app/base/components/DHCPTable/DHCPTable.tsx
+++ b/src/app/base/components/DHCPTable/DHCPTable.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { ExternalLink } from "@canonical/maas-react-components";
 import { List, MainTable } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import TitledSection from "../TitledSection";
 

--- a/src/app/base/components/DeviceLink/DeviceLink.test.tsx
+++ b/src/app/base/components/DeviceLink/DeviceLink.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeviceLink, { Labels } from "./DeviceLink";

--- a/src/app/base/components/DeviceLink/DeviceLink.tsx
+++ b/src/app/base/components/DeviceLink/DeviceLink.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/base/components/DhcpForm/DhcpForm.test.tsx
+++ b/src/app/base/components/DhcpForm/DhcpForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as FieldLabels } from "../DhcpFormFields";

--- a/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
+++ b/src/app/base/components/DhcpFormFields/DhcpFormFields.test.tsx
@@ -1,7 +1,7 @@
 import * as reduxToolkit from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels } from "./DhcpFormFields";

--- a/src/app/base/components/FabricLink/FabricLink.test.tsx
+++ b/src/app/base/components/FabricLink/FabricLink.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FabricLink, { Labels } from "./FabricLink";

--- a/src/app/base/components/FabricLink/FabricLink.tsx
+++ b/src/app/base/components/FabricLink/FabricLink.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/base/components/FormikForm/FormikForm.test.tsx
+++ b/src/app/base/components/FormikForm/FormikForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FormikForm from "./FormikForm";

--- a/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -1,7 +1,6 @@
 import { Field, Formik } from "formik";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import * as Yup from "yup";
 
@@ -22,8 +21,8 @@ import {
 
 const mockStore = configureStore<RootState>();
 const mockUseNavigate = vi.fn();
-vi.mock("react-router-dom-v5-compat", async () => {
-  const actual: object = await vi.importActual("react-router-dom-v5-compat");
+vi.mock("react-router-dom", async () => {
+  const actual: object = await vi.importActual("react-router-dom");
   return {
     ...actual,
     useNavigate: () => mockUseNavigate,

--- a/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -7,7 +7,7 @@ import type { FormikContextType } from "formik";
 import { useFormikContext } from "formik";
 import { withFormikDevtools } from "formik-devtools-extension";
 import { useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 import type { AnyAction } from "redux";
 
 import type { FormikFormButtonsProps } from "@/app/base/components/FormikFormButtons";

--- a/src/app/base/components/MachineLink/MachineLink.test.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.test.tsx
@@ -1,7 +1,7 @@
 import * as reduxToolkit from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MachineLink, { Labels } from "./MachineLink";

--- a/src/app/base/components/MachineLink/MachineLink.tsx
+++ b/src/app/base/components/MachineLink/MachineLink.tsx
@@ -1,5 +1,5 @@
 import { Spinner } from "@canonical/react-components";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import urls from "@/app/base/urls";
 import type { Machine, MachineMeta } from "@/app/store/machine/types";

--- a/src/app/base/components/ModelNotFound/ModelNotFound.test.tsx
+++ b/src/app/base/components/ModelNotFound/ModelNotFound.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ModelNotFound from "./ModelNotFound";

--- a/src/app/base/components/ModelNotFound/ModelNotFound.tsx
+++ b/src/app/base/components/ModelNotFound/ModelNotFound.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import PageContent from "../PageContent";
 

--- a/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
+++ b/src/app/base/components/NodeConfigurationFields/NodeConfigurationFields.test.tsx
@@ -1,7 +1,7 @@
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import NodeConfigurationFields, { Label } from "./NodeConfigurationFields";

--- a/src/app/base/components/NodeSummaryNetworkCard/NodeSummaryNetworkCard.tsx
+++ b/src/app/base/components/NodeSummaryNetworkCard/NodeSummaryNetworkCard.tsx
@@ -3,7 +3,7 @@ import { Fragment } from "react";
 
 import { Card, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import NetworkCardTable from "./NetworkCardTable";
 

--- a/src/app/base/components/NotificationGroup/Notification/Notification.tsx
+++ b/src/app/base/components/NotificationGroup/Notification/Notification.tsx
@@ -1,7 +1,7 @@
 import { Notification } from "@canonical/react-components";
 import type { NotificationProps } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import settingsURLs from "@/app/settings/urls";
 import authSelectors from "@/app/store/auth/selectors";

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -2,7 +2,7 @@ import type { HTMLProps, ReactNode } from "react";
 
 import classNames from "classnames";
 import { useSelector } from "react-redux";
-import { matchPath, useLocation } from "react-router-dom-v5-compat";
+import { matchPath, useLocation } from "react-router-dom";
 
 import AppSidePanel from "../AppSidePanel";
 import ErrorBoundary from "../ErrorBoundary/ErrorBoundary";

--- a/src/app/base/components/SSHKeyList/SSHKeyList.tsx
+++ b/src/app/base/components/SSHKeyList/SSHKeyList.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from "react";
 
 import { Button, Notification } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import type { NavigateFunction } from "react-router-dom-v5-compat";
-import { useNavigate } from "react-router-dom-v5-compat";
+import type { NavigateFunction } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/preferences/urls";

--- a/src/app/base/components/SecondaryNavigation/SecondaryNavigation.tsx
+++ b/src/app/base/components/SecondaryNavigation/SecondaryNavigation.tsx
@@ -1,6 +1,6 @@
 import classNames from "classnames";
-import type { Location } from "react-router-dom-v5-compat";
-import { Link, matchPath, useLocation } from "react-router-dom-v5-compat";
+import type { Location } from "react-router-dom";
+import { Link, matchPath, useLocation } from "react-router-dom";
 
 import { useThemeContext } from "@/app/base/theme-context";
 

--- a/src/app/base/components/SpaceLink/SpaceLink.test.tsx
+++ b/src/app/base/components/SpaceLink/SpaceLink.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SpaceLink from "./SpaceLink";

--- a/src/app/base/components/SpaceLink/SpaceLink.tsx
+++ b/src/app/base/components/SpaceLink/SpaceLink.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/base/components/SubnetLink/SubnetLink.test.tsx
+++ b/src/app/base/components/SubnetLink/SubnetLink.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SubnetLink from "./SubnetLink";

--- a/src/app/base/components/SubnetLink/SubnetLink.tsx
+++ b/src/app/base/components/SubnetLink/SubnetLink.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/base/components/TableActions/TableActions.tsx
+++ b/src/app/base/components/TableActions/TableActions.tsx
@@ -1,5 +1,5 @@
 import { Button, Tooltip } from "@canonical/react-components";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import CopyButton from "@/app/base/components/CopyButton";
 

--- a/src/app/base/components/TagLinks/TagLinks.test.tsx
+++ b/src/app/base/components/TagLinks/TagLinks.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import TagLinks from "./TagLinks";
 

--- a/src/app/base/components/TagLinks/TagLinks.tsx
+++ b/src/app/base/components/TagLinks/TagLinks.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import type { Tag } from "@/app/store/tag/types";
 

--- a/src/app/base/components/VLANLink/VLANLink.test.tsx
+++ b/src/app/base/components/VLANLink/VLANLink.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import VLANLink from "./VLANLink";

--- a/src/app/base/components/VLANLink/VLANLink.tsx
+++ b/src/app/base/components/VLANLink/VLANLink.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/base/components/VaultNotification/VaultNotification.tsx
+++ b/src/app/base/components/VaultNotification/VaultNotification.tsx
@@ -1,6 +1,6 @@
 import { Notification } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import controllerSelectors from "@/app/store/controller/selectors";
 import { vaultEnabled as vaultEnabledSelectors } from "@/app/store/general/selectors";

--- a/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
+++ b/src/app/base/components/node/MachinesHeader/MachinesHeader.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MachinesHeader from "./MachinesHeader";

--- a/src/app/base/components/node/NodeDevices/NodeDevices.tsx
+++ b/src/app/base/components/node/NodeDevices/NodeDevices.tsx
@@ -4,7 +4,7 @@ import { useEffect } from "react";
 import classNames from "classnames";
 import pluralize from "pluralize";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import NodeDevicesWarning from "./NodeDevicesWarning";
 

--- a/src/app/base/components/node/NodeLink/NodeLink.test.tsx
+++ b/src/app/base/components/node/NodeLink/NodeLink.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import NodeLink from "./NodeLink";

--- a/src/app/base/components/node/NodeLogs/NodeLogs.tsx
+++ b/src/app/base/components/node/NodeLogs/NodeLogs.tsx
@@ -1,6 +1,6 @@
 import { Tabs } from "@canonical/react-components";
 import { Route, useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DownloadMenu from "./DownloadMenu";
 import EventLogs from "./EventLogs";

--- a/src/app/base/components/node/NodeTestDetails/NodeTestDetails.tsx
+++ b/src/app/base/components/node/NodeTestDetails/NodeTestDetails.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Col, Row, Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import NodeTestDetailsLogs from "./NodeTestDetailsLogs";
 

--- a/src/app/base/components/node/NodeTestsTable/TestActions/TestActions.tsx
+++ b/src/app/base/components/node/NodeTestsTable/TestActions/TestActions.tsx
@@ -1,6 +1,6 @@
 import type { ContextualMenuProps } from "@canonical/react-components";
 import type { LinkProps } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import type { SetExpanded } from "../NodeTestsTable";
 import { ScriptResultAction } from "../NodeTestsTable";

--- a/src/app/base/components/node/NodeTestsTable/TestHistory/TestHistory.tsx
+++ b/src/app/base/components/node/NodeTestsTable/TestHistory/TestHistory.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 import { Button, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link, useLocation } from "react-router-dom-v5-compat";
+import { Link, useLocation } from "react-router-dom";
 
 import ScriptStatus from "@/app/base/components/ScriptStatus";
 import type { RootState } from "@/app/store/root/types";

--- a/src/app/base/components/node/OverviewCard/CpuCard/CpuCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/CpuCard/CpuCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import CpuCard from "./CpuCard";

--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from "@canonical/react-components";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import {
   useFetchActions,

--- a/src/app/base/components/node/OverviewCard/MemoryCard/MemoryCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/MemoryCard/MemoryCard.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MemoryCard from "./MemoryCard";

--- a/src/app/base/components/node/OverviewCard/OverviewCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/OverviewCard.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import OverviewCard from "./OverviewCard";

--- a/src/app/base/components/node/OverviewCard/StorageCard/StorageCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/StorageCard/StorageCard.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import StorageCard from "./StorageCard";

--- a/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
+++ b/src/app/base/components/node/SetZoneForm/SetZoneForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SetZoneForm from "./SetZoneForm";

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/AvailableStorageTable.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AvailableStorageTable from "./AvailableStorageTable";

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem/AddSpecialFilesystem.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddSpecialFilesystem from "./AddSpecialFilesystem";

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FilesystemsTable from "./FilesystemsTable";

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import UsedStorageTable from "./UsedStorageTable";
 

--- a/src/app/base/components/node/TestResults/TestResults.test.tsx
+++ b/src/app/base/components/node/TestResults/TestResults.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TestResults from "./TestResults";

--- a/src/app/base/components/node/TestResults/TestResults.tsx
+++ b/src/app/base/components/node/TestResults/TestResults.tsx
@@ -1,5 +1,5 @@
 import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { HardwareType } from "@/app/base/enum";
 import { useSendAnalytics } from "@/app/base/hooks";

--- a/src/app/base/components/node/networking/FabricColumn/FabricColumn.test.tsx
+++ b/src/app/base/components/node/networking/FabricColumn/FabricColumn.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FabricColumn from "./FabricColumn";

--- a/src/app/base/components/node/networking/FabricColumn/FabricColumn.tsx
+++ b/src/app/base/components/node/networking/FabricColumn/FabricColumn.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
 import fabricSelectors from "@/app/store/fabric/selectors";

--- a/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.tsx
+++ b/src/app/base/components/node/networking/SubnetColumn/SubnetColumn.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
 import { useIsAllNetworkingDisabled } from "@/app/base/hooks";

--- a/src/app/base/hooks/analytics.ts
+++ b/src/app/base/hooks/analytics.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from "react";
 
 import { useSelector } from "react-redux";
-import { useLocation } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
 
 import type { UsabillaLive } from "@/app/base/types";
 import authSelectors from "@/app/store/auth/selectors";

--- a/src/app/base/hooks/urls.test.tsx
+++ b/src/app/base/hooks/urls.test.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { useGetURLId } from "./urls";

--- a/src/app/base/hooks/urls.ts
+++ b/src/app/base/hooks/urls.ts
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 
-import { useLocation, useParams } from "react-router-dom-v5-compat";
+import { useLocation, useParams } from "react-router-dom";
 
 import { parseNumberId } from "@/app/utils";
 

--- a/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerConfiguration/ControllerConfiguration.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ControllerConfiguration from "./ControllerConfiguration";

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import type { Mock } from "vitest";
 

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
-import { Routes, Route } from "react-router-dom-v5-compat";
+import { Routes, Route } from "react-router-dom";
 
 import ControllerCommissioning from "./ControllerCommissioning";
 import ControllerConfiguration from "./ControllerConfiguration";

--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ControllerDetailsHeader from "./ControllerDetailsHeader";

--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerDetailsHeader.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import ControllerName from "./ControllerName";
 

--- a/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerName/ControllerName.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetailsHeader/ControllerName/ControllerName.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ControllerName from "./ControllerName";

--- a/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerStorage/ControllerStorage.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ControllerStorage from "./ControllerStorage";

--- a/src/app/controllers/views/ControllerList/ControllerList.test.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerList.test.tsx
@@ -1,7 +1,7 @@
 import { Provider } from "react-redux";
 import { useLocation } from "react-router";
 import { MemoryRouter, Route } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ControllerList from "./ControllerList";

--- a/src/app/controllers/views/ControllerList/ControllerList.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerList.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import ControllerListHeader from "./ControllerListHeader";
 import ControllerListTable from "./ControllerListTable";

--- a/src/app/controllers/views/ControllerList/ControllerListTable/VLANsColumn/VLANsColumn.tsx
+++ b/src/app/controllers/views/ControllerList/ControllerListTable/VLANsColumn/VLANsColumn.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
 import urls from "@/app/base/urls";

--- a/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceConfiguration/DeviceConfiguration.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeviceConfiguration, { Label } from "./DeviceConfiguration";

--- a/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetails.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 
 import DeviceConfiguration from "./DeviceConfiguration";
 import DeviceDetailsHeader from "./DeviceDetailsHeader";

--- a/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceDetailsHeader/DeviceDetailsHeader.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DeviceName from "./DeviceName";
 

--- a/src/app/devices/views/DeviceList/DeviceList.tsx
+++ b/src/app/devices/views/DeviceList/DeviceList.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import DeviceListHeader from "./DeviceListHeader";
 import DeviceListTable from "./DeviceListTable";

--- a/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
+++ b/src/app/devices/views/DeviceList/DeviceListTable/DeviceListTable.tsx
@@ -1,5 +1,5 @@
 import { MainTable } from "@canonical/react-components";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import OwnerColumn from "./OwnerColumn";
 

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/AddRecordForm/AddRecordForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddRecordForm, { Labels as AddRecordFormLabels } from "./AddRecordForm";

--- a/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainDetailsHeader/DeleteDomainForm/DeleteDomainForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeleteDomainForm, {

--- a/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
+++ b/src/app/domains/views/DomainDetails/DomainSummary/DomainSummary.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DomainSummary, { Labels as DomainSummaryLabels } from "./DomainSummary";

--- a/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/DeleteRecordForm/DeleteRecordForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeleteRecordForm, {

--- a/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/EditRecordForm/EditRecordForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import EditRecordForm, {

--- a/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
+++ b/src/app/domains/views/DomainDetails/ResourceRecords/ResourceRecords.tsx
@@ -10,7 +10,7 @@ import {
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DeleteRecordForm from "./DeleteRecordForm";
 import EditRecordForm from "./EditRecordForm";

--- a/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainListHeaderForm/DomainListHeaderForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DomainListHeaderForm, {

--- a/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
+++ b/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { DomainListSidePanelViews } from "../constants";

--- a/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
+++ b/src/app/domains/views/DomainsList/DomainsTable/DomainsTable.tsx
@@ -1,6 +1,6 @@
 import { MainTable, ContextualMenu } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { DomainListSidePanelViews } from "../constants";
 

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesForm.test.tsx
@@ -1,7 +1,7 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FetchImagesForm, {

--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchedImages/FetchedImages.test.tsx
@@ -1,7 +1,7 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FetchedImages, { Labels as FetchedImagesLabels } from "./FetchedImages";

--- a/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/OtherImages/OtherImages.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import OtherImages, { Labels as OtherImagesLabels } from "./OtherImages";

--- a/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/UbuntuCoreImages/UbuntuCoreImages.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import UbuntuCoreImages, {

--- a/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/UbuntuImages/UbuntuImages.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import UbuntuImages, { Labels as UbuntuImagesLabels } from "./UbuntuImages";

--- a/src/app/intro/components/IntroSection/IntroSection.test.tsx
+++ b/src/app/intro/components/IntroSection/IntroSection.test.tsx
@@ -1,6 +1,6 @@
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import IntroSection from "./IntroSection";
 

--- a/src/app/intro/components/IntroSection/IntroSection.tsx
+++ b/src/app/intro/components/IntroSection/IntroSection.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 
 import { Notification, Spinner } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import PageContent from "@/app/base/components/PageContent";
 import type { Props as PageContentProps } from "@/app/base/components/PageContent/PageContent";

--- a/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
+++ b/src/app/intro/views/ImagesIntro/ImagesIntro.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ImagesIntro, { Labels as ImagesIntroLabels } from "./ImagesIntro";

--- a/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
+++ b/src/app/intro/views/ImagesIntro/ImagesIntro.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Button, Icon, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate, Link } from "react-router-dom-v5-compat";
+import { useNavigate, Link } from "react-router-dom";
 
 import urls from "@/app/base/urls";
 import SyncedImages from "@/app/images/views/ImageList/SyncedImages";

--- a/src/app/intro/views/Intro.tsx
+++ b/src/app/intro/views/Intro.tsx
@@ -2,12 +2,7 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 
 import { useSelector } from "react-redux";
-import {
-  Route,
-  Routes,
-  useLocation,
-  useNavigate,
-} from "react-router-dom-v5-compat";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 
 import { useExitURL } from "../hooks";
 

--- a/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as ConnectivityCardLabels } from "./ConnectivityCard/ConnectivityCard";

--- a/src/app/intro/views/MaasIntro/MaasIntro.tsx
+++ b/src/app/intro/views/MaasIntro/MaasIntro.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { Card, Icon } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 import * as Yup from "yup";
 
 import ConnectivityCard from "./ConnectivityCard";

--- a/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
+++ b/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MaasIntroSuccess, {

--- a/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
+++ b/src/app/intro/views/MaasIntroSuccess/MaasIntroSuccess.tsx
@@ -1,6 +1,6 @@
 import { Button, List } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import urls from "@/app/base/urls";
 import IntroCard from "@/app/intro/components/IntroCard";

--- a/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import type { SpyInstance } from "vitest";
 

--- a/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
+++ b/src/app/kvm/components/KVMConfigurationCard/KVMConfigurationCard.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import KVMConfigurationCard from "./KVMConfigurationCard";

--- a/src/app/kvm/components/KVMForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
+++ b/src/app/kvm/components/KVMForms/AddLxd/SelectProjectForm/SelectProjectFormFields/SelectProjectFormFields.tsx
@@ -9,7 +9,7 @@ import {
 } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import type { NewPodValues } from "../../types";
 

--- a/src/app/kvm/components/KVMForms/DeleteForm/DeleteForm.tsx
+++ b/src/app/kvm/components/KVMForms/DeleteForm/DeleteForm.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { Col, Icon, NotificationSeverity } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 import * as Yup from "yup";
 
 import ActionForm from "@/app/base/components/ActionForm";

--- a/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.test.tsx
+++ b/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LXDHostToolbar from "./LXDHostToolbar";

--- a/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.tsx
+++ b/src/app/kvm/components/LXDHostToolbar/LXDHostToolbar.tsx
@@ -1,7 +1,7 @@
 import { Icon, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import Switch from "@/app/base/components/Switch";
 import { useFetchActions, useSendAnalytics } from "@/app/base/hooks";

--- a/src/app/kvm/components/LXDVMsTable/VMsTable/NameColumn/NameColumn.tsx
+++ b/src/app/kvm/components/LXDVMsTable/VMsTable/NameColumn/NameColumn.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
 import urls from "@/app/base/urls";

--- a/src/app/kvm/components/NameColumn/NameColumn.tsx
+++ b/src/app/kvm/components/NameColumn/NameColumn.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
 

--- a/src/app/kvm/components/SettingsBackLink/SettingsBackLink.test.tsx
+++ b/src/app/kvm/components/SettingsBackLink/SettingsBackLink.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import SettingsBackLink from "./SettingsBackLink";
 

--- a/src/app/kvm/hooks.test.tsx
+++ b/src/app/kvm/hooks.test.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { renderHook } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import type { MockStoreEnhanced } from "redux-mock-store";
 

--- a/src/app/kvm/hooks.tsx
+++ b/src/app/kvm/hooks.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { useLocation } from "react-router-dom-v5-compat";
+import { useLocation } from "react-router-dom";
 
 import urls from "@/app/base/urls";
 import { podActions } from "@/app/store/pod";

--- a/src/app/kvm/views/KVM.tsx
+++ b/src/app/kvm/views/KVM.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 
 import KVMList from "./KVMList";
 import LXDClusterDetails from "./LXDClusterDetails";

--- a/src/app/kvm/views/KVMList/KVMList.tsx
+++ b/src/app/kvm/views/KVMList/KVMList.tsx
@@ -3,7 +3,7 @@ import { useEffect } from "react";
 
 import { Col, Row, Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { useLocation, useNavigate } from "react-router-dom-v5-compat";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import KVMListHeader from "./KVMListHeader";
 import LxdTable from "./LxdTable";

--- a/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
+++ b/src/app/kvm/views/KVMList/KVMListHeader/KVMListHeader.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import KVMListHeader from "./KVMListHeader";

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetails.tsx
@@ -2,12 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
-import {
-  Route,
-  Routes,
-  useLocation,
-  useNavigate,
-} from "react-router-dom-v5-compat";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 
 import LXDClusterDetailsHeader from "./LXDClusterDetailsHeader";
 import LXDClusterDetailsRedirect from "./LXDClusterDetailsRedirect";

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LXDClusterDetailsHeader from "./LXDClusterDetailsHeader";

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsHeader/LXDClusterDetailsHeader.tsx
@@ -4,7 +4,7 @@ import { Button, Icon, Spinner } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsRedirect/LXDClusterDetailsRedirect.test.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterDetailsRedirect/LXDClusterDetailsRedirect.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { Router } from "react-router";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LXDClusterDetailsRedirect, { Label } from "./LXDClusterDetailsRedirect";

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostSettings/LXDClusterHostSettings.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import ModelNotFound from "@/app/base/components/ModelNotFound";
 import { useGetURLId, useWindowTitle } from "@/app/base/hooks";

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHostVMs/LXDClusterHostVMs.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import ModelNotFound from "@/app/base/components/ModelNotFound";
 import { useGetURLId, useWindowTitle } from "@/app/base/hooks";

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHosts.tsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from "react";
 
 import { Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { useLocation, useNavigate } from "react-router-dom-v5-compat";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterHosts/LXDClusterHostsTable/LXDClusterHostsTable.tsx
@@ -10,7 +10,7 @@ import {
 import type { Location } from "history";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import TableHeader from "@/app/base/components/TableHeader";
 import { useFetchActions, useTableSort } from "@/app/base/hooks";

--- a/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
+++ b/src/app/kvm/views/LXDClusterDetails/LXDClusterVMs/LXDClusterVMs.tsx
@@ -1,6 +1,6 @@
 import { Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import LXDClusterSummaryCard from "../LXDClusterSummaryCard";
 

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetails.tsx
@@ -2,12 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 
 import { useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
-import {
-  Route,
-  Routes,
-  useLocation,
-  useNavigate,
-} from "react-router-dom-v5-compat";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 
 import LXDSingleDetailsHeader from "./LXDSingleDetailsHeader";
 import LXDSingleResources from "./LXDSingleResources";

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LXDSingleDetailsHeader from "./LXDSingleDetailsHeader";

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleDetailsHeader/LXDSingleDetailsHeader.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { Button, Icon, Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.test.tsx
+++ b/src/app/kvm/views/LXDSingleDetails/LXDSingleSettings/LXDSingleSettings.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LXDSingleSettings from "./LXDSingleSettings";

--- a/src/app/kvm/views/VirshDetails/VirshDetails.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshDetails.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { useSelector } from "react-redux";
 import { Redirect } from "react-router-dom";
-import { Route, Routes, useNavigate } from "react-router-dom-v5-compat";
+import { Route, Routes, useNavigate } from "react-router-dom";
 
 import VirshDetailsHeader from "./VirshDetailsHeader";
 import VirshResources from "./VirshResources";

--- a/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshDetailsHeader/VirshDetailsHeader.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import VirshDetailsActionMenu from "./VirshDetailsActionMenu";
 

--- a/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
+++ b/src/app/kvm/views/VirshDetails/VirshSettings/VirshSettings.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import VirshSettings from "./VirshSettings";

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddMachineForm from "./AddMachineForm";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneResults/CloneResults.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import CloneResults, { CloneErrorCodes } from "./CloneResults";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneResults/CloneResults.tsx
@@ -12,7 +12,7 @@ import {
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import type { APIError, SetSearchFilter } from "@/app/base/types";
 import urls from "@/app/base/urls";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeployForm from "../DeployForm";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -12,7 +12,7 @@ import {
 import classNames from "classnames";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import type { DeployFormValues } from "../DeployForm";
 

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/OverrideTestForm/OverrideTestForm.tsx
@@ -1,6 +1,6 @@
 import { Col, Row } from "@canonical/react-components";
 import { useDispatch } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import * as Yup from "yup";
 
 import ActionForm from "@/app/base/components/ActionForm";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagForm.test.tsx
@@ -1,7 +1,7 @@
 import * as reduxToolkit from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagForm, { Label } from "./TagForm";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.test.tsx
@@ -2,7 +2,7 @@ import * as reduxToolkit from "@reduxjs/toolkit";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagFormChanges, { Label, RowType } from "./TagFormChanges";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormChanges/TagFormChanges.tsx
@@ -10,7 +10,7 @@ import {
 } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 import type { ColumnWithLooseAccessor } from "react-table";
 
 import TagChip from "../TagChip";

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/TagForm/TagFormFields/TagFormFields.test.tsx
@@ -2,7 +2,7 @@ import * as reduxToolkit from "@reduxjs/toolkit";
 import { Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Label as TagFormChangesLabel } from "../TagFormChanges/TagFormChanges";

--- a/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineCommissioning/MachineCommissioning.test.tsx
@@ -2,7 +2,7 @@ import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { render, screen } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MachineCommissioning from ".";

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MachineForm from "./MachineForm";

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import PowerForm from "./PowerForm";

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagForm from "./TagForm";

--- a/src/app/machines/views/MachineDetails/MachineDetails.tsx
+++ b/src/app/machines/views/MachineDetails/MachineDetails.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { useDispatch } from "react-redux";
 import { Redirect, useLocation } from "react-router-dom";
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 
 import MachineCommissioning from "./MachineCommissioning";
 import MachineConfiguration from "./MachineConfiguration";

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import MachineName from "./MachineName";
 

--- a/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.tsx
+++ b/src/app/machines/views/MachineDetails/MachineInstances/MachineInstances.tsx
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 
 import { Spinner, Row, Col, MainTable } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import { useWindowTitle } from "@/app/base/hooks";
 import { useGetURLId } from "@/app/base/hooks/urls";

--- a/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.test.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 
 import { storageLayoutOptions } from "./ChangeStorageLayoutMenu/ChangeStorageLayoutMenu";
 import MachineStorage from "./MachineStorage";

--- a/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
+++ b/src/app/machines/views/MachineDetails/MachineStorage/MachineStorage.tsx
@@ -1,7 +1,7 @@
 import { ExternalLink } from "@canonical/maas-react-components";
 import { Spinner, Strip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import ChangeStorageLayoutMenu from "./ChangeStorageLayoutMenu";
 

--- a/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/MachineSummary.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import NumaCard from "./NumaCard";
 import TestResults from "./TestResults";

--- a/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SummaryNotifications from "./SummaryNotifications";

--- a/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/SummaryNotifications/SummaryNotifications.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import {
   useFetchActions,

--- a/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
+++ b/src/app/machines/views/MachineDetails/MachineSummary/TestResults/TestResults.tsx
@@ -1,5 +1,5 @@
 import { Button, Icon, ICONS, Tooltip } from "@canonical/react-components";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { HardwareType } from "@/app/base/enum";
 import { useSendAnalytics } from "@/app/base/hooks";

--- a/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineTests/MachineTests.test.tsx
@@ -1,7 +1,7 @@
 import * as reactComponentHooks from "@canonical/react-components/dist/hooks";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MachineTests from ".";

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.tsx
@@ -4,7 +4,7 @@ import { MainToolbar } from "@canonical/maas-react-components";
 import { Button, Col, Icon } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useDispatch } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DebounceSearchBox from "@/app/base/components/DebounceSearchBox";
 import GroupSelect from "@/app/base/components/GroupSelect";

--- a/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/FabricColumn/FabricColumn.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import MachineTestStatus from "../MachineTestStatus";
 

--- a/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/NameColumn/NameColumn.tsx
@@ -3,7 +3,7 @@ import { memo } from "react";
 import { Button, Tooltip } from "@canonical/react-components";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import MachineCheckbox from "../MachineCheckbox";
 

--- a/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/PoolColumn/PoolColumn.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useState } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
 import urls from "@/app/base/urls";

--- a/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/StatusColumn/StatusColumn.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { Spinner, Tooltip } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
 import TooltipButton from "@/app/base/components/TooltipButton";

--- a/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/ZoneColumn/ZoneColumn.tsx
@@ -2,7 +2,7 @@ import { memo, useEffect, useState } from "react";
 
 import { Spinner, Tooltip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
 import urls from "@/app/base/urls";

--- a/src/app/machines/views/Machines.test.tsx
+++ b/src/app/machines/views/Machines.test.tsx
@@ -1,7 +1,7 @@
 import * as reduxToolkit from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { MachineSidePanelViews } from "../constants";

--- a/src/app/machines/views/Machines.tsx
+++ b/src/app/machines/views/Machines.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { useSelector } from "react-redux";
-import { useLocation, useNavigate, useMatch } from "react-router-dom-v5-compat";
+import { useLocation, useNavigate, useMatch } from "react-router-dom";
 import { useStorageState } from "react-storage-hooks";
 
 import MachineForms from "../components/MachineForms";

--- a/src/app/networkDiscovery/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
+++ b/src/app/networkDiscovery/views/DiscoveryAddForm/DiscoveryAddFormFields/DiscoveryAddFormFields.tsx
@@ -1,7 +1,7 @@
 import { Col, Row, Select } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import type { DiscoveryAddValues } from "../types";
 import { DeviceType } from "../types";

--- a/src/app/networkDiscovery/views/NetworkDiscovery.tsx
+++ b/src/app/networkDiscovery/views/NetworkDiscovery.tsx
@@ -1,6 +1,6 @@
 import { Notification } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 
 import NetworkForm from "../components/NetworkForm";
 

--- a/src/app/networkDiscovery/views/NetworkDiscoveryConfigurationForm/NetworkDiscoveryConfigurationSubnetForm/NetworkDiscoveryConfigurationSubnetForm.tsx
+++ b/src/app/networkDiscovery/views/NetworkDiscoveryConfigurationForm/NetworkDiscoveryConfigurationSubnetForm/NetworkDiscoveryConfigurationSubnetForm.tsx
@@ -1,6 +1,6 @@
 import { Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import FormikField from "@/app/base/components/FormikField";
 import FormikForm from "@/app/base/components/FormikForm";

--- a/src/app/networkDiscovery/views/NetworkDiscoveryHeader/NetworkDiscoveryHeader.tsx
+++ b/src/app/networkDiscovery/views/NetworkDiscoveryHeader/NetworkDiscoveryHeader.tsx
@@ -2,7 +2,7 @@ import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
 import { useLocation } from "react-router-dom";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { NetworkDiscoverySidePanelViews } from "../constants";
 

--- a/src/app/pools/components/PoolDeleteForm/PoolDeleteForm.tsx
+++ b/src/app/pools/components/PoolDeleteForm/PoolDeleteForm.tsx
@@ -1,6 +1,6 @@
 import { useOnEscapePressed } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useAddMessage } from "@/app/base/hooks";

--- a/src/app/pools/components/PoolForm/PoolForm.test.tsx
+++ b/src/app/pools/components/PoolForm/PoolForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { PoolForm, Labels as PoolFormLabels } from "./PoolForm";

--- a/src/app/pools/views/PoolAdd/PoolAdd.test.tsx
+++ b/src/app/pools/views/PoolAdd/PoolAdd.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import { PoolAdd, Label as PoolAddLabel } from "./PoolAdd";
 

--- a/src/app/pools/views/PoolAdd/PoolAdd.tsx
+++ b/src/app/pools/views/PoolAdd/PoolAdd.tsx
@@ -1,5 +1,5 @@
 import { useOnEscapePressed } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import urls from "@/app/base/urls";
 import PoolForm from "@/app/pools/components/PoolForm";

--- a/src/app/pools/views/PoolDelete/PoolDelete.tsx
+++ b/src/app/pools/views/PoolDelete/PoolDelete.tsx
@@ -1,5 +1,5 @@
 import { useOnEscapePressed } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import { useGetURLId } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/pools/views/PoolEdit/PoolEdit.tsx
+++ b/src/app/pools/views/PoolEdit/PoolEdit.tsx
@@ -1,6 +1,6 @@
 import { Spinner, useOnEscapePressed } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import ModelNotFound from "@/app/base/components/ModelNotFound";
 import { useGetURLId } from "@/app/base/hooks/urls";

--- a/src/app/pools/views/PoolList/PoolList.test.tsx
+++ b/src/app/pools/views/PoolList/PoolList.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import PoolList from "./PoolList";
 

--- a/src/app/pools/views/PoolList/PoolList.tsx
+++ b/src/app/pools/views/PoolList/PoolList.tsx
@@ -6,7 +6,7 @@ import {
   Row,
 } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import TableActions from "@/app/base/components/TableActions";
 import { useFetchActions, useWindowTitle } from "@/app/base/hooks";

--- a/src/app/pools/views/Pools.tsx
+++ b/src/app/pools/views/Pools.tsx
@@ -2,7 +2,7 @@ import { MainToolbar } from "@canonical/maas-react-components";
 import { Button } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
-import { Link, Route, Routes } from "react-router-dom-v5-compat";
+import { Link, Route, Routes } from "react-router-dom";
 
 import PoolDelete from "./PoolDelete";
 import PoolList from "./PoolList";

--- a/src/app/preferences/components/Routes/Routes.tsx
+++ b/src/app/preferences/components/Routes/Routes.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from "react-router";
-import { Route, Routes as ReactRouterRoutes } from "react-router-dom-v5-compat";
+import { Route, Routes as ReactRouterRoutes } from "react-router-dom";
 
 import DeleteSSHKey from "../../views/SSHKeys/DeleteSSHKey";
 import DeleteSSLKey from "../../views/SSLKeys/DeleteSSLKey";

--- a/src/app/preferences/views/APIKeys/APIKeyDelete/APIKeyDelete.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyDelete/APIKeyDelete.tsx
@@ -1,5 +1,5 @@
 import { useOnEscapePressed } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import { useGetURLId } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/app/preferences/views/APIKeys/APIKeyDeleteForm/APIKeyDeleteForm.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyDeleteForm/APIKeyDeleteForm.tsx
@@ -1,5 +1,5 @@
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useAddMessage } from "@/app/base/hooks";

--- a/src/app/preferences/views/APIKeys/APIKeyEdit/APIKeyEdit.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyEdit/APIKeyEdit.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 
 import { Label as APIKeyFormLabels } from "../APIKeyForm/APIKeyForm";
 

--- a/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { APIKeyForm, Label as APIKeyFormLabels } from "./APIKeyForm";

--- a/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyForm/APIKeyForm.tsx
@@ -1,6 +1,6 @@
 import { Col, Row, useOnEscapePressed } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 import * as Yup from "yup";
 
 import FormikField from "@/app/base/components/FormikField";

--- a/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.test.tsx
+++ b/src/app/preferences/views/APIKeys/APIKeyList/APIKeyList.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import APIKeyList, { Label as APIKeyListLabels } from "./APIKeyList";
 

--- a/src/app/preferences/views/Details/Details.test.tsx
+++ b/src/app/preferences/views/Details/Details.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Details, Label as DetailsLabels } from "./Details";

--- a/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.test.tsx
@@ -1,6 +1,6 @@
 import { createMemoryHistory } from "history";
 import { MemoryRouter, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import { AddSSHKey, Label as AddSSHKeyLabels } from "./AddSSHKey";
 

--- a/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/AddSSHKey/AddSSHKey.tsx
@@ -1,5 +1,5 @@
 import { useOnEscapePressed } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import SSHKeyForm from "@/app/base/components/SSHKeyForm";
 import urls from "@/app/base/urls";

--- a/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { useOnEscapePressed } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate, useSearchParams } from "react-router-dom-v5-compat";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useAddMessage } from "@/app/base/hooks";

--- a/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.tsx
+++ b/src/app/preferences/views/SSHKeys/SSHKeyList/SSHKeyList.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import SSHKeyList, { Label as SSHKeyListLabels } from "./SSHKeyList";
 

--- a/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
+++ b/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { AddSSLKey, Label as AddSSLKeyLabels } from "./AddSSLKey";

--- a/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/AddSSLKey/AddSSLKey.tsx
@@ -6,7 +6,7 @@ import {
 } from "@canonical/react-components";
 import type { TextareaProps } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 import * as Yup from "yup";
 
 import FormikField from "@/app/base/components/FormikField";

--- a/src/app/preferences/views/SSLKeys/DeleteSSLKey/DeleteSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/DeleteSSLKey/DeleteSSLKey.tsx
@@ -1,6 +1,6 @@
 import { useOnEscapePressed } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import ModelActionForm from "@/app/base/components/ModelActionForm";
 import { useAddMessage, useGetURLId } from "@/app/base/hooks";

--- a/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.tsx
+++ b/src/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import SSLKeyList, { Label as SSLKeyListLabels } from "./SSLKeyList";
 

--- a/src/app/settings/components/Routes/Routes.tsx
+++ b/src/app/settings/components/Routes/Routes.tsx
@@ -1,5 +1,5 @@
 import { Redirect } from "react-router-dom";
-import { Route, Routes as ReactRouterRoutes } from "react-router-dom-v5-compat";
+import { Route, Routes as ReactRouterRoutes } from "react-router-dom";
 
 import PageContent from "@/app/base/components/PageContent";
 import urls from "@/app/base/urls";

--- a/src/app/settings/components/SettingsTable/SettingsTable.tsx
+++ b/src/app/settings/components/SettingsTable/SettingsTable.tsx
@@ -8,7 +8,7 @@ import {
 } from "@canonical/react-components";
 import type { MainTableProps } from "@canonical/react-components";
 import classNames from "classnames";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import SearchBox from "@/app/base/components/SearchBox";
 

--- a/src/app/settings/views/Configuration/Commissioning/Commissioning.test.tsx
+++ b/src/app/settings/views/Configuration/Commissioning/Commissioning.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as CommissioningFormLabels } from "../CommissioningForm/CommissioningForm";

--- a/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
+++ b/src/app/settings/views/Configuration/CommissioningForm/CommissioningForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import CommissioningForm from "./CommissioningForm";

--- a/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
+++ b/src/app/settings/views/Configuration/CommissioningFormFields/CommissioningFormFields.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import CommissioningForm from "../CommissioningForm";

--- a/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
+++ b/src/app/settings/views/Configuration/DeployForm/DeployForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeployForm from "./DeployForm";

--- a/src/app/settings/views/Configuration/General/General.test.tsx
+++ b/src/app/settings/views/Configuration/General/General.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as FormLabels } from "../GeneralForm/GeneralForm";

--- a/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
+++ b/src/app/settings/views/Configuration/GeneralForm/GeneralForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import GeneralForm from "./GeneralForm";

--- a/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParameters/KernelParameters.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as KPFormLabels } from "../KernelParametersForm/KernelParametersForm";

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import KernelParametersForm, {

--- a/src/app/settings/views/Dhcp/DhcpAdd/DhcpAdd.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpAdd/DhcpAdd.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import { DhcpAdd } from "./DhcpAdd";
 

--- a/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpEdit/DhcpEdit.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 
 import { DhcpEdit } from "./DhcpEdit";
 

--- a/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.test.tsx
@@ -1,6 +1,6 @@
 import { createMemoryHistory } from "history";
 import { MemoryRouter, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import { DhcpForm } from "./DhcpForm";
 

--- a/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.tsx
+++ b/src/app/settings/views/Dhcp/DhcpForm/DhcpForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import BaseDhcpForm from "@/app/base/components/DhcpForm";
 import type { DHCPFormValues } from "@/app/base/components/DhcpForm/types";

--- a/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpList/DhcpList.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DhcpList from "./DhcpList";

--- a/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
+++ b/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import DhcpTarget from "./DhcpTarget";
 

--- a/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.tsx
+++ b/src/app/settings/views/Dhcp/DhcpTarget/DhcpTarget.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 import { Spinner } from "@canonical/react-components";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import urls from "@/app/base/urls";
 import { useDhcpTarget } from "@/app/settings/hooks";

--- a/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.tsx
+++ b/src/app/settings/views/Images/ThirdPartyDrivers/ThirdPartyDrivers.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as TPDFormLabels } from "../ThirdPartyDriversForm/ThirdPartyDriversForm";

--- a/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.tsx
+++ b/src/app/settings/views/Images/ThirdPartyDriversForm/ThirdPartyDriversForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ThirdPartyDriversForm, {

--- a/src/app/settings/views/Images/VMWare/VMWare.test.tsx
+++ b/src/app/settings/views/Images/VMWare/VMWare.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as VMWareFormLabels } from "../VMWareForm/VMWareForm";

--- a/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
+++ b/src/app/settings/views/Images/VMWareForm/VMWareForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import VMWareForm, { Labels as VMWareFormLabels } from "./VMWareForm";

--- a/src/app/settings/views/Images/Windows/Windows.test.tsx
+++ b/src/app/settings/views/Images/Windows/Windows.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as WindowsFormLabels } from "../WindowsForm/WindowsForm";

--- a/src/app/settings/views/Images/WindowsForm/WindowsForm.test.tsx
+++ b/src/app/settings/views/Images/WindowsForm/WindowsForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import WindowsForm, { Labels as WindowsFormLabels } from "./WindowsForm";

--- a/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as LicenseKeyFormLabels } from "../LicenseKeyForm/LicenseKeyForm";

--- a/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyEdit/LicenseKeyEdit.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { useParams } from "react-router-dom-v5-compat";
+import { useParams } from "react-router-dom";
 
 import LicenseKeyForm from "../LicenseKeyForm";
 

--- a/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as FormFieldsLabels } from "../LicenseKeyFormFields/LicenseKeyFormFields";

--- a/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyForm/LicenseKeyForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 import * as Yup from "yup";
 
 import LicenseKeyFormFields from "../LicenseKeyFormFields";

--- a/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
+++ b/src/app/settings/views/LicenseKeys/LicenseKeyList/LicenseKeyList.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import LicenseKeyList from ".";

--- a/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
+++ b/src/app/settings/views/Network/DnsForm/DnsForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DnsForm from "./DnsForm";

--- a/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
+++ b/src/app/settings/views/Network/NetworkDiscoveryForm/NetworkDiscoveryForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import NetworkDiscoveryForm from "./NetworkDiscoveryForm";

--- a/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
+++ b/src/app/settings/views/Network/NtpForm/NtpForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import NtpForm from "./NtpForm";

--- a/src/app/settings/views/Network/ProxyForm/ProxyForm.test.tsx
+++ b/src/app/settings/views/Network/ProxyForm/ProxyForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ProxyForm from "./ProxyForm";

--- a/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.test.tsx
+++ b/src/app/settings/views/Network/ProxyFormFields/ProxyFormFields.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ProxyForm from "../ProxyForm";

--- a/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
+++ b/src/app/settings/views/Network/SyslogForm/SyslogForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SyslogForm from "./SyslogForm";

--- a/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoriesList/RepositoriesList.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import RepositoriesList, {

--- a/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 
 import RepositoryAdd from "./RepositoryAdd";
 

--- a/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.tsx
+++ b/src/app/settings/views/Repositories/RepositoryAdd/RepositoryAdd.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom-v5-compat";
+import { useParams } from "react-router-dom";
 
 import RepositoryForm from "../RepositoryForm";
 

--- a/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 
 import { Labels as RepositoryFormLabels } from "../RepositoryFormFields/RepositoryFormFields";
 

--- a/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.tsx
+++ b/src/app/settings/views/Repositories/RepositoryEdit/RepositoryEdit.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { useParams } from "react-router-dom-v5-compat";
+import { useParams } from "react-router-dom";
 
 import RepositoryForm from "../RepositoryForm";
 

--- a/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as RepositoryFormLabels } from "../RepositoryFormFields/RepositoryFormFields";

--- a/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.tsx
+++ b/src/app/settings/views/Repositories/RepositoryForm/RepositoryForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 import * as Yup from "yup";
 
 import RepositoryFormFields from "../RepositoryFormFields";

--- a/src/app/settings/views/Repositories/RepositoryFormFields/RepositoryFormFields.test.tsx
+++ b/src/app/settings/views/Repositories/RepositoryFormFields/RepositoryFormFields.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import RepositoryForm from "../RepositoryForm";
 import { Labels as RepositoryFormLabels } from "../RepositoryFormFields/RepositoryFormFields";

--- a/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptsList/ScriptsList.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels as ScriptsListLabels } from "./ScriptsList";

--- a/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
+++ b/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.test.tsx
@@ -2,7 +2,7 @@ import { createMemoryHistory } from "history";
 import type { FileWithPath } from "react-dropzone";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import type { Dispatch } from "redux";
 import configureStore from "redux-mock-store";
 

--- a/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.tsx
+++ b/src/app/settings/views/Scripts/ScriptsUpload/ScriptsUpload.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames";
 import type { FileRejection, FileWithPath } from "react-dropzone";
 import { useDropzone } from "react-dropzone";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import type { ReadScriptResponse } from "./readScript";
 import readScript from "./readScript";

--- a/src/app/settings/views/Security/SecurityProtocols/TLSEnabled/TLSEnabled.test.tsx
+++ b/src/app/settings/views/Security/SecurityProtocols/TLSEnabled/TLSEnabled.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TLSEnabled, { Labels } from "./TLSEnabled";

--- a/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import StorageForm from "./StorageForm";

--- a/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import StorageForm from "../StorageForm";

--- a/src/app/settings/views/Users/UserAdd/UserAdd.test.tsx
+++ b/src/app/settings/views/Users/UserAdd/UserAdd.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import { UserAdd } from "./UserAdd";
 

--- a/src/app/settings/views/Users/UserDeleteForm/UserDeleteForm.tsx
+++ b/src/app/settings/views/Users/UserDeleteForm/UserDeleteForm.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { Col, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import FormikForm from "@/app/base/components/FormikForm";
 import { useAddMessage } from "@/app/base/hooks";

--- a/src/app/settings/views/Users/UserEdit/UserEdit.test.tsx
+++ b/src/app/settings/views/Users/UserEdit/UserEdit.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 
 import { UserEdit } from "./UserEdit";
 

--- a/src/app/settings/views/Users/UserForm/UserForm.test.tsx
+++ b/src/app/settings/views/Users/UserForm/UserForm.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { UserForm, Labels as UserFormLabels } from "./UserForm";

--- a/src/app/settings/views/Users/UserForm/UserForm.tsx
+++ b/src/app/settings/views/Users/UserForm/UserForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import BaseUserForm from "@/app/base/components/UserForm";
 import type { Props as UserFormProps } from "@/app/base/components/UserForm/UserForm";

--- a/src/app/settings/views/Users/UsersList/UsersList.test.tsx
+++ b/src/app/settings/views/Users/UsersList/UsersList.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import UsersList from "./UsersList";

--- a/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
+++ b/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ReservedRangeForm, { Labels } from "./ReservedRangeForm";

--- a/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
+++ b/src/app/subnets/components/ReservedRanges/ReservedRanges.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ReservedRanges, { Labels } from "./ReservedRanges";

--- a/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
+++ b/src/app/subnets/views/FabricDetails/EditFabric/EditFabric.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import EditFabric from "./EditFabric";

--- a/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetails.test.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FabricDetails from "./FabricDetails";

--- a/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricDetailsHeader/FabricDeleteForm/FabricDeleteForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FabricDeleteForm from "./FabricDeleteForm";

--- a/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricSummary/FabricSummary.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FabricSummary from "./FabricSummary";

--- a/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.test.tsx
+++ b/src/app/subnets/views/FabricDetails/FabricVLANs/FabricVLANs.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, Route, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import FabricVLANs from "./FabricVLANs";

--- a/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddFabric.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddFabric from "./AddFabric";

--- a/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddSpace.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddSpace from "./AddSpace";

--- a/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddSubnet.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddSubnet from "./AddSubnet";

--- a/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
+++ b/src/app/subnets/views/FormActions/components/AddVlan.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddVlan from "./AddVlan";

--- a/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceDetails.test.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SpaceDetails from "./SpaceDetails";

--- a/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceDetailsHeader/SpaceDetailsHeader.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { Router, Route } from "react-router";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { SpaceDetailsSidePanelViews } from "../constants";

--- a/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceSubnets/SpaceSubnets.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter, Route } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, Route, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SpaceSubnets from "./SpaceSubnets";

--- a/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummary.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SpaceSummary from "./SpaceSummary";

--- a/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.test.tsx
+++ b/src/app/subnets/views/SpaceDetails/SpaceSummary/SpaceSummaryForm/SpaceSummaryForm.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SpaceSummaryForm from "./SpaceSummaryForm";

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/AddStaticRouteForm/AddStaticRouteForm.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels } from "../StaticRoutes";

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/EditStaticRouteForm/EditStaticRouteForm.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Labels } from "../StaticRoutes";

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { AddStaticRouteFormLabels } from "./AddStaticRouteForm/AddStaticRouteForm";

--- a/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SubnetDetails from "./SubnetDetails";

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/DeleteSubnet/DeleteSubnet.test.tsx
@@ -1,8 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { Router } from "react-router";
-import { Route } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { Route, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeleteSubnet from "./DeleteSubnet";

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/EditBootArchitectures/EditBootArchitectures.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import { Headers } from "./BootArchitecturesTable";

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import MapSubnet from "./MapSubnet";

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetActionForms/components/MapSubnet/MapSubnet.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 
 import { Notification, Spinner, Strip } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import FormikForm from "@/app/base/components/FormikForm";
 import { useCycled } from "@/app/base/hooks";

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SubnetSummary from "./SubnetSummary";

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummaryForm/SubnetSummaryForm.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SubnetSummaryForm from "./SubnetSummaryForm";

--- a/src/app/subnets/views/SubnetsList/SubnetsList.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useCallback } from "react";
 
 import { MainToolbar } from "@canonical/maas-react-components";
 import { ContextualMenu } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import SubnetsControls from "./SubnetsControls";
 import SubnetsTable from "./SubnetsTable";

--- a/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsTable/SubnetsTable.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SubnetsTable from "./SubnetsTable";

--- a/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
+++ b/src/app/subnets/views/SubnetsList/SubnetsTable/components.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { Button } from "@canonical/react-components";
 import classNames from "classnames";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { SubnetsColumns } from "./constants";
 import type {

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.test.tsx
@@ -1,7 +1,6 @@
 import { Formik } from "formik";
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import type { ConfigureDHCPValues } from "../ConfigureDHCP";

--- a/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
+++ b/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DHCPStatus from "./DHCPStatus";

--- a/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -7,7 +7,7 @@ import {
   Spinner,
 } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import ControllerLink from "@/app/base/components/ControllerLink";
 import Definition from "@/app/base/components/Definition";

--- a/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
+++ b/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import EditVLAN from "./EditVLAN";

--- a/src/app/subnets/views/VLANDetails/VLANDeleteForm/VLANDeleteForm.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDeleteForm/VLANDeleteForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import VLANDeleteForm from "./VLANDeleteForm";

--- a/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetails.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import VLANDetails from "./VLANDetails";

--- a/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANSubnets/VLANSubnets.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import VLANSubnets from "./VLANSubnets";

--- a/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANSummary/VLANControllers/VLANControllers.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import VLANControllers from "./VLANControllers";

--- a/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.test.tsx
@@ -1,6 +1,5 @@
 import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { MemoryRouter, CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import VLANSummary from "./VLANSummary";

--- a/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/AddTagForm/AddTagForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddTagForm, { Label } from "./AddTagForm";

--- a/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
+++ b/src/app/tags/components/AppliedTo/AppliedTo.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AppliedTo from "./AppliedTo";

--- a/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
+++ b/src/app/tags/components/NodesTagsLink/NodesTagsLink.test.tsx
@@ -1,5 +1,5 @@
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 
 import NodesTagsLink from "./NodesTagsLink";
 

--- a/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
+++ b/src/app/tags/components/NodesTagsLink/NodesTagsLink.tsx
@@ -1,5 +1,5 @@
 import pluralize from "pluralize";
-import { Link, useLocation } from "react-router-dom-v5-compat";
+import { Link, useLocation } from "react-router-dom";
 
 import urls from "@/app/base/urls";
 import { ControllerMeta } from "@/app/store/controller/types";

--- a/src/app/tags/components/TagDetails/TagDetails.test.tsx
+++ b/src/app/tags/components/TagDetails/TagDetails.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagDetails from "./TagDetails";

--- a/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import AddTagForm, { Label } from "./AddTagForm";

--- a/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
+++ b/src/app/tags/components/TagsHeader/AddTagForm/AddTagForm.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Col, NotificationSeverity, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 import * as Yup from "yup";
 
 import FormikField from "@/app/base/components/FormikField";

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.test.tsx
@@ -3,7 +3,7 @@ import * as reduxToolkit from "@reduxjs/toolkit";
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 import type { Mock } from "vitest";
 

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagForm.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 
 import { Col, NotificationSeverity, Row } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import DeleteTagFormWarnings from "./DeleteTagFormWarnings";
 

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.test.tsx
@@ -1,7 +1,7 @@
 import * as reduxToolkit from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import DeleteTagFormWarnings from "./DeleteTagFormWarnings";

--- a/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.tsx
+++ b/src/app/tags/components/TagsHeader/DeleteTagForm/DeleteTagFormWarnings/DeleteTagFormWarnings.tsx
@@ -1,7 +1,7 @@
 import { Notification } from "@canonical/react-components";
 import pluralize from "pluralize";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import urls from "@/app/base/urls";
 import { useFetchMachineCount } from "@/app/store/machine/utils/hooks";

--- a/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
+++ b/src/app/tags/components/TagsHeader/TagsHeader.test.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 import type { Mock } from "vitest";
 
 import TagsHeader, { Label } from "./TagsHeader";

--- a/src/app/tags/components/TagsHeader/TagsHeader.tsx
+++ b/src/app/tags/components/TagsHeader/TagsHeader.tsx
@@ -1,7 +1,7 @@
 import { MainToolbar } from "@canonical/maas-react-components";
 import { Button, Icon } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import SearchBox from "@/app/base/components/SearchBox";
 import SegmentedControl from "@/app/base/components/SegmentedControl";

--- a/src/app/tags/views/TagDetails/TagDetails.test.tsx
+++ b/src/app/tags/views/TagDetails/TagDetails.test.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom-v5-compat";
+import { Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagDetails from "./TagDetails";

--- a/src/app/tags/views/TagList/TagList.test.tsx
+++ b/src/app/tags/views/TagList/TagList.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagList from "./TagList";

--- a/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
+++ b/src/app/tags/views/TagList/TagTable/TagTable.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagTable, { Label, TestId } from "./TagTable";

--- a/src/app/tags/views/TagList/TagTable/TagTable.tsx
+++ b/src/app/tags/views/TagList/TagTable/TagTable.tsx
@@ -7,7 +7,7 @@ import type {
   PropsWithSpread,
 } from "@canonical/react-components";
 import { Icon, MainTable, Strip } from "@canonical/react-components";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { TAGS_PER_PAGE } from "../constants";
 

--- a/src/app/tags/views/TagMachines/TagMachines.test.tsx
+++ b/src/app/tags/views/TagMachines/TagMachines.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagMachines, { Label } from "./TagMachines";

--- a/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
+++ b/src/app/tags/views/TagUpdate/TagUpdate.test.tsx
@@ -1,7 +1,7 @@
 import { createMemoryHistory } from "history";
 import { Provider } from "react-redux";
 import { MemoryRouter, Route, Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import TagUpdate from "./TagUpdate";

--- a/src/app/tags/views/Tags.tsx
+++ b/src/app/tags/views/Tags.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 import { useSelector } from "react-redux";
-import { Route, Routes, useMatch } from "react-router-dom-v5-compat";
+import { Route, Routes, useMatch } from "react-router-dom";
 
 import TagsHeader from "../components/TagsHeader";
 import TagForms from "../components/TagsHeader/TagForms";

--- a/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetails.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { CompatRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ZoneDetails from "./ZoneDetails";

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsForm/ZoneDetailsForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ZoneDetailsForm from "./ZoneDetailsForm";

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter, Route } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ZoneDetailsHeader from "./ZoneDetailsHeader";

--- a/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
+++ b/src/app/zones/views/ZoneDetails/ZoneDetailsHeader/ZoneDetailsHeader.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 
 import { Button } from "@canonical/react-components";
 import { useSelector, useDispatch } from "react-redux";
-import { useNavigate } from "react-router-dom-v5-compat";
+import { useNavigate } from "react-router-dom";
 
 import DeleteConfirm from "./DeleteConfirm";
 

--- a/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListForm/ZonesListForm.test.tsx
@@ -1,6 +1,6 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { CompatRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import ZonesListForm from "./ZonesListForm";

--- a/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
@@ -1,6 +1,6 @@
 import { MainTable } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-import { Link } from "react-router-dom-v5-compat";
+import { Link } from "react-router-dom";
 
 import { useFetchActions } from "@/app/base/hooks";
 import urls from "@/app/base/urls";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,7 @@ import { StrictMode } from "react";
 
 import { createRoot } from "react-dom/client";
 import { Provider } from "react-redux";
-import { Router } from "react-router-dom";
-import { CompatRouter } from "react-router-dom-v5-compat";
+import { Router, CompatRouter } from "react-router-dom";
 
 import packageInfo from "../package.json";
 

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -5,8 +5,7 @@ import type { RenderOptions, RenderResult } from "@testing-library/react";
 import { render, screen, renderHook } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
-import { BrowserRouter } from "react-router-dom";
-import { CompatRouter, Route, Routes } from "react-router-dom-v5-compat";
+import { BrowserRouter, CompatRouter, Route, Routes } from "react-router-dom";
 import type { MockStoreEnhanced } from "redux-mock-store";
 import configureStore from "redux-mock-store";
 


### PR DESCRIPTION
## Done
- Basic global find-and-replace to remove react-router-dom-v5-compat imports (use react-router-dom instead)

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
