### PR TITLE
chore: Disable SASS errors for dependencies MAASENG-4549

### DIFF
--- a/src/app/base/components/DebounceSearchBox/_index.scss
+++ b/src/app/base/components/DebounceSearchBox/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin DebounceSearchBox {
   .debounce-search-box {
     position: relative;
@@ -19,7 +21,7 @@
   .debounce-search-box__spinner-container {
     // Use Vanilla's calculation for the the height of the search box
     height: calc(
-      #{2 * $spv-nudge + map-get($line-heights, default-text)} - #{2 * $bar-thickness}
+      #{2 * $spv-nudge + map.get($line-heights, default-text)} - #{2 * $bar-thickness}
     );
     margin: $bar-thickness 0;
     position: absolute;

--- a/src/app/base/components/FilterAccordion/_index.scss
+++ b/src/app/base/components/FilterAccordion/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin FilterAccordion {
   [class^="p-button"].has-icon.filter-accordion__toggle,
   .filter-accordion__item,
@@ -55,7 +57,7 @@
       background-position-x: $sph--large;
       background-position-y: center;
       background-repeat: no-repeat;
-      background-size: map-get($icon-sizes, default);
+      background-size: map.get($icon-sizes, default);
       font-weight: 400;
     }
   }

--- a/src/app/base/components/NotificationGroup/_index.scss
+++ b/src/app/base/components/NotificationGroup/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin NotificationGroup {
   .p-notification-group {
     // When the notification group is expanded, we override the usual spacing
@@ -29,7 +31,7 @@
         background-color: $color-mid-light;
         content: "";
         height: 1px;
-        left: 2 * $sph--large + map-get($icon-sizes, default);
+        left: 2 * $sph--large + map.get($icon-sizes, default);
         position: absolute;
         right: 0;
         top: 0;

--- a/src/app/base/components/TableMenu/_index.scss
+++ b/src/app/base/components/TableMenu/_index.scss
@@ -1,5 +1,8 @@
+@use "sass:map";
+@use "sass:math";
+
 @mixin TableMenu {
-  $icon-size: map-get($icon-sizes, default);
+  $icon-size: map.get($icon-sizes, default);
   $icon-space: $icon-size + $sph--small + $sph--large;
 
   .p-table-menu--hasIcon .p-contextual-menu__non-interactive {
@@ -26,7 +29,7 @@
   }
 
   .p-table-menu__icon-space {
-    $icon-space: map-get($icon-sizes, default);
+    $icon-space: map.get($icon-sizes, default);
     display: inline-block;
     width: $icon-space;
   }

--- a/src/app/base/components/node/OverviewCard/_index.scss
+++ b/src/app/base/components/node/OverviewCard/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin OverviewCard {
   .overview-card {
     @extend %base-grid;
@@ -135,7 +137,7 @@
       .overview-card__memory {
         @include pseudo-border(top);
         &::before {
-          right: -#{map-get($grid-gutter-widths, default)};
+          right: -#{map.get($grid-gutter-widths, default)};
         }
         margin-left: $sph--large;
         padding-left: 0;

--- a/src/app/base/components/node/networking/NetworkTable/_index.scss
+++ b/src/app/base/components/node/networking/NetworkTable/_index.scss
@@ -1,7 +1,9 @@
+@use "sass:map";
+
 @mixin NetworkTable {
   .network-table {
     @include truncated-border(
-      $width: #{2 * map-get($icon-sizes, default) + $sph--small}
+      $width: #{2 * map.get($icon-sizes, default) + $sph--small}
     );
 
     th,

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/_index.scss
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/_index.scss
@@ -1,7 +1,9 @@
+@use "sass:map";
+
 @mixin DeviceNetworkTable {
   .device-network-table {
     @include truncated-border(
-      $width: #{2 * map-get($icon-sizes, default) + $sph--small}
+      $width: #{2 * map.get($icon-sizes, default) + $sph--small}
     );
 
     th,

--- a/src/app/kvm/components/VmResources/_index.scss
+++ b/src/app/kvm/components/VmResources/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin VmResources {
   .vm-resources {
     padding: $sph--large;
@@ -9,7 +11,7 @@
     padding: $spv--x-small $sph--small;
     // Subtract small screen gutter width and card inner padding to center dropdown.
     width: calc(
-      100vw - #{(map-get($grid-gutter-widths, small) + $sph--large) * 2}
+      100vw - #{(map.get($grid-gutter-widths, small) + $sph--large) * 2}
     );
 
     .fqdn-col,
@@ -25,7 +27,7 @@
 
     @media only screen and (min-width: $breakpoint-small) {
       width: calc(
-        100vw - #{(map-get($grid-gutter-widths, default) + $sph--large) * 2}
+        100vw - #{(map.get($grid-gutter-widths, default) + $sph--large) * 2}
       );
 
       .power-col {

--- a/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/_index.scss
+++ b/src/app/machines/views/MachineDetails/MachineSummary/NumaCard/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin NumaCard {
 
   .numa-card {
@@ -23,7 +25,7 @@
     @extend %vf-button-base;
     background-position: right center;
     background-repeat: no-repeat;
-    background-size: map-get($icon-sizes, default);
+    background-size: map.get($icon-sizes, default);
     border: 0;
     margin: 0;
     padding: 0 #{$sp-unit * 5} 0 0;

--- a/src/app/settings/components/SettingsTable/_index.scss
+++ b/src/app/settings/components/SettingsTable/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 @mixin SettingsTable {
   .settings-table {
     display: grid;
@@ -26,8 +28,8 @@
     &::after {
       background: linear-gradient(
         to top,
-        transparentize($color-mid-light, 0.85),
-        transparentize($color-mid-light, 0.85) 1px,
+        color.scale($color-mid-light, $alpha: -85%),
+        color.scale($color-mid-light, $alpha: -85%) 1px,
         transparent 1px,
         transparent
       );

--- a/src/app/subnets/views/SubnetDetails/SubnetActionForms/components/EditBootArchitectures/BootArchitecturesTable/_index.scss
+++ b/src/app/subnets/views/SubnetDetails/SubnetActionForms/components/EditBootArchitectures/BootArchitecturesTable/_index.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 @mixin BootArchitecturesTable {
   .boot-architectures-table {
     .name-col {
@@ -28,7 +30,7 @@
       background-color: $color-light;
 
       &.is-selected {
-        background-color: transparentize($color-link, 0.85);
+        background-color: color.scale($color-link, $alpha: -85%);
       }
     }
   }

--- a/src/scss/_patterns_double-row.scss
+++ b/src/scss/_patterns_double-row.scss
@@ -1,5 +1,8 @@
+@use "sass:map";
+@use "sass:math";
+
 @mixin maas-double-row {
-  $icon-space: map-get($icon-sizes, default);
+  $icon-space: map.get($icon-sizes, default);
 
   .p-double-row--with-icon,
   .p-double-row {

--- a/src/scss/_patterns_forms.scss
+++ b/src/scss/_patterns_forms.scss
@@ -1,3 +1,5 @@
+@use "sass:map";
+
 @mixin maas-forms {
   // Adds an "X" close button to the right of an input. Used in Add Machine form
   // for removing extra MAC addresses.
@@ -15,7 +17,7 @@
   // Align icon size with form validation font size
   .p-form-validation__message [class*="p-icon--"] {
     @extend %icon;
-    @include vf-icon-size(#{map-get($font-sizes, small)}rem);
+    @include vf-icon-size(#{map.get($font-sizes, small)}rem);
   }
 
   // Add class to checkbox so that label does not change opacity when disabled
@@ -48,7 +50,7 @@
   // small. Used for displaying very long strings, e.g. certificates.
   .p-textarea--readonly {
     color: $color-dark !important;
-    font-size: #{map-get($font-sizes, small)}rem;
+    font-size: #{map.get($font-sizes, small)}rem;
   }
 
   // Override checkbox labels when the text should not appear as

--- a/src/scss/_patterns_grids.scss
+++ b/src/scss/_patterns_grids.scss
@@ -1,10 +1,12 @@
+@use "sass:map";
+
 @mixin maas-grids {
   %base-grid {
     display: grid;
-    grid-column-gap: map-get($grid-gutter-widths, default);
+    grid-column-gap: map.get($grid-gutter-widths, default);
 
     @media only screen and (max-width: $breakpoint-small) {
-      grid-column-gap: map-get($grid-gutter-widths, small);
+      grid-column-gap: map.get($grid-gutter-widths, small);
     }
   }
 }

--- a/src/scss/_patterns_typography.scss
+++ b/src/scss/_patterns_typography.scss
@@ -1,3 +1,5 @@
+@use "sass:string";
+
 @mixin maas-typography {
   .p-heading--small {
     @extend %table-header-label;
@@ -18,6 +20,6 @@
   }
 
   .p-text--code {
-    font-family: unquote($font-monospace);
+    font-family: string.unquote($font-monospace);
   }
 }

--- a/src/scss/_pseudo-border.scss
+++ b/src/scss/_pseudo-border.scss
@@ -1,3 +1,6 @@
+@use "sass:map";
+@use "sass:math";
+
 @mixin pseudo-border($pos) {
   position: relative;
 
@@ -18,7 +21,7 @@
   } @else if $pos == left {
     &::after {
       bottom: 0;
-      left: -#{math.div(map-get($grid-gutter-widths, default), 2)};
+      left: -#{math.div(map.get($grid-gutter-widths, default), 2)};
       top: 0;
       width: 1px;
     }

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -1,8 +1,11 @@
+@use 'sass:color';
+@use 'sass:math';
+
 // Vanilla settings:
 $grid-max-width: math.div(1920, 16) * 1rem; // express in rems for easier calculations
 
 $color-navigation-background: #666;
-$color-navigation-background--hover: darken($color-navigation-background, 3%);
+$color-navigation-background--hover: color.scale($color-navigation-background, $lightness: -3%);
 
 $breakpoint-node-action-menu-group: 793px;
 $breakpoint-kvm-resources-card: 1300px;

--- a/src/scss/_utilities.scss
+++ b/src/scss/_utilities.scss
@@ -1,3 +1,7 @@
+@use "sass:color";
+@use "sass:map";
+@use "sass:string";
+
 @mixin maas-utilities {
   %display-flex {
     display: flex !important;
@@ -205,7 +209,7 @@
   }
 
   .u-text--default-size {
-    font-size: map-get($base-font-sizes, base) !important;
+    font-size: map.get($base-font-sizes, base) !important;
     font-weight: $font-weight-regular-text !important;
   }
 
@@ -218,7 +222,7 @@
   }
 
   .u-text--monospace {
-    font-family: unquote($font-monospace) !important;
+    font-family: string.unquote($font-monospace) !important;
   }
 
   .u-no-line-height {
@@ -263,7 +267,7 @@
 
   @each $name, $color in $nav-theme-colors {
     .is-maas-#{$name}--accent {
-      background-color: lighten($color, 5%) !important;
+      background-color: color.scale($color, $lightness: 5%) !important;
     }
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,15 @@ export default defineConfig(({ mode }) => {
   return {
     envDir: "./",
     base: "/",
+    css: {
+      preprocessorOptions: {
+        scss: {
+          api: "modern",
+          quietDeps: true,
+          silenceDeprecations: ["import"],
+        },
+      },
+    },
     define: {
       "process.env": env,
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,7 +23,7 @@ export default defineConfig(({ mode }) => {
         scss: {
           api: "modern",
           quietDeps: true,
-          silenceDeprecations: ["import"],
+          silenceDeprecations: ["import", "global-builtin"],
         },
       },
     },


### PR DESCRIPTION
## Done

- Silenced SASS deprecation warnings coming from dependencies in `vite.config.ts`
- Resolved in-project deprecation warnings
- Silenced all import warnings as per the [Vanilla JS Discourse post](https://discourse.canonical.com/t/how-to-deal-with-sass-deprecation-warnings-with-vanilla/5243)

## QA steps

- [x] Open `vite.config.ts`
- [x] Comment out lines 21-29
- [x] Run the dev server using `yarn start`
- [x] Ensure that all SASS warnings are from external packages
- [x] Revert the commenting in step 2
- [x] Re-run the dev server
- [x] Verify no SASS warnings are shown

## Fixes

Resolves: 

[MAASENG-4549](https://warthogs.atlassian.net/browse/MAASENG-4549)


[MAASENG-4549]: https://warthogs.atlassian.net/browse/MAASENG-4549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ