### PR TITLE
fix: html error formatting MAASENG-2935

### DIFF
--- a/src/app/utils/formatErrors.test.ts
+++ b/src/app/utils/formatErrors.test.ts
@@ -51,4 +51,23 @@ describe("formatErrors", () => {
       "The primary rack controller must be up and running to set a secondary rack controller."
     );
   });
+
+  it("can handle HTML", () => {
+    const html = `
+    <html>
+      <head>
+        <title>502 Bad Gateway</title>
+      </head>
+      <body>
+        <center>
+          <h1>502 Bad Gateway</h1>
+        </center>
+        <hr>
+        <center>nginx/1.18.0 (Ubuntu)</center>
+      </body>
+    </html>
+    `;
+
+    expect(formatErrors(html)).toEqual("502 Bad Gateway nginx/1.18.0 (Ubuntu)");
+  });
 });

--- a/src/app/utils/formatErrors.ts
+++ b/src/app/utils/formatErrors.ts
@@ -73,7 +73,7 @@ const parseHtmlToText = (htmlContent: string): string | null => {
       // Trim any leading or trailing whitespace from the resulting text
       .trim();
 
-    return strippedText !== "" ? strippedText : null;
+    return strippedText || null;
   }
 
   // Return the original content if the body tag is not found

--- a/src/app/utils/formatErrors.ts
+++ b/src/app/utils/formatErrors.ts
@@ -60,10 +60,34 @@ const parseObjectError = (
   return null;
 };
 
+const parseHtmlToText = (htmlContent: string): string | null => {
+  const bodyMatch = htmlContent.match(/<body[^>]*>([\s\S]*?)<\/body>/i);
+
+  if (bodyMatch) {
+    const bodyContent = bodyMatch[1];
+    const strippedText = bodyContent
+      // Remove all HTML tags from the body content
+      .replace(/<[^>]+>/g, "")
+      // Collapse multiple consecutive whitespace characters into a single space
+      .replace(/\s+/g, " ")
+      // Trim any leading or trailing whitespace from the resulting text
+      .trim();
+
+    return strippedText !== "" ? strippedText : null;
+  }
+
+  // Return the original content if the body tag is not found
+  return htmlContent;
+};
+
 type ErrorFormatter = (errors: any, errorKey?: string) => FlattenedError;
-const errorTypeFormatters: Record<string, ErrorFormatter> = {
+
+type ErrorTypeFormat = "string" | "object" | "html";
+
+const errorTypeFormatters: Record<ErrorTypeFormat, ErrorFormatter> = {
   string: parseJSONError,
   object: parseObjectError,
+  html: parseHtmlToText,
 };
 
 export type ErrorType<E = null, I = any, K extends keyof I = any> =
@@ -84,7 +108,26 @@ export const formatErrors = <E, I, K extends keyof I>(
   if (!errors) {
     return null;
   }
-  const errorType = typeof errors;
-  const formatErrors = errorTypeFormatters[errorType];
-  return formatErrors ? formatErrors(errors, errorKey) : null;
+
+  const isHTMLContent = (content: string): boolean => {
+    return /<\/?[a-z][\s\S]*>/i.test(content);
+  };
+
+  const getErrorType = (errors: ErrorType<E, I, K>): ErrorTypeFormat => {
+    if (typeof errors === "string" && isHTMLContent(errors)) {
+      return "html";
+    }
+    return typeof errors in errorTypeFormatters
+      ? (typeof errors as ErrorTypeFormat)
+      : "string";
+  };
+
+  const errorType = getErrorType(errors);
+  const formatErrorsByType = errorTypeFormatters[errorType];
+
+  if (formatErrorsByType) {
+    return formatErrorsByType(errors, errorKey);
+  }
+
+  return null;
 };


### PR DESCRIPTION
## Done
In some rare scenarios HTML content might be returned as a response. This change makes sure that we display text only and not entire raw HTML string.

- fix: html error formatting MAASENG-2935

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

HTML formatting is hard QA without simulating an actual nginx error and also already covered by tests. Focus on verifying that other errors are displayed as before.

- Attempt to login using incorrect credentials
- Ensure that login validation error is displayed correctly

<!-- Steps for QA. -->

## Fixes

Fixes: MAASENG-2935

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
### Before
![image](https://github.com/canonical/maas-ui/assets/7452681/d202d85a-f83e-4f14-abb9-8c4c736bc0db)

### After
![Google Chrome screenshot 001831@2x](https://github.com/canonical/maas-ui/assets/7452681/0a18c242-05ff-4e12-a88b-e1b2f4093f4a)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
