### PR TITLE
fix(machines): tab link highlighting on machine summary 3.5 backport

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
+++ b/src/app/machines/views/MachineDetails/MachineHeader/MachineHeader.tsx
@@ -153,6 +153,7 @@ const MachineHeader = ({
       subtitleLoading={!isMachineDetails(machine)}
       tabLinks={[
         {
+          active: pathname.startsWith(`${urlBase}/summary`),
           component: Link,
           label: "Summary",
           to: `${urlBase}/summary`,


### PR DESCRIPTION
## Done
- 3.5 backport of #5407 

<!--
- Itemised list of what was changed by this PR.
-->
