### PR TITLE
fix(machines): Allow deselection of machines in a selected group MAASENG-3720

### DIFF
--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -317,3 +317,47 @@ it("can dispatch an action to unselect the group", async () => {
     store.getActions().find((action) => action.type === expected.type)
   ).toStrictEqual(expected);
 });
+
+it("can dispatch an action to unselect the group when it's partially selected", async () => {
+  const group = factory.machineStateListGroup({
+    count: 2,
+    items: ["abc123", "ghi789"],
+    name: "admin2",
+    value: "admin-2",
+  });
+  state.machine.lists[callId].groups = [
+    factory.machineStateListGroup({
+      count: 2,
+      items: ["def456"],
+      name: "admin1",
+      value: "admin-1",
+    }),
+    group,
+  ];
+  state.machine.selected = {
+    items: ["def456", "abc123"],
+  };
+
+  const store = mockStore(state);
+  renderWithMockStore(
+    <GroupCheckbox
+      callId={callId}
+      group={group}
+      groupName="admin2"
+      grouping={FetchGroupKey.AgentName}
+    />,
+    {
+      store,
+    }
+  );
+
+  await userEvent.click(screen.getByRole("checkbox"));
+
+  const expected = machineActions.setSelected({
+    items: ["def456"],
+  });
+
+  expect(
+    store.getActions().find((action) => action.type === expected.type)
+  ).toStrictEqual(expected);
+});

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -30,7 +30,7 @@ beforeEach(() => {
   });
 });
 
-it.skip("is disabled if all machines are selected", () => {
+it("is disabled if all machines are selected", () => {
   state.machine.selected = {
     filter: {
       owner: "admin",
@@ -50,7 +50,7 @@ it.skip("is disabled if all machines are selected", () => {
   expect(screen.getByRole("checkbox")).toBeDisabled();
 });
 
-it.skip("is disabled if there are no machines in the group", () => {
+it("is disabled if there are no machines in the group", () => {
   const group = factory.machineStateListGroup({
     count: 0,
     name: "admin2",
@@ -71,7 +71,7 @@ it.skip("is disabled if there are no machines in the group", () => {
   expect(screen.getByRole("checkbox")).toBeDisabled();
 });
 
-it.skip("is not disabled if there are machines in the group", () => {
+it("is not disabled if there are machines in the group", () => {
   state.machine.lists[callId].groups = [
     factory.machineStateListGroup({
       count: 1,
@@ -93,7 +93,7 @@ it.skip("is not disabled if there are machines in the group", () => {
   expect(screen.getByRole("checkbox")).not.toBeDisabled();
 });
 
-it.skip("is unchecked if there are no filters, groups or items selected", () => {
+it("is unchecked if there are no filters, groups or items selected", () => {
   state.machine.selected = null;
   renderWithMockStore(
     <GroupCheckbox
@@ -109,7 +109,7 @@ it.skip("is unchecked if there are no filters, groups or items selected", () => 
   expect(screen.getByRole("checkbox")).not.toBeChecked();
 });
 
-it.skip("is checked if all machines are selected", () => {
+it("is checked if all machines are selected", () => {
   state.machine.selected = {
     filter: {
       owner: "admin",
@@ -129,9 +129,9 @@ it.skip("is checked if all machines are selected", () => {
   expect(screen.getByRole("checkbox")).toBeChecked();
 });
 
-it.skip("is checked if the group is selected", () => {
+it("is checked if the group is selected", () => {
   state.machine.selected = {
-    groups: ["admin-2"],
+    items: ["machine1", "machine2", "machine3"],
   };
   renderWithMockStore(
     <GroupCheckbox
@@ -147,7 +147,7 @@ it.skip("is checked if the group is selected", () => {
   expect(screen.getByRole("checkbox")).toBeChecked();
 });
 
-it.skip("is partially checked if a machine in the group is selected", () => {
+it("is partially checked if a machine in the group is selected", () => {
   const group = factory.machineStateListGroup({
     count: 2,
     items: ["abc123", "def456"],
@@ -172,7 +172,7 @@ it.skip("is partially checked if a machine in the group is selected", () => {
   expect(screen.getByRole("checkbox")).toBePartiallyChecked();
 });
 
-it.skip("is not checked if a selected machine is in another group", () => {
+it("is not checked if a selected machine is in another group", () => {
   const group = factory.machineStateListGroup({
     count: 2,
     items: ["abc123"],

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.test.tsx
@@ -16,6 +16,7 @@ const group = factory.machineStateListGroup({
   count: 2,
   name: "admin2",
   value: "admin-2",
+  items: ["machine1", "machine2", "machine3"],
 });
 beforeEach(() => {
   state = factory.rootState({
@@ -29,7 +30,7 @@ beforeEach(() => {
   });
 });
 
-it("is disabled if all machines are selected", () => {
+it.skip("is disabled if all machines are selected", () => {
   state.machine.selected = {
     filter: {
       owner: "admin",
@@ -49,7 +50,7 @@ it("is disabled if all machines are selected", () => {
   expect(screen.getByRole("checkbox")).toBeDisabled();
 });
 
-it("is disabled if there are no machines in the group", () => {
+it.skip("is disabled if there are no machines in the group", () => {
   const group = factory.machineStateListGroup({
     count: 0,
     name: "admin2",
@@ -70,7 +71,7 @@ it("is disabled if there are no machines in the group", () => {
   expect(screen.getByRole("checkbox")).toBeDisabled();
 });
 
-it("is not disabled if there are machines in the group", () => {
+it.skip("is not disabled if there are machines in the group", () => {
   state.machine.lists[callId].groups = [
     factory.machineStateListGroup({
       count: 1,
@@ -92,7 +93,7 @@ it("is not disabled if there are machines in the group", () => {
   expect(screen.getByRole("checkbox")).not.toBeDisabled();
 });
 
-it("is unchecked if there are no filters, groups or items selected", () => {
+it.skip("is unchecked if there are no filters, groups or items selected", () => {
   state.machine.selected = null;
   renderWithMockStore(
     <GroupCheckbox
@@ -108,7 +109,7 @@ it("is unchecked if there are no filters, groups or items selected", () => {
   expect(screen.getByRole("checkbox")).not.toBeChecked();
 });
 
-it("is checked if all machines are selected", () => {
+it.skip("is checked if all machines are selected", () => {
   state.machine.selected = {
     filter: {
       owner: "admin",
@@ -128,7 +129,7 @@ it("is checked if all machines are selected", () => {
   expect(screen.getByRole("checkbox")).toBeChecked();
 });
 
-it("is checked if the group is selected", () => {
+it.skip("is checked if the group is selected", () => {
   state.machine.selected = {
     groups: ["admin-2"],
   };
@@ -146,7 +147,7 @@ it("is checked if the group is selected", () => {
   expect(screen.getByRole("checkbox")).toBeChecked();
 });
 
-it("is partially checked if a machine in the group is selected", () => {
+it.skip("is partially checked if a machine in the group is selected", () => {
   const group = factory.machineStateListGroup({
     count: 2,
     items: ["abc123", "def456"],
@@ -171,7 +172,7 @@ it("is partially checked if a machine in the group is selected", () => {
   expect(screen.getByRole("checkbox")).toBePartiallyChecked();
 });
 
-it("is not checked if a selected machine is in another group", () => {
+it.skip("is not checked if a selected machine is in another group", () => {
   const group = factory.machineStateListGroup({
     count: 2,
     items: ["abc123"],
@@ -216,44 +217,14 @@ it("can dispatch an action to select the group", async () => {
       store,
     }
   );
+
   await userEvent.click(screen.getByRole("checkbox"));
+
   const expected = machineActions.setSelected({
     grouping: FetchGroupKey.AgentName,
-    groups: ["admin-2"],
+    items: ["machine1", "machine2", "machine3"],
   });
-  expect(
-    store.getActions().find((action) => action.type === expected.type)
-  ).toStrictEqual(expected);
-});
 
-it("removes selected machines that are in the group that was clicked", async () => {
-  const group = factory.machineStateListGroup({
-    count: 2,
-    items: ["abc123"],
-    name: "admin2",
-    value: "admin-2",
-  });
-  state.machine.lists[callId].groups = [group];
-  state.machine.selected = {
-    items: ["abc123", "def456"],
-  };
-  const store = mockStore(state);
-  renderWithMockStore(
-    <GroupCheckbox
-      callId={callId}
-      group={group}
-      groupName="admin2"
-      grouping={FetchGroupKey.AgentName}
-    />,
-    {
-      store,
-    }
-  );
-  await userEvent.click(screen.getByRole("checkbox"));
-  const expected = machineActions.setSelected({
-    items: ["def456"],
-    groups: [],
-  });
   expect(
     store.getActions().find((action) => action.type === expected.type)
   ).toStrictEqual(expected);
@@ -277,6 +248,7 @@ it("does not overwrite selected machines in different groups", async () => {
   state.machine.selected = {
     items: ["def456"],
   };
+
   const store = mockStore(state);
   renderWithMockStore(
     <GroupCheckbox
@@ -289,12 +261,14 @@ it("does not overwrite selected machines in different groups", async () => {
       store,
     }
   );
+
   await userEvent.click(screen.getByRole("checkbox"));
+
   const expected = machineActions.setSelected({
     grouping: FetchGroupKey.AgentName,
-    groups: ["admin-2"],
-    items: ["def456"],
+    items: ["def456", "abc123"],
   });
+
   expect(
     store.getActions().find((action) => action.type === expected.type)
   ).toStrictEqual(expected);
@@ -317,9 +291,9 @@ it("can dispatch an action to unselect the group", async () => {
     group,
   ];
   state.machine.selected = {
-    groups: ["admin-1", "admin-2"],
-    items: ["def456"],
+    items: ["def456", "abc123"],
   };
+
   const store = mockStore(state);
   renderWithMockStore(
     <GroupCheckbox
@@ -332,11 +306,13 @@ it("can dispatch an action to unselect the group", async () => {
       store,
     }
   );
+
   await userEvent.click(screen.getByRole("checkbox"));
+
   const expected = machineActions.setSelected({
-    groups: ["admin-1"],
     items: ["def456"],
   });
+
   expect(
     store.getActions().find((action) => action.type === expected.type)
   ).toStrictEqual(expected);

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
@@ -68,7 +68,7 @@ const GroupCheckbox = ({
           newSelected.grouping = grouping;
         } else if (
           !checked &&
-          group.items.every((item) => newSelected.items?.includes(item))
+          group.items.some((item) => newSelected.items?.includes(item))
         ) {
           // If the checkbox has been unchecked and the group's visible items are
           // in the list then remove them.

--- a/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
+++ b/src/app/machines/views/MachineList/MachineListTable/GroupCheckbox/GroupCheckbox.tsx
@@ -30,8 +30,8 @@ const GroupCheckbox = ({
   // Whether this group is currently selected.
   const groupSelected =
     !!selected &&
-    "groups" in selected &&
-    selected.groups?.includes(group.value);
+    "items" in selected &&
+    group.items.every((item) => selected.items?.includes(item));
   // Whether some of the machines in the group are selected.
   const childrenSelected =
     !!selected &&
@@ -54,29 +54,29 @@ const GroupCheckbox = ({
       onGenerateSelected={(checked) => {
         let newSelected =
           !selected || "filter" in selected
-            ? { groups: [] }
+            ? { items: [] }
             : cloneDeep(selected);
-        newSelected.groups = newSelected.groups ?? [];
+        newSelected.items = newSelected.items ?? [];
 
-        if (checked && !newSelected.groups?.includes(group.value)) {
-          // If the checkbox has been checked and the group is not in the list
-          // then add it.
-          newSelected.groups.push(group.value);
+        if (
+          checked &&
+          !group.items.every((item) => newSelected.items?.includes(item))
+        ) {
+          // If the checkbox has been checked and the group's visible items are not
+          // in the list, add them.
+          newSelected.items = newSelected.items.concat(group.items);
           newSelected.grouping = grouping;
-        } else if (!checked && newSelected.groups?.includes(group.value)) {
-          // If the checkbox has been unchecked and the group is in the list
-          // then remove it.
-          newSelected.groups = newSelected.groups.filter(
-            (selectedGroup) => selectedGroup !== group.value
+        } else if (
+          !checked &&
+          group.items.every((item) => newSelected.items?.includes(item))
+        ) {
+          // If the checkbox has been unchecked and the group's visible items are
+          // in the list then remove them.
+          newSelected.items = newSelected.items.filter(
+            (selectedItem) => !group.items.includes(selectedItem)
           );
         }
-        // Remove any individually selected machines that are in the group that has
-        // just been selected
-        if (selected && "items" in selected) {
-          newSelected.items = selected.items?.filter(
-            (systemId) => !group?.items.includes(systemId)
-          );
-        }
+
         return newSelected;
       }}
     />


### PR DESCRIPTION
## Done
- Selecting a group of machines:
  - adds the system IDs of (visible) machines in that group to the selection state, instead of the group key
  - does NOT select every machine in that group, only the ones on screen
- Machines in a selected group can now be unselected

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

_I recommend doing this using a MAAS instance with a good amount of sample data._

- [ ] Go to machine list
- [ ] Select a group of machines
- [ ] Ensure the checkboxes are all checked in that group, but not disabled
- [ ] Ensure you can unselect machines
- [ ] Select a group of machines that's bigger than what can be shown on one page ("Ready" is good in sampledata)
- [ ] Ensure only the machines on that page are selected

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-3720](https://warthogs.atlassian.net/browse/MAASENG-3720)
Resolves [LP:2056157](https://bugs.launchpad.net/maas-ui/+bug/2056157)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/d04d8cb2-86ae-4b9a-9db7-80937f682673)

### After
![image](https://github.com/user-attachments/assets/d70aeb11-c393-4a45-ae3f-d76f0250c186)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-3720]: https://warthogs.atlassian.net/browse/MAASENG-3720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ