### PR TITLE
feat(machines): Add kernel crash dump indicator to details page MAASENG-3760

### DIFF
--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.test.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.test.tsx
@@ -248,4 +248,6 @@ describe("node is a machine", () => {
     expect(screen.getByText(DetailsCardLabels.Pool)).toBeInTheDocument();
     expect(screen.getByText("swimming")).toBeInTheDocument();
   });
+
+  it.todo("shows the status of kernel crash dumps on the machine");
 });

--- a/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
+++ b/src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx
@@ -1,4 +1,4 @@
-import { Spinner } from "@canonical/react-components";
+import { Icon, Spinner } from "@canonical/react-components";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
 import { Link } from "react-router-dom";
@@ -36,6 +36,7 @@ export enum Labels {
   PowerTypeLink = "Power type ›",
   Tags = "Tags",
   TagsLink = "Tags ›",
+  KernelCrashDump = "Kernel crash dump",
 }
 
 const DetailsCard = ({ node }: Props): JSX.Element => {
@@ -59,6 +60,7 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
     node.power_type
   );
   const tagsDisplay = getTagsDisplay(machineTags);
+  const kernelCrashDumpEnabled = true;
 
   useFetchActions([generalActions.fetchPowerTypes, tagActions.fetch]);
 
@@ -196,6 +198,22 @@ const DetailsCard = ({ node }: Props): JSX.Element => {
           <Spinner data-testid="loading-tags" />
         )}
       </div>
+      {import.meta.env.VITE_APP_KERNEL_CRASH_DUMP_ENABLED === "true" && (
+        <div>
+          <div className="u-text--muted">{Labels.KernelCrashDump}</div>
+          <span>
+            {kernelCrashDumpEnabled ? (
+              <>
+                <Icon name="success-grey" /> enabled
+              </>
+            ) : (
+              <>
+                <Icon name="error-grey" /> disabled
+              </>
+            )}
+          </span>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Done
- Added kernel crash dump state indicator to machine details

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Add the following to your `.env.local`:
```env
VITE_APP_KERNEL_CRASH_DUMP_ENABLED = true
```
- [ ] Checkout this branch locally and spin up the dev server
- [ ] Go to a machine's details page
- [ ] Ensure you can see the status of kernel crash dump (enabled)
- [ ] Go to `src/app/base/components/node/OverviewCard/DetailsCard/DetailsCard.tsx` in your code editor
- [ ] Set `kernelCrashDumpEnabled` on L63 to `false`
- [ ] Ensure the indicator on the details page is disabled

<!-- Steps for QA. -->

## Fixes

Fixes [MAASENG-3760](https://warthogs.atlassian.net/browse/MAASENG-3760)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

![image](https://github.com/user-attachments/assets/908c3e23-43b8-4d35-b098-2165a33eb164)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-3760]: https://warthogs.atlassian.net/browse/MAASENG-3760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ