### PR TITLE
ci: set tics full report artifact path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: tics-report
-          path: /tmp/tics/ticstmpdir
+          path: /tmp/tics
           retention-days: 7
 
   build:


### PR DESCRIPTION
## Done
- ci: set tics full report artifact path

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] ensure that TICS artifact has been uploaded as expected in the `Upload TICS Report` step https://github.com/canonical/maas-ui/actions/runs/10491733615/job/29062284787?pr=5527

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
