### PR TITLE
fix(machines): tab link highlighting on machine summary MAASENG-3035

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -153,6 +153,7 @@ const MachineHeader = ({
       subtitleLoading={!isMachineDetails(machine)}
       tabLinks={[
         {
+          active: pathname.startsWith(`${urlBase}/summary`),
           component: Link,
           label: "Summary",
           to: `${urlBase}/summary`,


### PR DESCRIPTION
## Done
- Fixed tab link highlighting for machine summary

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to a machine's details
- [ ] Ensure the "summary" tab link is highlighted
- [ ] Click one of the other tabs and then click on "summary"
- [ ] Ensure the "summary" tab link is highlighted

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-3035](https://warthogs.atlassian.net/browse/MAASENG-3035)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/7c15003f-69a6-4910-b27a-e6674835ad2c)

### After
![image](https://github.com/canonical/maas-ui/assets/35104482/52dc97c6-ffdb-4983-8cca-87e230c82a48)


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
