### PR TITLE
ci: add TICS workflow with artifact upload MAASENG-3276

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report
+          path: .coverage
       - uses: actions/checkout@v4
       - name: Run TICS Analyzer
         uses: tiobe/tics-github-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Install
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: CYPRESS_INSTALL_BINARY=0 yarn install
@@ -40,7 +40,7 @@ jobs:
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Install
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: CYPRESS_INSTALL_BINARY=0 yarn install
@@ -83,6 +83,31 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+  tics-report:
+    name: TICS Report
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run TICS Analyzer
+        uses: tiobe/tics-github-action@v3
+        with:
+          mode: qserver
+          project: maas-ui
+          viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
+          ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
+          installTics: true
+          tmpdir: /tmp/tics
+          branchdir: .
+
+      - name: Upload TICS Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tics-report
+          path: /tmp/tics/ticstmpdir
+          retention-days: 7
+
   build:
     name: Build
     timeout-minutes: 15
@@ -98,7 +123,7 @@ jobs:
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Install
         if: steps.yarn-cache.outputs.cache-hit != 'true'
         run: CYPRESS_INSTALL_BINARY=0 yarn install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,7 +103,7 @@ jobs:
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
           tmpdir: /tmp/tics
-          branchdir: ${{ GITHUB_WORKSPACE }}
+          branchdir: ${{ github.workspace }}
 
       - name: Upload TICS Report
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,7 @@ jobs:
       - name: Run TICS Analyzer
         uses: tiobe/tics-github-action@v3
         with:
+          # Use 'qserver' for push to main branch, 'client' for others. See: https://github.com/tiobe/tics-github-action?tab=readme-ov-file#client-default
           mode: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'qserver' || 'client' }}
           project: maas-ui
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Run TICS Analyzer
         uses: tiobe/tics-github-action@v3
         with:
-          mode: qserver
+          mode: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'qserver' || 'client' }}
           project: maas-ui
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}
           installTics: true
           tmpdir: /tmp/tics
-          branchdir: .
+          branchdir: ${{ GITHUB_WORKSPACE }}
 
       - name: Upload TICS Report
         if: always()


### PR DESCRIPTION
## Done
This pull request introduces a new CI workflow that adds TICS GitHub Action. This will execute TICS analysis on push to main and upload the generated artifacts to our TICS Dashboard: https://canonical.tiobe.com/tiobeweb/TICS/

-  add TICS workflow with artifact upload
 
<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] verify that the workflow ran successfully https://github.com/canonical/maas-ui/pull/5466#issuecomment-2301603860
- [x] check that the generated TICS report artifacts were uploaded and maas-ui has been added to the dashboard


<!-- Steps for QA. -->

## Fixes

Fixes: https://warthogs.atlassian.net/browse/MAASENG-3399

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Notes
This currently fails with "Error: There was an error retrieving last QServer run date: HTTP request failed with status 400. Requested project not found: maas-ui".