### PR TITLE
fix(zones): unnecessary query invalidations and API calls

### DIFF
--- a/src/app/api/query/base.test.ts
+++ b/src/app/api/query/base.test.ts
@@ -34,6 +34,31 @@ it("calls useQuery with correct parameters", () => {
   });
 });
 
+it("skips query invalidation when connectedCount is unchanged", () => {
+  const initialState = rootState({
+    status: statusState({ connectedCount: 0 }),
+  });
+  const { rerender } = renderHookWithMockStore(
+    () => useWebsocketAwareQuery(mockQueryKey, mockQueryFn),
+    { initialState }
+  );
+
+  const mockInvalidateQueries = vi.fn();
+  const mockQueryClient: Partial<reactQuery.QueryClient> = {
+    invalidateQueries: mockInvalidateQueries,
+  };
+  vi.mocked(reactQuery.useQueryClient).mockReturnValue(
+    mockQueryClient as reactQuery.QueryClient
+  );
+
+  rerender(() => useWebsocketAwareQuery(mockQueryKey, mockQueryFn), {
+    state: rootState({
+      status: statusState({ connectedCount: 0 }),
+    }),
+  });
+  expect(mockInvalidateQueries).not.toHaveBeenCalled();
+});
+
 it("invalidates queries when connectedCount changes", () => {
   const initialState = rootState({
     status: statusState({ connectedCount: 0 }),
@@ -51,8 +76,10 @@ it("invalidates queries when connectedCount changes", () => {
     mockQueryClient as reactQuery.QueryClient
   );
 
-  rerender({
-    initialState: rootState({ status: statusState({ connectedCount: 1 }) }),
+  rerender(() => useWebsocketAwareQuery(mockQueryKey, mockQueryFn), {
+    state: rootState({
+      status: statusState({ connectedCount: 1 }),
+    }),
   });
   expect(mockInvalidateQueries).toHaveBeenCalled();
 });

--- a/src/app/api/query/base.ts
+++ b/src/app/api/query/base.ts
@@ -1,5 +1,6 @@
 import { useEffect, useCallback, useContext } from "react";
 
+import { usePrevious } from "@canonical/react-components";
 import type { QueryFunction, UseQueryOptions } from "@tanstack/react-query";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "react-redux";
@@ -56,10 +57,13 @@ export function useWebsocketAwareQuery<
   const { subscribe } = useWebSocket();
 
   const queryModelKey = Array.isArray(queryKey) ? queryKey[0] : "";
+  const previousConnectedCount = usePrevious(connectedCount);
 
   useEffect(() => {
-    queryClient.invalidateQueries();
-  }, [connectedCount, queryClient, queryKey]);
+    if (connectedCount !== previousConnectedCount) {
+      queryClient.invalidateQueries({ queryKey });
+    }
+  }, [connectedCount, previousConnectedCount, queryClient, queryKey]);
 
   useEffect(() => {
     return subscribe(

--- a/src/app/api/query/zones.ts
+++ b/src/app/api/query/zones.ts
@@ -4,8 +4,12 @@ import { fetchZones } from "@/app/api/endpoints";
 import { useWebsocketAwareQuery } from "@/app/api/query/base";
 import type { Zone, ZonePK } from "@/app/store/zone/types";
 
+const zoneKeys = {
+  list: ["zones"] as const,
+};
+
 export const useZones = () => {
-  return useWebsocketAwareQuery(["zones"], fetchZones);
+  return useWebsocketAwareQuery(zoneKeys.list, fetchZones);
 };
 
 export const useZoneCount = () =>
@@ -14,6 +18,6 @@ export const useZoneCount = () =>
   });
 
 export const useZoneById = (id?: ZonePK | null) =>
-  useWebsocketAwareQuery(["zones"], fetchZones, {
+  useWebsocketAwareQuery(zoneKeys.list, fetchZones, {
     select: selectById<Zone>(id ?? null),
   });


### PR DESCRIPTION


## Done
- fix(zones): unnecessary query invalidations and API calls
  - refactor: invalidate queries only when connectedCount changes
  - refactor: add zoneKeys

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to AZs page and ensure zones list is only fetched once

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
