### PR TITLE
feat: scroll to top of form when non-field errors are present MAASENG-3515

### DIFF
--- a/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.test.tsx
@@ -2,6 +2,7 @@ import { Field, Formik } from "formik";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
+import type { Mock } from "vitest";
 import * as Yup from "yup";
 
 import FormikFormContent from "./FormikFormContent";
@@ -31,7 +32,12 @@ vi.mock("react-router-dom", async () => {
 
 describe("FormikFormContent", () => {
   let state: RootState;
+  let scrollIntoViewSpy: Mock;
+
   beforeEach(() => {
+    scrollIntoViewSpy = vi.fn();
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoViewSpy;
+
     state = factory.rootState({
       config: factory.configState({
         items: [
@@ -99,6 +105,18 @@ describe("FormikFormContent", () => {
     );
 
     expect(screen.getByText("Uh oh!")).toBeInTheDocument();
+  });
+
+  it("scrolls non-field errors into view when present", () => {
+    renderWithBrowserRouter(
+      <Formik initialValues={{}} onSubmit={vi.fn()}>
+        <FormikFormContent errors="Uh oh!">Content</FormikFormContent>
+      </Formik>,
+      { state }
+    );
+
+    expect(screen.getByText("Uh oh!")).toBeInTheDocument();
+    expect(scrollIntoViewSpy).toHaveBeenCalledTimes(1);
   });
 
   it("can display non-field errors from the __all__ key", () => {

--- a/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, AriaAttributes } from "react";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useId, useRef } from "react";
 
 import { ContentSection } from "@canonical/maas-react-components";
 import { Form, Notification } from "@canonical/react-components";
@@ -110,6 +110,7 @@ const FormikFormContent = <V extends object, E = null>({
     allowUnchanged,
   });
   const [hasSaved, resetHasSaved] = useCycled(saved);
+  const notificationId = useId();
   const hasErrors = !!errors;
 
   // Run onValuesChanged function whenever formik values change.
@@ -168,10 +169,18 @@ const FormikFormContent = <V extends object, E = null>({
     }
   }, [navigate, savedRedirect, saved]);
 
+  useEffect(() => {
+    if (nonFieldError) {
+      document
+        .getElementById(notificationId)
+        ?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [nonFieldError, notificationId]);
+
   const renderFormContent = () => (
     <>
       {!!nonFieldError && (
-        <Notification severity="negative" title="Error:">
+        <Notification id={notificationId} severity="negative" title="Error:">
           {nonFieldError}
         </Notification>
       )}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -8,21 +8,26 @@ const fetchMocker = createFetchMock(vi);
 
 fetchMocker.enableMocks();
 const originalObserver = window.ResizeObserver;
+const originalScrollIntoView = window.HTMLElement.prototype.scrollIntoView;
 
 beforeAll(() => {
   // disable act warnings
   global.IS_REACT_ACT_ENVIRONMENT = false;
 });
 
-// mock ResizeObserver for MainToolbar
 beforeEach(() => {
+  // mock ResizeObserver for MainToolbar
   window.ResizeObserver = vi.fn(() => ({
     observe: vi.fn(),
     unobserve: vi.fn(),
     disconnect: vi.fn(),
   }));
+
+  // mock scrollIntoView for FormikFormContent
+  window.HTMLElement.prototype.scrollIntoView = vi.fn();
 });
 
 afterEach(() => {
   window.ResizeObserver = originalObserver;
+  window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
 });


### PR DESCRIPTION
## Done
- When a non-field (i.e. backend) error is received after submitting a form, the error message will now automatically be scrolled into view

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to machine list
- [ ] Open "Add machine" form
- [ ] Zoom in (or shrink window) until the MAC address field is off-screen
- [ ] Scroll down and enter a MAC address that's already in use on your MAAS instance
- [ ] Fill out the other mandatory fields and submit the form
- [ ] Ensure that the error message from the backend is scrolled into view

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-3515](https://warthogs.atlassian.net/browse/MAASENG-3515)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->


[MAASENG-3515]: https://warthogs.atlassian.net/browse/MAASENG-3515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ