### PR TITLE
feat(machines): Add kernel crash dump checkbox to deploy form MAASENG-3759

### DIFF
--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -1,6 +1,7 @@
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
+import { test } from "vitest";
 
 import DeployForm from "../DeployForm";
 
@@ -15,6 +16,8 @@ import {
   renderWithBrowserRouter,
 } from "@/testing/utils";
 
+const kernelCrashDumpEnabled =
+  process.env.VITE_APP_KERNEL_CRASH_DUMP_ENABLED === "true";
 const mockStore = configureStore();
 
 describe("DeployFormFields", () => {
@@ -708,4 +711,54 @@ describe("DeployFormFields", () => {
       screen.queryByRole("checkbox", { name: "Register as MAAS KVM host" })
     ).not.toBeInTheDocument();
   });
+
+  test.runIf(kernelCrashDumpEnabled)(
+    "shows a tooltip for minimum OS requirements",
+    async () => {
+      renderWithBrowserRouter(
+        <DeployForm
+          clearSidePanelContent={vi.fn()}
+          machines={[]}
+          processingCount={0}
+          viewingDetails={false}
+        />,
+        { route: "/machines/add", state }
+      );
+
+      await userEvent.hover(
+        screen.getAllByRole("button", { name: "help-mid-dark" })[1]
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveTextContent(
+          "Ubuntu 24.04 LTS or higher."
+        );
+      });
+    }
+  );
+
+  test.runIf(kernelCrashDumpEnabled)(
+    "shows a tooltip for minimum hardware requirements",
+    async () => {
+      renderWithBrowserRouter(
+        <DeployForm
+          clearSidePanelContent={vi.fn()}
+          machines={[]}
+          processingCount={0}
+          viewingDetails={false}
+        />,
+        { route: "/machines/add", state }
+      );
+
+      await userEvent.hover(
+        screen.getAllByRole("button", { name: "help-mid-dark" })[0]
+      );
+
+      await waitFor(() => {
+        expect(screen.getByRole("tooltip")).toHaveTextContent(
+          ">= 4 CPU threads, >= 6GB RAM, Reserve >5x RAM size as free disk space in /var."
+        );
+      });
+    }
+  );
 });

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -298,10 +298,7 @@ export const DeployFormFields = (): JSX.Element => {
                       message="Ubuntu 24.04 LTS or higher."
                     />{" "}
                     must meet the minimum requirements and secure boot must be
-                    disabled. Check crash dump status in machine details.{" "}
-                    <ExternalLink to="https://ubuntu.com/server/docs/kernel-crash-dump">
-                      More about kernel crash dump
-                    </ExternalLink>
+                    disabled. Check crash dump status in machine details.
                   </>
                 }
                 label={

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -276,6 +276,46 @@ export const DeployFormFields = (): JSX.Element => {
               name="enableHwSync"
               type="checkbox"
             />
+
+            {import.meta.env.VITE_APP_KERNEL_CRASH_DUMP_ENABLED === "true" && (
+              <FormikField
+                help={
+                  <>
+                    To enable kernel crash dump, the hardware{" "}
+                    <TooltipButton
+                      iconName="help-mid-dark"
+                      message={
+                        <span className="u-align-text--center u-flex--center">
+                          {" "}
+                          &gt;= 4 CPU threads, <br /> &gt;= 6GB RAM, <br />
+                          Reserve &gt;5x RAM size as free disk space in /var.
+                        </span>
+                      }
+                    />{" "}
+                    and OS{" "}
+                    <TooltipButton
+                      iconName="help-mid-dark"
+                      message="Ubuntu 24.04 LTS or higher."
+                    />{" "}
+                    must meet the minimum requirements and secure boot must be
+                    disabled. Check crash dump status in machine details.{" "}
+                    <ExternalLink to="https://ubuntu.com/server/docs/kernel-crash-dump">
+                      More about kernel crash dump
+                    </ExternalLink>
+                  </>
+                }
+                label={
+                  <>
+                    Try to enable kernel crash dump{" "}
+                    <ExternalLink to="https://ubuntu.com/server/docs/kernel-crash-dump">
+                      Kernel crash dump docs
+                    </ExternalLink>
+                  </>
+                }
+                name="kernel_crash_dump"
+                type="checkbox"
+              />
+            )}
           </Col>
         </Row>
         {user && user.sshkeys_count === 0 && (


### PR DESCRIPTION
## Done
- Added kernel crash dump checkbox to machine deploy form

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Add the following to your `.env.local`:
```env
VITE_APP_KERNEL_CRASH_DUMP_ENABLED = true
```
- [ ] Go to /machines and open the deploy form
- [ ] Ensure the kernel crash dump checkbox is present and matches [the spec](https://www.figma.com/design/OmFXnkivsTiPVshh8bzSZn/Kernel-crash-dumbs?node-id=70-39122&node-type=frame&t=kUuNXWhjQ1xclH4L-0)
- [ ] Run the test suite for DeployFormFields (`src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx)` and ensure it passes*

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-3759](https://warthogs.atlassian.net/browse/MAASENG-3759)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

![image](https://github.com/user-attachments/assets/7d2b743c-eedb-48f3-b755-3fa93609e4fe)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

*This is because these tests are set to skip if the feature flag is not present, which is the case in CI.



[MAASENG-3759]: https://warthogs.atlassian.net/browse/MAASENG-3759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ