### PR TITLE
feat: move VLAN inline forms to side panel

### DIFF
--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.test.tsx
@@ -50,7 +50,7 @@ it("correctly initialises data if the VLAN has DHCP from rack controllers", asyn
   // Wait for Formik validateOnMount to run.
   await waitFor(() => {
     expect(
-      screen.getByRole("region", { name: "Configure DHCP" })
+      screen.getByRole("form", { name: "Configure DHCP" })
     ).toBeInTheDocument();
   });
 
@@ -90,7 +90,7 @@ it("correctly initialises data if the VLAN has relayed DHCP", async () => {
   // Wait for Formik validateOnMount to run.
   await waitFor(() => {
     expect(
-      screen.getByRole("region", { name: "Configure DHCP" })
+      screen.getByRole("form", { name: "Configure DHCP" })
     ).toBeInTheDocument();
   });
 
@@ -127,7 +127,7 @@ it("shows an error if no rack controllers are connected to the VLAN", async () =
   });
 
   expect(
-    screen.getByRole("region", { name: "Configure DHCP" })
+    screen.getByRole("form", { name: "Configure DHCP" })
   ).toBeInTheDocument();
 
   expect(

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCP.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 
 import { ExternalLink } from "@canonical/maas-react-components";
-import { Card, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -9,7 +9,6 @@ import ConfigureDHCPFields from "./ConfigureDHCPFields";
 import DHCPReservedRanges from "./DHCPReservedRanges";
 
 import FormikForm from "@/app/base/components/FormikForm";
-import TitledSection from "@/app/base/components/TitledSection";
 import docsUrls from "@/app/base/docsUrls";
 import { useFetchActions, useCycled } from "@/app/base/hooks";
 import { controllerActions } from "@/app/store/controller";
@@ -158,83 +157,82 @@ const ConfigureDHCP = ({ closeForm, id }: Props): JSX.Element | null => {
     });
 
   return (
-    <Card>
-      <TitledSection className="u-no-padding" title="Configure DHCP">
-        {loading ? (
-          <span data-testid="loading-data">
-            <Spinner text="Loading..." />
-          </span>
-        ) : (
-          <FormikForm<ConfigureDHCPValues>
-            allowUnchanged
-            buttonsHelp={
-              <ExternalLink to={docsUrls.dhcp}>About DHCP</ExternalLink>
-            }
-            cleanup={cleanup}
-            errors={configureDHCPError}
-            initialValues={{
-              dhcpType: isId(vlan.relay_vlan)
-                ? DHCPType.RELAY
-                : DHCPType.CONTROLLERS,
-              enableDHCP: true,
-              endIP: "",
-              gatewayIP: "",
-              primaryRack: vlan.primary_rack || "",
-              relayVLAN: vlan.relay_vlan || "",
-              secondaryRack: vlan.secondary_rack || "",
-              startIP: "",
-              subnet: "",
-            }}
-            onCancel={closeForm}
-            onSaveAnalytics={{
-              action: "Configure DHCP",
-              category: "VLAN details",
-              label: "Configure DHCP form",
-            }}
-            onSubmit={(values) => {
-              resetConfiguredDHCP();
-              dispatch(cleanup());
-              const { enableDHCP, primaryRack, relayVLAN, secondaryRack } =
-                values;
-              const params: ConfigureDHCPParams = {
-                controllers: [],
-                id: vlan.id,
-                relay_vlan: null,
-              };
-              if (enableDHCP) {
-                if (primaryRack) {
-                  params.controllers.push(primaryRack);
-                }
-                if (secondaryRack) {
-                  params.controllers.push(secondaryRack);
-                }
-                if (isId(relayVLAN)) {
-                  params.relay_vlan = Number(relayVLAN);
-                }
-                if (isId(values.subnet)) {
-                  params.extra = {
-                    end: values.endIP,
-                    gateway: values.gatewayIP,
-                    start: values.startIP,
-                    subnet: Number(values.subnet),
-                  };
-                }
+    <>
+      {loading ? (
+        <span data-testid="loading-data">
+          <Spinner text="Loading..." />
+        </span>
+      ) : (
+        <FormikForm<ConfigureDHCPValues>
+          allowUnchanged
+          aria-label="Configure DHCP"
+          buttonsHelp={
+            <ExternalLink to={docsUrls.dhcp}>About DHCP</ExternalLink>
+          }
+          cleanup={cleanup}
+          errors={configureDHCPError}
+          initialValues={{
+            dhcpType: isId(vlan.relay_vlan)
+              ? DHCPType.RELAY
+              : DHCPType.CONTROLLERS,
+            enableDHCP: true,
+            endIP: "",
+            gatewayIP: "",
+            primaryRack: vlan.primary_rack || "",
+            relayVLAN: vlan.relay_vlan || "",
+            secondaryRack: vlan.secondary_rack || "",
+            startIP: "",
+            subnet: "",
+          }}
+          onCancel={closeForm}
+          onSaveAnalytics={{
+            action: "Configure DHCP",
+            category: "VLAN details",
+            label: "Configure DHCP form",
+          }}
+          onSubmit={(values) => {
+            resetConfiguredDHCP();
+            dispatch(cleanup());
+            const { enableDHCP, primaryRack, relayVLAN, secondaryRack } =
+              values;
+            const params: ConfigureDHCPParams = {
+              controllers: [],
+              id: vlan.id,
+              relay_vlan: null,
+            };
+            if (enableDHCP) {
+              if (primaryRack) {
+                params.controllers.push(primaryRack);
               }
-              dispatch(vlanActions.configureDHCP(params));
-            }}
-            onSuccess={() => closeForm()}
-            saved={saved}
-            saving={configuringDHCP}
-            submitLabel="Configure DHCP"
-            validateOnMount
-            validationSchema={Schema}
-          >
-            <ConfigureDHCPFields vlan={vlan} />
-            <DHCPReservedRanges id={vlan.id} />
-          </FormikForm>
-        )}
-      </TitledSection>
-    </Card>
+              if (secondaryRack) {
+                params.controllers.push(secondaryRack);
+              }
+              if (isId(relayVLAN)) {
+                params.relay_vlan = Number(relayVLAN);
+              }
+              if (isId(values.subnet)) {
+                params.extra = {
+                  end: values.endIP,
+                  gateway: values.gatewayIP,
+                  start: values.startIP,
+                  subnet: Number(values.subnet),
+                };
+              }
+            }
+            dispatch(vlanActions.configureDHCP(params));
+          }}
+          onSuccess={() => closeForm()}
+          saved={saved}
+          saving={configuringDHCP}
+          submitLabel="Configure DHCP"
+          validateOnMount
+          validationSchema={Schema}
+        >
+          <ConfigureDHCPFields vlan={vlan} />
+          <DHCPReservedRanges id={vlan.id} />
+        </FormikForm>
+      )}
+    </>
   );
 };
 

--- a/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
+++ b/src/app/subnets/views/VLANDetails/ConfigureDHCP/ConfigureDHCPFields/ConfigureDHCPFields.tsx
@@ -44,7 +44,7 @@ const ConfigureDHCPFields = ({ vlan }: Props): JSX.Element => {
 
   return (
     <Row>
-      <Col size={6}>
+      <Col size={12}>
         <FormikField
           label="MAAS provides DHCP"
           name="enableDHCP"

--- a/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
+++ b/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx
@@ -19,7 +19,7 @@ it("shows a spinner if data is loading", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={1} openForm={vi.fn()} />
+        <DHCPStatus id={1} />
       </MemoryRouter>
     </Provider>
   );
@@ -38,7 +38,7 @@ it(`shows a warning and disables Configure DHCP button if there are no subnets
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={vi.fn()} />
+        <DHCPStatus id={vlan.id} />
       </MemoryRouter>
     </Provider>
   );
@@ -66,7 +66,7 @@ it("does not show a warning if there are subnets attached to the VLAN", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={vi.fn()} />
+        <DHCPStatus id={vlan.id} />
       </MemoryRouter>
     </Provider>
   );
@@ -92,7 +92,7 @@ it("renders correctly when a VLAN does not have DHCP enabled", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={vi.fn()} />
+        <DHCPStatus id={vlan.id} />
       </MemoryRouter>
     </Provider>
   );
@@ -116,7 +116,7 @@ it("renders correctly when a VLAN has external DHCP", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={vi.fn()} />
+        <DHCPStatus id={vlan.id} />
       </MemoryRouter>
     </Provider>
   );
@@ -148,7 +148,7 @@ it("renders correctly when a VLAN has relayed DHCP", () => {
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={vi.fn()} />
+        <DHCPStatus id={vlan.id} />
       </MemoryRouter>
     </Provider>
   );
@@ -178,7 +178,7 @@ it("renders correctly when a VLAN has MAAS-configured DHCP without high availabi
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={vi.fn()} />
+        <DHCPStatus id={vlan.id} />
       </MemoryRouter>
     </Provider>
   );
@@ -225,7 +225,7 @@ it("renders correctly when a VLAN has MAAS-configured DHCP with high availabilit
   render(
     <Provider store={store}>
       <MemoryRouter>
-        <DHCPStatus id={vlan.id} openForm={vi.fn()} />
+        <DHCPStatus id={vlan.id} />
       </MemoryRouter>
     </Provider>
   );

--- a/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -14,6 +14,7 @@ import Definition from "@/app/base/components/Definition";
 import TitledSection from "@/app/base/components/TitledSection";
 import docsUrls from "@/app/base/docsUrls";
 import { useFetchActions } from "@/app/base/hooks";
+import { SidePanelViews, useSidePanel } from "@/app/base/side-panel-context";
 import urls from "@/app/base/urls";
 import { fabricActions } from "@/app/store/fabric";
 import fabricSelectors from "@/app/store/fabric/selectors";
@@ -29,7 +30,6 @@ import { isId } from "@/app/utils";
 
 type Props = {
   id: VLAN[VLANMeta.PK] | null;
-  openForm: () => void;
 };
 
 // Note this is not the same as the getDHCPStatus VLAN util as it uses slightly
@@ -54,7 +54,8 @@ const getDHCPStatus = (vlan: VLAN, vlans: VLAN[], fabrics: Fabric[]) => {
   return "Disabled";
 };
 
-const DHCPStatus = ({ id, openForm }: Props): JSX.Element | null => {
+const DHCPStatus = ({ id }: Props): JSX.Element | null => {
+  const { setSidePanelContent, setSidePanelSize } = useSidePanel();
   const fabrics = useSelector(fabricSelectors.all);
   const fabricsLoading = useSelector(fabricSelectors.loading);
   const vlans = useSelector(vlanSelectors.all);
@@ -91,7 +92,13 @@ const DHCPStatus = ({ id, openForm }: Props): JSX.Element | null => {
   return (
     <TitledSection
       buttons={
-        <Button disabled={!hasVLANSubnets} onClick={openForm}>
+        <Button
+          disabled={!hasVLANSubnets}
+          onClick={() => {
+            setSidePanelSize("large");
+            setSidePanelContent({ view: SidePanelViews.ConfigureDHCP });
+          }}
+        >
           Configure DHCP
         </Button>
       }

--- a/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.tsx
+++ b/src/app/subnets/views/VLANDetails/EditVLAN/EditVLAN.tsx
@@ -107,7 +107,7 @@ const EditVLAN = ({ close, id, ...props }: Props): JSX.Element | null => {
       {...props}
     >
       <Row>
-        <Col size={6}>
+        <Col size={12}>
           <FormikField label="VID" name="vid" required type="text" />
           <FormikField label="Name" name="name" type="text" />
           <FormikField label="MTU" name="mtu" type="text" />
@@ -117,7 +117,7 @@ const EditVLAN = ({ close, id, ...props }: Props): JSX.Element | null => {
             name="description"
           />
         </Col>
-        <Col size={6}>
+        <Col size={12}>
           <SpaceSelect
             defaultOption={{ label: getSpaceDisplay(null), value: "" }}
             name="space"

--- a/src/app/subnets/views/VLANDetails/VLANActionForms/VLANActionForms.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANActionForms/VLANActionForms.tsx
@@ -1,4 +1,7 @@
-import type { SetSidePanelContent } from "@/app/base/side-panel-context";
+import ConfigureDHCP from "../ConfigureDHCP";
+import EditVLAN from "../EditVLAN";
+
+import { type SetSidePanelContent } from "@/app/base/side-panel-context";
 import type { Subnet, SubnetMeta } from "@/app/store/subnet/types";
 import type { VLAN, VLANMeta } from "@/app/store/vlan/types";
 import ReservedRangeDeleteForm from "@/app/subnets/components/ReservedRangeDeleteForm";
@@ -26,19 +29,30 @@ const VLANActionForms = ({
   subnetId,
   vlanId,
 }: VLANActionFormProps) => {
-  const ActionForm = actionForms[activeForm];
+  const clearSidePanelContent = () => setSidePanelContent(null);
 
-  if (!ActionForm) {
-    return null;
+  switch (activeForm) {
+    case VLANActionTypes.ConfigureDHCP: {
+      return <ConfigureDHCP closeForm={clearSidePanelContent} id={vlanId} />;
+    }
+    case VLANActionTypes.EditVLAN:
+      return <EditVLAN close={clearSidePanelContent} id={vlanId} />;
+
+    default: {
+      const ActionForm = actionForms[activeForm];
+
+      if (!ActionForm) {
+        return null;
+      }
+      return (
+        <ActionForm
+          setSidePanelContent={setSidePanelContent}
+          subnetId={subnetId}
+          vlanId={vlanId}
+        />
+      );
+    }
   }
-
-  return (
-    <ActionForm
-      setSidePanelContent={setSidePanelContent}
-      subnetId={subnetId}
-      vlanId={vlanId}
-    />
-  );
 };
 
 export default VLANActionForms;

--- a/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
 
-import ConfigureDHCP from "./ConfigureDHCP";
 import DHCPStatus from "./DHCPStatus";
 import VLANActionForms from "./VLANActionForms";
 import VLANDetailsHeader from "./VLANDetailsHeader";
@@ -40,7 +39,6 @@ const VLANDetails = (): JSX.Element => {
   const subnets = useSelector((state: RootState) =>
     subnetSelectors.getByIds(state, vlan?.subnet_ids || [])
   );
-  const [showDHCPForm, setShowDHCPForm] = useState(false);
   useWindowTitle(`${vlan?.name || "VLAN"} details`);
 
   useEffect(() => {
@@ -97,16 +95,10 @@ const VLANDetails = (): JSX.Element => {
       }
       sidePanelTitle={activeForm ? vlanActionLabels[activeForm] : ""}
     >
-      {showDHCPForm ? (
-        <ConfigureDHCP closeForm={() => setShowDHCPForm(false)} id={id} />
-      ) : (
-        <>
-          <VLANSummary id={id} />
-          <DHCPStatus id={id} openForm={() => setShowDHCPForm(true)} />
-          <ReservedRanges hasVLANSubnets={subnets.length > 0} vlanId={id} />
-          <VLANSubnets id={id} />
-        </>
-      )}
+      <VLANSummary id={id} />
+      <DHCPStatus id={id} />
+      <ReservedRanges hasVLANSubnets={subnets.length > 0} vlanId={id} />
+      <VLANSubnets id={id} />
       <DHCPSnippets modelName={VLANMeta.MODEL} subnetIds={vlan.subnet_ids} />
     </PageContent>
   );

--- a/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANSummary/VLANSummary.tsx
@@ -1,14 +1,13 @@
-import { Col, Row } from "@canonical/react-components";
+import { Button, Col, Row } from "@canonical/react-components";
 import { useSelector } from "react-redux";
-
-import EditVLAN from "../EditVLAN";
 
 import VLANControllers from "./VLANControllers";
 
 import Definition from "@/app/base/components/Definition";
-import EditableSection from "@/app/base/components/EditableSection";
 import FabricLink from "@/app/base/components/FabricLink";
 import SpaceLink from "@/app/base/components/SpaceLink";
+import TitledSection from "@/app/base/components/TitledSection";
+import { SidePanelViews, useSidePanel } from "@/app/base/side-panel-context";
 import authSelectors from "@/app/store/auth/selectors";
 import type { RootState } from "@/app/store/root/types";
 import vlanSelectors from "@/app/store/vlan/selectors";
@@ -20,6 +19,7 @@ type Props = {
 
 const VLANSummary = ({ id }: Props): JSX.Element | null => {
   const isAdmin = useSelector(authSelectors.isAdmin);
+  const { setSidePanelContent } = useSidePanel();
   const vlan = useSelector((state: RootState) =>
     vlanSelectors.getById(state, id)
   );
@@ -29,33 +29,38 @@ const VLANSummary = ({ id }: Props): JSX.Element | null => {
   }
 
   return (
-    <EditableSection
-      canEdit={isAdmin}
-      renderContent={(editing, setEditing) =>
-        editing ? (
-          <EditVLAN close={() => setEditing(false)} id={id} />
-        ) : (
-          <Row>
-            <Col size={6}>
-              <Definition description={`${vlan.vid}`} label="VID" />
-              <Definition description={vlan.name} label="Name" />
-              <Definition description={`${vlan.mtu}`} label="MTU" />
-              <Definition description={vlan.description} label="Description" />
-            </Col>
-            <Col size={6}>
-              <Definition label="Space">
-                <SpaceLink id={vlan.space} />
-              </Definition>
-              <Definition label="Fabric">
-                <FabricLink id={vlan.fabric} />
-              </Definition>
-              <VLANControllers id={id} />
-            </Col>
-          </Row>
+    <TitledSection
+      buttons={
+        isAdmin && (
+          <Button
+            onClick={() =>
+              setSidePanelContent({ view: SidePanelViews.EditVLAN })
+            }
+          >
+            Edit
+          </Button>
         )
       }
       title="VLAN summary"
-    />
+    >
+      <Row>
+        <Col size={6}>
+          <Definition description={`${vlan.vid}`} label="VID" />
+          <Definition description={vlan.name} label="Name" />
+          <Definition description={`${vlan.mtu}`} label="MTU" />
+          <Definition description={vlan.description} label="Description" />
+        </Col>
+        <Col size={6}>
+          <Definition label="Space">
+            <SpaceLink id={vlan.space} />
+          </Definition>
+          <Definition label="Fabric">
+            <FabricLink id={vlan.fabric} />
+          </Definition>
+          <VLANControllers id={id} />
+        </Col>
+      </Row>
+    </TitledSection>
   );
 };
 

--- a/src/app/subnets/views/VLANDetails/constants.ts
+++ b/src/app/subnets/views/VLANDetails/constants.ts
@@ -3,25 +3,31 @@ import type { ValueOf } from "@canonical/react-components";
 import type { SidePanelContent } from "@/app/base/types";
 
 export const VLANActionTypes = {
+  ConfigureDHCP: "ConfigureDHCP",
   DeleteVLAN: "DeleteVLAN",
   ReserveRange: "ReserveRange",
   DeleteReservedRange: "DeleteReservedRange",
+  EditVLAN: "EditVLAN",
 } as const;
 export type VLANActionType = ValueOf<typeof VLANActionTypes>;
 
 export const vlanActionLabels = {
+  [VLANActionTypes.ConfigureDHCP]: "Configure DHCP",
   [VLANActionTypes.DeleteVLAN]: "Delete VLAN",
   [VLANActionTypes.ReserveRange]: "Reserve range",
   [VLANActionTypes.DeleteReservedRange]: "Delete reserved range",
+  [VLANActionTypes.EditVLAN]: "Edit VLAN",
 } as const;
 
 export const VLANDetailsSidePanelViews = {
+  [VLANActionTypes.ConfigureDHCP]: ["", VLANActionTypes.ConfigureDHCP],
   [VLANActionTypes.DeleteVLAN]: ["", VLANActionTypes.DeleteVLAN],
   [VLANActionTypes.ReserveRange]: ["", VLANActionTypes.ReserveRange],
   [VLANActionTypes.DeleteReservedRange]: [
     "",
     VLANActionTypes.DeleteReservedRange,
   ],
+  [VLANActionTypes.EditVLAN]: ["", VLANActionTypes.EditVLAN],
 } as const;
 
 export type VLANDetailsSidePanelContent = SidePanelContent<


### PR DESCRIPTION
## Done
Moved VLAN inline forms to side panel
- Edit VLAN
- Configure DHCP

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Visit VLAN details page `/vlan/<vlan_id>`
- [ ] Click on the `Edit VLAN` and `Configure DHCP` buttons
- [ ] Ensure they both open in a side panel and work correctly
- [ ] Ensure that the Configure DHCP side panel is wider to cater for the table.

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-2985](https://warthogs.atlassian.net/browse/MAASENG-2985)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
### Before
![image](https://github.com/canonical/maas-ui/assets/47540149/8d2f0bd7-e3c8-4794-8ca9-36526682b15b)
![image](https://github.com/canonical/maas-ui/assets/47540149/251c061b-1938-4652-8b22-3a267bf417d9)

### After
![image](https://github.com/canonical/maas-ui/assets/47540149/9e210417-51e7-4306-8464-fa3982e47134)
![image](https://github.com/canonical/maas-ui/assets/47540149/13a1cd5c-0388-4f3f-b8f3-fc2b104502f6)


## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2985]: https://warthogs.atlassian.net/browse/MAASENG-2985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ