### PR TITLE
fix(api): use '/' as the baseUrl for the API client

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -17,6 +17,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           scopes: |
+            api
             base
             controllers
             deps

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "release": "yarn clean && yarn install && CI=true yarn test && yarn build && yarn version --new-version",
     "serve-proxy": "nodemon ./scripts/proxy.js",
     "serve-react": "vite --host",
-    "serve-static-demo": "STATIC_DEMO=true PROXY_PORT=80 nodemon ./scripts/proxy.js",
+    "serve-static-demo": "STATIC_DEMO=true PROXY_PORT=8400 nodemon ./scripts/proxy.js",
     "serve": "vite preview",
     "show-ready": "wait-on http-get://0.0.0.0:8401 && nodemon ./scripts/proxy-ready.js",
     "sitespeed:ci": "docker run -v \"$(pwd)/sitespeed.io:/sitespeed.io\" --network=host sitespeedio/sitespeed.io:25.2.1 --config /sitespeed.io/config.json /sitespeed.io/scripts/machines.js --multi --spa",

--- a/src/hey-api.ts
+++ b/src/hey-api.ts
@@ -2,7 +2,7 @@ import type { CreateClientConfig } from "./app/apiclient/client.gen";
 
 export const createClientConfig: CreateClientConfig = (config) => ({
   ...config,
-  baseUrl: import.meta.env.BASE_URL,
+  baseUrl: "/",
   headers: {
     cookie: document.cookie,
   },


### PR DESCRIPTION
## Done
- Changed `baseUrl` of API client to `/` 
- Changed `PROXY_PORT` to 8400 in static demo serve
- (drive-by) Allowed "api" as a commit message scope

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Clone this branch and run `yarn build`
- [x] Serve the build with `yarn serve-static-demo`
- [x] Go to `http://localhost:8400`
- [x] Go to SSH keys
- [x] Ensure the list loads
- [x] Go to Zones
- [x] Ensure the list loads

<!-- Steps for QA. -->
