### PR TITLE
feat(preferences): Migrate SSH key form to API v3 MAASENG-4448

### DIFF
--- a/src/app/api/query/sshKeys.ts
+++ b/src/app/api/query/sshKeys.ts
@@ -1,14 +1,29 @@
 import type { Options } from "@hey-api/client-fetch";
-import type { UseQueryOptions } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
 
 import { useWebsocketAwareQuery } from "./base";
 
 import type {
+  CreateUserSshkeysError,
+  CreateUserSshkeysResponse,
+  ImportUserSshkeysData,
+  ImportUserSshkeysError,
+  ImportUserSshkeysResponse,
+  CreateUserSshkeysData,
   ListUserSshkeysData,
   ListUserSshkeysError,
   ListUserSshkeysResponse,
 } from "@/app/apiclient";
-import { listUserSshkeysOptions } from "@/app/apiclient/@tanstack/react-query.gen";
+import {
+  createUserSshkeysMutation,
+  importUserSshkeysMutation,
+  listUserSshkeysOptions,
+  listUserSshkeysQueryKey,
+} from "@/app/apiclient/@tanstack/react-query.gen";
 
 export const useListSshKeys = (options?: Options<ListUserSshkeysData>) => {
   return useWebsocketAwareQuery(
@@ -18,4 +33,40 @@ export const useListSshKeys = (options?: Options<ListUserSshkeysData>) => {
       ListUserSshkeysResponse
     >
   );
+};
+
+export const useCreateSshKeys = (
+  mutationOptions?: Options<CreateUserSshkeysData>
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    CreateUserSshkeysResponse,
+    CreateUserSshkeysError,
+    Options<CreateUserSshkeysData>
+  >({
+    ...createUserSshkeysMutation(mutationOptions),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: listUserSshkeysQueryKey(),
+      });
+    },
+  });
+};
+
+export const useImportSshKeys = (
+  mutationOptions?: Options<ImportUserSshkeysData>
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ImportUserSshkeysResponse,
+    ImportUserSshkeysError,
+    Options<ImportUserSshkeysData>
+  >({
+    ...importUserSshkeysMutation(mutationOptions),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: listUserSshkeysQueryKey(),
+      });
+    },
+  });
 };

--- a/src/app/api/query/zones.ts
+++ b/src/app/api/query/zones.ts
@@ -60,9 +60,7 @@ export const useGetZone = (options: Options<GetZoneData>) => {
   );
 };
 
-export const useCreateZone = (
-  mutationOptions?: Partial<Options<CreateZoneData>>
-) => {
+export const useCreateZone = (mutationOptions?: Options<CreateZoneData>) => {
   const queryClient = useQueryClient();
   return useMutation<
     CreateZoneResponse,
@@ -78,9 +76,7 @@ export const useCreateZone = (
   });
 };
 
-export const useUpdateZone = (
-  mutationOptions?: Partial<Options<UpdateZoneData>>
-) => {
+export const useUpdateZone = (mutationOptions?: Options<UpdateZoneData>) => {
   const queryClient = useQueryClient();
   return useMutation<
     UpdateZoneResponse,
@@ -94,9 +90,7 @@ export const useUpdateZone = (
   });
 };
 
-export const useDeleteZone = (
-  mutationOptions?: Partial<Options<DeleteZoneData>>
-) => {
+export const useDeleteZone = (mutationOptions?: Options<DeleteZoneData>) => {
   const queryClient = useQueryClient();
   return useMutation<
     DeleteZoneResponse,

--- a/src/app/base/components/FormikFormContent/FormikFormContent.tsx
+++ b/src/app/base/components/FormikFormContent/FormikFormContent.tsx
@@ -55,6 +55,9 @@ const generateNonFieldError = <V extends object, E = null>(
     if (typeof errors === "string" || React.isValidElement(errors)) {
       return errors;
     } else if (typeof errors === "object") {
+      if ("message" in errors) {
+        return errors.message;
+      }
       let otherErrors: string[] = [];
       // Display any errors for keys that don't match form fields.
       Object.entries(errors).forEach(([key, value]) => {

--- a/src/app/base/components/SSHKeyForm/SSHKeyForm.tsx
+++ b/src/app/base/components/SSHKeyForm/SSHKeyForm.tsx
@@ -1,16 +1,16 @@
-import { useState } from "react";
-
-import { useDispatch, useSelector } from "react-redux";
 import * as Yup from "yup";
 
 import SSHKeyFormFields from "./SSHKeyFormFields";
 import type { SSHKeyFormValues } from "./types";
 
+import { useCreateSshKeys, useImportSshKeys } from "@/app/api/query/sshKeys";
+import type {
+  CreateUserSshkeysError,
+  ImportUserSshkeysError,
+  SshKeysProtocolType,
+} from "@/app/apiclient";
 import FormikForm from "@/app/base/components/FormikForm";
 import type { Props as FormikFormProps } from "@/app/base/components/FormikForm/FormikForm";
-import { useAddMessage } from "@/app/base/hooks";
-import { sshkeyActions } from "@/app/store/sshkey";
-import sshkeySelectors from "@/app/store/sshkey/selectors";
 
 const SSHKeySchema = Yup.object().shape({
   protocol: Yup.string().required("Source is required"),
@@ -29,34 +29,34 @@ type Props = {
 } & Partial<FormikFormProps<SSHKeyFormValues>>;
 
 export const SSHKeyForm = ({ cols, ...props }: Props): JSX.Element => {
-  const dispatch = useDispatch();
-  const [adding, setAdding] = useState(false);
-  const errors = useSelector(sshkeySelectors.errors);
-  const saved = useSelector(sshkeySelectors.saved);
-  const saving = useSelector(sshkeySelectors.saving);
-
-  useAddMessage(
-    adding && saved,
-    sshkeyActions.cleanup,
-    "SSH key successfully imported.",
-    () => setAdding(false)
-  );
+  const uploadSshKey = useCreateSshKeys();
+  const importSshKey = useImportSshKeys();
 
   return (
-    <FormikForm<SSHKeyFormValues>
-      cleanup={sshkeyActions.cleanup}
-      errors={errors}
+    <FormikForm<
+      SSHKeyFormValues,
+      ImportUserSshkeysError | CreateUserSshkeysError
+    >
+      errors={uploadSshKey.error || importSshKey.error}
       initialValues={{ auth_id: "", protocol: "", key: "" }}
       onSubmit={(values) => {
-        setAdding(true);
         if (values.key && values.key !== "") {
-          dispatch(sshkeyActions.create(values));
+          uploadSshKey.mutate({
+            body: {
+              key: values.key,
+            },
+          });
         } else {
-          dispatch(sshkeyActions.import(values));
+          importSshKey.mutate({
+            body: {
+              auth_id: values.auth_id,
+              protocol: values.protocol as SshKeysProtocolType,
+            },
+          });
         }
       }}
-      saved={saved}
-      saving={saving}
+      saved={uploadSshKey.isSuccess || importSshKey.isSuccess}
+      saving={uploadSshKey.isPending || importSshKey.isPending}
       submitLabel="Import SSH key"
       validationSchema={SSHKeySchema}
       {...props}

--- a/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.test.tsx
+++ b/src/app/base/components/SSHKeyForm/SSHKeyFormFields/SSHKeyFormFields.test.tsx
@@ -2,29 +2,15 @@ import { Formik } from "formik";
 
 import SSHKeyFormFields from "./SSHKeyFormFields";
 
-import type { RootState } from "@/app/store/root/types";
-import * as factory from "@/testing/factories";
-import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+import { renderWithProviders, screen, userEvent } from "@/testing/utils";
 
 describe("SSHKeyFormFields", () => {
-  let state: RootState;
-
-  beforeEach(() => {
-    state = factory.rootState({
-      sshkey: factory.sshKeyState({
-        loading: false,
-        loaded: true,
-        items: [],
-      }),
-    });
-  });
-
   it("can render", () => {
-    renderWithBrowserRouter(
+    renderWithProviders(
       <Formik initialValues={{}} onSubmit={vi.fn()}>
         <SSHKeyFormFields />
       </Formik>,
-      { route: "/", state }
+      { route: "/" }
     );
     expect(
       screen.getByRole("combobox", { name: "Source" })
@@ -38,11 +24,11 @@ describe("SSHKeyFormFields", () => {
   });
 
   it("can show id field", async () => {
-    renderWithBrowserRouter(
+    renderWithProviders(
       <Formik initialValues={{}} onSubmit={vi.fn()}>
         <SSHKeyFormFields />
       </Formik>,
-      { route: "/", state }
+      { route: "/" }
     );
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: "Source" }),
@@ -54,11 +40,11 @@ describe("SSHKeyFormFields", () => {
   });
 
   it("can show key field", async () => {
-    renderWithBrowserRouter(
+    renderWithProviders(
       <Formik initialValues={{}} onSubmit={vi.fn()}>
         <SSHKeyFormFields />
       </Formik>,
-      { route: "/", state }
+      { route: "/" }
     );
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: "Source" }),

--- a/src/testing/resolvers/sshKeys.ts
+++ b/src/testing/resolvers/sshKeys.ts
@@ -3,6 +3,8 @@ import { http, HttpResponse } from "msw";
 import { BASE_URL } from "../utils";
 
 import type {
+  CreateUserSshkeysError,
+  ImportUserSshkeysError,
   ListUserSshkeysError,
   ListUserSshkeysResponse,
 } from "@/app/apiclient";
@@ -41,6 +43,18 @@ const mockListSshKeysError: ListUserSshkeysError = {
   kind: "Error", // This will always be 'Error' for every error response
 };
 
+const mockCreateSshKeysError: CreateUserSshkeysError = {
+  message: "An SSH key with this fingerprint already exists.",
+  code: 409,
+  kind: "Error",
+};
+
+const mockImportSshKeysError: ImportUserSshkeysError = {
+  message: "Internal server error",
+  code: 500,
+  kind: "Error",
+};
+
 let mockSshKeys = structuredClone(initialMockSshKeys);
 
 const sshKeyResolvers = {
@@ -54,6 +68,32 @@ const sshKeyResolvers = {
     error: (error: ListUserSshkeysError = mockListSshKeysError) =>
       http.get(`${BASE_URL}MAAS/a/v3/users/me/sshkeys`, () => {
         sshKeyResolvers.listSshKeys.resolved = true;
+        return HttpResponse.json(error, { status: error.code });
+      }),
+  },
+  createSshKey: {
+    resolved: false,
+    handler: () =>
+      http.post(`${BASE_URL}MAAS/a/v3/users/me/sshkeys`, () => {
+        sshKeyResolvers.createSshKey.resolved = true;
+        return HttpResponse.json({});
+      }),
+    error: (error: CreateUserSshkeysError = mockCreateSshKeysError) =>
+      http.post(`${BASE_URL}MAAS/a/v3/users/me/sshkeys`, () => {
+        sshKeyResolvers.createSshKey.resolved = true;
+        return HttpResponse.json(error, { status: error.code });
+      }),
+  },
+  importSshKey: {
+    resolved: false,
+    handler: () =>
+      http.post(`${BASE_URL}MAAS/a/v3/users/me/sshkeys:import`, () => {
+        sshKeyResolvers.importSshKey.resolved = true;
+        return HttpResponse.json({});
+      }),
+    error: (error: ImportUserSshkeysError = mockImportSshKeysError) =>
+      http.post(`${BASE_URL}MAAS/a/v3/users/me/sshkeys:import`, () => {
+        sshKeyResolvers.importSshKey.resolved = true;
         return HttpResponse.json(error, { status: error.code });
       }),
   },


### PR DESCRIPTION
## Done
- Created hooks for adding + importing SSH keys
- Created mock resolvers for adding + importing SSH keys
- Use query hooks instead of redux actions in SSH key form
- (drive-by) Removed unnecessary `Partial` of options types in zones mutation hooks

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to /account/prefs/ssh-keys
- [x] Upload an SSH key (paste a public key)
- [x] Ensure the key uploads successfully and is added to the list
- [x] Try upload the key again
- [x] Ensure an error message is displayed correctly
- [x] Import SSH keys from GH or LP (might be flakey due to VM stuff)
- [x] Ensure keys are imported and list is refreshed

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-4448](https://warthogs.atlassian.net/browse/MAASENG-4448)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->


[MAASENG-4448]: https://warthogs.atlassian.net/browse/MAASENG-4448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ