### PR TITLE
docs: Explain React Query implementation in MAASUI.md MAASENG-3598

### DIFF
--- a/docs/MAASUI.md
+++ b/docs/MAASUI.md
@@ -101,6 +101,34 @@ Many of the Vanilla components have React implementations which you can find in 
 
 If you need a vanilla component that does not already exist, first implement it in MAAS-UI and then propose it to the react-components repo.
 
+### TanStack Query
+
+We use [TanStack Query](https://tanstack.com/query/latest/docs/framework/react/overview) for our API functions used to interact with the backend. React Query acts as our data fetching and posting tool, allowing for a single-form communication structure for all endpoints, and providing a query cache. The query cache serves to alleviate the load of numerous API calls by storing the responses and only requesting new data if said cache is marked as stale.
+
+In addition to TanStack Query, we also use [Hey API](https://heyapi.dev) as our codegen for creating the aforementioned API functions from an OpenAPI spec document. Hey API's generated files, contained in \`[app/apiclient](https://github.com/canonical/maas-ui/tree/main/src/app/apiclient)\`, allow us to accurately update our data types and API calls according to the most recent specification provided. The generated SDK functions are wrapped by custom query functions found in \`[app/api/query](https://github.com/canonical/maas-ui/tree/main/src/app/api/query)\`, manually written to correspond to each endpoint. It is these SDK-wrapping functions that are used across the codebase, alongside the generated types, to communicate with the back-end.
+
+#### Typical Query Function
+
+A typical query function is simply a call to its corresponding SDK function with provided types and exposed options, wrapped in a custom web socket hook we use to allow for invalidating the query cache through messages pushed by the back-end. In the case where the query affects the data being displayed, the query function also invalidates the cache upon success to execute a fetch of the newly modified data.
+
+```ts
+export const useCreateZone = (mutationOptions?: Options<CreateZoneData>) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    CreateZoneResponse,
+    CreateZoneError,
+    Options<CreateZoneData>
+  >({
+    ...createZoneMutation(mutationOptions),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: listZonesQueryKey(),
+      });
+    },
+  });
+};
+```
+
 ### Redux
 
 We use [Redux](https://redux.js.org/introduction/getting-started) as our state-management tool. To put it briefly, Redux is responsible for storing all the app-wide state (in the “store”) and provides a predictable methodology for changing that state. The normal flow is this: an action is dispatched, and as a consequence, some state is changed via a reducer function. Actions can be dispatched directly by the user from the UI, or elsewhere (e.g. a server).
@@ -124,7 +152,7 @@ A typical slice contains:
 - An `items` property for storing the list of all items of a particular model
 - Associated `loading`, `loaded`, and `errors` properties
 
-```ts
+```
 controller: {
   items: Controller[],
   loading: boolean,
@@ -143,7 +171,7 @@ The state slice for the `machine` model includes additional properties: `lists`,
 - Filters supported by the server are stored in `machine.filters`
 - `machine.lists` contains machine IDs for each request, referencing data in `machine.items`
 
-```ts
+```
 machine: {
   items: Machine[];
   lists: { [query: string]: Machine["system_id"][] };
@@ -251,7 +279,7 @@ The attribute can be applied to any component or element:
 Which can then be used within a test:
 
 ```javascript
-expect(wrapper.find("[data-testid='content']").text()).toBe(“Content”);
+expect(wrapper.find("[data-testid='content']").text()).toBe("Content");
 ```
 
 #### Model factories

--- a/docs/MAASUI.md
+++ b/docs/MAASUI.md
@@ -62,6 +62,8 @@ When developing new features or extending existing ones, consider the following:
 
 The high-level interactions between the React side of the frontend and the API are illustrated below.
 
+> NOTE: MAAS-UI currently utilises both REST and web socket API through TanStack Query and Redux, respectively.
+
 ![code-structure](https://github.com/user-attachments/assets/d7abb957-f5f7-453d-9dab-a1ff749a222d)
 
 ## React
@@ -105,7 +107,7 @@ If you need a vanilla component that does not already exist, first implement it 
 
 We use [TanStack Query](https://tanstack.com/query/latest/docs/framework/react/overview) for our API functions used to interact with the backend. React Query acts as our data fetching and posting tool, allowing for a single-form communication structure for all endpoints, and providing a query cache. The query cache serves to alleviate the load of numerous API calls by storing the responses and only requesting new data if said cache is marked as stale.
 
-In addition to TanStack Query, we also use [Hey API](https://heyapi.dev) as our codegen for creating the aforementioned API functions from an OpenAPI spec document. Hey API's generated files, contained in \`[app/apiclient](https://github.com/canonical/maas-ui/tree/main/src/app/apiclient)\`, allow us to accurately update our data types and API calls according to the most recent specification provided. The generated SDK functions are wrapped by custom query functions found in \`[app/api/query](https://github.com/canonical/maas-ui/tree/main/src/app/api/query)\`, manually written to correspond to each endpoint. It is these SDK-wrapping functions that are used across the codebase, alongside the generated types, to communicate with the back-end.
+In addition to TanStack Query, we also use [Hey API](https://heyapi.dev) as our codegen for creating the aforementioned API functions from an OpenAPI spec document. Hey API's generated files, contained in \`[app/apiclient](https://github.com/canonical/maas-ui/tree/main/src/app/apiclient)\`, allow us to accurately update our data types and API calls according to the most recent specification provided. The generated SDK functions are wrapped by custom query functions found in \`[app/api/query](https://github.com/canonical/maas-ui/tree/main/src/app/api/query)\`, manually written to correspond to each endpoint.
 
 #### Typical Query Function
 

--- a/docs/MAASUI.md
+++ b/docs/MAASUI.md
@@ -62,7 +62,7 @@ When developing new features or extending existing ones, consider the following:
 
 The high-level interactions between the React side of the frontend and the API are illustrated below.
 
-![code-structure](https://user-images.githubusercontent.com/47540149/214085014-a48a1645-afb0-434b-b5e9-07ae798c571a.png)
+![code-structure](https://github.com/user-attachments/assets/d7abb957-f5f7-453d-9dab-a1ff749a222d)
 
 ## React
 

--- a/docs/MAASUI.md
+++ b/docs/MAASUI.md
@@ -131,6 +131,8 @@ export const useCreateZone = (mutationOptions?: Options<CreateZoneData>) => {
 
 ### Redux
 
+> NOTE: MAAS-UI will be completely migrating to TanStack Query for its API structure, and phase out the use of Redux. This transition is being carried out by migrating each endpoint separately, and removing the migrated types from the Redux store.
+
 We use [Redux](https://redux.js.org/introduction/getting-started) as our state-management tool. To put it briefly, Redux is responsible for storing all the app-wide state (in the “store”) and provides a predictable methodology for changing that state. The normal flow is this: an action is dispatched, and as a consequence, some state is changed via a reducer function. Actions can be dispatched directly by the user from the UI, or elsewhere (e.g. a server).
 
 ![redux](https://user-images.githubusercontent.com/47540149/214085476-46535bee-cc9d-407e-a569-90014ab7f7b2.png)


### PR DESCRIPTION
## Done

- Added TanStack Query section to explain the current implementation
- Updated the diagram to include TanStack Query
- Added a note stating the intending deprecation of web sockets and migration to TanStack Query

## Fixes

Resolves: 

[MAASENG-3598](https://warthogs.atlassian.net/browse/MAASENG-3598)
[MAASENG-3599](https://warthogs.atlassian.net/browse/MAASENG-3599)


[MAASENG-3598]: https://warthogs.atlassian.net/browse/MAASENG-3598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAASENG-3599]: https://warthogs.atlassian.net/browse/MAASENG-3599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ