### PR TITLE
feat(devices): Integrate dynamic IP validation with "Add Device" form MAASENG-2982

### DIFF
--- a/src/app/base/components/PrefixedIpInput/index.ts
+++ b/src/app/base/components/PrefixedIpInput/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./PrefixedIpInput";
+export { formatIpAddress } from "./utils";

--- a/src/app/base/components/PrefixedIpInput/utils.test.ts
+++ b/src/app/base/components/PrefixedIpInput/utils.test.ts
@@ -1,0 +1,15 @@
+import { formatIpAddress } from "./utils";
+
+it("can format an IPv4 address", () => {
+  const ip = "10";
+  const cidr = "192.168.0.0/24";
+
+  expect(formatIpAddress(ip, cidr)).toBe("192.168.0.10");
+});
+
+it("can format an IPv6 address", () => {
+  const ip = ":10";
+  const cidr = "2001:db8::/32";
+
+  expect(formatIpAddress(ip, cidr)).toBe("2001:db8::10");
+});

--- a/src/app/base/components/PrefixedIpInput/utils.ts
+++ b/src/app/base/components/PrefixedIpInput/utils.ts
@@ -1,0 +1,26 @@
+import { isIPv4 } from "is-ip";
+
+import {
+  getImmutableAndEditableOctets,
+  getIpRangeFromCidr,
+} from "@/app/utils/subnetIpRange";
+
+/**
+ * Formats the PrefixedIpInput value into a complete IP address.
+ *
+ * @param ip The partial IP address to format
+ * @param cidr The subnet's CIDR notation
+ * @returns The formatted IP address
+ */
+export const formatIpAddress = (ip: string | undefined, cidr: string) => {
+  const [startIp, endIp] = getIpRangeFromCidr(cidr);
+  const [immutableOctets, _] = getImmutableAndEditableOctets(startIp, endIp);
+  const networkAddress = cidr.split("/")[0];
+  const ipv6Prefix = networkAddress.substring(
+    0,
+    networkAddress.lastIndexOf(":")
+  );
+  const subnetIsIpv4 = isIPv4(networkAddress);
+
+  return subnetIsIpv4 ? `${immutableOctets}.${ip}` : `${ipv6Prefix}${ip}`;
+};

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.test.tsx
@@ -29,7 +29,9 @@ describe("AddDeviceForm", () => {
         loaded: true,
       }),
       subnet: factory.subnetState({
-        items: [factory.subnet({ id: 0, name: "subnet" })],
+        items: [
+          factory.subnet({ id: 0, name: "subnet", cidr: "192.168.1.0/24" }),
+        ],
         loaded: true,
       }),
       zone: factory.zoneState({
@@ -121,10 +123,7 @@ describe("AddDeviceForm", () => {
       "0"
     );
 
-    await userEvent.type(
-      getFieldFromCard(0, "IP address", "textbox"),
-      "192.168.1.1"
-    );
+    await userEvent.type(getFieldFromCard(0, "IP address", "textbox"), "1");
 
     await userEvent.type(
       getFieldFromCard(1, "MAC address", "textbox"),

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 
 import { Col, Row, Spinner, Strip } from "@canonical/react-components";
+import ipaddr from "ipaddr.js";
+import { isIP, isIPv4 } from "is-ip";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
@@ -10,6 +12,7 @@ import type { AddDeviceValues } from "./types";
 import DomainSelect from "@/app/base/components/DomainSelect";
 import FormikField from "@/app/base/components/FormikField";
 import FormikForm from "@/app/base/components/FormikForm";
+import { formatIpAddress } from "@/app/base/components/PrefixedIpInput";
 import ZoneSelect from "@/app/base/components/ZoneSelect";
 import { useFetchActions, useAddMessage } from "@/app/base/hooks";
 import type { ClearSidePanelContent } from "@/app/base/types";
@@ -23,6 +26,7 @@ import { subnetActions } from "@/app/store/subnet";
 import subnetSelectors from "@/app/store/subnet/selectors";
 import { zoneActions } from "@/app/store/zone";
 import zoneSelectors from "@/app/store/zone/selectors";
+import { isIpInSubnet } from "@/app/utils/subnetIpRange";
 
 type Props = {
   clearSidePanelContent: ClearSidePanelContent;
@@ -38,17 +42,76 @@ const AddDeviceSchema = Yup.object().shape({
           .matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
           .required("MAC address is required"),
         ip_assignment: Yup.string().required("IP assignment is required"),
-        ip_address: Yup.string().when("ip_assignment", {
-          is: (ipAssignment: DeviceIpAssignment) =>
-            ipAssignment === DeviceIpAssignment.STATIC ||
-            ipAssignment === DeviceIpAssignment.EXTERNAL,
-          then: Yup.string().required("IP address is required"),
-        }),
+        ip_address: Yup.string()
+          .when("ip_assignment", {
+            is: (ipAssignment: DeviceIpAssignment) =>
+              ipAssignment === DeviceIpAssignment.STATIC,
+            then: Yup.string()
+              .test({
+                name: "ip-is-valid",
+                message: "This is not a valid IP address",
+                test: (ip_address, context) => {
+                  try {
+                    return isIP(
+                      formatIpAddress(
+                        ip_address,
+                        context.parent.subnet_cidr as string
+                      )
+                    );
+                  } catch (e) {
+                    return false;
+                  }
+                },
+              })
+              .test({
+                name: "ip-is-in-subnet",
+                message: "The IP address is outside of the subnet's range.",
+                test: (ip_address, context) => {
+                  try {
+                    const cidr: string = context.parent.subnet_cidr;
+                    const networkAddress = cidr.split("/")[0];
+                    const prefixLength = parseInt(cidr.split("/")[1]);
+                    const subnetIsIpv4 = isIPv4(networkAddress);
+
+                    const ip = formatIpAddress(ip_address, cidr);
+                    if (subnetIsIpv4) {
+                      return isIpInSubnet(ip, cidr);
+                    } else {
+                      try {
+                        const addr = ipaddr.parse(ip);
+                        const netAddr = ipaddr.parse(networkAddress);
+                        return addr.match(netAddr, prefixLength);
+                      } catch (e) {
+                        return false;
+                      }
+                    }
+                  } catch (e) {
+                    return false;
+                  }
+                },
+              }),
+          })
+          .when("ip_assignment", {
+            is: (ipAssignment: DeviceIpAssignment) =>
+              ipAssignment === DeviceIpAssignment.EXTERNAL,
+            then: Yup.string().test({
+              name: "ip-is-valid",
+              message: "This is not a valid IP address",
+              test: (ip_address) => isIP(`${ip_address}`),
+            }),
+          })
+          .when("ip_assignment", {
+            is: (ipAssignment: DeviceIpAssignment) =>
+              ipAssignment === DeviceIpAssignment.STATIC ||
+              ipAssignment === DeviceIpAssignment.EXTERNAL,
+            then: Yup.string().required("IP address is required"),
+          }),
         subnet: Yup.number().when("ip_assignment", {
           is: (ipAssignment: DeviceIpAssignment) =>
             ipAssignment === DeviceIpAssignment.STATIC,
           then: Yup.number().required("Subnet is required"),
         }),
+        subnet_cidr: Yup.string(),
       })
     )
     .min(1, "At least one interface must be defined"),
@@ -111,6 +174,7 @@ export const AddDeviceForm = ({
             mac: "",
             name: "eth0",
             subnet: "",
+            subnet_cidr: "",
           },
         ],
         zone: (zones.length && zones[0].name) || "",
@@ -125,8 +189,15 @@ export const AddDeviceForm = ({
         const { domain, hostname, interfaces, zone } = values;
         const normalisedInterfaces = interfaces.map((iface) => {
           const subnet = parseInt(iface.subnet);
+          const ip =
+            iface.ip_assignment === DeviceIpAssignment.STATIC
+              ? formatIpAddress(iface.ip_address, iface.subnet_cidr)
+              : iface.ip_assignment === DeviceIpAssignment.EXTERNAL
+                ? iface.ip_address
+                : null;
+
           return {
-            ip_address: iface.ip_address || null,
+            ip_address: ip || null,
             ip_assignment: iface.ip_assignment,
             mac: iface.mac,
             name: iface.name,

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceForm.tsx
@@ -51,6 +51,7 @@ const AddDeviceSchema = Yup.object().shape({
                 name: "ip-is-valid",
                 message: "This is not a valid IP address",
                 test: (ip_address, context) => {
+                  // Wrap this in a try/catch since the subnet might not be loaded yet
                   try {
                     return isIP(
                       formatIpAddress(
@@ -67,6 +68,7 @@ const AddDeviceSchema = Yup.object().shape({
                 name: "ip-is-in-subnet",
                 message: "The IP address is outside of the subnet's range.",
                 test: (ip_address, context) => {
+                  // Wrap this in a try/catch since the subnet might not be loaded yet
                   try {
                     const cidr: string = context.parent.subnet_cidr;
                     const networkAddress = cidr.split("/")[0];
@@ -174,6 +176,7 @@ export const AddDeviceForm = ({
             mac: "",
             name: "eth0",
             subnet: "",
+            // Capture the subnet CIDR so we can validate the IP address against it.
             subnet_cidr: "",
           },
         ],
@@ -196,6 +199,7 @@ export const AddDeviceForm = ({
                 ? iface.ip_address
                 : null;
 
+          // subnet_cidr is omitted, since it's only needed for validation.
           return {
             ip_address: ip || null,
             ip_assignment: iface.ip_assignment,

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.test.tsx
@@ -29,6 +29,7 @@ describe("AddDeviceInterfaces", () => {
         mac: "",
         name: "eth0",
         subnet: "",
+        subnet_cidr: "",
       },
     ];
     state = factory.rootState({
@@ -53,7 +54,7 @@ describe("AddDeviceInterfaces", () => {
     expect(screen.queryByTestId("ip-address-field")).not.toBeInTheDocument();
   });
 
-  it("shows the IP address field for external IP assignment", () => {
+  it("shows the standard IP address field for external IP assignment", () => {
     interfaces[0].ip_assignment = DeviceIpAssignment.EXTERNAL;
     const store = mockStore(state);
     renderWithBrowserRouter(
@@ -63,11 +64,15 @@ describe("AddDeviceInterfaces", () => {
       { store }
     );
 
-    expect(screen.queryByTestId("subnet-field")).not.toBeInTheDocument();
     expect(screen.getByTestId("ip-address-field")).toBeInTheDocument();
+
+    expect(screen.queryByTestId("subnet-field")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("prefixed-ip-address-field")
+    ).not.toBeInTheDocument();
   });
 
-  it("shows both the subnet and IP address fields for static IP assignment", () => {
+  it("shows the subnet field when static IP assignment is selected", () => {
     interfaces[0].ip_assignment = DeviceIpAssignment.STATIC;
     const store = mockStore(state);
     renderWithBrowserRouter(
@@ -78,7 +83,25 @@ describe("AddDeviceInterfaces", () => {
     );
 
     expect(screen.getByTestId("subnet-field")).toBeInTheDocument();
-    expect(screen.getByTestId("ip-address-field")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("prefixed-ip-address-field")
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the prefixed IP address field when a subnet is selected", () => {
+    interfaces[0].ip_assignment = DeviceIpAssignment.STATIC;
+    interfaces[0].subnet = state.subnet.items[0].id.toString();
+
+    const store = mockStore(state);
+    renderWithBrowserRouter(
+      <Formik initialValues={{ interfaces }} onSubmit={vi.fn()}>
+        <AddDeviceInterfaces />
+      </Formik>,
+      { store }
+    );
+
+    expect(screen.getByTestId("prefixed-ip-address-field")).toBeInTheDocument();
+    expect(screen.queryByTestId("ip-address-field")).not.toBeInTheDocument();
   });
 
   it("can add and remove interfaces", async () => {

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
@@ -2,21 +2,94 @@ import type { ChangeEvent } from "react";
 import { useRef } from "react";
 
 import { Button, Card, Icon } from "@canonical/react-components";
-import { useFormikContext } from "formik";
+import { Field, useFormikContext } from "formik";
+import { useSelector } from "react-redux";
 
-import type { AddDeviceValues } from "../types";
+import type { AddDeviceInterface, AddDeviceValues } from "../types";
 
 import FormikField from "@/app/base/components/FormikField";
 import IpAssignmentSelect from "@/app/base/components/IpAssignmentSelect";
 import MacAddressField from "@/app/base/components/MacAddressField";
+import PrefixedIpInput from "@/app/base/components/PrefixedIpInput";
 import SubnetSelect from "@/app/base/components/SubnetSelect";
 import { DeviceIpAssignment } from "@/app/store/device/types";
+import type { RootState } from "@/app/store/root/types";
+import subnetSelectors from "@/app/store/subnet/selectors";
 import { getNextName } from "@/app/utils";
+
+const AddDeviceInterfaceFields = ({
+  deleteDisabled,
+  iface,
+  index,
+  removeInterface,
+}: {
+  deleteDisabled: boolean;
+  iface: AddDeviceInterface;
+  index: number;
+  removeInterface: (id: number) => void;
+}) => {
+  const { handleChange, setFieldValue, errors } =
+    useFormikContext<AddDeviceValues>();
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, parseInt(iface.subnet))
+  );
+
+  const showSubnetField = iface.ip_assignment === DeviceIpAssignment.STATIC;
+  const showIpAddressField =
+    iface.ip_assignment === DeviceIpAssignment.STATIC ||
+    iface.ip_assignment === DeviceIpAssignment.EXTERNAL;
+
+  return (
+    <Card data-testid="interface-card" key={iface.id}>
+      <FormikField
+        label="Name"
+        name={`interfaces[${index}].name`}
+        type="text"
+      />
+      <MacAddressField
+        label="MAC address"
+        name={`interfaces[${index}].mac`}
+        required
+      />
+      <IpAssignmentSelect
+        name={`interfaces[${index}].ip_assignment`}
+        onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+          handleChange(e);
+          setFieldValue(`interfaces[${index}].subnet`, "");
+          setFieldValue(`interfaces[${index}].ip_address`, "");
+        }}
+        required
+      />
+      {showSubnetField ? (
+        <SubnetSelect
+          data-testid="subnet-field"
+          name={`interfaces[${index}].subnet`}
+        />
+      ) : null}
+      {showIpAddressField && subnet ? (
+        <Field
+          cidr={subnet.cidr}
+          component={PrefixedIpInput}
+          data-testid="ip-address-field"
+          errors={errors.interfaces?.[index]}
+          label="IP address"
+          name={`interfaces[${index}].ip_address`}
+        />
+      ) : null}
+      {!deleteDisabled ? (
+        <div className="u-align--right">
+          <Button onClick={() => removeInterface(iface.id)} type="button">
+            Delete
+          </Button>
+        </div>
+      ) : null}
+    </Card>
+  );
+};
 
 export const AddDeviceInterfaces = (): JSX.Element => {
   const currentId = useRef<number>(0);
   const {
-    handleChange,
     setFieldValue,
     values: { interfaces },
   } = useFormikContext<AddDeviceValues>();
@@ -49,59 +122,15 @@ export const AddDeviceInterfaces = (): JSX.Element => {
   return (
     <>
       <h4>Interfaces</h4>
-      {interfaces.map((iface, i) => {
-        const showSubnetField =
-          iface.ip_assignment === DeviceIpAssignment.STATIC;
-        const showIpAddressField =
-          iface.ip_assignment === DeviceIpAssignment.STATIC ||
-          iface.ip_assignment === DeviceIpAssignment.EXTERNAL;
-        const deleteDisabled = interfaces.length <= 1;
-
-        return (
-          <Card data-testid="interface-card" key={iface.id}>
-            <FormikField
-              label="Name"
-              name={`interfaces[${i}].name`}
-              type="text"
-            />
-            <MacAddressField
-              label="MAC address"
-              name={`interfaces[${i}].mac`}
-              required
-            />
-            <IpAssignmentSelect
-              name={`interfaces[${i}].ip_assignment`}
-              onChange={(e: ChangeEvent<HTMLSelectElement>) => {
-                handleChange(e);
-                setFieldValue(`interfaces[${i}].subnet`, "");
-                setFieldValue(`interfaces[${i}].ip_address`, "");
-              }}
-              required
-            />
-            {showSubnetField ? (
-              <SubnetSelect
-                data-testid="subnet-field"
-                name={`interfaces[${i}].subnet`}
-              />
-            ) : null}
-            {showIpAddressField ? (
-              <FormikField
-                data-testid="ip-address-field"
-                label="IP address"
-                name={`interfaces[${i}].ip_address`}
-                type="text"
-              />
-            ) : null}
-            {!deleteDisabled ? (
-              <div className="u-align--right">
-                <Button onClick={() => removeInterface(iface.id)} type="button">
-                  Delete
-                </Button>
-              </div>
-            ) : null}
-          </Card>
-        );
-      })}
+      {interfaces.map((iface, i) => (
+        <AddDeviceInterfaceFields
+          deleteDisabled={interfaces.length === 1}
+          iface={iface}
+          index={i}
+          key={iface.id}
+          removeInterface={removeInterface}
+        />
+      ))}
       <Button
         data-testid="add-interface"
         hasIcon

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/AddDeviceInterfaces/AddDeviceInterfaces.tsx
@@ -20,12 +20,10 @@ import { getNextName } from "@/app/utils";
 const AddDeviceInterfaceFields = ({
   deleteDisabled,
   iface,
-  index,
   removeInterface,
 }: {
   deleteDisabled: boolean;
   iface: AddDeviceInterface;
-  index: number;
   removeInterface: (id: number) => void;
 }) => {
   const { handleChange, setFieldValue } = useFormikContext<AddDeviceValues>();
@@ -35,9 +33,9 @@ const AddDeviceInterfaceFields = ({
 
   useEffect(() => {
     if (iface.ip_assignment === DeviceIpAssignment.STATIC && subnet) {
-      setFieldValue(`interfaces[${index}].subnet_cidr`, subnet.cidr);
+      setFieldValue(`interfaces[${iface.id}].subnet_cidr`, subnet.cidr);
     }
-  }, [iface.ip_assignment, index, setFieldValue, subnet]);
+  }, [iface.id, iface.ip_assignment, setFieldValue, subnet]);
 
   const showSubnetField = iface.ip_assignment === DeviceIpAssignment.STATIC;
 
@@ -45,27 +43,27 @@ const AddDeviceInterfaceFields = ({
     <Card data-testid="interface-card" key={iface.id}>
       <FormikField
         label="Name"
-        name={`interfaces[${index}].name`}
+        name={`interfaces[${iface.id}].name`}
         type="text"
       />
       <MacAddressField
         label="MAC address"
-        name={`interfaces[${index}].mac`}
+        name={`interfaces[${iface.id}].mac`}
         required
       />
       <IpAssignmentSelect
-        name={`interfaces[${index}].ip_assignment`}
+        name={`interfaces[${iface.id}].ip_assignment`}
         onChange={(e: ChangeEvent<HTMLSelectElement>) => {
           handleChange(e);
-          setFieldValue(`interfaces[${index}].subnet`, "");
-          setFieldValue(`interfaces[${index}].ip_address`, "");
+          setFieldValue(`interfaces[${iface.id}].subnet`, "");
+          setFieldValue(`interfaces[${iface.id}].ip_address`, "");
         }}
         required
       />
       {showSubnetField ? (
         <SubnetSelect
           data-testid="subnet-field"
-          name={`interfaces[${index}].subnet`}
+          name={`interfaces[${iface.id}].subnet`}
         />
       ) : null}
       {iface.ip_assignment === DeviceIpAssignment.STATIC ? (
@@ -75,14 +73,14 @@ const AddDeviceInterfaceFields = ({
             component={PrefixedIpInput}
             data-testid="prefixed-ip-address-field"
             label="IP address"
-            name={`interfaces[${index}].ip_address`}
+            name={`interfaces[${iface.id}].ip_address`}
           />
         ) : null
       ) : iface.ip_assignment === DeviceIpAssignment.EXTERNAL ? (
         <FormikField
           data-testid="ip-address-field"
           label="IP address"
-          name={`interfaces[${index}].ip_address`}
+          name={`interfaces[${iface.id}].ip_address`}
           type="text"
         />
       ) : null}
@@ -132,11 +130,10 @@ export const AddDeviceInterfaces = (): JSX.Element => {
   return (
     <>
       <h4>Interfaces</h4>
-      {interfaces.map((iface, i) => (
+      {interfaces.map((iface) => (
         <AddDeviceInterfaceFields
           deleteDisabled={interfaces.length === 1}
           iface={iface}
-          index={i}
           key={iface.id}
           removeInterface={removeInterface}
         />

--- a/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/types.ts
+++ b/src/app/devices/components/DeviceHeaderForms/AddDeviceForm/types.ts
@@ -15,6 +15,7 @@ export type AddDeviceInterface = {
   mac: CreateParamsInterface["mac"];
   name: NonNullable<CreateParamsInterface["name"]>;
   subnet: string;
+  subnet_cidr: string;
 };
 
 export type AddDeviceValues = {


### PR DESCRIPTION
## Done
- Created `formatIpAddress` util
- Moved `AddDeviceInterface` form fields to its own component
- Integrated `PrefixedIpInput` field when "Static" IP assignment is selected
- Only show IP field when a subnet has been selected (static only)
- Added validation for IPv4 and IPv6 addresses

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to `/devices` and click "Add Device"
- [ ] Select "Static" for IP assignment on the interface
- [ ] Ensure only the subnet field is shown
- [ ] Select a subnet
- [ ] Ensure the `PrefixedIpInput` field is shown and the prefix matches the selected subnet
- [ ] Type in some out-of-range IPs and ensure an error is shown
- [ ] Type in some non-numerical text and ensure an error is shown
- [ ] Select "External" for IP assignment
- [ ] Ensure the subnet field is gone
- [ ] Ensure the "IP address" field is just a standard text field
- [ ] Type in something that isn't an IP address
- [ ] Ensure an error is shown
- [ ] Select "Static" again and fill out the form correctly
- [ ] Submit the form, and ensure the device has been added with a correct IP address

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-2982](https://warthogs.atlassian.net/browse/MAASENG-2982)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### After selecting "Static" IP assignment

#### Before
![image](https://github.com/canonical/maas-ui/assets/35104482/2aa01435-4d69-4dcf-965a-26501f4ab02f)

#### After
![image](https://github.com/canonical/maas-ui/assets/35104482/6bcc706d-d873-4c3f-9c09-00ccec8555fb)

### IP address field when using "Static" IP assignment
![image](https://github.com/canonical/maas-ui/assets/35104482/fd860fb2-8ecc-4db9-90ea-a4cbd190e92e)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

- Pre-filling the form based on MAC address has been de-scoped, since one MAC can theoretically have multiple assigned IPs across subnets
- Showing an error if an entered IP is reserved has been de-scoped, since multiple subnets with the same CIDR can exist on separate VLANs (the same IP could be reserved on one, but available on the other).

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-2982]: https://warthogs.atlassian.net/browse/MAASENG-2982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ