### PR TITLE
fix: update docs links for ip ranges and network discovery

### DIFF
--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -1,10 +1,10 @@
 name: MAAS Docs link checker
 on:
   schedule:
-    - cron: "0 14 * * 1-5" # At 14:00 every day-of-week from Monday through Friday.
+    - cron: "0 05 * * 1-5" # At 05:00 every day-of-week from Monday through Friday.
   push:
     branches:
-      - main
+      - fix-docs-links-* # Branches that start with fix-docs-links-
 
 jobs:
   docs:

--- a/src/app/base/docsUrls.ts
+++ b/src/app/base/docsUrls.ts
@@ -14,10 +14,10 @@ const docsUrls = {
   dhcp: "https://maas.io/docs/about-dhcp-in-maas",
   ipmi: "https://maas.io/docs/reference-power-drivers#p-17434-ipmi",
   ipRanges:
-    "https://maas.io/docs/how-to-customise-maas-networks#p-9070-create-ips-and-ranges",
+    "https://maas.io/docs/about-maas-networking#p-20679-ip-range-management-and-static-ip-assignments",
   kvmIntroduction: "https://maas.io/docs/how-to-use-lxd-vms",
   networkDiscovery:
-    "https://maas.io/docs/how-to-customise-maas-networks#p-9070-manage-network-discovery",
+    "https://maas.io/docs/about-maas-networking#p-20679-network-discovery",
   rackController:
     "https://maas.io/docs/about-controllers#p-13954-rack-controllers",
   sshKeys: "https://maas.io/docs/how-to-manage-user-access#p-9090-add-ssh-keys",


### PR DESCRIPTION
## Done
- Updated link for IP ranges
- Updated link for network discovery
- Changed links checker schedule to run at 5am UTC instead of 2pm UTC (so it's up to date before we all log on)
- Run links checker on push to branches that begin with `fix-docs-links-`

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] ensure [this run](https://github.com/ndv99/maas-ui/actions/runs/13411313814/job/37461989921) of the links checker has passed

<!-- Steps for QA. -->

