### PR TITLE
feat(images): Implement design for image table MAASENG-4360

### DIFF
--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -167,8 +167,11 @@ const GenericTable = <T extends { id: string | number }>({
       <thead>
         {table.getHeaderGroups().map((headerGroup) => (
           <tr key={headerGroup.id}>
-            {headerGroup.headers.filter(filterHeaders).map((header) => (
-              <TableHeader header={header} key={header.id} />
+            {headerGroup.headers.filter(filterHeaders).map((header, index) => (
+              <>
+                <TableHeader header={header} key={header.id} />
+                {index === 2 ? <th className="select-alignment" /> : null}
+              </>
             ))}
           </tr>
         ))}

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -7,15 +7,12 @@
   }
 
   .group-select,
-  .select {
+  .select,
+  .select-alignment {
     width: 2rem;
   }
 
   th.select {
     display: none;
-  }
-
-  th:not(.release):not(.group-select) {
-    padding-left: 2rem;
   }
 }

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -14,4 +14,8 @@
   th.select {
     display: none;
   }
+
+  th:not(.release):not(.group-select) {
+    padding-left: 2rem;
+  }
 }

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -1,10 +1,17 @@
 .p-generic-table {
-  thead, tbody {
+
+  thead,
+  tbody {
     display: table-row-group;
     width: 100%;
   }
 
-  .group-select, .select {
+  .group-select,
+  .select {
     width: 2rem;
+  }
+
+  th.select {
+    display: none;
   }
 }

--- a/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
+++ b/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
@@ -181,7 +181,7 @@ const useImageTableColumns = ({
                     ? isCommissioningImage
                       ? "Cannot delete images of the default commissioning release."
                       : "Cannot delete images that are currently being imported."
-                    : null
+                    : "Deletes this image."
                 }
                 onDelete={() => onDelete(row)}
               />


### PR DESCRIPTION
## Done
- Added tooltip for delete icon in Images Table
- Aligned header text starting from "Release title" to the text "Ubuntu" in header belowe

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] On MAAS-UI go to configuration/images
- [x] Hover over delete icon to see the tooltip
- [x] Look at header if "Release title" is aligned with the "Ubuntu" text

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-4360](https://warthogs.atlassian.net/browse/MAASENG-4360)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
![images_table](https://github.com/user-attachments/assets/173d60a5-3f76-44ea-89be-6e3a1350ed34)


[MAASENG-4360]: https://warthogs.atlassian.net/browse/MAASENG-4360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ