### PR TITLE
ci: fix issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-failure.md
+++ b/.github/ISSUE_TEMPLATE/ci-failure.md
@@ -1,6 +1,6 @@
 ---
 name: '{{ env.WORKFLOW }} failure'
-about: ''
+about: 'CI failure'
 title: '{{ env.BRANCH_NAME }} {{ env.WORKFLOW }} run failed'
 assignees: ''
 


### PR DESCRIPTION
The "about" (i.e. the description property, see
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax) cannot be blank.

## Done
- fix issue template

## QA steps

- needs to be run in CI

## Fixes

Fixes: 

The issue template but does not fix the timeout issue we're having in CI (see e.g. [this run](https://github.com/tmerten/maas-ui/actions/runs/10217065720/job/28270004040)). 

(FYI: The timeout is set to 60 seconds, so the problem seems to be unrelated to the timeout.)