### PR TITLE
fix(zones): Show error messages for zone mutations MAASENG-4541

### DIFF
--- a/src/app/zones/views/ZonesList/ZonesListTable/AddZone/AddZone.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/AddZone/AddZone.test.tsx
@@ -11,7 +11,7 @@ import {
   waitFor,
 } from "@/testing/utils";
 
-setupMockServer(zoneResolvers.createZone.handler());
+const mockServer = setupMockServer(zoneResolvers.createZone.handler());
 
 describe("AddZone", () => {
   it("runs closeForm function when the cancel button is clicked", async () => {
@@ -38,5 +38,24 @@ describe("AddZone", () => {
     await userEvent.click(screen.getByRole("button", { name: /Add AZ/i }));
 
     await waitFor(() => expect(zoneResolvers.createZone.resolved).toBeTruthy());
+  });
+
+  it("displays error message when create zone fails", async () => {
+    mockServer.use(
+      zoneResolvers.createZone.error({ code: 400, message: "Uh oh!" })
+    );
+
+    renderWithProviders(<AddZone closeForm={vi.fn()} />);
+
+    await userEvent.type(
+      screen.getByRole("textbox", { name: /name/i }),
+      "danger-zone"
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Add AZ/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Uh oh!/i)).toBeInTheDocument();
+    });
   });
 });

--- a/src/app/zones/views/ZonesList/ZonesListTable/AddZone/AddZone.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/AddZone/AddZone.tsx
@@ -1,6 +1,7 @@
 import { Row, Col, Textarea } from "@canonical/react-components";
 
 import { useCreateZone } from "@/app/api/query/zones";
+import type { CreateZoneError } from "@/app/apiclient";
 import FormikField from "@/app/base/components/FormikField";
 import FormikForm from "@/app/base/components/FormikForm";
 
@@ -17,8 +18,9 @@ const AddZone = ({ closeForm }: Props): JSX.Element => {
   const createZone = useCreateZone();
 
   return (
-    <FormikForm<CreateZoneValues>
+    <FormikForm<CreateZoneValues, CreateZoneError>
       aria-label="Add AZ"
+      errors={createZone.error}
       initialValues={{
         description: "",
         name: "",

--- a/src/app/zones/views/ZonesList/ZonesListTable/DeleteZone/DeleteZone.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/DeleteZone/DeleteZone.test.tsx
@@ -2,7 +2,16 @@ import { Formik } from "formik";
 
 import DeleteZone from "./DeleteZone";
 
-import { userEvent, screen, renderWithBrowserRouter } from "@/testing/utils";
+import { zoneResolvers } from "@/testing/resolvers/zones";
+import {
+  userEvent,
+  screen,
+  renderWithBrowserRouter,
+  setupMockServer,
+  waitFor,
+} from "@/testing/utils";
+
+const mockServer = setupMockServer(zoneResolvers.deleteZone.handler());
 
 describe("DeleteZone", () => {
   it("calls closeForm on cancel click", async () => {
@@ -15,5 +24,23 @@ describe("DeleteZone", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(closeForm).toHaveBeenCalled();
+  });
+
+  it("displays error messages when delete zone fails", async () => {
+    mockServer.use(
+      zoneResolvers.deleteZone.error({ code: 400, message: "Uh oh!" })
+    );
+
+    renderWithBrowserRouter(
+      <Formik initialValues={{ images: [] }} onSubmit={vi.fn()}>
+        <DeleteZone closeForm={vi.fn()} id={2} />
+      </Formik>
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Uh oh!/i)).toBeInTheDocument();
+    });
   });
 });

--- a/src/app/zones/views/ZonesList/ZonesListTable/DeleteZone/DeleteZone.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/DeleteZone/DeleteZone.tsx
@@ -18,6 +18,7 @@ const DeleteZone: React.FC<DeleteZoneProps> = ({ closeForm, id }) => {
   return (
     <ModelActionForm
       aria-label="Confirm AZ deletion"
+      errors={deleteZone.error}
       initialValues={{}}
       message="Are you sure you want to delete this AZ?"
       modelType="zone"

--- a/src/app/zones/views/ZonesList/ZonesListTable/EditZone/EditZone.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/EditZone/EditZone.tsx
@@ -2,6 +2,7 @@ import { Row, Col, Textarea } from "@canonical/react-components";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { useGetZone, useUpdateZone } from "@/app/api/query/zones";
+import type { UpdateZoneError } from "@/app/apiclient";
 import { getZoneQueryKey } from "@/app/apiclient/@tanstack/react-query.gen";
 import FormikField from "@/app/base/components/FormikField";
 import FormikForm from "@/app/base/components/FormikForm";
@@ -24,8 +25,9 @@ const EditZone = ({ id, closeForm }: Props): JSX.Element | null => {
 
   if (zone) {
     return (
-      <FormikForm<CreateZoneValues>
+      <FormikForm<CreateZoneValues, UpdateZoneError>
         aria-label="Edit AZ"
+        errors={editZone.error}
         initialValues={{
           description: zone.description,
           name: zone.name,


### PR DESCRIPTION
## Done
- Passed errors to form components in:
  - AddZone
  - DeleteZone
  - EditZone
- Added error resolvers for all zone mutations
<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to zones 
- [x] Add a zone (with a name that is already taken)
- [x] Ensure the request fails and an error message is shown
- [x] Add a zone with a unique name
- [x] Edit the zone to have a conflicting name
- [x] Ensure the request fails and an error message is shown
- [x] Comment out line 102 in `src/app/zones/views/ZonesList/ZonesListTable/useZonesTableColumns/useZonesTableColumns.tsx`
- [x] Try to delete the default zone
- [x] Ensure an error message is displayed

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-4541](https://warthogs.atlassian.net/browse/MAASENG-4541)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
![image](https://github.com/user-attachments/assets/4dadca4a-93de-40dc-98f7-e77a06cae184)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-4541]: https://warthogs.atlassian.net/browse/MAASENG-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ