### PR TITLE
ci: remove tics debug branch from workflow trigger

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,8 +1,5 @@
 name: Test coverage and TiCS Report
 on:
-  push:
-    branches:
-      - ci-tics-main
   schedule:  # uses last commit on default branch (main)
     - cron: "30 0 * * 6" # At 0:30 on Saturday
   # temporarily disabling client mode due to quota


### PR DESCRIPTION
## Done
- Removed `ci-tics-main` from coverage workflow trigger

<!--
- Itemised list of what was changed by this PR.
-->
