### PR TITLE
refactor: pod selectors caching

### DIFF
--- a/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
+++ b/src/app/base/components/AppSideNavigation/AppSideNavigation.test.tsx
@@ -349,17 +349,21 @@ describe("GlobalSideNav", () => {
     );
   });
 
-  it("hides the 'Virsh' link if the user does not have any Virsh KVM hosts", () => {
-    const { rerender } = renderWithBrowserRouter(<AppSideNavigation />, {
+  it("displays 'Virsh' link if user has Virsh KVM hosts", () => {
+    renderWithBrowserRouter(<AppSideNavigation />, {
       route: "/machines",
       state,
     });
 
     expect(screen.getByRole("link", { name: "Virsh" })).toBeInTheDocument();
+  });
 
+  it("hides 'Virsh' link if user has no Virsh KVM hosts", () => {
     state.pod.items = [];
-
-    rerender(<AppSideNavigation />);
+    renderWithBrowserRouter(<AppSideNavigation />, {
+      route: "/machines",
+      state,
+    });
 
     expect(
       screen.queryByRole("link", { name: "Virsh" })

--- a/src/app/store/pod/selectors.ts
+++ b/src/app/store/pod/selectors.ts
@@ -25,18 +25,18 @@ const defaultSelectors = generateBaseSelectors<PodState, Pod, PodMeta.PK>(
  * @param {RootState} state - The redux state.
  * @returns {Pod[]} A list of all KVMs.
  */
-const kvms = (state: RootState): Pod[] =>
-  state.pod.items.filter((pod) =>
-    [PodType.LXD, PodType.VIRSH].includes(pod.type)
-  );
+const kvms = createSelector([defaultSelectors.all], (pods) =>
+  pods.filter((pod) => [PodType.LXD, PodType.VIRSH].includes(pod.type))
+);
 
 /**
  * Returns all LXD pods.
  * @param state - The redux state.
  * @returns A list of all LXD pods.
  */
-const lxd = (state: RootState): Pod[] =>
-  state.pod.items.filter((pod) => pod.type === PodType.LXD);
+const lxd = createSelector([defaultSelectors.all], (pods) =>
+  pods.filter((pod) => pod.type === PodType.LXD)
+);
 
 /**
  * Returns all LXD single hosts (i.e. LXD pods that are not cluster hosts).
@@ -101,8 +101,9 @@ const searchInCluster = createSelector(
  * @param state - The redux state.
  * @returns A list of all virsh pods.
  */
-const virsh = (state: RootState): Pod[] =>
-  state.pod.items.filter((pod) => pod.type === PodType.VIRSH);
+const virsh = createSelector([defaultSelectors.all], (pods) =>
+  pods.filter((pod) => pod.type === PodType.VIRSH)
+);
 
 /**
  * Returns active pod id.


### PR DESCRIPTION
## Done
- refactor: pod selectors caching

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to LXD page and verify all items are displayed as expected
- [ ] Go to Virsh page and verify all items are displayed as expected
- [ ] Verify that no warning about redux selectors is displayed in the console

<!-- Steps for QA. -->


<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
