### PR TITLE
fix(machines): Allow ports at the end of IPMI addresses LP#2087965

### DIFF
--- a/src/app/store/general/utils/powerTypes.ts
+++ b/src/app/store/general/utils/powerTypes.ts
@@ -1,4 +1,4 @@
-import { isIP } from "is-ip";
+import { isIP, isIPv6 } from "is-ip";
 import * as Yup from "yup";
 import type { ObjectShape } from "yup/lib/object";
 
@@ -56,12 +56,32 @@ const getPowerFieldSchema = (fieldType: PowerFieldType) => {
     case PowerFieldType.MULTIPLE_CHOICE:
       return Yup.array().of(Yup.string());
     case PowerFieldType.IP_ADDRESS:
-    case PowerFieldType.VIRSH_ADDRESS:
-    case PowerFieldType.LXD_ADDRESS:
       return Yup.string().test({
         name: "is-ip-address",
         message: "Please enter a valid IP address.",
-        test: (value) => isIP(value as string),
+        test: (value) => {
+          if (typeof value !== "string") {
+            return false;
+          }
+          if (value.includes("[") && value.includes("]")) {
+            // This is an IPv6 address with a port number
+            const openingBracketIndex = value.indexOf("[");
+            const closingBracketIndex = value.indexOf("]");
+            const ip = value.slice(
+              openingBracketIndex + 1,
+              closingBracketIndex
+            );
+            // We use +2 here to include the `:` before the port number
+            const port = value.slice(closingBracketIndex + 2);
+            return isIPv6(ip) && !isNaN(parseInt(port));
+          } else if (value.split(":").length === 2) {
+            // This is an IPv4 address with a port number
+            const [ip, port] = value.split(":");
+            return isIP(ip) && !isNaN(parseInt(port));
+          } else {
+            return isIP(value);
+          }
+        },
       });
     default:
       return Yup.string();

--- a/src/app/store/general/utils/powerTypes.ts
+++ b/src/app/store/general/utils/powerTypes.ts
@@ -5,6 +5,7 @@ import type { ObjectShape } from "yup/lib/object";
 import type { PowerField, PowerType } from "@/app/store/general/types";
 import { PowerFieldScope, PowerFieldType } from "@/app/store/general/types";
 import type { PowerParameters } from "@/app/store/types/node";
+import { isValidPortNumber } from "@/app/utils/isValidPortNumber";
 
 /**
  * Formats power parameters by what is expected by the api. Also, React expects
@@ -63,6 +64,10 @@ const getPowerFieldSchema = (fieldType: PowerFieldType) => {
           if (typeof value !== "string") {
             return false;
           }
+          // reject if value contains whitespace
+          if (value.includes(" ")) {
+            return false;
+          }
           if (value.includes("[") && value.includes("]")) {
             // This is an IPv6 address with a port number
             const openingBracketIndex = value.indexOf("[");
@@ -73,11 +78,19 @@ const getPowerFieldSchema = (fieldType: PowerFieldType) => {
             );
             // We use +2 here to include the `:` before the port number
             const port = value.slice(closingBracketIndex + 2);
-            return isIPv6(ip) && !isNaN(parseInt(port));
+            return (
+              isIPv6(ip) &&
+              !isNaN(parseInt(port)) &&
+              isValidPortNumber(parseInt(port))
+            );
           } else if (value.split(":").length === 2) {
             // This is an IPv4 address with a port number
             const [ip, port] = value.split(":");
-            return isIP(ip) && !isNaN(parseInt(port));
+            return (
+              isIP(ip) &&
+              !isNaN(parseInt(port)) &&
+              isValidPortNumber(parseInt(port))
+            );
           } else {
             return isIP(value);
           }

--- a/src/app/utils/index.ts
+++ b/src/app/utils/index.ts
@@ -36,3 +36,4 @@ export {
   timeSpanToMinutes,
 } from "./timeSpan";
 export { parseCommaSeparatedValues } from "./parseCommaSeparatedValues";
+export { isValidPortNumber } from "./isValidPortNumber";

--- a/src/app/utils/isValidPortNumber.test.ts
+++ b/src/app/utils/isValidPortNumber.test.ts
@@ -1,0 +1,15 @@
+import { isValidPortNumber } from ".";
+
+it("returns true for any number between 0 and 65535", () => {
+  for (let i = 0; i <= 65535; i++) {
+    expect(isValidPortNumber(i)).toBe(true);
+  }
+});
+
+it("returns false for numbers larger than 65535", () => {
+  expect(isValidPortNumber(65536)).toBe(false);
+});
+
+it("returns false for numbers smaller than 0", () => {
+  expect(isValidPortNumber(-1)).toBe(false);
+});

--- a/src/app/utils/isValidPortNumber.ts
+++ b/src/app/utils/isValidPortNumber.ts
@@ -1,0 +1,9 @@
+/**
+ * Checks if a given port number is valid (between 0 and 65535).
+ *
+ * @param port The port number to check.
+ * @returns True if valid, false otherwise.
+ */
+export const isValidPortNumber = (port: number): boolean => {
+  return port >= 0 && port <= 65535;
+};


### PR DESCRIPTION
## Done
- Added extra validation steps to IP address power field to account for ports
- Removed IP validation from LXD and Virsh address fields as these can be hostnames or other non-IP-address things.

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to a machine with an IPMI power type
- [ ] Go to "Configuration" and edit the power parameters
- [ ] Enter an IPv4 address with a port and tab out of the field afterwards
- [ ] Ensure no errors are shown
- [ ] Enter an invalid IP address and tab out of the field afterwards
- [ ] Ensure an error is shown
- [ ] Enter an IPv6 address with a port (you'll need to wrap the address in square brackets, e.g. `[2008:d45::1]:8000`
- [ ] Tab out of the field
- [ ] Ensure no errors are shown

<!-- Steps for QA. -->

## Fixes

Fixes [LP#2087965](https://bugs.launchpad.net/maas/+bug/2087965)
Fixes [MAASENG-4172](https://warthogs.atlassian.net/browse/MAASENG-4172)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->



[MAASENG-4172]: https://warthogs.atlassian.net/browse/MAASENG-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ