### PR TITLE
feat(machines): Add new IP address field to Edit Physical form MAASENG-3453

### DIFF
--- a/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/EditPhysicalForm/EditPhysicalForm.tsx
@@ -218,9 +218,10 @@ const EditPhysicalForm = ({
         // Clear the errors from the previous submission.
         dispatch(cleanup());
 
-        const ip = values.ip_address
-          ? formatIpAddress(values.ip_address, values.subnet_cidr)
-          : "";
+        const ip =
+          values.ip_address && values.subnet_cidr
+            ? formatIpAddress(values.ip_address, values.subnet_cidr)
+            : "";
         type Payload = EditPhysicalValues & {
           interface_id: NetworkInterface["id"];
           system_id: Machine["system_id"];

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
@@ -33,7 +33,7 @@ export type NetworkValues = {
   mode?: NetworkLinkMode | "";
   fabric: NodeVlan["fabric_id"] | "";
   subnet?: NetworkLink["subnet_id"] | "";
-  subnet_cidr: Subnet["cidr"] | "";
+  subnet_cidr?: Subnet["cidr"] | "";
   vlan: NetworkInterface["vlan_id"] | "";
 };
 

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
@@ -1,18 +1,21 @@
+import { useEffect } from "react";
+
 import { useFormikContext } from "formik";
+import { isIPv4 } from "is-ip";
 import { useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import FabricSelect from "@/app/base/components/FabricSelect";
 import FormikField from "@/app/base/components/FormikField";
 import LinkModeSelect from "@/app/base/components/LinkModeSelect";
+import PrefixedIpInput from "@/app/base/components/PrefixedIpInput";
 import SubnetSelect from "@/app/base/components/SubnetSelect";
 import VLANSelect from "@/app/base/components/VLANSelect";
 import fabricSelectors from "@/app/store/fabric/selectors";
 import type { Fabric } from "@/app/store/fabric/types";
 import subnetSelectors from "@/app/store/subnet/selectors";
 import type { Subnet } from "@/app/store/subnet/types";
-import { NetworkLinkMode } from "@/app/store/types/enum";
-import type { NetworkInterfaceTypes } from "@/app/store/types/enum";
+import { NetworkInterfaceTypes, NetworkLinkMode } from "@/app/store/types/enum";
 import type {
   NetworkInterface,
   NetworkLink,
@@ -20,12 +23,17 @@ import type {
 } from "@/app/store/types/node";
 import type { VLAN } from "@/app/store/vlan/types";
 import { toFormikNumber } from "@/app/utils";
+import {
+  getImmutableAndEditableOctets,
+  getIpRangeFromCidr,
+} from "@/app/utils/subnetIpRange";
 
 export type NetworkValues = {
   ip_address?: NetworkLink["ip_address"];
   mode?: NetworkLinkMode | "";
   fabric: NodeVlan["fabric_id"] | "";
   subnet?: NetworkLink["subnet_id"] | "";
+  subnet_cidr: Subnet["cidr"] | "";
   vlan: NetworkInterface["vlan_id"] | "";
 };
 
@@ -42,6 +50,7 @@ export const networkFieldsInitialValues = {
   mode: "",
   fabric: "",
   subnet: "",
+  subnet_cidr: "",
   vlan: "",
 } as NetworkValues;
 
@@ -74,6 +83,22 @@ const NetworkFields = ({
   const subnets: Subnet[] = useSelector(subnetSelectors.all);
   const { handleChange, setFieldValue, values } =
     useFormikContext<NetworkValues>();
+
+  useEffect(() => {
+    if (
+      interfaceType === NetworkInterfaceTypes.PHYSICAL &&
+      subnets &&
+      values.subnet
+    ) {
+      const subnet = subnets.find(
+        ({ id }) => id === toFormikNumber(values.subnet)
+      );
+      if (subnet) {
+        setFieldValue("subnet_cidr", subnet.cidr);
+      }
+    }
+  }, [interfaceType, setFieldValue, subnets, values.subnet]);
+
   const resetFollowingFields = (
     name: keyof NetworkValues,
     hasSubnet?: boolean
@@ -92,6 +117,7 @@ const NetworkFields = ({
       setFieldValue(fieldOrder[i], value);
     }
   };
+
   return (
     <>
       <FabricSelect
@@ -155,10 +181,39 @@ const NetworkFields = ({
               const subnet = subnets.find(
                 ({ id }) => id === toFormikNumber(values.subnet)
               );
-              setFieldValue(
-                "ip_address",
-                subnet?.statistics.first_address || ""
-              );
+              if (interfaceType === NetworkInterfaceTypes.PHYSICAL && subnet) {
+                const [startIp, endIp] = getIpRangeFromCidr(subnet.cidr);
+                const [immutableOctets, _] = getImmutableAndEditableOctets(
+                  startIp,
+                  endIp
+                );
+                const networkAddress = subnet.cidr.split("/")[0];
+                const ipv6Prefix = networkAddress.substring(
+                  0,
+                  networkAddress.lastIndexOf(":")
+                );
+                const subnetIsIpv4 = isIPv4(networkAddress);
+
+                if (subnetIsIpv4) {
+                  setFieldValue(
+                    "ip_address",
+                    subnet.statistics.first_address.replace(
+                      `${immutableOctets}.`,
+                      ""
+                    )
+                  );
+                } else {
+                  setFieldValue(
+                    "ip_address",
+                    subnet.statistics.first_address.replace(`${ipv6Prefix}`, "")
+                  );
+                }
+              } else {
+                setFieldValue(
+                  "ip_address",
+                  subnet?.statistics.first_address || ""
+                );
+              }
             } else {
               setFieldValue("ip_address", "");
             }
@@ -167,7 +222,18 @@ const NetworkFields = ({
         />
       ) : null}
       {values.mode === NetworkLinkMode.STATIC ? (
-        <FormikField label={Label.IPAddress} name="ip_address" type="text" />
+        interfaceType === NetworkInterfaceTypes.PHYSICAL ? (
+          values.subnet_cidr ? (
+            <FormikField
+              cidr={values.subnet_cidr}
+              component={PrefixedIpInput}
+              label={Label.IPAddress}
+              name="ip_address"
+            />
+          ) : null
+        ) : (
+          <FormikField label={Label.IPAddress} name="ip_address" type="text" />
+        )
       ) : null}
     </>
   );

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
@@ -181,7 +181,11 @@ const NetworkFields = ({
               const subnet = subnets.find(
                 ({ id }) => id === toFormikNumber(values.subnet)
               );
-              if (interfaceType === NetworkInterfaceTypes.PHYSICAL && subnet) {
+              if (
+                interfaceType === NetworkInterfaceTypes.PHYSICAL &&
+                subnet &&
+                editing
+              ) {
                 const [startIp, endIp] = getIpRangeFromCidr(subnet.cidr);
                 const [immutableOctets, _] = getImmutableAndEditableOctets(
                   startIp,
@@ -222,7 +226,7 @@ const NetworkFields = ({
         />
       ) : null}
       {values.mode === NetworkLinkMode.STATIC ? (
-        interfaceType === NetworkInterfaceTypes.PHYSICAL ? (
+        interfaceType === NetworkInterfaceTypes.PHYSICAL && editing ? (
           values.subnet_cidr ? (
             <FormikField
               cidr={values.subnet_cidr}


### PR DESCRIPTION
## Done
- Added `PrefixedIpInput` to the "Edit Physical" form
- Added subnet-based IP validation to the form schema

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to a "Ready" machine
- [x] Go to the network tab for that machine
- [x] Click on the dropdown for an interface and click "Edit Physical"
- [x] Select "Static (Client configured)" IP assignment
- [x] Ensure the IP address field is shown, and the help text is correct for the subnet
- [ ] Test the validation (non-numeric characters, out-of-range address for subnet)

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-3453](https://warthogs.atlassian.net/browse/MAASENG-3453)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/9f02c124-8b93-45ff-add8-70098313889d)

### After
![image](https://github.com/user-attachments/assets/4c2688a7-c1c3-471e-8508-d4b673cc79d7)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-3453]: https://warthogs.atlassian.net/browse/MAASENG-3453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ