### PR TITLE
feat(subnets): refactor subnet details into tabs MAASENG-2973

### DIFF
--- a/cypress/e2e/with-users/subnets/staticroutes.spec.ts
+++ b/cypress/e2e/with-users/subnets/staticroutes.spec.ts
@@ -15,6 +15,8 @@ context("Static Routes", () => {
     });
     cy.findByRole("heading", { level: 1 }).invoke("text").as("subnet");
 
+    cy.findByRole("link", { name: /static routes/i }).click();
+
     cy.findByRole("button", { name: /add static route/i }).click();
     cy.get("@subnet").then((subnet: unknown) => {
       cy.findByRole("complementary", { name: /Add static route/i }).within(

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -153,7 +153,6 @@ const MachineHeader = ({
       subtitleLoading={!isMachineDetails(machine)}
       tabLinks={[
         {
-          active: pathname.startsWith(`${urlBase}/summary`),
           component: Link,
           label: "Summary",
           to: `${urlBase}/summary`,

--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -153,6 +153,7 @@ const MachineHeader = ({
       subtitleLoading={!isMachineDetails(machine)}
       tabLinks={[
         {
+          active: pathname.startsWith(`${urlBase}/summary`),
           component: Link,
           label: "Summary",
           to: `${urlBase}/summary`,

--- a/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
+++ b/src/app/subnets/components/DHCPSnippets/DHCPSnippets.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { useSelector } from "react-redux";
 
 import DHCPTable from "@/app/base/components/DHCPTable";
@@ -23,7 +24,12 @@ const DHCPSnippets = ({ modelName, subnetIds }: Props): JSX.Element => {
   useFetchActions([subnetActions.fetch, ipRangeActions.fetch]);
 
   return (
-    <DHCPTable ipRanges={ipranges} modelName={modelName} subnets={subnets} />
+    <DHCPTable
+      className={classNames({ "u-no-padding--top": modelName === "subnet" })}
+      ipRanges={ipranges}
+      modelName={modelName}
+      subnets={subnets}
+    />
   );
 };
 

--- a/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -262,6 +262,7 @@ const ReservedRanges = ({
           }
         />
       }
+      className={classNames({ "u-no-padding--top": isSubnet })}
       title="Reserved ranges"
     >
       {isDisabled ? (

--- a/src/app/subnets/urls.ts
+++ b/src/app/subnets/urls.ts
@@ -5,6 +5,8 @@ import type { VLAN, VLANMeta } from "@/app/store/vlan/types";
 import type { SubnetsUrlParams } from "@/app/subnets/types";
 import { argPath, isId } from "@/app/utils";
 
+const withSubnetId = argPath<{ id: Subnet[SubnetMeta.PK] }>;
+
 const urls = {
   index: "/networks",
   indexWithParams: (options: SubnetsUrlParams): string => {
@@ -19,6 +21,11 @@ const urls = {
     index: argPath<{ id: Space[SpaceMeta.PK] }>("/space/:id"),
   },
   subnet: {
+    summary: withSubnetId("/subnet/:id/summary"),
+    staticRoutes: withSubnetId("/subnet/:id/static-routes"),
+    reservedIpAddresses: withSubnetId("/subnet/:id/reserved-ip-addresses"),
+    dhcpSnippets: withSubnetId("/subnet/:id/dhcp-snippets"),
+    usedIpAddresses: withSubnetId("/subnet/:id/used-ip-addresses"),
     index: argPath<{ id: Subnet[SubnetMeta.PK] }>("/subnet/:id"),
   },
   vlan: {

--- a/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticRoutes/StaticRoutes.tsx
@@ -126,6 +126,7 @@ const StaticRoutes = ({ subnetId }: Props): JSX.Element | null => {
           </Button>
         ) : null
       }
+      className="u-no-padding--top"
       title="Static routes"
     >
       <MainTable

--- a/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetails.test.tsx
@@ -1,34 +1,83 @@
-import { Provider } from "react-redux";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
 import configureStore from "redux-mock-store";
 
 import SubnetDetails from "./SubnetDetails";
 
 import urls from "@/app/base/urls";
+import type { RootState } from "@/app/store/root/types";
 import { staticRouteActions } from "@/app/store/staticroute";
 import { subnetActions } from "@/app/store/subnet";
 import * as factory from "@/testing/factories";
-import { render, screen } from "@/testing/utils";
+import { renderWithBrowserRouter, screen, waitFor } from "@/testing/utils";
 
 const mockStore = configureStore();
 
+let state: RootState;
+
+beforeEach(() => {
+  state = factory.rootState({
+    subnet: factory.subnetState({
+      items: [factory.subnet({ id: 1 })],
+    }),
+  });
+});
+
+[
+  {
+    component: "SubnetSummary",
+    path: urls.subnets.subnet.summary({ id: 1 }),
+    title: "Subnet summary",
+  },
+  {
+    component: "StaticRoutes",
+    path: urls.subnets.subnet.staticRoutes({ id: 1 }),
+    title: "Static routes",
+  },
+  {
+    component: "ReservedRanges",
+    path: urls.subnets.subnet.reservedIpAddresses({ id: 1 }),
+    title: "Reserved ranges",
+  },
+  {
+    component: "DHCPSnippets",
+    path: urls.subnets.subnet.dhcpSnippets({ id: 1 }),
+    title: "DHCP snippets",
+  },
+  {
+    component: "SubnetUsedIPs",
+    path: urls.subnets.subnet.usedIpAddresses({ id: 1 }),
+    title: "Used IP addresses",
+  },
+].forEach(({ component, path, title }) => {
+  it(`Displays ${component} at ${path}`, async () => {
+    renderWithBrowserRouter(<SubnetDetails />, {
+      route: path,
+      state,
+      routePattern: `${urls.subnets.subnet.index(null)}/*`,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: title })).toBeInTheDocument();
+    });
+  });
+});
+
+it("redirects to summary", () => {
+  renderWithBrowserRouter(<SubnetDetails />, {
+    route: urls.subnets.subnet.index({ id: 1 }),
+    state,
+    routePattern: `${urls.subnets.subnet.index(null)}/*`,
+  });
+
+  expect(window.location.pathname).toBe(urls.subnets.subnet.summary({ id: 1 }));
+});
+
 it("dispatches actions to fetch necessary data and set subnet as active on mount", () => {
-  const state = factory.rootState();
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: urls.subnets.subnet.index({ id: 1 }) }]}
-      >
-        <Routes>
-          <Route
-            element={<SubnetDetails />}
-            path={urls.subnets.subnet.index(null)}
-          />
-        </Routes>
-      </MemoryRouter>
-    </Provider>
-  );
+  renderWithBrowserRouter(<SubnetDetails />, {
+    store,
+    route: urls.subnets.subnet.index({ id: 1 }),
+    routePattern: `${urls.subnets.subnet.index(null)}/*`,
+  });
 
   const expectedActions = [
     subnetActions.get(1),
@@ -46,22 +95,11 @@ it("dispatches actions to fetch necessary data and set subnet as active on mount
 });
 
 it("dispatches actions to unset active subnet and clean up on unmount", () => {
-  const state = factory.rootState();
   const store = mockStore(state);
-  const { unmount } = render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: urls.subnets.subnet.index({ id: 1 }) }]}
-      >
-        <Routes>
-          <Route
-            element={<SubnetDetails />}
-            path={urls.subnets.subnet.index(null)}
-          />
-        </Routes>
-      </MemoryRouter>
-    </Provider>
-  );
+  const { unmount } = renderWithBrowserRouter(<SubnetDetails />, {
+    store,
+    route: urls.subnets.subnet.index({ id: 1 }),
+  });
 
   unmount();
 
@@ -83,53 +121,29 @@ it("dispatches actions to unset active subnet and clean up on unmount", () => {
 });
 
 it("displays a message if the subnet does not exist", () => {
-  const state = factory.rootState({
-    subnet: factory.subnetState({
-      items: [],
-      loading: false,
-    }),
+  state.subnet = factory.subnetState({
+    items: [],
+    loading: false,
   });
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: urls.subnets.subnet.index({ id: 1 }) }]}
-      >
-        <Routes>
-          <Route
-            element={<SubnetDetails />}
-            path={urls.subnets.subnet.index(null)}
-          />
-        </Routes>
-      </MemoryRouter>
-    </Provider>
-  );
+  renderWithBrowserRouter(<SubnetDetails />, {
+    store,
+    route: urls.subnets.subnet.index({ id: 1 }),
+  });
 
   expect(screen.getByText("Subnet not found")).toBeInTheDocument();
 });
 
 it("shows a spinner if the subnet has not loaded yet", () => {
-  const state = factory.rootState({
-    subnet: factory.subnetState({
-      items: [],
-      loading: true,
-    }),
+  state.subnet = factory.subnetState({
+    items: [],
+    loading: true,
   });
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter
-        initialEntries={[{ pathname: urls.subnets.subnet.index({ id: 1 }) }]}
-      >
-        <Routes>
-          <Route
-            element={<SubnetDetails />}
-            path={urls.subnets.subnet.index(null)}
-          />
-        </Routes>
-      </MemoryRouter>
-    </Provider>
-  );
+  renderWithBrowserRouter(<SubnetDetails />, {
+    store,
+    route: urls.subnets.subnet.index({ id: 1 }),
+  });
 
   expect(
     screen.getByTestId("section-header-title-spinner")

--- a/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetails.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import { useDispatch, useSelector } from "react-redux";
+import { Navigate, Route, Routes } from "react-router-dom";
 
 import StaticRoutes from "./StaticRoutes";
 import SubnetDetailsHeader from "./SubnetDetailsHeader";
@@ -13,6 +14,7 @@ import PageContent from "@/app/base/components/PageContent/PageContent";
 import SectionHeader from "@/app/base/components/SectionHeader";
 import { useGetURLId, useWindowTitle } from "@/app/base/hooks";
 import { useSidePanel } from "@/app/base/side-panel-context";
+import urls from "@/app/base/urls";
 import type { RootState } from "@/app/store/root/types";
 import { staticRouteActions } from "@/app/store/staticroute";
 import { subnetActions } from "@/app/store/subnet";
@@ -27,7 +29,7 @@ import {
   subnetActionLabels,
   SubnetActionTypes,
 } from "@/app/subnets/views/SubnetDetails/constants";
-import { isId } from "@/app/utils";
+import { getRelativeRoute, isId } from "@/app/utils";
 
 const SubnetDetails = (): JSX.Element => {
   const { sidePanelContent, setSidePanelContent } = useSidePanel();
@@ -80,6 +82,8 @@ const SubnetDetails = (): JSX.Element => {
       ? (name as SubnetActionType)
       : null;
 
+  const base = urls.subnets.subnet.index(null);
+
   return (
     <PageContent
       header={<SubnetDetailsHeader subnet={subnet} />}
@@ -95,12 +99,53 @@ const SubnetDetails = (): JSX.Element => {
       }
       sidePanelTitle={activeForm ? subnetActionLabels[activeForm] : ""}
     >
-      <SubnetSummary id={id} />
-      <Utilisation statistics={subnet.statistics} />
-      <StaticRoutes subnetId={id} />
-      <ReservedRanges subnetId={id} />
-      <DHCPSnippets modelName={SubnetMeta.MODEL} subnetIds={[id]} />
-      <SubnetUsedIPs subnetId={id} />
+      <Routes>
+        <Route
+          element={
+            <Navigate replace to={urls.subnets.subnet.summary({ id })} />
+          }
+          index
+        />
+        <Route
+          element={
+            <>
+              <SubnetSummary id={id} />
+              <Utilisation statistics={subnet.statistics} />
+            </>
+          }
+          path={getRelativeRoute(urls.subnets.subnet.summary(null), base)}
+        />
+        <Route
+          element={<StaticRoutes subnetId={id} />}
+          path={getRelativeRoute(urls.subnets.subnet.staticRoutes(null), base)}
+        />
+        <Route
+          element={<ReservedRanges subnetId={id} />}
+          path={getRelativeRoute(
+            urls.subnets.subnet.reservedIpAddresses(null),
+            base
+          )}
+        />
+        <Route
+          element={
+            <DHCPSnippets modelName={SubnetMeta.MODEL} subnetIds={[id]} />
+          }
+          path={getRelativeRoute(urls.subnets.subnet.dhcpSnippets(null), base)}
+        />
+        <Route
+          element={<SubnetUsedIPs subnetId={id} />}
+          path={getRelativeRoute(
+            urls.subnets.subnet.usedIpAddresses(null),
+            base
+          )}
+        />
+        <Route
+          element={
+            <Navigate replace to={urls.subnets.subnet.summary({ id })} />
+          }
+          path={base}
+        />
+      </Routes>
     </PageContent>
   );
 };

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
@@ -1,4 +1,6 @@
 import { ContextualMenu } from "@canonical/react-components";
+import { useLocation } from "react-router";
+import { Link } from "react-router-dom";
 
 import SectionHeader from "@/app/base/components/SectionHeader";
 import { useSidePanel } from "@/app/base/side-panel-context";
@@ -16,6 +18,8 @@ type Props = {
 
 const SubnetDetailsHeader = ({ subnet }: Props): JSX.Element => {
   const { setSidePanelContent } = useSidePanel();
+  const { pathname } = useLocation();
+  const urlBase = `/subnet/${subnet.id}`;
   return (
     <SectionHeader
       buttons={[
@@ -36,6 +40,38 @@ const SubnetDetailsHeader = ({ subnet }: Props): JSX.Element => {
         />,
       ]}
       subtitleLoading={!isSubnetDetails(subnet)}
+      tabLinks={[
+        {
+          active: pathname.startsWith(`${urlBase}/summary`),
+          component: Link,
+          label: "Summary",
+          to: `${urlBase}/summary`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/static-routes`),
+          component: Link,
+          label: "Static routes",
+          to: `${urlBase}/static-routes`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/reserved-ranges`),
+          component: Link,
+          label: "Reserved IPs",
+          to: `${urlBase}/reserved-ip-addresses`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/dhcp-snippets`),
+          component: Link,
+          label: "DHCP snippets",
+          to: `${urlBase}/dhcp-snippets`,
+        },
+        {
+          active: pathname.startsWith(`${urlBase}/used-ip-addresses`),
+          component: Link,
+          label: "Used IP addresses",
+          to: `${urlBase}/used-ip-addresses`,
+        },
+      ]}
       title={subnet.name}
     />
   );

--- a/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetDetailsHeader/SubnetDetailsHeader.tsx
@@ -54,7 +54,7 @@ const SubnetDetailsHeader = ({ subnet }: Props): JSX.Element => {
           to: `${urlBase}/static-routes`,
         },
         {
-          active: pathname.startsWith(`${urlBase}/reserved-ranges`),
+          active: pathname.startsWith(`${urlBase}/reserved-ip-addresses`),
           component: Link,
           label: "Reserved IPs",
           to: `${urlBase}/reserved-ip-addresses`,

--- a/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetSummary/SubnetSummary.tsx
@@ -41,6 +41,7 @@ const SubnetSummary = ({ id }: Props): JSX.Element | null => {
 
   return (
     <EditableSection
+      className="u-no-padding--top"
       renderContent={(editing, setEditing) =>
         editing ? (
           <SubnetSummaryForm

--- a/src/app/subnets/views/SubnetDetails/SubnetUsedIPs/SubnetUsedIPs.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetUsedIPs/SubnetUsedIPs.tsx
@@ -92,7 +92,7 @@ const SubnetUsedIPs = ({ subnetId }: Props): JSX.Element => {
   const loading = useSelector(subnetSelectors.loading);
 
   return (
-    <TitledSection title="Used IP addresses">
+    <TitledSection className="u-no-padding--top" title="Used IP addresses">
       <MainTable
         className="used-ip-table p-table-expanding--light"
         defaultSort="ip"


### PR DESCRIPTION
## Done
- split up subnet details into separate routes
- added tab links for each route
- added urls for:
  - summary
  - static routes
  - reserved ips
  - dhcp snippets
  - used ips
- ~~(drive-by fix) fixed summary tab highlighting on machine details~~

<!--
- Itemised list of what was changed by this PR.
-->

## To do

- [x] write/refactor unit tests
- [x] fix inevitably failing cypress tests

## QA steps

- [ ] go to subnets and click on a subnet
- [ ] ensure that you are redirected to `/subnet/:id/summary`
- [ ] ensure that only summary and utilisation are visible on this page
- [ ] click on each of the links and:
  - [ ] ensure only the correct content for that page is displayed
  - [ ] ensure the URL slug is sensible in your opinion

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2973](https://warthogs.atlassian.net/browse/MAASENG-2973)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/e6fc955e-1db7-4c75-8236-b1ea4fafc5d3)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/8c42b898-c5f0-40d8-a376-362786b41e0a)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-2973]: https://warthogs.atlassian.net/browse/MAASENG-2973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ