### PR TITLE
chore: Add scopes to PR lint workflow MAASENG-3414

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -19,6 +19,7 @@ jobs:
           scopes: |
             base
             controllers
+            deps
             devices
             domains
             images

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -15,3 +15,22 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          scopes: |
+            base
+            controllers
+            devices
+            domains
+            images
+            intro
+            kvm
+            machines
+            networkDiscovery
+            pools
+            preferences
+            settings
+            store
+            subnets
+            tags
+            utils
+            zones


### PR DESCRIPTION
## Done
- chore: Add scopes to PR lint workflow

Fixes: https://warthogs.atlassian.net/browse/MAASENG-3414

## QA
- Verify that PR lint failed for `chore(invalid-scope)` https://github.com/canonical/maas-ui/actions/runs/9593881088/job/26455264222?pr=5473

![Google Chrome screenshot 002029@2x](https://github.com/canonical/maas-ui/assets/7452681/50b0d0c5-1f2d-4c96-917d-8aaf18e04d7a)

## Spec
[MA201 - Conventional commits](https://docs.google.com/document/d/1_bX6y_XnZHw0p5QgPZV-_lm-6wr-LyM2Vd_DO4V2IsI/edit#heading=h.833o1m6v1nlg)