### PR TITLE
ci: fix tics analysis action

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-coverage-tics:
     name: Run tests with coverage and generate TiCS report
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4
@@ -51,9 +51,6 @@ jobs:
           # See:
           # https://github.com/tiobe/tics-github-action?tab=readme-ov-file#tics-github-action
           mode: ${{ github.event_name == 'pull_request' && 'client' || 'qserver' }}
-          # In case of a scheduled run, we want TiCS to analyze main,
-          # otherwise the ref (branch/tag) we just pushed to
-          branchname: ${{ github.event_name == 'schedule' && 'main' || github.ref_name }}
           project: maas-ui
           viewerUrl: https://canonical.tiobe.com/tiobeweb/TICS/api/cfg?name=default
           ticsAuthToken: ${{ secrets.TICSAUTHTOKEN }}


### PR DESCRIPTION
## Done

- Changed runner to `ubuntu-22.04` from `ubuntu-latest`
- Removed branch specification 

## Fixes

Fixes: 
-  `ubuntu-latest` recently changed to 24.04, which currently as a bug causing runs to be aborted for no apparent reason
- specifying branch to `main` causes a branch named 'main' not found error in TiCS analysis step



