### PR TITLE
feat(subnets): Edit reserved IPs MAASENG-2976 & MAASENG-2984

### DIFF
--- a/src/app/store/reservedip/reducers.test.ts
+++ b/src/app/store/reservedip/reducers.test.ts
@@ -128,6 +128,56 @@ describe("create reducers", () => {
   });
 });
 
+describe("update reducers", () => {
+  it("should correctly reduce updateStart", () => {
+    const initialState = factory.reservedIpState({ saving: false });
+    expect(reducers(initialState, actions.updateStart())).toEqual(
+      factory.reservedIpState({
+        saving: true,
+      })
+    );
+  });
+
+  it("should correctly reduce updateSuccess", () => {
+    const reservedIp = factory.reservedIp();
+    const initialState = factory.reservedIpState({
+      items: [reservedIp],
+      saving: true,
+      saved: false,
+    });
+    expect(reducers(initialState, actions.updateSuccess(reservedIp))).toEqual(
+      factory.reservedIpState({
+        saving: false,
+        saved: true,
+        items: [reservedIp],
+      })
+    );
+  });
+
+  it("should correctly reduce updateError", () => {
+    const initialState = factory.reservedIpState({
+      saving: true,
+      saved: false,
+    });
+    expect(reducers(initialState, actions.updateError("Error"))).toEqual(
+      factory.reservedIpState({
+        saving: false,
+        errors: "Error",
+      })
+    );
+  });
+
+  it("should correctly reduce updateNotify", () => {
+    const items = [factory.reservedIp(), factory.reservedIp()];
+    const initialState = factory.reservedIpState({
+      items,
+    });
+    expect(
+      reducers(initialState, actions.updateNotify(items[1])).items
+    ).toEqual(items);
+  });
+});
+
 describe("delete reducers", () => {
   it("should correctly reduce deleteStart", () => {
     const initialState = factory.reservedIpState({ saving: false });

--- a/src/app/store/reservedip/slice.ts
+++ b/src/app/store/reservedip/slice.ts
@@ -71,6 +71,20 @@ const reservedIpSlice = createSlice({
         }
       },
     },
+    updateSuccess: (
+      state: ReservedIpState,
+      action: PayloadAction<ReservedIp>
+    ) => {
+      commonReducers.updateSuccess(state);
+      const item = action.payload;
+      const index = (state.items as ReservedIp[]).findIndex(
+        (draftItem: ReservedIp) =>
+          draftItem[ReservedIpMeta.PK] === item[ReservedIpMeta.PK]
+      );
+      if (index !== -1) {
+        state.items[index] = item;
+      }
+    },
   },
 });
 

--- a/src/app/subnets/views/SubnetDetails/StaticDHCPLease/ReserveDHCPLease/ReserveDHCPLease.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticDHCPLease/ReserveDHCPLease/ReserveDHCPLease.tsx
@@ -159,6 +159,7 @@ const ReserveDHCPLease = ({
         isEditing ? "Edit static DHCP lease" : "Reserve static DHCP lease"
       }
       cleanup={cleanup}
+      enableReinitialize
       errors={errors}
       initialValues={initialValues}
       onCancel={onClose}

--- a/src/app/subnets/views/SubnetDetails/StaticDHCPLease/ReserveDHCPLease/ReserveDHCPLease.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticDHCPLease/ReserveDHCPLease/ReserveDHCPLease.tsx
@@ -21,6 +21,8 @@ import {
   isIpInSubnet,
 } from "@/app/utils/subnetIpRange";
 
+const MAX_COMMENT_LENGTH = 255;
+
 type Props = Pick<
   SubnetActionProps,
   "subnetId" | "setSidePanelContent" | "reservedIpId"
@@ -168,20 +170,29 @@ const ReserveDHCPLease = ({
       }
       validationSchema={ReserveDHCPLeaseSchema}
     >
-      <FormikField
-        cidr={subnet.cidr}
-        component={PrefixedIpInput}
-        label="IP address"
-        name="ip_address"
-        required
-      />
-      <MacAddressField label="MAC address" name="mac_address" />
-      <FormikField
-        label="Comment"
-        name="comment"
-        placeholder="Static DHCP lease purpose"
-        type="text"
-      />
+      {({ values }: { values: FormValues }) => (
+        <>
+          <FormikField
+            cidr={subnet.cidr}
+            component={PrefixedIpInput}
+            label="IP address"
+            name="ip_address"
+            required
+          />
+          <MacAddressField label="MAC address" name="mac_address" />
+          <FormikField
+            className="u-margin-bottom--x-small"
+            label="Comment"
+            maxLength={MAX_COMMENT_LENGTH}
+            name="comment"
+            placeholder="Static DHCP lease purpose"
+            type="text"
+          />
+          <small className="u-flex--end">
+            {values.comment.length}/{MAX_COMMENT_LENGTH}
+          </small>
+        </>
+      )}
     </FormikForm>
   );
 };

--- a/src/app/subnets/views/SubnetDetails/StaticDHCPLease/ReserveDHCPLease/ReserveDHCPLease.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticDHCPLease/ReserveDHCPLease/ReserveDHCPLease.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 
 import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
@@ -56,7 +56,7 @@ const ReserveDHCPLease = ({
   const loading = subnetLoading || reservedIpLoading;
   const isEditing = !!reservedIpId;
 
-  const initialValues = useMemo(() => {
+  const getInitialValues = () => {
     if (reservedIp && subnet) {
       const [startIp, endIp] = getIpRangeFromCidr(subnet.cidr);
       const [immutableOctets, _] = getImmutableAndEditableOctets(
@@ -75,7 +75,9 @@ const ReserveDHCPLease = ({
         comment: "",
       };
     }
-  }, [reservedIp, subnet]);
+  };
+
+  const initialValues = getInitialValues();
 
   const onClose = () => setSidePanelContent(null);
 

--- a/src/app/subnets/views/SubnetDetails/StaticDHCPLease/StaticDHCPTable/StaticDHCPTable.test.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticDHCPLease/StaticDHCPTable/StaticDHCPTable.test.tsx
@@ -1,7 +1,19 @@
 import StaticDHCPTable from "./StaticDHCPTable";
 
+import * as sidePanelHooks from "@/app/base/side-panel-context";
+import { SubnetActionTypes } from "@/app/subnets/views/SubnetDetails/constants";
 import { reservedIp } from "@/testing/factories/reservedip";
-import { renderWithBrowserRouter, screen } from "@/testing/utils";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const setSidePanelContent = vi.fn();
+beforeAll(() => {
+  vi.spyOn(sidePanelHooks, "useSidePanel").mockReturnValue({
+    setSidePanelContent,
+    sidePanelContent: null,
+    setSidePanelSize: vi.fn(),
+    sidePanelSize: "regular",
+  });
+});
 
 it("renders a static DHCP table with no data", () => {
   renderWithBrowserRouter(<StaticDHCPTable loading={false} reservedIps={[]} />);
@@ -26,4 +38,32 @@ it("renders a static DHCP table when data is provided", () => {
   expect(
     screen.getByRole("cell", { name: reservedIps[0].ip })
   ).toBeInTheDocument();
+});
+
+it("opens the side panel with the correct view when the edit button is clicked", async () => {
+  const reservedIps = [reservedIp()];
+  renderWithBrowserRouter(
+    <StaticDHCPTable loading={false} reservedIps={reservedIps} />
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+  expect(setSidePanelContent).toHaveBeenCalledWith({
+    extras: { reservedIpId: reservedIps[0].id },
+    view: ["", SubnetActionTypes.ReserveDHCPLease],
+  });
+});
+
+it("opens the side panel with the correct view when the delete button is clicked", async () => {
+  const reservedIps = [reservedIp()];
+  renderWithBrowserRouter(
+    <StaticDHCPTable loading={false} reservedIps={reservedIps} />
+  );
+
+  await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+  expect(setSidePanelContent).toHaveBeenCalledWith({
+    extras: { reservedIpId: reservedIps[0].id },
+    view: ["", SubnetActionTypes.DeleteDHCPLease],
+  });
 });

--- a/src/app/subnets/views/SubnetDetails/StaticDHCPLease/StaticDHCPTable/StaticDHCPTable.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticDHCPLease/StaticDHCPTable/StaticDHCPTable.tsx
@@ -62,7 +62,12 @@ const generateRows = (
                 extras: { reservedIpId: reservedIp.id },
               })
             }
-            onEdit={() => {}}
+            onEdit={() =>
+              setSidePanelContent({
+                view: SubnetDetailsSidePanelViews.ReserveDHCPLease,
+                extras: { reservedIpId: reservedIp.id },
+              })
+            }
           />
         </td>
       </tr>

--- a/src/app/subnets/views/SubnetDetails/SubnetActionForms/SubnetActionForms.tsx
+++ b/src/app/subnets/views/SubnetDetails/SubnetActionForms/SubnetActionForms.tsx
@@ -28,7 +28,7 @@ const FormComponents: Record<
   [SubnetActionTypes.ReserveRange]: ReservedRangeForm,
   [SubnetActionTypes.DeleteReservedRange]: ReservedRangeDeleteForm,
   [SubnetActionTypes.ReserveDHCPLease]: ReserveDHCPLease,
-  [SubnetActionTypes.EditDHCPLease]: () => null,
+  [SubnetActionTypes.EditDHCPLease]: ReserveDHCPLease,
   [SubnetActionTypes.DeleteDHCPLease]: DeleteDHCPLease,
 };
 

--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -112,6 +112,10 @@
     flex-wrap: wrap !important;
   }
 
+  .u-margin-bottom--x-small {
+    margin-bottom: $sp-x-small !important;
+  }
+
   .u-no-border {
     border: 0 !important;
   }


### PR DESCRIPTION
## Done
- Enabled "Edit" button on static dhcp lease table
- Added `updateSuccess` reducer
- Added `reservedIpId` prop to `ReserveDHCPLease` form
- `ReserveDHCPLease` form now pre-fills data when the above prop is provided
- Added a character counter and character limit to the add/edit form

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

### Prerequisites

Add the following lines to your `.env.local`:*

```
MAAS_URL = "http://nick-dv.ddns.net:5240/"
VITE_APP_STATIC_IPS_ENABLED = true
```

### Steps

- [ ] Open dev tools, open WS connection
- [ ] Go to `/MAAS/r/subnet/4/address-reservation`
- [ ] Click "Reserve Static DHCP lease"
- [ ] Fill out the form (correctly!) and submit
- [ ] Click the "Edit" button for this IP
- [ ] Change some values (make sure they are correct)
- [ ] Submit the form
- [ ] Ensure a request has been made to update this reserved IP (id should match the creation request)
- [ ] Ensure the list has been updated

<!-- Steps for QA. -->

## Screenshots

![image](https://github.com/canonical/maas-ui/assets/35104482/efd7ca3a-6957-4896-ab50-e1584b579641)

## Fixes

- Fixes [MAASENG-2976](https://warthogs.atlassian.net/browse/MAASENG-2976)
- Fixes [MAASENG-2984](https://warthogs.atlassian.net/browse/MAASENG-2984)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Notes

*Ping me when you're QAing so I can open the firewall port for you.

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2976]: https://warthogs.atlassian.net/browse/MAASENG-2976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAASENG-2984]: https://warthogs.atlassian.net/browse/MAASENG-2984?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ