### PR TITLE
fix: enable deletion of images queued for download

### DIFF
--- a/src/app/images/components/ImagesTable/ImagesTable.test.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.test.tsx
@@ -274,6 +274,7 @@ it("disables delete action for images being downloaded", async () => {
       title: "18.04 LTS",
       complete: false,
       status: "Downloading 50%",
+      downloading: true,
     }),
   ];
   const image = {

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -149,7 +149,8 @@ const generateResourceRow = ({
   const { os, release } = splitResourceName(resource.name);
   const isCommissioningImage =
     os === "ubuntu" && release === commissioningRelease;
-  const canBeDeleted = !isCommissioningImage && resource.complete;
+  const canBeDeleted =
+    !isCommissioningImage && (resource.complete || !resource.downloading);
   let statusIcon = <Spinner />;
   let statusText = resource.status;
 


### PR DESCRIPTION
## Done
- Enabled the delete button for queued for download
<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Visit `/images`
- [ ] Select an image for download
- [ ] Ensure that the delete button is enabled while the image is in a queued status
- [ ] Ensure that the image can be deleted

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-2909](https://warthogs.atlassian.net/browse/MAASENG-2909)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![image](https://github.com/canonical/maas-ui/assets/47540149/0c4f8846-ad0c-418f-a255-fbb81108b68d)

### After
![image](https://github.com/canonical/maas-ui/assets/47540149/45452706-84b7-4251-8608-d0c41bfdb188)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2909]: https://warthogs.atlassian.net/browse/MAASENG-2909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ