### PR TITLE
fix(machines): Broken routes for machine and controller logs lp2060133

### DIFF
--- a/src/app/base/components/node/NodeLogs/NodeLogs.test.tsx
+++ b/src/app/base/components/node/NodeLogs/NodeLogs.test.tsx
@@ -48,6 +48,7 @@ describe("NodeLogs", () => {
         {
           route: path,
           state,
+          routePattern: `${urls.machines.machine.logs.index(null)}/*`,
         }
       );
       expect(screen.getByLabelText(label)).toBeInTheDocument();

--- a/src/app/base/components/node/NodeLogs/NodeLogs.tsx
+++ b/src/app/base/components/node/NodeLogs/NodeLogs.tsx
@@ -8,6 +8,7 @@ import InstallationOutput from "./InstallationOutput";
 import type { ControllerDetails } from "@/app/store/controller/types";
 import type { MachineDetails } from "@/app/store/machine/types";
 import type { Node } from "@/app/store/types/node";
+import { getRelativeRoute } from "@/app/utils";
 
 type GenerateURL = (
   args: { id: Node["system_id"] } | null,
@@ -29,6 +30,7 @@ const NodeLogs = ({ node, urls }: Props): JSX.Element => {
   const showingOutput = pathname.startsWith(
     urls.installationOutput({ id: node.system_id })
   );
+
   return (
     <>
       <div className="u-position--relative">
@@ -55,10 +57,17 @@ const NodeLogs = ({ node, urls }: Props): JSX.Element => {
       <Routes>
         <Route
           element={<InstallationOutput node={node} />}
-          path={urls.installationOutput(null)}
+          path={getRelativeRoute(
+            urls.installationOutput(null),
+            urls.index(null)
+          )}
         />
         {[urls.index(null), urls.events(null)].map((path) => (
-          <Route element={<EventLogs node={node} />} key={path} path={path} />
+          <Route
+            element={<EventLogs node={node} />}
+            key={path}
+            path={getRelativeRoute(path, urls.index(null))}
+          />
         ))}
       </Routes>
     </>

--- a/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerDetails.tsx
@@ -160,24 +160,10 @@ const ControllerDetails = (): JSX.Element => {
           />
           <Route
             element={<ControllerLogs systemId={id} />}
-            path={getRelativeRoute(
+            path={`${getRelativeRoute(
               urls.controllers.controller.logs.index(null),
               base
-            )}
-          />
-          <Route
-            element={<ControllerLogs systemId={id} />}
-            path={getRelativeRoute(
-              urls.controllers.controller.logs.events(null),
-              base
-            )}
-          />
-          <Route
-            element={<ControllerLogs systemId={id} />}
-            path={getRelativeRoute(
-              urls.controllers.controller.logs.installationOutput(null),
-              base
-            )}
+            )}/*`}
           />
           <Route
             element={<ControllerConfiguration systemId={id} />}

--- a/src/app/controllers/views/ControllerDetails/ControllerLogs/ControllerLogs.test.tsx
+++ b/src/app/controllers/views/ControllerDetails/ControllerLogs/ControllerLogs.test.tsx
@@ -50,6 +50,7 @@ describe("ControllerLogs", () => {
       renderWithBrowserRouter(<ControllerLogs systemId="abc123" />, {
         route: path,
         state,
+        routePattern: `${urls.controllers.controller.logs.index(null)}/*`,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });

--- a/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineLogs/MachineLogs.test.tsx
@@ -48,6 +48,7 @@ describe("MachineLogs", () => {
       renderWithBrowserRouter(<MachineLogs systemId="abc123" />, {
         route: path,
         state,
+        routePattern: `${urls.machines.machine.logs.index(null)}/*`,
       });
       expect(screen.getByLabelText(label)).toBeInTheDocument();
     });


### PR DESCRIPTION
## Done
- Fixed broken routes for event logs and installation outputs in machine details

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

Machines

- [ ] Go to a machine's details page and click on logs
- [ ] Ensure you can see the event logs
- [ ] Click on installation output and ensure you can see it

Controllers

- [ ] Go to a controller's details page and click on logs
- [ ] Ensure you can see the event logs
- [ ] Click on installation output and ensure you can see it

<!-- Steps for QA. -->

## Fixes

Fixes [lp2060133](https://bugs.launchpad.net/maas/+bug/2060133)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/01aa514f-0441-4635-99f1-03d5ce5472a7)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/b961c9e7-6d56-4a71-a03b-37373b0d5dee)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

