### PR TITLE
feat(preferences): Migrate SSH key deletion to API v3 MAASENG-4449

### DIFF
--- a/src/app/api/query/sshKeys.test.ts
+++ b/src/app/api/query/sshKeys.test.ts
@@ -1,5 +1,14 @@
-import { useListSshKeys } from "./sshKeys";
+import {
+  useCreateSshKeys,
+  useDeleteSshKey,
+  useImportSshKeys,
+  useListSshKeys,
+} from "./sshKeys";
 
+import type {
+  SshKeyImportFromSourceRequest,
+  SshKeyManualUploadRequest,
+} from "@/app/apiclient";
 import { mockSshKeys, sshKeyResolvers } from "@/testing/resolvers/sshKeys";
 import {
   renderHookWithProviders,
@@ -7,12 +16,48 @@ import {
   waitFor,
 } from "@/testing/utils";
 
-setupMockServer(sshKeyResolvers.listSshKeys.handler());
+setupMockServer(
+  sshKeyResolvers.listSshKeys.handler(),
+  sshKeyResolvers.createSshKey.handler(),
+  sshKeyResolvers.importSshKey.handler(),
+  sshKeyResolvers.deleteSshKey.handler()
+);
 
 describe("useListSshKeys", () => {
   it("should return SSH keys data", async () => {
     const { result } = renderHookWithProviders(() => useListSshKeys());
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockSshKeys);
+  });
+});
+
+describe("useCreateSshKeys", () => {
+  it("should create a new SSH key", async () => {
+    const newSshKey: SshKeyManualUploadRequest = {
+      key: "ssh-rsa aabb",
+    };
+    const { result } = renderHookWithProviders(() => useCreateSshKeys());
+    result.current.mutate({ body: newSshKey });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe("useImportSshKeys", () => {
+  it("should import a new SSH key", async () => {
+    const newSshKey: SshKeyImportFromSourceRequest = {
+      protocol: "lp",
+      auth_id: "coolUsername",
+    };
+    const { result } = renderHookWithProviders(() => useImportSshKeys());
+    result.current.mutate({ body: newSshKey });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe("useDeleteSshKey", () => {
+  it("should delete an SSH key", async () => {
+    const { result } = renderHookWithProviders(() => useDeleteSshKey());
+    result.current.mutate({ path: { id: 1 } });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
 });

--- a/src/app/api/query/sshKeys.ts
+++ b/src/app/api/query/sshKeys.ts
@@ -17,9 +17,13 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysError,
   ListUserSshkeysResponse,
+  DeleteUserSshkeyData,
+  DeleteUserSshkeyResponse,
+  DeleteUserSshkeyError,
 } from "@/app/apiclient";
 import {
   createUserSshkeysMutation,
+  deleteUserSshkeyMutation,
   importUserSshkeysMutation,
   listUserSshkeysOptions,
   listUserSshkeysQueryKey,
@@ -63,6 +67,24 @@ export const useImportSshKeys = (
     Options<ImportUserSshkeysData>
   >({
     ...importUserSshkeysMutation(mutationOptions),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: listUserSshkeysQueryKey(),
+      });
+    },
+  });
+};
+
+export const useDeleteSshKey = (
+  mutationOptions?: Options<DeleteUserSshkeyData>
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    DeleteUserSshkeyResponse,
+    DeleteUserSshkeyError,
+    Options<DeleteUserSshkeyData>
+  >({
+    ...deleteUserSshkeyMutation(mutationOptions),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: listUserSshkeysQueryKey(),

--- a/src/app/base/components/ModelActionForm/ModelActionForm.tsx
+++ b/src/app/base/components/ModelActionForm/ModelActionForm.tsx
@@ -4,23 +4,22 @@ import { Col, Row } from "@canonical/react-components";
 
 import type { Props as FormikFormProps } from "@/app/base/components/FormikForm/FormikForm";
 import FormikForm from "@/app/base/components/FormikForm/FormikForm";
-import type { EmptyObject } from "@/app/base/types";
 
-type Props = {
+type Props<V extends object, E = null> = {
   modelType: string;
   message?: ReactNode;
-} & FormikFormProps<EmptyObject>;
+} & FormikFormProps<V, E>;
 
-const ModelActionForm = ({
+const ModelActionForm = <V extends object, E = null>({
   modelType,
   message,
   submitAppearance = "negative",
   submitLabel = "Delete",
-  initialValues = {},
+  initialValues,
   ...props
-}: Props) => {
+}: Props<V, E>) => {
   return (
-    <FormikForm
+    <FormikForm<V, E>
       initialValues={initialValues}
       submitAppearance={submitAppearance}
       submitLabel={submitLabel}

--- a/src/app/base/components/SSHKeyForm/SSHKeyForm.tsx
+++ b/src/app/base/components/SSHKeyForm/SSHKeyForm.tsx
@@ -49,7 +49,7 @@ export const SSHKeyForm = ({ cols, ...props }: Props): JSX.Element => {
         } else {
           importSshKey.mutate({
             body: {
-              auth_id: values.auth_id,
+              auth_id: values.auth_id as string,
               protocol: values.protocol as SshKeysProtocolType,
             },
           });

--- a/src/app/base/components/SSHKeyForm/types.ts
+++ b/src/app/base/components/SSHKeyForm/types.ts
@@ -1,7 +1,7 @@
 import type { SshKeyResponse } from "@/app/apiclient";
 
 export type SSHKeyFormValues = {
-  protocol: SshKeyResponse["protocol"];
+  protocol: SshKeyResponse["protocol"] | "";
   auth_id: SshKeyResponse["auth_id"];
   key: SshKeyResponse["key"];
 };

--- a/src/app/base/components/SSHKeyForm/types.ts
+++ b/src/app/base/components/SSHKeyForm/types.ts
@@ -1,7 +1,7 @@
-import type { KeySource, SSHKey } from "@/app/store/sshkey/types";
+import type { SshKeyResponse } from "@/app/apiclient";
 
 export type SSHKeyFormValues = {
-  protocol: KeySource["protocol"];
-  auth_id: KeySource["auth_id"];
-  key: SSHKey["key"];
+  protocol: SshKeyResponse["protocol"];
+  auth_id: SshKeyResponse["auth_id"];
+  key: SshKeyResponse["key"];
 };

--- a/src/app/base/components/SSHKeyForm/types.ts
+++ b/src/app/base/components/SSHKeyForm/types.ts
@@ -1,7 +1,7 @@
 import type { SshKeyResponse } from "@/app/apiclient";
 
 export type SSHKeyFormValues = {
-  protocol: SshKeyResponse["protocol"] | "";
+  protocol: SshKeyResponse["protocol"] | "upload" | "";
   auth_id: SshKeyResponse["auth_id"];
   key: SshKeyResponse["key"];
 };

--- a/src/app/preferences/types.ts
+++ b/src/app/preferences/types.ts
@@ -1,12 +1,13 @@
 import type { ValueOf } from "@canonical/react-components";
 
+import type { SshKeyResponse } from "../apiclient";
+
 import type { PreferenceSidePanelViews } from "./constants";
 
 import type { SidePanelContent, SetSidePanelContent } from "@/app/base/types";
-import type { SSHKey } from "@/app/store/sshkey/types";
 
 type SSHKeyGroup = {
-  keys: SSHKey[];
+  keys: SshKeyResponse[];
 };
 export type PreferenceSidePanelContent = SidePanelContent<
   ValueOf<typeof PreferenceSidePanelViews>,

--- a/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.test.tsx
@@ -2,43 +2,14 @@ import DeleteSSHKey from "./DeleteSSHKey";
 
 import * as sidePanelHooks from "@/app/base/side-panel-context";
 import { PreferenceSidePanelViews } from "@/app/preferences/constants";
-import * as factory from "@/testing/factories";
 import { sshKeyResolvers } from "@/testing/resolvers/sshKeys";
 import {
-  renderWithProviders,
+  renderWithBrowserRouter,
   screen,
   setupMockServer,
   userEvent,
   waitFor,
 } from "@/testing/utils";
-
-const keys = [
-  factory.sshKeyV3({
-    id: 1,
-    key: "ssh-rsa aabb",
-    protocol: "lp",
-    auth_id: "koalaparty",
-  }),
-  factory.sshKeyV3({
-    id: 2,
-    key: "ssh-rsa ccdd",
-    protocol: "gh",
-    auth_id: "koalaparty",
-  }),
-  factory.sshKeyV3({
-    id: 3,
-    key: "ssh-rsa eeff",
-    protocol: "lp",
-    auth_id: "maaate",
-  }),
-  factory.sshKeyV3({
-    id: 4,
-    key: "ssh-rsa gghh",
-    protocol: "gh",
-    auth_id: "koalaparty",
-  }),
-  factory.sshKeyV3({ id: 5, key: "ssh-rsa gghh" }),
-];
 
 const mockServer = setupMockServer(sshKeyResolvers.deleteSshKey.handler());
 
@@ -48,7 +19,6 @@ describe("DeleteSSHKey", () => {
       setSidePanelContent: vi.fn(),
       sidePanelContent: {
         view: PreferenceSidePanelViews.DELETE_SSH_KEYS,
-        extras: { group: { keys } },
       },
       setSidePanelSize: vi.fn(),
       sidePanelSize: "regular",
@@ -56,7 +26,7 @@ describe("DeleteSSHKey", () => {
   });
 
   it("renders", () => {
-    renderWithProviders(<DeleteSSHKey />, {
+    renderWithBrowserRouter(<DeleteSSHKey />, {
       route: "/account/prefs/ssh-keys/delete?ids=2,3",
     });
     expect(
@@ -68,7 +38,7 @@ describe("DeleteSSHKey", () => {
   });
 
   it("can delete a group of SSH keys", async () => {
-    renderWithProviders(<DeleteSSHKey />, {
+    renderWithBrowserRouter(<DeleteSSHKey />, {
       route: "/account/prefs/ssh-keys/delete?ids=2,3",
     });
     await userEvent.click(screen.getByRole("button", { name: /delete/i }));
@@ -82,7 +52,7 @@ describe("DeleteSSHKey", () => {
     mockServer.use(
       sshKeyResolvers.deleteSshKey.error({ message: "Uh oh!", code: 404 })
     );
-    renderWithProviders(<DeleteSSHKey />, {
+    renderWithBrowserRouter(<DeleteSSHKey />, {
       route: "/account/prefs/ssh-keys/delete?ids=2,3",
     });
 

--- a/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.test.tsx
@@ -1,95 +1,95 @@
-import configureStore from "redux-mock-store";
-
 import DeleteSSHKey from "./DeleteSSHKey";
 
 import * as sidePanelHooks from "@/app/base/side-panel-context";
 import { PreferenceSidePanelViews } from "@/app/preferences/constants";
-import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
-import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+import { sshKeyResolvers } from "@/testing/resolvers/sshKeys";
+import {
+  renderWithProviders,
+  screen,
+  setupMockServer,
+  userEvent,
+  waitFor,
+} from "@/testing/utils";
 
-let state: RootState;
-const mockStore = configureStore<RootState>();
+const keys = [
+  factory.sshKeyV3({
+    id: 1,
+    key: "ssh-rsa aabb",
+    protocol: "lp",
+    auth_id: "koalaparty",
+  }),
+  factory.sshKeyV3({
+    id: 2,
+    key: "ssh-rsa ccdd",
+    protocol: "gh",
+    auth_id: "koalaparty",
+  }),
+  factory.sshKeyV3({
+    id: 3,
+    key: "ssh-rsa eeff",
+    protocol: "lp",
+    auth_id: "maaate",
+  }),
+  factory.sshKeyV3({
+    id: 4,
+    key: "ssh-rsa gghh",
+    protocol: "gh",
+    auth_id: "koalaparty",
+  }),
+  factory.sshKeyV3({ id: 5, key: "ssh-rsa gghh" }),
+];
 
-beforeEach(() => {
-  const keys = [
-    factory.sshKey({
-      id: 1,
-      key: "ssh-rsa aabb",
-      keysource: { protocol: "lp", auth_id: "koalaparty" },
-    }),
-    factory.sshKey({
-      id: 2,
-      key: "ssh-rsa ccdd",
-      keysource: { protocol: "gh", auth_id: "koalaparty" },
-    }),
-    factory.sshKey({
-      id: 3,
-      key: "ssh-rsa eeff",
-      keysource: { protocol: "lp", auth_id: "maaate" },
-    }),
-    factory.sshKey({
-      id: 4,
-      key: "ssh-rsa gghh",
-      keysource: { protocol: "gh", auth_id: "koalaparty" },
-    }),
-    factory.sshKey({ id: 5, key: "ssh-rsa gghh" }),
-  ];
-  vi.spyOn(sidePanelHooks, "useSidePanel").mockReturnValue({
-    setSidePanelContent: vi.fn(),
-    sidePanelContent: {
-      view: PreferenceSidePanelViews.DELETE_SSH_KEYS,
-      extras: { group: { keys } },
-    },
-    setSidePanelSize: vi.fn(),
-    sidePanelSize: "regular",
+const mockServer = setupMockServer(sshKeyResolvers.deleteSshKey.handler());
+
+describe("DeleteSSHKey", () => {
+  beforeEach(() => {
+    vi.spyOn(sidePanelHooks, "useSidePanel").mockReturnValue({
+      setSidePanelContent: vi.fn(),
+      sidePanelContent: {
+        view: PreferenceSidePanelViews.DELETE_SSH_KEYS,
+        extras: { group: { keys } },
+      },
+      setSidePanelSize: vi.fn(),
+      sidePanelSize: "regular",
+    });
   });
-  state = factory.rootState({
-    sshkey: factory.sshKeyState({
-      loading: false,
-      loaded: true,
-      items: keys,
-    }),
+
+  it("renders", () => {
+    renderWithProviders(<DeleteSSHKey />, {
+      route: "/account/prefs/ssh-keys/delete?ids=2,3",
+    });
+    expect(
+      screen.getByRole("form", { name: "Delete SSH key confirmation" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Are you sure you want to delete these SSH keys?")
+    ).toBeInTheDocument();
   });
-});
 
-it("renders", () => {
-  renderWithBrowserRouter(<DeleteSSHKey />, {
-    state,
-    route: "/account/prefs/ssh-keys/delete?ids=2,3",
+  it("can delete a group of SSH keys", async () => {
+    renderWithProviders(<DeleteSSHKey />, {
+      route: "/account/prefs/ssh-keys/delete?ids=2,3",
+    });
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(sshKeyResolvers.deleteSshKey.resolved).toBeTruthy();
+    });
   });
-  expect(
-    screen.getByRole("form", { name: "Delete SSH key confirmation" })
-  ).toBeInTheDocument();
-  expect(
-    screen.getByText("Are you sure you want to delete these SSH keys?")
-  ).toBeInTheDocument();
-});
 
-it("can delete a group of SSH keys", async () => {
-  const store = mockStore(state);
-  renderWithBrowserRouter(<DeleteSSHKey />, {
-    route: "/account/prefs/ssh-keys/delete?ids=2,3",
-    store,
+  it("can show errors encountered when deleting SSH keys", async () => {
+    mockServer.use(
+      sshKeyResolvers.deleteSshKey.error({ message: "Uh oh!", code: 404 })
+    );
+    renderWithProviders(<DeleteSSHKey />, {
+      route: "/account/prefs/ssh-keys/delete?ids=2,3",
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Uh oh!")).toBeInTheDocument();
+    });
   });
-  await userEvent.click(screen.getByRole("button", { name: /delete/i }));
-
-  expect(
-    store.getActions().some((action) => action.type === "sshkey/delete")
-  ).toBe(true);
-});
-
-it("can add a message when a SSH key is deleted", async () => {
-  state.sshkey.saved = true;
-  const store = mockStore(state);
-  renderWithBrowserRouter(<DeleteSSHKey />, {
-    route: "/account/prefs/ssh-keys/delete?ids=2,3",
-    store,
-  });
-  // Click on the delete button:
-  await userEvent.click(screen.getByRole("button", { name: /delete/i }));
-
-  const actions = store.getActions();
-  expect(actions.some((action) => action.type === "sshkey/cleanup")).toBe(true);
-  expect(actions.some((action) => action.type === "message/add")).toBe(true);
 });

--- a/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/DeleteSSHKey/DeleteSSHKey.tsx
@@ -1,32 +1,24 @@
 import { useOnEscapePressed } from "@canonical/react-components";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { useDeleteSshKey } from "@/app/api/query/sshKeys";
 import type { DeleteUserSshkeyError } from "@/app/apiclient";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
-import { useSidePanel } from "@/app/base/side-panel-context";
 import type { EmptyObject } from "@/app/base/types";
 import urls from "@/app/preferences/urls";
 
 const DeleteSSHKey = () => {
+  const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const onClose = () => navigate({ pathname: urls.sshKeys.index });
   useOnEscapePressed(() => onClose());
 
   const deleteSshKey = useDeleteSshKey();
 
-  const { sidePanelContent } = useSidePanel();
-
-  const getIds = () => {
-    const extras = sidePanelContent?.extras;
-    if (extras && "group" in extras && extras.group) {
-      return extras.group.keys.map((key) => key.id);
-    } else {
-      return [];
-    }
-  };
-
-  const ids = getIds();
+  const ids = searchParams
+    .get("ids")
+    ?.split(",")
+    .map((id) => Number(id));
 
   if (!ids || ids?.length === 0) {
     return <h4>SSH key not found</h4>;

--- a/src/testing/resolvers/sshKeys.ts
+++ b/src/testing/resolvers/sshKeys.ts
@@ -4,6 +4,7 @@ import { BASE_URL } from "../utils";
 
 import type {
   CreateUserSshkeysError,
+  DeleteUserSshkeyError,
   ImportUserSshkeysError,
   ListUserSshkeysError,
   ListUserSshkeysResponse,
@@ -55,6 +56,12 @@ const mockImportSshKeysError: ImportUserSshkeysError = {
   kind: "Error",
 };
 
+const mockDeleteSshKeyError: DeleteUserSshkeyError = {
+  message: "Not found",
+  code: 404,
+  kind: "Error",
+};
+
 let mockSshKeys = structuredClone(initialMockSshKeys);
 
 const sshKeyResolvers = {
@@ -95,6 +102,19 @@ const sshKeyResolvers = {
       http.post(`${BASE_URL}MAAS/a/v3/users/me/sshkeys:import`, () => {
         sshKeyResolvers.importSshKey.resolved = true;
         return HttpResponse.json(error, { status: error.code });
+      }),
+  },
+  deleteSshKey: {
+    resolved: false,
+    handler: () =>
+      http.delete(`${BASE_URL}MAAS/a/v3/users/me/sshkeys/:id`, () => {
+        sshKeyResolvers.deleteSshKey.resolved = true;
+        return HttpResponse.json({}, { status: 204 });
+      }),
+    error: (error: DeleteUserSshkeyError = mockDeleteSshKeyError) =>
+      http.delete(`${BASE_URL}MAAS/a/v3/users/me/sshkeys/:id`, () => {
+        sshKeyResolvers.deleteSshKey.resolved = true;
+        return HttpResponse.json(error, { status: 404 });
       }),
   },
 };


### PR DESCRIPTION
## Done
- Migrated SSH key delete form to API v3
- Added missing tests for ssh key query hooks
- Delete form now fetches IDs from side panel context instead of URL parameters
- Created mock resolver for SSH key deletion
- Added generic type props to ModelActionForm to support v3 API errors

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to /account/prefs/ssh-keys
- [x] If you don't have any keys, upload/import some
- [x] Delete a single SSH key 
- [x] Ensure the request succeeds and the list is updated
- [ ] Delete a group of SSH keys
- [ ] Ensure the request succeeds and the list is updated

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-4449](https://warthogs.atlassian.net/browse/MAASENG-4449)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->


[MAASENG-4449]: https://warthogs.atlassian.net/browse/MAASENG-4449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ