### PR TITLE
fix: update default MAAS backend in .env MAASENG-3597

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-MAAS_URL = "http://bolla.internal:5240/"
+MAAS_URL = "http://maas-ui-demo.internal:5240/"
 MAAS_WEBSOCKET_HOST=
 MAAS_WEBSOCKET_PORT=
 BASENAME="/MAAS"

--- a/docs/HACKING.md
+++ b/docs/HACKING.md
@@ -252,7 +252,7 @@ cd maas-ui
 
 ### Edit local config
 
-By default maas-ui will connect to `bolla.internal` which requires Canonical VPN access. Bolla runs on MAAS edge, which is the latest development version available.
+By default maas-ui will connect to `maas-ui-demo.internal` which requires Canonical VPN access. `maas-ui-demo.internal` runs on MAAS latest/edge, which is the latest development version available.
 
 If you wish to develop against a different MAAS then you can create a local env:
 


### PR DESCRIPTION
## Done
- Removed references to `bolla.internal` (RIP) and updated default MAAS backend to `maas-ui-demo.internal`

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Comment out any `MAAS_URL` definitions in your `.env.local` file
- [ ] Connect to the Canonical VPN and run MAAS UI 
- [ ] Ensure the UI connects to `maas-ui-demo.internal`*

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-3597](https://warthogs.atlassian.net/browse/MAASENG-3597)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Notes

*At the time of writing, `maas-ui-demo.internal` is not running fully, it appears to be in the midst of updating.

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-3597]: https://warthogs.atlassian.net/browse/MAASENG-3597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ