### PR TITLE
docs: Update badge links in readme to reflect true action status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ## MAAS UI
 
-![CI](https://github.com/canonical/maas-ui/workflows/CI/badge.svg)
-![Playwright Tests](https://github.com/canonical/maas-ui/workflows/Playwright%20Tests/badge.svg)
-![accessibility](https://github.com/canonical/maas-ui/workflows/accessibility/badge.svg)
-![Cypress](https://github.com/canonical/maas-ui/actions/workflows/cypress.yml/badge.svg)
-![sitespeed.io](https://github.com/canonical/maas-ui/actions/workflows/sitespeed.yml/badge.svg)
+[![CI](https://github.com/canonical/maas-ui/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/test.yml)
+[![Playwright Tests](https://github.com/canonical/maas-ui/actions/workflows/playwright.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/playwright.yml)
+[![Accessibility](https://github.com/canonical/maas-ui/actions/workflows/accessibility.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/accessibility.yml)
+[![Cypress](https://github.com/canonical/maas-ui/actions/workflows/cypress.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/cypress.yml)
+[![sitespeed.io](https://github.com/canonical/maas-ui/actions/workflows/sitespeed.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/sitespeed.yml)
+[![MAAS Docs link checker](https://github.com/canonical/maas-ui/actions/workflows/links-checker.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/links-checker.yml)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 [![Code Coverage](https://img.shields.io/badge/code--coverage-report-brightgreen.svg)](https://canonical.github.io/maas-ui/)
 [![Build upload](https://github.com/canonical/maas-ui/actions/workflows/upload.yml/badge.svg)](https://github.com/canonical/maas-ui/actions/workflows/upload.yml)


### PR DESCRIPTION
## Done
- Regenerated badges for GH actions
  - Actual status of action should be reflected
  - Badges should now all link to the appropriate job
- driveby: add badge for docs link checker

<!--
- Itemised list of what was changed by this PR.
-->

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/45bfaee8-0ee0-455d-8f27-d72a65a1ae40)

### After
![image](https://github.com/user-attachments/assets/ab95d88c-1016-4da9-9e44-5d9aa3a25f78)
Cypress and docs links checker are failing for real, unfortunately.

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
