### PR TITLE
fix:  Issue template for CI

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-failure.md
+++ b/.github/ISSUE_TEMPLATE/ci-failure.md
@@ -1,6 +1,6 @@
 ---
 name: '{{ env.WORKFLOW }} failure'
-about: ''
+about: 'CI failure'
 title: '{{ env.BRANCH_NAME }} {{ env.WORKFLOW }} run failed'
 assignees: ''
 


### PR DESCRIPTION
fix: Issue template for CI

The "about" (i.e. the description property, see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax) cannot be blank.

## Done
- Add a value to `about`

## QA steps

- This needs to be tested in CI

## Fixes

Fixes: 

The [create an issue of doc link checker CI runs](https://github.com/tmerten/maas-ui/actions/runs/10389278023/job/28766923103) part of the docs checker.
Does not fix the timeout problem but the timeout is set to 60 seconds so something else seems to be wrong there.