### PR TITLE
ci: fix links checker workflow

### DIFF
--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -2,9 +2,10 @@ name: MAAS Docs link checker
 on:
   schedule:
     - cron: "0 14 * * 1-5" # At 14:00 every day-of-week from Monday through Friday.
-  branches:
-    - main
-    - "3.5"
+  push:
+    branches:
+      - main
+      - "3.5"
 
 jobs:
   docs:


### PR DESCRIPTION
## Done
- ci: fix links checker

This adds `push` instead of `branches` directly under `on`

<!--
- Itemised list of what was changed by this PR.
-->
