### PR TITLE
fix: Prevent query client from fetching zones excessively on page load

### DIFF
--- a/src/app/api/query/base.test.ts
+++ b/src/app/api/query/base.test.ts
@@ -34,7 +34,8 @@ it("calls useQuery with correct parameters", () => {
   });
 });
 
-it("invalidates queries when connectedCount changes", () => {
+// TODO https://warthogs.atlassian.net/browse/MAASENG-3558
+it.skip("invalidates queries when connectedCount changes", () => {
   const initialState = rootState({
     status: statusState({ connectedCount: 0 }),
   });

--- a/src/app/api/query/base.ts
+++ b/src/app/api/query/base.ts
@@ -2,11 +2,9 @@ import { useEffect, useCallback, useContext } from "react";
 
 import type { QueryFunction, UseQueryOptions } from "@tanstack/react-query";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { useSelector } from "react-redux";
 
 import type { QueryKey } from "@/app/api/query-client";
 import { WebSocketContext } from "@/app/base/websocket-context";
-import statusSelectors from "@/app/store/status/selectors";
 import type { WebSocketEndpointModel } from "@/websocket-client";
 import { WebSocketMessageType } from "@/websocket-client";
 
@@ -52,14 +50,16 @@ export function useWebsocketAwareQuery<
   >
 ) {
   const queryClient = useQueryClient();
-  const connectedCount = useSelector(statusSelectors.connectedCount);
   const { subscribe } = useWebSocket();
-
   const queryModelKey = Array.isArray(queryKey) ? queryKey[0] : "";
 
-  useEffect(() => {
-    queryClient.invalidateQueries();
-  }, [connectedCount, queryClient, queryKey]);
+  // TODO: Investigate why the code below causes the zones endpoint to be polled 50 times on page load
+  // https://warthogs.atlassian.net/browse/MAASENG-3558
+
+  // const connectedCount = useSelector(statusSelectors.connectedCount);
+  // useEffect(() => {
+  //   queryClient.invalidateQueries();
+  // }, [connectedCount, queryClient, queryKey]);
 
   useEffect(() => {
     return subscribe(


### PR DESCRIPTION
## Done
- Removed `useEffect` in `useWebsocketAwareQuery` that was causing the zones endpoint to be fetched 50 times on page load
- Added TODO comment with a linked jira ticket to investigate this in future and determine if this code is needed

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to the UI and open dev tools
- [ ] Fully refresh the page (ctrl + F5), and ensure the zones endpoint is only called once
- [ ] Go to zones ("AZs"), and create/update/delete a zone
- [ ] Ensure that the zones list is automatically updated after each of these operations, *without* needing a page refresh

<!-- Steps for QA. -->

## Screenshots

This is how the network tools looked on initial page load for labmaas:
![image](https://github.com/user-attachments/assets/3624f707-c4ed-432d-951b-9fc42247cbf9)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

