### PR TITLE
fix: DHCPTable, TagForm, VLANDetails selectors

### DIFF
--- a/src/app/base/components/DHCPTable/DHCPTable.tsx
+++ b/src/app/base/components/DHCPTable/DHCPTable.tsx
@@ -140,13 +140,11 @@ const DHCPTable = ({
 }: Props): JSX.Element | null => {
   const [expanded, setExpanded] = useState<DHCPSnippet["id"] | null>(null);
   const dhcpsnippetLoading = useSelector(dhcpsnippetSelectors.loading);
+  const subnetIds = subnets?.map(({ id }) => id) || null;
   const dhcpsnippets = useSelector((state: RootState) =>
     node
       ? dhcpsnippetSelectors.getByNode(state, node?.system_id)
-      : dhcpsnippetSelectors.getBySubnets(
-          state,
-          subnets?.map(({ id }) => id)
-        )
+      : dhcpsnippetSelectors.getBySubnets(state, subnetIds)
   );
 
   useFetchActions([dhcpsnippetActions.fetch]);

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/TagForm/TagForm.tsx
@@ -25,11 +25,9 @@ const TagForm = ({ systemId }: Props): JSX.Element | null => {
   );
   const tagsLoading = useSelector(tagSelectors.loading);
   const taggingMachines = useSelector(machineSelectors.updatingTags);
+  const eventActions = [NodeActions.TAG, NodeActions.UNTAG];
   const errors = useSelector((state: RootState) =>
-    machineSelectors.eventErrorsForIds(state, systemId, [
-      NodeActions.TAG,
-      NodeActions.UNTAG,
-    ])
+    machineSelectors.eventErrorsForIds(state, systemId, eventActions)
   )[0]?.error;
   const canEdit = useCanEdit(machine, true);
 

--- a/src/app/subnets/views/VLANDetails/VLANDetails.tsx
+++ b/src/app/subnets/views/VLANDetails/VLANDetails.tsx
@@ -37,7 +37,7 @@ const VLANDetails = (): JSX.Element => {
   );
   const vlansLoading = useSelector(vlanSelectors.loading);
   const subnets = useSelector((state: RootState) =>
-    subnetSelectors.getByIds(state, vlan?.subnet_ids || [])
+    subnetSelectors.getByIds(state, vlan?.subnet_ids || null)
   );
   useWindowTitle(`${vlan?.name || "VLAN"} details`);
 


### PR DESCRIPTION
## Done
- fix: DHCPTable, TagForm, VLANDetails selectors

This pull request fixes the selectors in the DHCPTable, TagForm, and VLANDetails components.

In VLANDetails.tsx, the call to subnetSelectors.getByIds has been updated to pass null instead of an empty array when vlan?.subnet_ids is falsy.

In TagForm.tsx, the events array is now prevented from being re-created on every render.



<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to VLAN Details page and ensure that DHCP snippets are displayed and there is no warning in the console

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
