### PR TITLE
chore: exclude canonical deps from react-ecosystem

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,7 @@
       "groupName": "React ecosystem",
       "groupSlug": "react-ecosystem",
       "matchPackagePatterns": ["^react", "^@types/react"],
+      "excludePackagePatterns": ["^@canonical"],
       "schedule": ["before 5am on monday"]
     },
     {


### PR DESCRIPTION
## Done
- chore: exclude canonical deps from react-ecosystem

This will prevent renovate updates of e.g. @canonical/react-components as part of react ecosystem. @canonical/ deps should be always updated together with vanilla framework as part of internal dependencies. 

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
