### PR TITLE
fix: network discovery date truncation MAASENG-2991

### DIFF
--- a/src/app/networkDiscovery/views/DiscoveriesList/DiscoveriesList.tsx
+++ b/src/app/networkDiscovery/views/DiscoveriesList/DiscoveriesList.tsx
@@ -79,11 +79,7 @@ const generateRows = (
           content: discovery.observer_hostname,
         },
         {
-          content: (
-            <div className="u-truncate">
-              {formatUtcDatetime(discovery.last_seen)}
-            </div>
-          ),
+          content: <div>{formatUtcDatetime(discovery.last_seen)}</div>,
         },
         {
           content: (


### PR DESCRIPTION
## Done
- fix: network discovery date truncation

This means that date might be displayed in 2 lines, but that works on this page as we are already displaying double rows (e.g. in the MAC address).
 
<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to network Discovery page
- [ ] Ensure that UTC time is displayed in full

<!-- Steps for QA. -->

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-2991

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
### Before
![Google Chrome screenshot 001829@2x](https://github.com/canonical/maas-ui/assets/7452681/bd2135d6-fc08-4837-85bd-4a2fed61cd8e)


### After
![Google Chrome screenshot 001827@2x](https://github.com/canonical/maas-ui/assets/7452681/f4c29691-b50b-4d82-8543-496c5cc36faf)

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
