### PR TITLE
refactor: add generateGetReducers util MAASENG-3132 WIP

### DIFF
--- a/src/app/store/controller/slice.ts
+++ b/src/app/store/controller/slice.ts
@@ -290,12 +290,12 @@ const controllerSlice = createSlice({
       state.loading = false;
       state.loaded = true;
     },
-    ...generateGetReducers<ControllerState, Controller, ControllerMeta.PK>(
-      ControllerMeta.MODEL,
-      ControllerMeta.PK,
-      DEFAULT_STATUSES,
-      setErrors
-    ),
+    ...generateGetReducers<ControllerState, Controller, ControllerMeta.PK>({
+      modelName: ControllerMeta.MODEL,
+      primaryKey: ControllerMeta.PK,
+      defaultStatuses: DEFAULT_STATUSES,
+      setErrors,
+    }),
     getSummaryXml: {
       prepare: (params: GetSummaryXmlParams) => ({
         meta: {

--- a/src/app/store/controller/slice.ts
+++ b/src/app/store/controller/slice.ts
@@ -25,6 +25,7 @@ import { NodeActions } from "@/app/store/types/node";
 import type { GenericItemMeta, StatusHandlers } from "@/app/store/utils/slice";
 import {
   generateCommonReducers,
+  generateGetReducers,
   generateStatusHandlers,
   genericInitialState,
   updateErrors,
@@ -289,49 +290,12 @@ const controllerSlice = createSlice({
       state.loading = false;
       state.loaded = true;
     },
-    get: {
-      prepare: (id: Controller[ControllerMeta.PK]) => ({
-        meta: {
-          model: ControllerMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { [ControllerMeta.PK]: id },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getError: (
-      state: ControllerState,
-      action: PayloadAction<ControllerState["errors"]>
-    ) => {
-      state.errors = action.payload;
-      state = setErrors(state, action, "get");
-      state.loading = false;
-      state.saving = false;
-    },
-    getStart: (state: ControllerState) => {
-      state.loading = true;
-    },
-    getSuccess: (state: ControllerState, action: PayloadAction<Controller>) => {
-      const controller = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: Controller) =>
-          draftItem[ControllerMeta.PK] === controller[ControllerMeta.PK]
-      );
-      if (i !== -1) {
-        state.items[i] = controller;
-      } else {
-        state.items.push(controller);
-        // Set up the statuses for this controller.
-        state.statuses[controller[ControllerMeta.PK]] = DEFAULT_STATUSES;
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers<ControllerState, Controller, ControllerMeta.PK>(
+      ControllerMeta.MODEL,
+      ControllerMeta.PK,
+      DEFAULT_STATUSES,
+      setErrors
+    ),
     getSummaryXml: {
       prepare: (params: GetSummaryXmlParams) => ({
         meta: {

--- a/src/app/store/device/slice.ts
+++ b/src/app/store/device/slice.ts
@@ -226,12 +226,12 @@ const deviceSlice = createSlice({
     deleteInterfaceError: statusHandlers.deleteInterface.error,
     deleteInterfaceStart: statusHandlers.deleteInterface.start,
     deleteInterfaceSuccess: statusHandlers.deleteInterface.success,
-    ...generateGetReducers(
-      DeviceMeta.MODEL,
-      DeviceMeta.PK,
-      DEFAULT_STATUSES,
-      setErrors
-    ),
+    ...generateGetReducers({
+      modelName: DeviceMeta.MODEL,
+      primaryKey: DeviceMeta.PK,
+      defaultStatuses: DEFAULT_STATUSES,
+      setErrors,
+    }),
     linkSubnet: {
       prepare: (params: LinkSubnetParams) => ({
         meta: {

--- a/src/app/store/device/slice.ts
+++ b/src/app/store/device/slice.ts
@@ -24,6 +24,7 @@ import type {
 import { NodeActions } from "@/app/store/types/node";
 import {
   generateCommonReducers,
+  generateGetReducers,
   generateStatusHandlers,
   genericInitialState,
   updateErrors,
@@ -225,49 +226,12 @@ const deviceSlice = createSlice({
     deleteInterfaceError: statusHandlers.deleteInterface.error,
     deleteInterfaceStart: statusHandlers.deleteInterface.start,
     deleteInterfaceSuccess: statusHandlers.deleteInterface.success,
-    get: {
-      prepare: (id: Device[DeviceMeta.PK]) => ({
-        meta: {
-          model: DeviceMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { [DeviceMeta.PK]: id },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getError: (
-      state: DeviceState,
-      action: PayloadAction<DeviceState["errors"]>
-    ) => {
-      state.errors = action.payload;
-      state = setErrors(state, action, "get");
-      state.loading = false;
-      state.saving = false;
-    },
-    getStart: (state: DeviceState) => {
-      state.loading = true;
-    },
-    getSuccess: (state: DeviceState, action: PayloadAction<Device>) => {
-      const device = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: Device) =>
-          draftItem[DeviceMeta.PK] === device[DeviceMeta.PK]
-      );
-      if (i !== -1) {
-        state.items[i] = device;
-      } else {
-        state.items.push(device);
-        // Set up the statuses for this device.
-        state.statuses[device[DeviceMeta.PK]] = DEFAULT_STATUSES;
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers(
+      DeviceMeta.MODEL,
+      DeviceMeta.PK,
+      DEFAULT_STATUSES,
+      setErrors
+    ),
     linkSubnet: {
       prepare: (params: LinkSubnetParams) => ({
         meta: {

--- a/src/app/store/domain/reducers.test.ts
+++ b/src/app/store/domain/reducers.test.ts
@@ -199,21 +199,6 @@ describe("domain reducer", () => {
     );
   });
 
-  // Related to: https://bugs.launchpad.net/maas/+bug/1931654.
-  it("reduces getError when the error when a domain can't be found", () => {
-    const domainState = factory.domainState({
-      errors: null,
-      saving: true,
-    });
-
-    expect(reducers(domainState, actions.getError("9"))).toEqual(
-      factory.domainState({
-        errors: "There was an error getting the domain.",
-        saving: false,
-      })
-    );
-  });
-
   it("reduces setDefaultError", () => {
     const domainState = factory.domainState({
       errors: null,
@@ -225,21 +210,6 @@ describe("domain reducer", () => {
     ).toEqual(
       factory.domainState({
         errors: "It didn't work",
-        saving: false,
-      })
-    );
-  });
-
-  // Related to: https://bugs.launchpad.net/maas/+bug/1931654.
-  it("reduces setDefaultError when the error when a domain can't be found", () => {
-    const domainState = factory.domainState({
-      errors: null,
-      saving: true,
-    });
-
-    expect(reducers(domainState, actions.setDefaultError("9"))).toEqual(
-      factory.domainState({
-        errors: "There was an error when setting default domain.",
         saving: false,
       })
     );
@@ -287,20 +257,6 @@ describe("domain reducer", () => {
       factory.domainState({
         active: null,
         errors: "Domain with this id does not exist",
-      })
-    );
-  });
-
-  // Related to: https://bugs.launchpad.net/maas/+bug/1931654.
-  it("reduces setActiveError when the error when a domain can't be found", () => {
-    const domainState = factory.domainState({
-      errors: null,
-    });
-
-    expect(reducers(domainState, actions.setActiveError("9"))).toEqual(
-      factory.domainState({
-        errors: "There was an error when setting active domain.",
-        saving: false,
       })
     );
   });

--- a/src/app/store/domain/slice.ts
+++ b/src/app/store/domain/slice.ts
@@ -23,6 +23,7 @@ import type {
 import type { APIError } from "@/app/base/types";
 import {
   generateCommonReducers,
+  generateGetReducers,
   genericInitialState,
 } from "@/app/store/utils/slice";
 
@@ -39,55 +40,10 @@ const domainSlice = createSlice({
       CreateParams,
       UpdateParams
     >(DomainMeta.MODEL, DomainMeta.PK),
-    get: {
-      prepare: (id: Domain[DomainMeta.PK]) => ({
-        meta: {
-          model: DomainMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { id },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getStart: (state: DomainState) => {
-      state.loading = true;
-    },
-    getError: (
-      state: DomainState,
-      action: PayloadAction<DomainState["errors"]>
-    ) => {
-      // API seems to return the domain id in payload.error not an error message
-      // when the domain can't be found. This override can be removed when the
-      // bug is fixed: https://bugs.launchpad.net/maas/+bug/1931654.
-      if (!isNaN(Number(action.payload))) {
-        // returned error string is a number (id of the domain)
-        state.errors = "There was an error getting the domain.";
-      } else {
-        // returned error string is an error message
-        state.errors = action.payload;
-      }
-
-      state.loading = false;
-      state.saving = false;
-    },
-    getSuccess: (state: DomainState, action: PayloadAction<Domain>) => {
-      const domain = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: Domain) => draftItem.id === domain.id
-      );
-      if (i !== -1) {
-        state.items[i] = domain;
-      } else {
-        state.items.push(domain);
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers<DomainState, Domain, DomainMeta.PK>(
+      DomainMeta.MODEL,
+      DomainMeta.PK
+    ),
     setDefault: {
       prepare: (id: Domain[DomainMeta.PK]) => ({
         meta: {

--- a/src/app/store/domain/slice.ts
+++ b/src/app/store/domain/slice.ts
@@ -40,11 +40,10 @@ const domainSlice = createSlice({
       CreateParams,
       UpdateParams
     >(DomainMeta.MODEL, DomainMeta.PK),
-    ...generateGetReducers<DomainState, Domain, DomainMeta.PK>(
-      DomainMeta.MODEL,
-      DomainMeta.PK,
-      null
-    ),
+    ...generateGetReducers<DomainState, Domain, DomainMeta.PK>({
+      modelName: DomainMeta.MODEL,
+      primaryKey: DomainMeta.PK,
+    }),
     setDefault: {
       prepare: (id: Domain[DomainMeta.PK]) => ({
         meta: {

--- a/src/app/store/domain/slice.ts
+++ b/src/app/store/domain/slice.ts
@@ -42,7 +42,8 @@ const domainSlice = createSlice({
     >(DomainMeta.MODEL, DomainMeta.PK),
     ...generateGetReducers<DomainState, Domain, DomainMeta.PK>(
       DomainMeta.MODEL,
-      DomainMeta.PK
+      DomainMeta.PK,
+      null
     ),
     setDefault: {
       prepare: (id: Domain[DomainMeta.PK]) => ({
@@ -67,16 +68,7 @@ const domainSlice = createSlice({
       action: PayloadAction<SetDefaultErrors>
     ) => {
       state.saving = false;
-      // API seems to return the domain id in payload.error not an error message
-      // when the domain can't be found. This override can be removed when the
-      // bug is fixed: https://bugs.launchpad.net/maas/+bug/1931654.
-      if (!isNaN(Number(action.payload))) {
-        // returned error string is a number (id of the domain)
-        state.errors = "There was an error when setting default domain.";
-      } else {
-        // returned error string is an error message
-        state.errors = action.payload;
-      }
+      state.errors = action.payload;
     },
     setDefaultSuccess: (state: DomainState, action: PayloadAction<Domain>) => {
       state.saving = false;
@@ -112,16 +104,7 @@ const domainSlice = createSlice({
       action: PayloadAction<DomainState["errors"]>
     ) => {
       state.active = null;
-      // API seems to return the domain id in payload.error not an error message
-      // when the domain can't be found. This override can be removed when the
-      // bug is fixed: https://bugs.launchpad.net/maas/+bug/1931654.
-      if (!isNaN(Number(action.payload))) {
-        // returned error string is a number (id of the domain)
-        state.errors = "There was an error when setting active domain.";
-      } else {
-        // returned error string is an error message
-        state.errors = action.payload;
-      }
+      state.errors = action.payload;
     },
     setActiveSuccess: (
       state: DomainState,

--- a/src/app/store/fabric/slice.ts
+++ b/src/app/store/fabric/slice.ts
@@ -25,7 +25,8 @@ const fabricSlice = createSlice({
     >(FabricMeta.MODEL, FabricMeta.PK),
     ...generateGetReducers<FabricState, Fabric, FabricMeta.PK>(
       FabricMeta.MODEL,
-      FabricMeta.PK
+      FabricMeta.PK,
+      null
     ),
     setActive: {
       prepare: (id: Fabric[FabricMeta.PK] | null) => ({

--- a/src/app/store/fabric/slice.ts
+++ b/src/app/store/fabric/slice.ts
@@ -23,11 +23,10 @@ const fabricSlice = createSlice({
       CreateParams,
       UpdateParams
     >(FabricMeta.MODEL, FabricMeta.PK),
-    ...generateGetReducers<FabricState, Fabric, FabricMeta.PK>(
-      FabricMeta.MODEL,
-      FabricMeta.PK,
-      null
-    ),
+    ...generateGetReducers<FabricState, Fabric, FabricMeta.PK>({
+      modelName: FabricMeta.MODEL,
+      primaryKey: FabricMeta.PK,
+    }),
     setActive: {
       prepare: (id: Fabric[FabricMeta.PK] | null) => ({
         meta: {

--- a/src/app/store/fabric/slice.ts
+++ b/src/app/store/fabric/slice.ts
@@ -6,6 +6,7 @@ import type { CreateParams, Fabric, FabricState, UpdateParams } from "./types";
 
 import {
   generateCommonReducers,
+  generateGetReducers,
   genericInitialState,
 } from "@/app/store/utils/slice";
 
@@ -22,46 +23,10 @@ const fabricSlice = createSlice({
       CreateParams,
       UpdateParams
     >(FabricMeta.MODEL, FabricMeta.PK),
-    get: {
-      prepare: (id: Fabric[FabricMeta.PK]) => ({
-        meta: {
-          model: FabricMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { [FabricMeta.PK]: id },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getError: (
-      state: FabricState,
-      action: PayloadAction<FabricState["errors"]>
-    ) => {
-      state.errors = action.payload;
-      state.loading = false;
-      state.saving = false;
-    },
-    getStart: (state: FabricState) => {
-      state.loading = true;
-    },
-    getSuccess: (state: FabricState, action: PayloadAction<Fabric>) => {
-      const fabric = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: Fabric) =>
-          draftItem[FabricMeta.PK] === fabric[FabricMeta.PK]
-      );
-      if (i !== -1) {
-        state.items[i] = fabric;
-      } else {
-        state.items.push(fabric);
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers<FabricState, Fabric, FabricMeta.PK>(
+      FabricMeta.MODEL,
+      FabricMeta.PK
+    ),
     setActive: {
       prepare: (id: Fabric[FabricMeta.PK] | null) => ({
         meta: {

--- a/src/app/store/iprange/slice.ts
+++ b/src/app/store/iprange/slice.ts
@@ -26,7 +26,8 @@ const ipRangeSlice = createSlice({
     >(IPRangeMeta.MODEL, IPRangeMeta.PK),
     ...generateGetReducers<IPRangeState, IPRange, IPRangeMeta.PK>(
       IPRangeMeta.MODEL,
-      IPRangeMeta.PK
+      IPRangeMeta.PK,
+      null
     ),
   },
 });

--- a/src/app/store/iprange/slice.ts
+++ b/src/app/store/iprange/slice.ts
@@ -24,11 +24,10 @@ const ipRangeSlice = createSlice({
       CreateParams,
       UpdateParams
     >(IPRangeMeta.MODEL, IPRangeMeta.PK),
-    ...generateGetReducers<IPRangeState, IPRange, IPRangeMeta.PK>(
-      IPRangeMeta.MODEL,
-      IPRangeMeta.PK,
-      null
-    ),
+    ...generateGetReducers<IPRangeState, IPRange, IPRangeMeta.PK>({
+      modelName: IPRangeMeta.MODEL,
+      primaryKey: IPRangeMeta.PK,
+    }),
   },
 });
 

--- a/src/app/store/iprange/slice.ts
+++ b/src/app/store/iprange/slice.ts
@@ -1,4 +1,3 @@
-import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 
 import { IPRangeMeta } from "./types";
@@ -11,6 +10,7 @@ import type {
 
 import {
   generateCommonReducers,
+  generateGetReducers,
   genericInitialState,
 } from "@/app/store/utils/slice";
 
@@ -24,46 +24,10 @@ const ipRangeSlice = createSlice({
       CreateParams,
       UpdateParams
     >(IPRangeMeta.MODEL, IPRangeMeta.PK),
-
-    get: {
-      prepare: (id: IPRange[IPRangeMeta.PK]) => ({
-        meta: {
-          model: IPRangeMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { id },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getStart: (state: IPRangeState) => {
-      state.loading = true;
-    },
-    getError: (
-      state: IPRangeState,
-      action: PayloadAction<IPRangeState["errors"]>
-    ) => {
-      state.errors = action.payload;
-      state.loading = false;
-      state.saving = false;
-    },
-    getSuccess: (state: IPRangeState, action: PayloadAction<IPRange>) => {
-      const ipRange = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: IPRange) => draftItem.id === ipRange.id
-      );
-      if (i !== -1) {
-        state.items[i] = ipRange;
-      } else {
-        state.items.push(ipRange);
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers<IPRangeState, IPRange, IPRangeMeta.PK>(
+      IPRangeMeta.MODEL,
+      IPRangeMeta.PK
+    ),
   },
 });
 

--- a/src/app/store/pod/slice.ts
+++ b/src/app/store/pod/slice.ts
@@ -19,6 +19,7 @@ import { generateStatusHandlers } from "@/app/store/utils";
 import type { GenericItemMeta } from "@/app/store/utils";
 import {
   generateCommonReducers,
+  generateGetReducers,
   genericInitialState,
 } from "@/app/store/utils/slice";
 
@@ -151,44 +152,11 @@ const podSlice = createSlice({
         }
       });
     },
-    get: {
-      prepare: (podID: Pod[PodMeta.PK]) => ({
-        meta: {
-          model: PodMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { id: podID },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getStart: (state: PodState) => {
-      state.loading = true;
-    },
-    getError: (state: PodState, action: PayloadAction<PodState["errors"]>) => {
-      state.errors = action.payload;
-      state.loading = false;
-      state.saving = false;
-    },
-    getSuccess: (state: PodState, action: PayloadAction<Pod>) => {
-      const pod = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: Pod) => draftItem.id === pod.id
-      );
-      if (i !== -1) {
-        state.items[i] = pod;
-      } else {
-        state.items.push(pod);
-        // Set up the statuses for this pod.
-        state.statuses[pod.id] = DEFAULT_STATUSES;
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers<PodState, Pod, PodMeta.PK>(
+      PodMeta.MODEL,
+      PodMeta.PK,
+      DEFAULT_STATUSES
+    ),
     getProjects: {
       prepare: (params: GetProjectsParams) => ({
         meta: {

--- a/src/app/store/pod/slice.ts
+++ b/src/app/store/pod/slice.ts
@@ -152,11 +152,11 @@ const podSlice = createSlice({
         }
       });
     },
-    ...generateGetReducers<PodState, Pod, PodMeta.PK>(
-      PodMeta.MODEL,
-      PodMeta.PK,
-      DEFAULT_STATUSES
-    ),
+    ...generateGetReducers<PodState, Pod, PodMeta.PK>({
+      modelName: PodMeta.MODEL,
+      primaryKey: PodMeta.PK,
+      defaultStatuses: DEFAULT_STATUSES,
+    }),
     getProjects: {
       prepare: (params: GetProjectsParams) => ({
         meta: {

--- a/src/app/store/space/slice.ts
+++ b/src/app/store/space/slice.ts
@@ -23,11 +23,10 @@ const spaceSlice = createSlice({
       CreateParams,
       UpdateParams
     >(SpaceMeta.MODEL, SpaceMeta.PK),
-    ...generateGetReducers<SpaceState, Space, SpaceMeta.PK>(
-      SpaceMeta.MODEL,
-      SpaceMeta.PK,
-      null
-    ),
+    ...generateGetReducers<SpaceState, Space, SpaceMeta.PK>({
+      modelName: SpaceMeta.MODEL,
+      primaryKey: SpaceMeta.PK,
+    }),
     setActive: {
       prepare: (id: Space[SpaceMeta.PK] | null) => ({
         meta: {

--- a/src/app/store/space/slice.ts
+++ b/src/app/store/space/slice.ts
@@ -25,7 +25,8 @@ const spaceSlice = createSlice({
     >(SpaceMeta.MODEL, SpaceMeta.PK),
     ...generateGetReducers<SpaceState, Space, SpaceMeta.PK>(
       SpaceMeta.MODEL,
-      SpaceMeta.PK
+      SpaceMeta.PK,
+      null
     ),
     setActive: {
       prepare: (id: Space[SpaceMeta.PK] | null) => ({

--- a/src/app/store/space/slice.ts
+++ b/src/app/store/space/slice.ts
@@ -6,6 +6,7 @@ import type { CreateParams, Space, SpaceState, UpdateParams } from "./types";
 
 import {
   generateCommonReducers,
+  generateGetReducers,
   genericInitialState,
 } from "@/app/store/utils/slice";
 
@@ -22,45 +23,10 @@ const spaceSlice = createSlice({
       CreateParams,
       UpdateParams
     >(SpaceMeta.MODEL, SpaceMeta.PK),
-    get: {
-      prepare: (id: Space[SpaceMeta.PK]) => ({
-        meta: {
-          model: SpaceMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { [SpaceMeta.PK]: id },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getError: (
-      state: SpaceState,
-      action: PayloadAction<SpaceState["errors"]>
-    ) => {
-      state.errors = action.payload;
-      state.loading = false;
-      state.saving = false;
-    },
-    getStart: (state: SpaceState) => {
-      state.loading = true;
-    },
-    getSuccess: (state: SpaceState, action: PayloadAction<Space>) => {
-      const space = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: Space) => draftItem[SpaceMeta.PK] === space[SpaceMeta.PK]
-      );
-      if (i !== -1) {
-        state.items[i] = space;
-      } else {
-        state.items.push(space);
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers<SpaceState, Space, SpaceMeta.PK>(
+      SpaceMeta.MODEL,
+      SpaceMeta.PK
+    ),
     setActive: {
       prepare: (id: Space[SpaceMeta.PK] | null) => ({
         meta: {

--- a/src/app/store/subnet/slice.ts
+++ b/src/app/store/subnet/slice.ts
@@ -15,6 +15,7 @@ import {
   genericInitialState,
   generateStatusHandlers,
   updateErrors,
+  generateGetReducers,
 } from "@/app/store/utils/slice";
 import type { GenericItemMeta } from "@/app/store/utils/slice";
 import { isId } from "@/app/utils";
@@ -92,47 +93,11 @@ const subnetSlice = createSlice({
       state.loading = false;
       state.loaded = true;
     },
-    get: {
-      prepare: (id: Subnet[SubnetMeta.PK]) => ({
-        meta: {
-          model: SubnetMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { [SubnetMeta.PK]: id },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getError: (
-      state: SubnetState,
-      action: PayloadAction<SubnetState["errors"]>
-    ) => {
-      state.errors = action.payload;
-      state.loading = false;
-      state.saving = false;
-    },
-    getStart: (state: SubnetState) => {
-      state.loading = true;
-    },
-    getSuccess: (state: SubnetState, action: PayloadAction<Subnet>) => {
-      const subnet = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: Subnet) =>
-          draftItem[SubnetMeta.PK] === subnet[SubnetMeta.PK]
-      );
-      if (i !== -1) {
-        state.items[i] = subnet;
-      } else {
-        state.items.push(subnet);
-        state.statuses[subnet[SubnetMeta.PK]] = DEFAULT_STATUSES;
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers<SubnetState, Subnet, SubnetMeta.PK>(
+      SubnetMeta.MODEL,
+      SubnetMeta.PK,
+      DEFAULT_STATUSES
+    ),
     scan: {
       prepare: (id: Subnet[SubnetMeta.PK]) => ({
         meta: {

--- a/src/app/store/subnet/slice.ts
+++ b/src/app/store/subnet/slice.ts
@@ -93,11 +93,11 @@ const subnetSlice = createSlice({
       state.loading = false;
       state.loaded = true;
     },
-    ...generateGetReducers<SubnetState, Subnet, SubnetMeta.PK>(
-      SubnetMeta.MODEL,
-      SubnetMeta.PK,
-      DEFAULT_STATUSES
-    ),
+    ...generateGetReducers<SubnetState, Subnet, SubnetMeta.PK>({
+      modelName: SubnetMeta.MODEL,
+      primaryKey: SubnetMeta.PK,
+      defaultStatuses: DEFAULT_STATUSES,
+    }),
     scan: {
       prepare: (id: Subnet[SubnetMeta.PK]) => ({
         meta: {

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -505,28 +505,33 @@ export const generateGetReducers = <
   S extends CommonStateTypes | StatusStateTypes | EventErrorStateTypes,
   T extends S["items"][0],
   K extends keyof T,
->(
-  name: keyof SliceState<S>,
-  indexKey: K,
-  defaultStatuses: S extends StatusStateTypes
+>({
+  modelName,
+  primaryKey,
+  defaultStatuses,
+  setErrors,
+}: {
+  modelName: keyof SliceState<S>;
+  primaryKey: K;
+  defaultStatuses?: S extends StatusStateTypes
     ? S["statuses"][T[K] & keyof S["statuses"]]
-    : null,
+    : never;
   setErrors?: (
     state: S,
     action: PayloadAction<S["errors"]> | null,
     event: string | null
-  ) => S
-) => {
+  ) => S;
+}) => {
   return {
     get: {
       prepare: (id: T[K]) => ({
         meta: {
-          model: name,
+          model: modelName,
           method: "get",
         },
         payload: {
           params: {
-            [indexKey]: id,
+            [primaryKey]: id,
           },
         },
       }),
@@ -548,7 +553,7 @@ export const generateGetReducers = <
     getSuccess: (state: S, action: PayloadAction<T>) => {
       const item = action.payload;
       const index = (state.items as T[]).findIndex(
-        (draftItem: T) => draftItem[indexKey] === item[indexKey]
+        (draftItem: T) => draftItem[primaryKey] === item[primaryKey]
       );
       if (index !== -1) {
         state.items[index] = item;
@@ -556,7 +561,7 @@ export const generateGetReducers = <
         (state.items as T[]).push(item);
         if ("statuses" in state && defaultStatuses) {
           (state.statuses as StatusStateTypes["statuses"])[
-            item[indexKey] as keyof StatusStateTypes["statuses"]
+            item[primaryKey] as keyof StatusStateTypes["statuses"]
           ] = defaultStatuses;
         }
       }

--- a/src/app/store/utils/slice.ts
+++ b/src/app/store/utils/slice.ts
@@ -500,3 +500,52 @@ export const generateStatusHandlers = <
     },
     {}
   );
+
+export const generateGetReducers = <
+  S extends CommonStateTypes,
+  T extends S["items"][0],
+  K extends keyof T,
+>(
+  name: keyof SliceState<S>,
+  indexKey: K
+) => {
+  return {
+    get: {
+      prepare: (id: T[K]) => ({
+        meta: {
+          model: name,
+          method: "get",
+        },
+        payload: {
+          params: {
+            id,
+          },
+        },
+      }),
+      reducer: () => {
+        // No state changes need to be handled for this action.
+      },
+    },
+    getStart: (state: S) => {
+      state.loading = true;
+    },
+    getError: (state: S, action: PayloadAction<S["errors"]>) => {
+      state.errors = action.payload;
+      state.loading = false;
+      state.saving = false;
+    },
+    getSuccess: (state: S, action: PayloadAction<T>) => {
+      const item = action.payload;
+      const i = (state.items as T[]).findIndex(
+        (draftItem) => draftItem[indexKey] === item[indexKey]
+      );
+      if (i !== -1) {
+        state.items[i] = item;
+      } else {
+        (state.items as T[]).push(item);
+      }
+      state.loading = false;
+      state.saving = false;
+    },
+  };
+};

--- a/src/app/store/vlan/slice.ts
+++ b/src/app/store/vlan/slice.ts
@@ -103,11 +103,11 @@ const vlanSlice = createSlice({
       state.loading = false;
       state.loaded = true;
     },
-    ...generateGetReducers<VLANState, VLAN, VLANMeta.PK>(
-      VLANMeta.MODEL,
-      VLANMeta.PK,
-      DEFAULT_STATUSES
-    ),
+    ...generateGetReducers<VLANState, VLAN, VLANMeta.PK>({
+      modelName: VLANMeta.MODEL,
+      primaryKey: VLANMeta.PK,
+      defaultStatuses: DEFAULT_STATUSES,
+    }),
     setActive: {
       prepare: (id: VLAN[VLANMeta.PK] | null) => ({
         meta: {

--- a/src/app/store/vlan/slice.ts
+++ b/src/app/store/vlan/slice.ts
@@ -14,6 +14,7 @@ import type {
 
 import {
   generateCommonReducers,
+  generateGetReducers,
   generateStatusHandlers,
   genericInitialState,
   updateErrors,
@@ -102,46 +103,11 @@ const vlanSlice = createSlice({
       state.loading = false;
       state.loaded = true;
     },
-    get: {
-      prepare: (id: VLAN[VLANMeta.PK]) => ({
-        meta: {
-          model: VLANMeta.MODEL,
-          method: "get",
-        },
-        payload: {
-          params: { [VLANMeta.PK]: id },
-        },
-      }),
-      reducer: () => {
-        // No state changes need to be handled for this action.
-      },
-    },
-    getError: (
-      state: VLANState,
-      action: PayloadAction<VLANState["errors"]>
-    ) => {
-      state.errors = action.payload;
-      state.loading = false;
-      state.saving = false;
-    },
-    getStart: (state: VLANState) => {
-      state.loading = true;
-    },
-    getSuccess: (state: VLANState, action: PayloadAction<VLAN>) => {
-      const vlan = action.payload;
-      // If the item already exists, update it, otherwise
-      // add it to the store.
-      const i = state.items.findIndex(
-        (draftItem: VLAN) => draftItem[VLANMeta.PK] === vlan[VLANMeta.PK]
-      );
-      if (i !== -1) {
-        state.items[i] = vlan;
-      } else {
-        state.items.push(vlan);
-        state.statuses[vlan[VLANMeta.PK]] = DEFAULT_STATUSES;
-      }
-      state.loading = false;
-    },
+    ...generateGetReducers<VLANState, VLAN, VLANMeta.PK>(
+      VLANMeta.MODEL,
+      VLANMeta.PK,
+      DEFAULT_STATUSES
+    ),
     setActive: {
       prepare: (id: VLAN[VLANMeta.PK] | null) => ({
         meta: {


### PR DESCRIPTION
## Done
- refactor: add generateGetReducers util
  - remove workarounds for error return type https://bugs.launchpad.net/maas/+bug/1931654
  - refactor controller, device, iprange, pod, subnet, vlan, domain, iprange, space reducers

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to fabric details page
- [ ] Verify fabric has been displayed correctly
- [ ] Enter a non-existent domain id in the url, `e.g.` `/MAAS/r/domain/89` and verify an error is displayed
- [ ] Verify that all of the details pages for models below load correctly: controller, device, iprange, pod, subnet, vlan, domain, iprange, space


<!-- Steps for QA. -->

## Fixes

Fixes: MAASENG-3132

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
## After 

![Google Chrome screenshot 001873@2x](https://github.com/canonical/maas-ui/assets/7452681/3fc933aa-55b6-4a3f-aa7c-9bde70f70070)
Error for domain that does not exist is still displayed correctly.

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
