### PR TITLE
fix(images): Fallback as custom image when splitting OS from resource name

### DIFF
--- a/src/app/store/bootresource/utils.test.ts
+++ b/src/app/store/bootresource/utils.test.ts
@@ -41,7 +41,7 @@ describe("bootresource utils", () => {
         release: "centos70",
       });
       expect(splitResourceName("rocky9")).toStrictEqual({
-        os: "custom",
+        os: "other",
         release: "rocky9",
       });
       expect(splitResourceName("ubuntu/focal/amd64/generic")).toStrictEqual({

--- a/src/app/store/bootresource/utils.test.ts
+++ b/src/app/store/bootresource/utils.test.ts
@@ -40,13 +40,13 @@ describe("bootresource utils", () => {
         os: "centos",
         release: "centos70",
       });
-      expect(splitResourceName("ubuntu")).toStrictEqual({
-        os: "",
-        release: "",
+      expect(splitResourceName("rocky9")).toStrictEqual({
+        os: "custom",
+        release: "rocky9",
       });
       expect(splitResourceName("ubuntu/focal/amd64/generic")).toStrictEqual({
-        os: "",
-        release: "",
+        os: "ubuntu",
+        release: "focal",
       });
       expect(splitResourceName("")).toStrictEqual({ os: "", release: "" });
     });

--- a/src/app/store/bootresource/utils.ts
+++ b/src/app/store/bootresource/utils.ts
@@ -6,7 +6,7 @@ export const splitResourceName = (
   const split = name.split("/");
   return split.length === 2
     ? { os: split[0], release: split[1] }
-    : { os: "", release: "" };
+    : { os: "custom", release: name };
 };
 
 export const splitImageName = (

--- a/src/app/store/bootresource/utils.ts
+++ b/src/app/store/bootresource/utils.ts
@@ -9,7 +9,7 @@ export const splitResourceName = (
   }
   return split.length > 1
     ? { os: split[0], release: split[1] }
-    : { os: "custom", release: name };
+    : { os: "other", release: name };
 };
 
 export const splitImageName = (

--- a/src/app/store/bootresource/utils.ts
+++ b/src/app/store/bootresource/utils.ts
@@ -4,7 +4,10 @@ export const splitResourceName = (
   name: BootResource["name"]
 ): { os: string; release: string } => {
   const split = name.split("/");
-  return split.length === 2
+  if (name.length === 0) {
+    return { os: "", release: "" };
+  }
+  return split.length > 1
     ? { os: split[0], release: split[1] }
     : { os: "custom", release: name };
 };


### PR DESCRIPTION
## Done

- Set "custom" as the fallback for images that do not have the "os/release" naming format