### PR TITLE
feat(subnets): Use PrefixedIpInput in Reserve Range form MAASENG-3524

### DIFF
--- a/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.tsx
+++ b/src/app/subnets/components/ReservedRangeForm/ReservedRangeForm.tsx
@@ -1,11 +1,16 @@
 import { useCallback } from "react";
 
 import { Col, Row, Spinner } from "@canonical/react-components";
+import * as ipaddr from "ipaddr.js";
+import { isIP, isIPv4 } from "is-ip";
 import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import FormikField from "@/app/base/components/FormikField";
 import FormikForm from "@/app/base/components/FormikForm";
+import PrefixedIpInput, {
+  formatIpAddress,
+} from "@/app/base/components/PrefixedIpInput";
 import {
   useSidePanel,
   type SetSidePanelContent,
@@ -15,8 +20,14 @@ import ipRangeSelectors from "@/app/store/iprange/selectors";
 import type { IPRange } from "@/app/store/iprange/types";
 import { IPRangeType, IPRangeMeta } from "@/app/store/iprange/types";
 import type { RootState } from "@/app/store/root/types";
+import subnetSelectors from "@/app/store/subnet/selectors";
 import type { Subnet, SubnetMeta } from "@/app/store/subnet/types";
 import { isId } from "@/app/utils";
+import {
+  getImmutableAndEditableOctets,
+  getIpRangeFromCidr,
+  isIpInSubnet,
+} from "@/app/utils/subnetIpRange";
 
 type Props = {
   createType?: IPRangeType;
@@ -38,12 +49,6 @@ export enum Labels {
   Comment = "Purpose",
   StartIp = "Start IP address",
 }
-
-const Schema = Yup.object().shape({
-  comment: Yup.string(),
-  start_ip: Yup.string().required("Start IP is required"),
-  end_ip: Yup.string().required("End IP is required"),
-});
 
 const ReservedRangeForm = ({
   createType,
@@ -67,8 +72,15 @@ const ReservedRangeForm = ({
   const saved = useSelector(ipRangeSelectors.saved);
   const saving = useSelector(ipRangeSelectors.saving);
   const errors = useSelector(ipRangeSelectors.errors);
+  const subnet = useSelector((state: RootState) =>
+    subnetSelectors.getById(state, subnetId)
+  );
+  const subnetLoading = useSelector(subnetSelectors.loading);
+
   const cleanup = useCallback(() => ipRangeActions.cleanup(), []);
+
   const isEditing = isId(computedIpRangeId);
+  const showDynamicComment = isEditing && ipRange?.type === IPRangeType.Dynamic;
   const onClose = () => setSidePanelContent(null);
   let computedCreateType = createType;
   if (!createType) {
@@ -78,31 +90,111 @@ const ReservedRangeForm = ({
         : undefined;
   }
 
-  if (isEditing && !ipRange) {
+  if ((isEditing && !ipRange) || subnetLoading) {
     return (
       <span data-testid="Spinner">
         <Spinner text="Loading..." />
       </span>
     );
   }
-  let initialComment = "";
-  const showDynamicComment = isEditing && ipRange?.type === IPRangeType.Dynamic;
-  if (showDynamicComment) {
-    initialComment = "Dynamic";
-  } else if (isEditing) {
-    initialComment = ipRange?.comment ?? "";
+
+  if (!subnet) {
+    return null;
   }
+
+  const [startIp, endIp] = getIpRangeFromCidr(subnet.cidr);
+  const [immutableOctets, _] = getImmutableAndEditableOctets(startIp, endIp);
+  const networkAddress = subnet.cidr.split("/")[0];
+  const prefixLength = parseInt(subnet.cidr.split("/")[1]);
+  const subnetIsIpv4 = isIPv4(networkAddress);
+
+  const ReservedRangeSchema = Yup.object().shape({
+    comment: Yup.string(),
+    start_ip: Yup.string()
+      .required("Start IP is required")
+      .test({
+        name: "ip-is-valid",
+        message: "This is not a valid IP address",
+        test: (ip_address) => isIP(formatIpAddress(ip_address, subnet.cidr)),
+      })
+      .test({
+        name: "ip-is-in-subnet",
+        message: "The IP address is outside of the subnet's range.",
+        test: (ip_address) => {
+          const ip = formatIpAddress(ip_address, subnet.cidr);
+          if (subnetIsIpv4) {
+            return isIpInSubnet(ip, subnet.cidr as string);
+          } else {
+            try {
+              const addr = ipaddr.parse(ip);
+              const netAddr = ipaddr.parse(networkAddress);
+              return addr.match(netAddr, prefixLength);
+            } catch (e) {
+              return false;
+            }
+          }
+        },
+      }),
+    end_ip: Yup.string()
+      .required("End IP is required")
+      .test({
+        name: "ip-is-valid",
+        message: "This is not a valid IP address",
+        test: (ip_address) => isIP(formatIpAddress(ip_address, subnet.cidr)),
+      })
+      .test({
+        name: "ip-is-in-subnet",
+        message: "The IP address is outside of the subnet's range.",
+        test: (ip_address) => {
+          const ip = formatIpAddress(ip_address, subnet.cidr);
+          if (subnetIsIpv4) {
+            return isIpInSubnet(ip, subnet.cidr as string);
+          } else {
+            try {
+              const addr = ipaddr.parse(ip);
+              const netAddr = ipaddr.parse(networkAddress);
+              return addr.match(netAddr, prefixLength);
+            } catch (e) {
+              return false;
+            }
+          }
+        },
+      }),
+  });
+
+  const getInitialValues = () => {
+    let initialComment = "";
+    if (showDynamicComment) {
+      initialComment = "Dynamic";
+    } else if (isEditing) {
+      initialComment = ipRange?.comment ?? "";
+    }
+
+    let startIp = "";
+    let endIp = "";
+
+    if (isEditing && ipRange) {
+      startIp = subnetIsIpv4
+        ? ipRange?.start_ip.replace(`${immutableOctets}.`, "")
+        : ipRange?.start_ip.replace(`${networkAddress}`, "");
+      endIp = subnetIsIpv4
+        ? ipRange?.end_ip.replace(`${immutableOctets}.`, "")
+        : ipRange?.end_ip.replace(`${networkAddress}`, "");
+    }
+
+    return {
+      comment: initialComment,
+      end_ip: endIp,
+      start_ip: startIp,
+    };
+  };
 
   return (
     <FormikForm<FormValues>
       aria-label={isEditing ? Labels.EditRange : Labels.CreateRange}
       cleanup={cleanup}
       errors={errors}
-      initialValues={{
-        comment: initialComment,
-        end_ip: ipRange?.end_ip ?? "",
-        start_ip: ipRange?.start_ip ?? "",
-      }}
+      initialValues={getInitialValues()}
       onCancel={onClose}
       onSaveAnalytics={{
         action: "Save reserved range",
@@ -111,20 +203,25 @@ const ReservedRangeForm = ({
       }}
       onSubmit={(values) => {
         // Clear the errors from the previous submission.
+        const startIp = formatIpAddress(values.start_ip, subnet.cidr);
+        const endIp = formatIpAddress(values.end_ip, subnet.cidr);
         dispatch(cleanup());
         if (!isEditing && computedCreateType) {
           dispatch(
             ipRangeActions.create({
               subnet: subnetId,
               type: computedCreateType,
-              ...values,
+              start_ip: startIp,
+              end_ip: endIp,
+              comment: values.comment,
             })
           );
         } else if (isEditing && ipRange) {
           dispatch(
             ipRangeActions.update({
               [IPRangeMeta.PK]: ipRange[IPRangeMeta.PK],
-              ...values,
+              start_ip: startIp,
+              end_ip: endIp,
               // Reset the value of the comment field so that "Dynamic" isn't stored.
               comment: showDynamicComment ? ipRange?.comment : values.comment,
             })
@@ -136,24 +233,26 @@ const ReservedRangeForm = ({
       saved={saved}
       saving={saving}
       submitLabel={isEditing ? "Save" : "Reserve"}
-      validationSchema={Schema}
+      validationSchema={ReservedRangeSchema}
       {...props}
     >
       <Row>
         <Col size={12}>
           <FormikField
+            cidr={subnet.cidr}
+            component={PrefixedIpInput}
             label={Labels.StartIp}
             name="start_ip"
             required
-            type="text"
           />
         </Col>
         <Col size={12}>
           <FormikField
+            cidr={subnet.cidr}
+            component={PrefixedIpInput}
             label={Labels.EndIp}
             name="end_ip"
             required
-            type="text"
           />
         </Col>
         {isEditing || computedCreateType === IPRangeType.Reserved ? (


### PR DESCRIPTION
## Done
- Integrated `PrefixedIpInput` into the "Reserve Range" and "Reserve Dynamic Range" forms

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to a subnet's "Address reservation" page
- [ ] Open the "Reserve range" form
- [ ] Ensure the immutable octets of that subnet's IP are shown correctly
- [ ] Enter some non-numeric text and ensure an error is shown
- [ ] Enter an out-of-range IP address and ensure an error is shown
- [ ] Submit the form and ensure the new reserved range appears correctly in the table
- [ ] Go to a VLAN and open the "Reserve range" form
- [ ] Ensure normal text input fields are used
- [ ] Enter some non-numeric text and ensure an error is shown

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-3524](https://warthogs.atlassian.net/browse/MAASENG-3524)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/a3c9b1f1-ff69-43a4-b67d-4ed5fb1ded7b)

### After
![image](https://github.com/user-attachments/assets/ad03ef77-7208-41ae-84de-0bc26d822fc0)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->



[MAASENG-3524]: https://warthogs.atlassian.net/browse/MAASENG-3524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ