### PR TITLE
feat: Add help text for reserving static IPs to IP mode fields MAASENG-3911

### DIFF
--- a/src/app/base/components/IpAssignmentSelect/IpAssignmentSelect.tsx
+++ b/src/app/base/components/IpAssignmentSelect/IpAssignmentSelect.tsx
@@ -22,6 +22,11 @@ export const IpAssignmentSelect = ({
   return (
     <FormikField
       component={Select}
+      help={
+        import.meta.env.VITE_APP_STATIC_IPS_ENABLED === "true"
+          ? "To manage static DHCP leases for a device, go to the address reservation tab of a subnet."
+          : null
+      }
       label={label}
       options={[
         { label: Labels.DefaultOption, value: "", disabled: true },

--- a/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/NetworkFields/NetworkFields.tsx
@@ -172,6 +172,11 @@ const NetworkFields = ({
       {values.subnet ? (
         <LinkModeSelect
           defaultOption={null}
+          help={
+            import.meta.env.VITE_APP_STATIC_IPS_ENABLED === "true"
+              ? "To manage static DHCP leases for a machine, go to the address reservation tab of a subnet."
+              : null
+          }
           interfaceType={interfaceType}
           name="mode"
           onChange={(evt: React.ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
## Done
- Added help text about reserving IP addresses to the IP mode field in:
  - Add device
  - Add network discovery
  - Add/Edit device interface
  - Add/Edit machine interface

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

Help text: _"To manage static DHCP leases for a [machine/device], go to the address reservation tab of a subnet."_

- [x] Go to `/network-discovery` and open the form to add a discovery
- [x] Ensure the above help text is displayed under the "IP assignment" field
- [x] Go to `/devices` and open the "Add device" form
- [x] Ensure the above help text is displayed under the "IP assignment" field
- [x] Go to a device's network tab and click "Add interface"
- [x] Ensure the above help text is displayed under the "IP assignment" field
- [x] Open the "Edit physical" form for an existing interface on the device
- [x] Ensure the above help text is displayed under the "IP assignment" field
- [x] Go to a ready machine and add an interface
- [x] Select a subnet from the dropdown
- [x] Ensure the above help text is displayed under the "IP assignment" field
- [x] Edit an existing interface on the machine
- [x] Select a subnet (if not already selected)
- [x] Ensure the above help text is displayed under the "IP assignment" field

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

### Machine interface
![image](https://github.com/user-attachments/assets/042f3526-e39f-4e76-8312-cd3ff17c45b4)

### Add device
![image](https://github.com/user-attachments/assets/6d023199-e82f-47c8-90a1-4459ebdde4a5)

### Device interface
![image](https://github.com/user-attachments/assets/e87b7a72-6018-4574-9d14-5757d99850c1)

### Add network discovery
![image](https://github.com/user-attachments/assets/db18e837-91c1-4469-bce9-32e645dccb64)
