### PR TITLE
docs: update links to MAAS documentation MAASENG-4310

### DIFF
--- a/src/app/base/docsUrls.ts
+++ b/src/app/base/docsUrls.ts
@@ -1,6 +1,6 @@
 const docsUrls = {
   aboutNativeTLS: "https://maas.io/docs/how-to-implement-tls#enabling-tls-2",
-  addMachines: "https://maas.io/docs/how-to-manage-machines",
+  addMachines: "https://maas.io/docs/how-to-provision-machines",
   addNodesViaChassis:
     "https://maas.io/docs/how-to-manage-machines#add-machines-via-chassis-ui-2",
   autoRenewTLSCert:
@@ -8,23 +8,25 @@ const docsUrls = {
   cloudInit:
     "https://maas.io/docs/how-to-customise-machines#pre-seed-cloud-init-2",
   configurationJourney:
-    "https://maas.io/docs/how-to-install-maas#configure-maas-with-the-ui-10",
+    "https://maas.io/docs/how-to-install-maas#p-9034-maas-ui-setup",
   customisingDeployedMachines: "https://maas.io/docs/how-to-customise-machines",
-  dhcp: "https://maas.io/docs/how-to-enable-dhcp",
+  dhcp: "https://maas.io/docs/about-dhcp-in-maas",
   ipmi: "https://maas.io/docs/reference-power-drivers#ipmi-6",
-  ipRanges: "https://maas.io/docs/how-to-enable-dhcp#create-an-ip-range-ui-2",
-  kvmIntroduction: "https://maas.io/docs/about-virtual-machines",
+  ipRanges: "https://maas.io/docs/how-to-enable-dhcp#create-an-ip-range-ui-2", // broken link, no suitable replacement page that explains IP ranges
+  kvmIntroduction: "https://maas.io/docs/how-to-use-lxd-vms",
   networkDiscovery:
-    "https://maas.io/docs/about-maas-networks#network-discovery-5",
-  rackController: "https://maas.io/docs/how-to-configure-controllers",
+    "https://maas.io/docs/how-to-customise-maas-networks#p-9070-network-discovery",
+  rackController:
+    "https://maas.io/docs/how-to-provision-machines#p-9078-configure-controllers",
   sshKeys: "https://maas.io/docs/how-to-manage-user-access#add-ssh-keys-5",
-  tagsAutomatic: "https://maas.io/docs/how-to-manage-tags#automatic-tags-17",
+  tagsAutomatic: "https://maas.io/docs/how-to-manage-tags#automatic-tags-17", // moved to /how-to-use-group-machines, no functioning header link
   tagsKernelOptions:
-    "https://maas.io/docs/how-to-manage-tags#update-tag-kernel-options-22",
+    "https://maas.io/docs/how-to-manage-tags#update-tag-kernel-options-22", // moved to /how-to-use-group-machines, no functioning header link
   tagsXpathExpressions:
-    "https://maas.io/docs/how-to-manage-tags#automatic-tags-17",
+    "https://maas.io/docs/how-to-manage-tags#automatic-tags-17", // no suitable replacement page that explains Xpath expressions
   vaultIntegration: "https://maas.io/docs/how-to-integrate-vault",
-  windowsImages: "https://maas.io/docs/how-to-build-a-windows-image",
+  windowsImages:
+    "https://maas.io/docs/how-to-build-maas-images#p-17423-building-windows-images-with-packer",
 } as const;
 
 export default docsUrls;


### PR DESCRIPTION
## Done
- Updated non-functioning docs links to point to correct pages:
  - Add machines
  - Set up MAAS in the UI
  - DHCP
  - Configure controllers
  - Build windows images

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Clone this branch
- [ ] Run docs links test locally `yarn cypress-run-docs`
- [ ] Ensure all tests pass

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-4310](https://warthogs.atlassian.net/browse/MAASENG-4310)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->


## Notes

There are four links without suitable replacements available:

- IP ranges
  - Original link: https://maas.io/docs/how-to-enable-dhcp#create-an-ip-range-ui-2
  - Best available replacement: https://maas.io/docs/reference-maas-glossary#p-9410-i:~:text=Interfaces-,IP%20ranges
	- Highlight links only work in Chrome, no header link available
  - There's technically a heading for this on [this page](https://maas.io/docs/how-to-customise-dhcp), but it's literally just two steps on how to get to and submit the IP range form in the UI - from context, it looks like the intention is to link to an explanation of IP ranges in MAAS

- Automatic tags
  - Original link: https://maas.io/docs/how-to-manage-tags#automatic-tags-17
  - Best available replacement: https://maas.io/docs/how-to-use-group-machines#p-19384-tags-and-annotations:~:text=follows%3A%0A%7B%0A%20%20%20%20%22rebuilding%22%3A%20%22virtual%22%0A%7D-,Automatic%20tags,-MAAS%203.2%20and
	- Highlight links only work in Chrome, no header link available
- Kernel options in tags
  - Original link: https://maas.io/docs/how-to-manage-tags#update-kernel-options-22
  - Best available replacement: https://maas.io/docs/how-to-use-group-machines#p-19384-tags-and-annotations:~:text=2.0/tags/new_tag/%22%0A%7D-,Kernel%20option%20tags,-This%20feature%20is
	- Highlight links only work in Chrome, no header link available
- XPaths expressions in tags
  - Original link: https://maas.io/docs/how-to-manage-tags#automatic-tags-17
  - Best available replacement: *No suitable replacement*
	- It looks like we used to have a reference for XPath, but that doesn't appear to exist any more.

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
