### PR TITLE
fix(images): Save source update MAASENG-4589

### DIFF
--- a/src/app/base/components/ResourcePoolSelect/ResourcePoolSelect.test.tsx
+++ b/src/app/base/components/ResourcePoolSelect/ResourcePoolSelect.test.tsx
@@ -22,9 +22,13 @@ describe("ResourcePoolSelect", () => {
 
     await waitFor(() => expect(poolsResolvers.listPools.resolved).toBeTruthy());
 
+    await waitFor(() =>
+      expect(
+        screen.getByRole("option", { name: "swimming" })
+      ).toBeInTheDocument()
+    );
     const pools = screen.getAllByRole("option");
     expect(pools).toHaveLength(mockPools.items.length + 1);
-    expect(pools[1]).toHaveTextContent("swimming");
   });
 
   it("disables select if resource pools have not loaded", () => {

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -25,7 +25,7 @@ type SMImagesTableProps = {
   variant?: "full-height" | "regular";
 };
 
-const getImages = (resources: BootResource[]): Image[] => {
+export const getImages = (resources: BootResource[]): Image[] => {
   return resources.map((resource) => {
     const { os } = splitResourceName(resource.name);
     return {


### PR DESCRIPTION
## Done
- Added proper saving `dispatch` call to `ChangeSource`
- Modified `ChangeSourceFields` autofill to properly reflect custom sources

## QA steps

- [ ] Navigate to settings/images/source
- [ ] Change source to a custom source
- [ ] Click 'Save'
- [ ] Navigate to images/
- [ ] Verify the source is updated
- [ ] Navigate back to settings/images/source
- [ ] Verify the fields are autofilled with the custom source
- [ ] Change source to a maas.io
- [ ] Click 'Save'
- [ ] Navigate to images/
- [ ] Verify the source is updated

## Fixes

Fixes: 

[MAASENG-4589](https://warthogs.atlassian.net/browse/MAASENG-4589)


[MAASENG-4589]: https://warthogs.atlassian.net/browse/MAASENG-4589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ