### PR TITLE
fix: limit WebSocket message backlog on reconnection

### DIFF
--- a/src/websocket-client.ts
+++ b/src/websocket-client.ts
@@ -162,6 +162,10 @@ export class WebSocketClient {
   connect(): ReconnectingWebSocket {
     this.rws = new ReconnectingWebSocket(this.buildURL(), undefined, {
       debug: import.meta.env.VITE_APP_WEBSOCKET_DEBUG === "true",
+      // Limit message backlog on reconnection to prevent overwhelming the server
+      // with a flood of queued messages when the connection is re-established.
+      // Typical page load generates 5-25 messages; buffer allows for additional user actions.
+      maxEnqueuedMessages: 30,
     });
     return this.rws;
   }


### PR DESCRIPTION
## Done
- Updated WebSocket reconnection logic to limit message backlog

## QA steps

- [ ] Connect to the application and verify WebSocket connection is established
- [ ] Simulate a network interruption (e.g., disable/enable network connection)
- [ ] Confirm WebSocket reconnects successfully
- [ ] Check application logs to ensure no message flood occurs on reconnection
- [ ] Perform several actions in quick succession after reconnection to test the buffer

## Fixes

Fixes: https://bugs.launchpad.net/maas/+bug/2070304
https://warthogs.atlassian.net/browse/MAASENG-3433

## Screenshots

N/A

## Notes

This change introduces a `maxEnqueuedMessages` limit to prevent overwhelming the server with a backlog of messages upon WebSocket reconnection. The limit is set to 30, which accommodates the typical 5-25 messages generated on page load plus some buffer for additional user actions.

