### PR TITLE
feat(subnets): add tooltips for reserved IP comments MAASENG-3517

### DIFF
--- a/src/app/subnets/views/SubnetDetails/StaticDHCPLease/StaticDHCPTable/StaticDHCPTable.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticDHCPLease/StaticDHCPTable/StaticDHCPTable.tsx
@@ -53,7 +53,7 @@ const generateRows = (
             ? getNodeTypeDisplay(reservedIp.node_summary.node_type)
             : "—"}
         </td>
-        <td>{reservedIp.comment || "—"}</td>
+        <td title={reservedIp.comment}>{reservedIp.comment || "—"}</td>
         <td>
           <TableActions
             onDelete={() =>

--- a/src/app/subnets/views/SubnetDetails/StaticDHCPLease/StaticDHCPTable/StaticDHCPTable.tsx
+++ b/src/app/subnets/views/SubnetDetails/StaticDHCPLease/StaticDHCPTable/StaticDHCPTable.tsx
@@ -53,7 +53,9 @@ const generateRows = (
             ? getNodeTypeDisplay(reservedIp.node_summary.node_type)
             : "—"}
         </td>
-        <td title={reservedIp.comment}>{reservedIp.comment || "—"}</td>
+        <td className="u-no-wrap" title={reservedIp.comment}>
+          {reservedIp.comment || "—"}
+        </td>
         <td>
           <TableActions
             onDelete={() =>


### PR DESCRIPTION
## Done
- Added tooltips to the "comments" column of the static DHCP leases table

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

You'll need a backend that has the websocket model for reserved IPs - I have one up and running, ping me if you want to use it

- [ ] Go to `subnet/{id}/address-reservation`
- [ ] Reserve an IP address and enter a long comment (at least 60 characters)
- [ ] Submit the form
- [ ] Hover over the comment in the table, and ensure a tooltip appears with the full text of the comment

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-3517](https://warthogs.atlassian.net/browse/MAASENG-3517)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

![image](https://github.com/user-attachments/assets/d0dcf4c9-6cd1-4477-bf67-051d133b4620)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-3517]: https://warthogs.atlassian.net/browse/MAASENG-3517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ