### PR TITLE
fix(zones): re-added force refetch to refresh the tables on form action

### DIFF
--- a/src/app/zones/views/ZonesList/ZonesList.tsx
+++ b/src/app/zones/views/ZonesList/ZonesList.tsx
@@ -21,6 +21,9 @@ const ZonesList: React.FC = () => {
 
   const closeForm = () => {
     setSidePanelContent(null);
+    // useWebsocketAwareQuery filtering the invalidations prevents
+    // the hooks from causing a list update, this line forces it
+    void zonesCount.refetch();
   };
 
   let content = null;


### PR DESCRIPTION
## Done
- Re-introduced the force refetch to invalidate the zones list properly

## QA steps

- [ ] Ensure the zones list updates after form actions (create/edit/delete)
