### PR TITLE
style: Fixed trivial spelling error in keyring placeholder text

### DIFF
--- a/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.tsx
+++ b/src/app/images/views/ImageList/SyncedImages/ChangeSource/FetchImagesForm/FetchImagesFormFields/FetchImagesFormFields.tsx
@@ -74,7 +74,7 @@ const FetchImagesFormFields = (): JSX.Element => {
                 help="Path to the keyring to validate the mirror path."
                 label={Labels.KeyringFilename}
                 name="keyring_filename"
-                placeholder="e.g. /usr/share/keyrings/ubuntu-clooudimage-keyring.gpg"
+                placeholder="e.g. /usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"
                 type="text"
               />
               <FormikField


### PR DESCRIPTION
## Done
- Edited the placeholder text, changing it from "e.g. /usr/share/keyrings/ubuntu-clooudimage-keyring.gpg" to "e.g. /usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"

## QA steps

- navigate to the Change Source dialogue for custom images
- click on "advanced"
- verify the placeholder text is correct
<!-- Steps for QA. -->

## Fixes

Fixes: 

https://bugs.launchpad.net/maas-ui/+bug/2085803

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes
![Screenshot from 2024-10-28 17-18-08](https://github.com/user-attachments/assets/f40ad1e5-0d98-4f41-92f7-ef08d96ee55a)

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
