### PR TITLE
fix: use correct relative import for utils in sitespeed machine test

### DIFF
--- a/sitespeed.io/scripts/machines.js
+++ b/sitespeed.io/scripts/machines.js
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
-const { constructURL } = require("./utils");
+const { constructURL } = require("../utils");
 
 const TIMEOUT = 120000;
 


### PR DESCRIPTION
## Done
- Fixed import for `utils.js` in `machines.js`

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] 

<!-- Steps for QA. -->

## Fixes

Fixes: 

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
