### PR TITLE
refactor: fix selector memoization warning

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
@@ -21,7 +21,7 @@ const TagForm = ({ systemId }: Props): JSX.Element | null => {
     machineSelectors.getById(state, systemId)
   );
   const tags = useSelector((state: RootState) =>
-    tagSelectors.getByIDs(state, machine?.tags || [])
+    tagSelectors.getByIDs(state, machine?.tags || null)
   );
   const tagsLoading = useSelector(tagSelectors.loading);
   const taggingMachines = useSelector(machineSelectors.updatingTags);

--- a/src/app/store/subnet/selectors.ts
+++ b/src/app/store/subnet/selectors.ts
@@ -60,10 +60,10 @@ const active = createSelector(
 const getByIds = createSelector(
   [
     defaultSelectors.all,
-    (_state: RootState, ids: Subnet[SubnetMeta.PK][]) => ids,
+    (_state: RootState, ids: Subnet[SubnetMeta.PK][] | null) => ids,
   ],
-  (subnets, ids) => {
-    return subnets.filter(({ id }) => ids.includes(id));
+  (subnets, ids = []) => {
+    return subnets.filter(({ id }) => ids?.includes(id));
   }
 );
 

--- a/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
+++ b/src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.tsx
@@ -64,7 +64,7 @@ const DHCPStatus = ({ id }: Props): JSX.Element | null => {
     vlanSelectors.getById(state, id)
   );
   const vlanSubnets = useSelector((state: RootState) =>
-    subnetSelectors.getByIds(state, vlan?.subnet_ids || [])
+    subnetSelectors.getByIds(state, vlan?.subnet_ids || null)
   );
   const subnetsLoading = useSelector(subnetSelectors.loading);
 


### PR DESCRIPTION
## Done
- refactor: fix selector memoization warning

```
stderr | src/app/subnets/views/VLANDetails/DHCPStatus/DHCPStatus.test.tsx > shows a spinner if data is loading
Selector unknown returned a different result when called with the same parameters. This can lead to unnecessary rerenders.
Selectors that return a new reference (such as an object or an array) should be memoized: https://redux.js.org/usage/deriving-data-selectors#optimizing-selectors-with-memoization
```

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to tags page
- [ ] Verify it's displayed without errors

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
