### PR TITLE
fix(images): Images QA MAASENG-4536

### DIFF
--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.test.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.test.tsx
@@ -1,3 +1,4 @@
+import { render } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import configureStore from "redux-mock-store";
@@ -10,9 +11,8 @@ import * as factory from "@/testing/factories";
 import {
   userEvent,
   screen,
-  render,
   within,
-  renderWithBrowserRouter,
+  renderWithProviders,
 } from "@/testing/utils";
 
 const mockStore = configureStore<RootState>();
@@ -76,7 +76,7 @@ describe("SelectUpstreamImagesForm", () => {
   const store = mockStore(state);
 
   it("correctly sets initial values", async () => {
-    renderWithBrowserRouter(<SelectUpstreamImagesForm />, {
+    renderWithProviders(<SelectUpstreamImagesForm />, {
       state,
     });
 
@@ -148,7 +148,7 @@ describe("SelectUpstreamImagesForm", () => {
         },
       }),
     });
-    renderWithBrowserRouter(<SelectUpstreamImagesForm />, {
+    renderWithProviders(<SelectUpstreamImagesForm />, {
       state,
     });
 

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.test.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.test.tsx
@@ -79,19 +79,16 @@ describe("SelectUpstreamImagesForm", () => {
       state,
     });
 
-    await userEvent.click(screen.getByText("Ubuntu"));
-    await userEvent.click(screen.getByText("Centos"));
-
     const rowUbuntu = within(
-      screen.getByRole("row", { name: "16.04 LTS" })
-    ).getAllByRole("combobox");
+      screen.getByRole("row", { name: "16.04 LTS", hidden: true })
+    ).getAllByRole("combobox", { hidden: true });
 
     expect(rowUbuntu).toHaveLength(1);
     expect(within(rowUbuntu[0]).getByText("amd64, i386")).toBeInTheDocument();
 
     const rowOther = within(
-      screen.getByRole("row", { name: "centos70" })
-    ).getAllByRole("combobox");
+      screen.getByRole("row", { name: "centos70", hidden: true })
+    ).getAllByRole("combobox", { hidden: true });
 
     expect(rowOther).toHaveLength(1);
     expect(within(rowOther[0]).getByText("amd64")).toBeInTheDocument();

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.test.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.test.tsx
@@ -18,63 +18,64 @@ import {
 const mockStore = configureStore<RootState>();
 
 describe("SelectUpstreamImagesForm", () => {
-  it("correctly sets initial values", async () => {
-    const ubuntu = factory.bootResourceUbuntu({
-      arches: [
-        {
-          name: "amd64",
-          title: "amd64",
-          checked: false,
-          deleted: false,
-        },
-        {
-          name: "i386",
-          title: "i386",
-          checked: false,
-          deleted: false,
-        },
-      ],
-      releases: [
-        {
-          name: "xenial",
-          title: "16.04 LTS",
-          unsupported_arches: [],
-          checked: false,
-          deleted: false,
-        },
-      ],
-    });
-    const otherImages = [
-      factory.bootResourceOtherImage({
-        name: "centos/amd64/generic/centos70",
-        title: "CentOS 7",
-      }),
-    ];
-    const resources = [
-      factory.bootResource({
-        name: "ubuntu/xenial",
-        arch: "amd64",
+  const ubuntu = factory.bootResourceUbuntu({
+    arches: [
+      {
+        name: "amd64",
+        title: "amd64",
+        checked: false,
+        deleted: false,
+      },
+      {
+        name: "i386",
+        title: "i386",
+        checked: false,
+        deleted: false,
+      },
+    ],
+    releases: [
+      {
+        name: "xenial",
         title: "16.04 LTS",
-      }),
-      factory.bootResource({
-        name: "ubuntu/xenial",
-        arch: "i386",
-        title: "16.04 LTS",
-      }),
-      factory.bootResource({
-        name: "centos/centos70",
-        arch: "amd64",
-        title: "CentOS 7",
-      }),
-    ];
-    const state = factory.rootState({
-      bootresource: factory.bootResourceState({
-        resources,
-        ubuntu,
-        otherImages,
-      }),
-    });
+        unsupported_arches: [],
+        checked: false,
+        deleted: false,
+      },
+    ],
+  });
+  const otherImages = [
+    factory.bootResourceOtherImage({
+      name: "centos/amd64/generic/centos70",
+      title: "CentOS 7",
+    }),
+  ];
+  const resources = [
+    factory.bootResource({
+      name: "ubuntu/xenial",
+      arch: "amd64",
+      title: "16.04 LTS",
+    }),
+    factory.bootResource({
+      name: "ubuntu/xenial",
+      arch: "i386",
+      title: "16.04 LTS",
+    }),
+    factory.bootResource({
+      name: "centos/centos70",
+      arch: "amd64",
+      title: "CentOS 7",
+    }),
+  ];
+  const state = factory.rootState({
+    bootresource: factory.bootResourceState({
+      resources,
+      ubuntu,
+      otherImages,
+    }),
+  });
+  const store = mockStore(state);
 
+  it("correctly sets initial values", async () => {
     renderWithBrowserRouter(<SelectUpstreamImagesForm />, {
       state,
     });
@@ -95,62 +96,6 @@ describe("SelectUpstreamImagesForm", () => {
   });
 
   it("can dispatch an action to save ubuntu images", async () => {
-    const ubuntu = factory.bootResourceUbuntu({
-      arches: [
-        {
-          name: "amd64",
-          title: "amd64",
-          checked: false,
-          deleted: false,
-        },
-        {
-          name: "i386",
-          title: "i386",
-          checked: false,
-          deleted: false,
-        },
-      ],
-      releases: [
-        {
-          name: "xenial",
-          title: "16.04 LTS",
-          unsupported_arches: [],
-          checked: false,
-          deleted: false,
-        },
-      ],
-    });
-    const otherImages = [
-      factory.bootResourceOtherImage({
-        name: "centos/amd64/generic/centos70",
-        title: "CentOS 7",
-      }),
-    ];
-    const resources = [
-      factory.bootResource({
-        name: "ubuntu/xenial",
-        arch: "amd64",
-        title: "16.04 LTS",
-      }),
-      factory.bootResource({
-        name: "ubuntu/xenial",
-        arch: "i386",
-        title: "16.04 LTS",
-      }),
-      factory.bootResource({
-        name: "centos/centos70",
-        arch: "amd64",
-        title: "CentOS 7",
-      }),
-    ];
-    const state = factory.rootState({
-      bootresource: factory.bootResourceState({
-        resources,
-        ubuntu,
-        otherImages,
-      }),
-    });
-    const store = mockStore(state);
     render(
       <Provider store={store}>
         <MemoryRouter>

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.test.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.test.tsx
@@ -6,7 +6,9 @@ import {
   groupImagesByOS,
 } from "@/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm";
 import type { DownloadImagesSelectProps } from "@/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect";
-import SelectUpstreamImagesSelect from "@/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect";
+import SelectUpstreamImagesSelect, {
+  getValueKey,
+} from "@/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect";
 import { ConfigNames } from "@/app/store/config/types";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
@@ -171,6 +173,9 @@ describe("SelectUpstreamImagesSelect", () => {
 
     await userEvent.click(checkbox);
 
-    expect(mockSetFieldValue).toHaveBeenCalled();
+    expect(mockSetFieldValue).toHaveBeenCalledWith(
+      getValueKey("Ubuntu", releases[0].title),
+      [groupedImages["Ubuntu"][releases[0].title][0]]
+    );
   });
 });

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.test.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.test.tsx
@@ -126,4 +126,51 @@ describe("SelectUpstreamImagesSelect", () => {
     expect(labels).toHaveLength(1);
     expect(labels[0]).toHaveTextContent("available");
   });
+
+  it("correctly calls setFieldValue", async () => {
+    const releases = [factory.bootResourceUbuntuRelease({ name: "focal" })];
+    const [available, deleted] = [
+      factory.bootResourceUbuntuArch({
+        name: "arch-1",
+        deleted: false,
+      }),
+      factory.bootResourceUbuntuArch({
+        name: "arch-2",
+        deleted: false,
+      }),
+    ];
+
+    const downloadableImages = getDownloadableImages(
+      releases,
+      [available, deleted],
+      []
+    );
+    const imagesByOS = groupImagesByOS(downloadableImages);
+    const groupedImages = groupArchesByRelease(imagesByOS);
+    const mockSetFieldValue = vi.fn();
+    renderWithProviders(
+      <Formik initialValues={{ images: [] }} onSubmit={vi.fn()}>
+        {({ values }: Pick<DownloadImagesSelectProps, "values">) => (
+          <SelectUpstreamImagesSelect
+            groupedImages={groupedImages}
+            setFieldValue={mockSetFieldValue}
+            values={values}
+          />
+        )}
+      </Formik>,
+      { state }
+    );
+
+    await userEvent.click(screen.getByText("Ubuntu"));
+
+    const combobox = screen.getByRole("combobox");
+
+    await userEvent.click(combobox);
+
+    const checkbox = screen.getAllByRole("checkbox")[0];
+
+    await userEvent.click(checkbox);
+
+    expect(mockSetFieldValue).toHaveBeenCalled();
+  });
 });

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.tsx
@@ -1,9 +1,15 @@
-import { useState } from "react";
+import { useMemo } from "react";
 
-import { MultiSelect, type MultiSelectItem } from "@canonical/react-components";
+import {
+  Accordion,
+  MultiSelect,
+  type MultiSelectItem,
+} from "@canonical/react-components";
+import type { Section } from "@canonical/react-components/dist/components/Accordion/Accordion";
 import { Field } from "formik";
 
 import type { GroupedImages } from "@/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm";
+
 import "./_index.scss";
 
 const getValueKey = (distro: string, release: string) =>
@@ -20,72 +26,47 @@ const SelectUpstreamImagesSelect = ({
   setFieldValue,
   groupedImages,
 }: DownloadImagesSelectProps) => {
-  const [expandedDistro, setExpandedDistro] = useState<Array<string>>([]);
-
-  return (
-    <>
-      {Object.keys(groupedImages).map((distro) => {
-        const isExpanded = expandedDistro.indexOf(distro) !== -1;
-
-        return (
-          <div className="p-accordion" key={distro}>
-            <button
-              aria-expanded={isExpanded}
-              className="p-accordion__tab"
-              onClick={() =>
-                setExpandedDistro((prevState) => {
-                  if (isExpanded) {
-                    return prevState.filter((value) => value !== distro);
-                  }
-                  return [...prevState, distro];
-                })
-              }
-              role="tab"
-              type="button"
-            >
-              <h2 className="p-heading--4">{distro}</h2>
-            </button>
-            {isExpanded && (
-              <section
-                aria-hidden={!isExpanded}
-                className="p-accordion__panel"
-                role="tabpanel"
-              >
-                <table className="download-images-table">
-                  <thead>
-                    <tr>
-                      <th>Release Title</th>
-                      <th>Architecture</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {Object.keys(groupedImages[distro]).map((release) => (
-                      <tr key={release}>
-                        <td>{release}</td>
-                        <td>
-                          <Field
-                            as={MultiSelect}
-                            items={groupedImages[distro][release]}
-                            name={getValueKey(distro, release)}
-                            onItemsUpdate={(items: MultiSelectItem) =>
-                              setFieldValue(getValueKey(distro, release), items)
-                            }
-                            placeholder="Select architectures"
-                            selectedItems={values[getValueKey(distro, release)]}
-                            variant="condensed"
-                          />
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </section>
-            )}
-          </div>
-        );
-      })}
-    </>
+  const accordionSections = useMemo(
+    () =>
+      Object.keys(groupedImages).map((distro) => {
+        return {
+          key: distro,
+          content: (
+            <table className="download-images-table">
+              <thead>
+                <tr>
+                  <th>Release Title</th>
+                  <th>Architecture</th>
+                </tr>
+              </thead>
+              <tbody>
+                {Object.keys(groupedImages[distro]).map((release) => (
+                  <tr key={release}>
+                    <td>{release}</td>
+                    <td>
+                      <Field
+                        as={MultiSelect}
+                        items={groupedImages[distro][release]}
+                        name={getValueKey(distro, release)}
+                        onItemsUpdate={(items: MultiSelectItem) =>
+                          setFieldValue(getValueKey(distro, release), items)
+                        }
+                        placeholder="Select architectures"
+                        selectedItems={values[getValueKey(distro, release)]}
+                        variant="condensed"
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ),
+          titleElement: "h4",
+          title: distro,
+        } as Section;
+      }),
+    [groupedImages, values, setFieldValue]
   );
+  return <Accordion sections={accordionSections} />;
 };
-
 export default SelectUpstreamImagesSelect;

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.tsx
@@ -2,11 +2,11 @@ import { useMemo } from "react";
 
 import {
   Accordion,
+  FormikField,
   MultiSelect,
   type MultiSelectItem,
 } from "@canonical/react-components";
 import type { Section } from "@canonical/react-components/dist/components/Accordion/Accordion";
-import { Field } from "formik";
 
 import type { GroupedImages } from "@/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm";
 
@@ -17,7 +17,7 @@ export const getValueKey = (distro: string, release: string) =>
 
 export type DownloadImagesSelectProps = {
   values: Record<string, MultiSelectItem[]>;
-  setFieldValue: (key: string, value: MultiSelectItem) => void;
+  setFieldValue: (key: string, value: MultiSelectItem[]) => void;
   groupedImages: GroupedImages;
 };
 
@@ -44,11 +44,11 @@ const SelectUpstreamImagesSelect = ({
                   <tr key={release}>
                     <td>{release}</td>
                     <td>
-                      <Field
-                        as={MultiSelect}
+                      <FormikField
+                        component={MultiSelect}
                         items={groupedImages[distro][release]}
                         name={getValueKey(distro, release)}
-                        onItemsUpdate={(items: MultiSelectItem) =>
+                        onItemsUpdate={(items: MultiSelectItem[]) =>
                           setFieldValue(getValueKey(distro, release), items)
                         }
                         placeholder="Select architectures"

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.tsx
@@ -12,7 +12,7 @@ import type { GroupedImages } from "@/app/images/components/ImagesForms/SelectUp
 
 import "./_index.scss";
 
-const getValueKey = (distro: string, release: string) =>
+export const getValueKey = (distro: string, release: string) =>
   `${distro}-${release}`.replace(".", "-");
 
 export type DownloadImagesSelectProps = {

--- a/src/app/settings/views/Images/ChangeSource/ChangeSourceFields/ChangeSourceFields.tsx
+++ b/src/app/settings/views/Images/ChangeSource/ChangeSourceFields/ChangeSourceFields.tsx
@@ -1,17 +1,15 @@
 import React from "react";
 
-import { Col, Row, Textarea } from "@canonical/react-components";
+import { Col, Icon, Row, Textarea, Tooltip } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 
 import FormikField from "@/app/base/components/FormikField";
 import ShowAdvanced from "@/app/base/components/ShowAdvanced";
-import TooltipButton from "@/app/base/components/TooltipButton";
 import type { ChangeSourceValues } from "@/app/settings/views/Images/ChangeSource/ChangeSource";
 import { BootResourceSourceType } from "@/app/store/bootresource/types";
 
 export enum Labels {
   AutoSyncImages = "Automatically sync images",
-  ChooseSource = "Choose source",
   MaasIo = "maas.io",
   Custom = "Custom",
   Url = "URL",
@@ -88,22 +86,25 @@ const ChangeSourceFields = () => {
             </ShowAdvanced>
           </>
         )}
-        <span className="u-flex--align-baseline">
-          <span>{Labels.AutoSyncImages}</span>
-          <TooltipButton
-            className="u-nudge-right--small"
-            iconName="help"
-            message={`Enables hourly image updates (sync) from the source configured below.`}
-          />
-          <span className="u-nudge-right">
-            <FormikField
-              data-testid="auto-sync-switch"
-              id="auto-sync-switch"
-              name="autoSync"
-              type="checkbox"
-            />
-          </span>
-        </span>
+        <FormikField
+          data-testid="auto-sync-switch"
+          id="auto-sync-switch"
+          label={
+            <>
+              {Labels.AutoSyncImages}
+              <Tooltip
+                className="u-nudge-right--small"
+                message={`Enables hourly image updates (sync) from the source configured below.`}
+              >
+                <div className="u-nudge-right--x-large">
+                  <Icon name="help" />
+                </div>
+              </Tooltip>
+            </>
+          }
+          name="autoSync"
+          type="checkbox"
+        />
       </Col>
     </Row>
   );

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,8 @@ export default defineConfig({
       reporter: [
         ["text"],
         ["html"],
-        ["cobertura", { file: "../.coverage/cobertura-coverage.xml" }],
+        ["lcov"],
+        ["cobertura", { file: "../coverage/cobertura-coverage.xml" }],
       ],
     },
   },


### PR DESCRIPTION
## Done

- Switched the `SelectUpstreamImagesSelect` OS accordions to Vanilla.js `Accordion` for standard styling
- Moved "Automatically sync images" checkbox to the left of the label in `ChangeSourceFields`
- Fixed broken tests, added cases for improved coverage
- Added `lcov` reporter and had `cobertura` output reports to the gitignored coverage directory

## QA steps

- [x] Navigate to Images
- [x] Open the `SelectUpstreamImages` form by clicking the "Select upstream images" button
- [x] Verify the accordions styling is as expected
- [x] Ensure the form functions as expected
- [x] Navigate to Settings->Images->Source
- [x] Verify the Automatically sync images checkbox is styled as expected
- [x] Verify the tooltip functions
- [x] Ensure the checkbox works by toggling it, clicking "Save", navigating to Images, and verifying syncing is toggled

## Fixes

Resolves: 

[MAASENG-4536](https://warthogs.atlassian.net/browse/MAASENG-4536)

Addresses:

[Images QA design](https://www.figma.com/design/VKK278yUxba3xGGxigTsrY/MAAS-Image-provisioning-QA?node-id=109-550&t=mdQFKM49Nzrh7tfd-4)

## Screenshots

<img width="527" alt="Screenshot 2025-03-05 at 15 40 31" src="https://github.com/user-attachments/assets/efacaa6c-79bc-4af2-bdb0-f76c16ac1963" />
<img width="946" alt="Screenshot 2025-03-05 at 18 51 52" src="https://github.com/user-attachments/assets/6ccfa980-ef29-4bd9-98f9-c0996fd811aa" />


[MAASENG-4536]: https://warthogs.atlassian.net/browse/MAASENG-4536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ