### PR TITLE
fix: Add "Tested with" before Ubuntu version in kernel crash dump OS requirement tooltips

### DIFF
--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -726,7 +726,7 @@ describe("DeployFormFields", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("tooltip")).toHaveTextContent(
-        "Ubuntu 24.04 LTS or higher."
+        "Ubuntu 16.04 LTS or higher."
       );
     });
   });

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -726,7 +726,7 @@ describe("DeployFormFields", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("tooltip")).toHaveTextContent(
-        "Ubuntu 16.04 LTS or higher."
+        "Ubuntu Tested with Ubuntu 24.04 LTS or higher."
       );
     });
   });

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.test.tsx
@@ -726,7 +726,7 @@ describe("DeployFormFields", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("tooltip")).toHaveTextContent(
-        "Ubuntu Tested with Ubuntu 24.04 LTS or higher."
+        "Tested with Ubuntu 24.04 LTS or higher."
       );
     });
   });

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -294,7 +294,7 @@ export const DeployFormFields = (): JSX.Element => {
                   and OS{" "}
                   <TooltipButton
                     iconName="help-mid-dark"
-                    message="Ubuntu 24.04 LTS or higher."
+                    message="Ubuntu 16.04 LTS or higher."
                   />{" "}
                   must meet the minimum requirements and secure boot must be
                   disabled. Check crash dump status in machine details.

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -294,7 +294,7 @@ export const DeployFormFields = (): JSX.Element => {
                   and OS{" "}
                   <TooltipButton
                     iconName="help-mid-dark"
-                    message="Ubuntu 16.04 LTS or higher."
+                    message="Ubuntu Tested with Ubuntu 24.04 LTS or higher."
                   />{" "}
                   must meet the minimum requirements and secure boot must be
                   disabled. Check crash dump status in machine details.

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -294,7 +294,7 @@ export const DeployFormFields = (): JSX.Element => {
                   and OS{" "}
                   <TooltipButton
                     iconName="help-mid-dark"
-                    message="Ubuntu Tested with Ubuntu 24.04 LTS or higher."
+                    message="Tested with Ubuntu 24.04 LTS or higher."
                   />{" "}
                   must meet the minimum requirements and secure boot must be
                   disabled. Check crash dump status in machine details.

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/DeployForm/DeployFormFields/DeployFormFields.tsx
@@ -291,13 +291,15 @@ export const DeployFormFields = (): JSX.Element => {
                       </span>
                     }
                   />{" "}
-                  and OS{" "}
+                  must meet the minimum requirements and the OS{" "}
                   <TooltipButton
                     iconName="help-mid-dark"
                     message="Tested with Ubuntu 24.04 LTS or higher."
                   />{" "}
-                  must meet the minimum requirements and secure boot must be
-                  disabled. Check crash dump status in machine details.
+                  must support it. Check crash dump status in machine details.{" "}
+                  <ExternalLink to="https://ubuntu.com/server/docs/kernel-crash-dump">
+                    More about kernel crash dump
+                  </ExternalLink>
                 </>
               }
               label={

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
@@ -128,7 +128,7 @@ describe("KernelParametersForm", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("tooltip")).toHaveTextContent(
-        "Ubuntu 16.04 LTS or higher."
+        "Ubuntu Tested with Ubuntu 24.04 LTS or higher."
       );
     });
   });

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
@@ -128,7 +128,7 @@ describe("KernelParametersForm", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("tooltip")).toHaveTextContent(
-        "Ubuntu 24.04 LTS or higher."
+        "Ubuntu 16.04 LTS or higher."
       );
     });
   });

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.test.tsx
@@ -128,7 +128,7 @@ describe("KernelParametersForm", () => {
 
     await waitFor(() => {
       expect(screen.getByRole("tooltip")).toHaveTextContent(
-        "Ubuntu Tested with Ubuntu 24.04 LTS or higher."
+        "Tested with Ubuntu 24.04 LTS or higher."
       );
     });
   });

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
@@ -89,7 +89,7 @@ const KernelParametersForm = (): JSX.Element => {
             and OS{" "}
             <TooltipButton
               iconName="help-mid-dark"
-              message="Ubuntu 16.04 LTS or higher."
+              message="Ubuntu Tested with Ubuntu 24.04 LTS or higher."
             />{" "}
             must meet the minimum requirements and secure boot must be disabled.
             Check crash dump status in machine details.{" "}

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
@@ -89,7 +89,7 @@ const KernelParametersForm = (): JSX.Element => {
             and OS{" "}
             <TooltipButton
               iconName="help-mid-dark"
-              message="Ubuntu Tested with Ubuntu 24.04 LTS or higher."
+              message="Tested with Ubuntu 24.04 LTS or higher."
             />{" "}
             must meet the minimum requirements and secure boot must be disabled.
             Check crash dump status in machine details.{" "}

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
@@ -89,7 +89,7 @@ const KernelParametersForm = (): JSX.Element => {
             and OS{" "}
             <TooltipButton
               iconName="help-mid-dark"
-              message="Ubuntu 24.04 LTS or higher."
+              message="Ubuntu 16.04 LTS or higher."
             />{" "}
             must meet the minimum requirements and secure boot must be disabled.
             Check crash dump status in machine details.{" "}

--- a/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
+++ b/src/app/settings/views/Configuration/KernelParametersForm/KernelParametersForm.tsx
@@ -86,13 +86,12 @@ const KernelParametersForm = (): JSX.Element => {
                 </span>
               }
             />{" "}
-            and OS{" "}
+            must meet the minimum requirements and the OS{" "}
             <TooltipButton
               iconName="help-mid-dark"
               message="Tested with Ubuntu 24.04 LTS or higher."
             />{" "}
-            must meet the minimum requirements and secure boot must be disabled.
-            Check crash dump status in machine details.{" "}
+            must support it. Check crash dump status in machine details.{" "}
             <ExternalLink to="https://ubuntu.com/server/docs/kernel-crash-dump">
               More about kernel crash dump
             </ExternalLink>


### PR DESCRIPTION
## Done
- Tooltips showing the minimum Ubuntu version for enabling kernel crash dumps now say "Tested with" before the version number.

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Open the deploy form
- [ ] Scroll to the bottom
- [ ] Hover the `?` after "OS" in the help text for the kernel crash dump checkbox
- [ ] Ensure the tooltip says "Tested with Ubuntu 24.04 LTS or higher"
- [ ] Go to /settings/configuration/kernel-parameters
- [ ] Hover the `?` after "OS" in the help text for the kernel crash dump checkbox
- [ ] Ensure the tooltip says "Tested with Ubuntu 24.04 LTS or higher"

<!-- Steps for QA. -->

## Screenshots

### Deploy form

#### Before
![image](https://github.com/user-attachments/assets/107217de-766b-461c-ac5d-884a329c1923)

#### After
![image](https://github.com/user-attachments/assets/7db188f4-be0e-43cb-b1ee-584ceb19e849)

### Settings

#### Before
![image](https://github.com/user-attachments/assets/fae92c18-4c06-457e-928a-a892d17f2767)

#### After
![image](https://github.com/user-attachments/assets/38a95ac8-2868-412a-81fe-0c7419aabc18)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

