### PR TITLE
fix: remove length limit for MAC address fields MAASENG-3518

### DIFF
--- a/src/app/base/components/MacAddressField/MacAddressField.tsx
+++ b/src/app/base/components/MacAddressField/MacAddressField.tsx
@@ -12,7 +12,6 @@ export const MacAddressField = ({ name, ...props }: Props): JSX.Element => {
 
   return (
     <FormikField
-      maxLength={17}
       name={name}
       onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {
         setFieldValue(name, formatMacAddress(evt.target.value));

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineFormFields/AddMachineFormFields.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineFormFields/AddMachineFormFields.tsx
@@ -63,7 +63,6 @@ export const AddMachineFormFields = ({ saved }: Props): JSX.Element => {
             <Input
               aria-label={`Extra MAC address ${i + 1}`}
               error={errors?.extra_macs && errors.extra_macs[i]}
-              maxLength={17}
               onChange={(e) => {
                 const newExtraMACs = [...extraMACs];
                 newExtraMACs[i] = formatMacAddress(e.target.value);

--- a/src/app/utils/formatMacAddress.test.ts
+++ b/src/app/utils/formatMacAddress.test.ts
@@ -11,10 +11,4 @@ describe("formatMacAddress", () => {
     expect(formatMacAddress("123")).toEqual("12:3");
     expect(formatMacAddress("123456789abc")).toEqual("12:34:56:78:9a:bc");
   });
-
-  it("truncates correctly", () => {
-    expect(formatMacAddress("12:34:56:78:9a:bc:de")).toEqual(
-      "12:34:56:78:9a:bc"
-    );
-  });
 });

--- a/src/app/utils/formatMacAddress.test.ts
+++ b/src/app/utils/formatMacAddress.test.ts
@@ -9,6 +9,10 @@ describe("formatMacAddress", () => {
 
   it("can correctly splice in separators", () => {
     expect(formatMacAddress("123")).toEqual("12:3");
-    expect(formatMacAddress("123456789abc")).toEqual("12:34:56:78:9a:bc:");
+    expect(formatMacAddress("123456789abc")).toEqual("12:34:56:78:9a:bc");
+  });
+
+  it("stops adding separators after the fifth one", () => {
+    expect(formatMacAddress("123456789abcde")).toEqual("12:34:56:78:9a:bcde");
   });
 });

--- a/src/app/utils/formatMacAddress.test.ts
+++ b/src/app/utils/formatMacAddress.test.ts
@@ -9,6 +9,6 @@ describe("formatMacAddress", () => {
 
   it("can correctly splice in separators", () => {
     expect(formatMacAddress("123")).toEqual("12:3");
-    expect(formatMacAddress("123456789abc")).toEqual("12:34:56:78:9a:bc");
+    expect(formatMacAddress("123456789abc")).toEqual("12:34:56:78:9a:bc:");
   });
 });

--- a/src/app/utils/formatMacAddress.ts
+++ b/src/app/utils/formatMacAddress.ts
@@ -7,8 +7,13 @@
 
 export const formatMacAddress = (value: string): string => {
   const hexValues = value.replace(/:/g, "");
-  if (value.length % 3 === 0) {
+
+  if (hexValues.length > 10) {
+    const firstTenValues = hexValues.slice(0, 10);
+    const lastValues = hexValues.slice(10);
+
+    return firstTenValues.replace(/([0-9A-Za-z]{2})/g, "$1:") + lastValues;
+  } else {
     return hexValues.replace(/([0-9A-Za-z]{2})/g, "$1:");
   }
-  return value;
 };

--- a/src/app/utils/formatMacAddress.ts
+++ b/src/app/utils/formatMacAddress.ts
@@ -8,7 +8,7 @@
 export const formatMacAddress = (value: string): string => {
   const hexValues = value.replace(/:/g, "");
   if (value.length % 3 === 0) {
-    return hexValues.replace(/([0-9A-Za-z]{2})/g, "$1:").substring(0, 17);
+    return hexValues.replace(/([0-9A-Za-z]{2})/g, "$1:");
   }
-  return value.substring(0, 17);
+  return value;
 };


### PR DESCRIPTION
## Done
- Removed length limit for MAC address inputs

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

(With a backend that supports reserved IPs)
- [ ] Go to `/subnet/[id]/address-reservation`
- [ ] Click "Reserve static DHCP lease"
- [ ] Start typing in the MAC address field
- [ ] Ensure that there is (effectively) no limit to the input length
- [ ] Go to `/machines`
- [ ] Click "Add machine"
- [ ] Test the MAC address field as above
- [ ] Click "Add MAC address"
- [ ] Test this additional field as above

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-3518](https://warthogs.atlassian.net/browse/MAASENG-3518)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

![image](https://github.com/user-attachments/assets/93214331-91af-4f8c-97a5-54904ffe1165)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-3518]: https://warthogs.atlassian.net/browse/MAASENG-3518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ