### PR TITLE
fix: add Origin header in the proxy so to bypass django CSRF protections

### DIFF
--- a/scripts/proxy.js
+++ b/scripts/proxy.js
@@ -33,6 +33,7 @@ app.use(
     onProxyReq(proxyReq) {
       // Django's CSRF protection requires requests to come from the correct
       // protocol, so this makes XHR requests work when using TLS certs.
+      proxyReq.setHeader("Origin", `${process.env.MAAS_URL.replace(/\/$/, "")}`);
       proxyReq.setHeader("Referer", `${process.env.MAAS_URL}${proxyReq.path}`);
     },
     secure: false,


### PR DESCRIPTION
## Done

Fix the e2e tests that are failing due to the new CSRF protections introduced in Django 4.x. We simply add in the proxy the fake Origin header. 

## QA steps

- deploy MAAS on an LXD container
- run the UI with `yarn start` on the host and point to the LXD container for the MAAS_URL
- try to reproduce the bug
