### PR TITLE
fix(kvm): ComposeForm pool id bug MAASENG-4664

### DIFF
--- a/src/app/kvm/components/KVMForms/ComposeForm/ComposeForm.tsx
+++ b/src/app/kvm/components/KVMForms/ComposeForm/ComposeForm.tsx
@@ -457,7 +457,7 @@ const ComposeForm = ({ clearSidePanelContent, hostId }: Props): JSX.Element => {
           interfaces: [],
           memory: defaults.memory,
           pinnedCores: "",
-          pool: `${zones.data?.items[0]?.id}` || "",
+          pool: `${pools.data?.items[0]?.id}` || "",
           zone: `${zones.data?.items[0]?.id}` || "",
         }}
         modelName="machine"


### PR DESCRIPTION
## Done

- Fixed the initial value assignment for `ComposeForm` pool field

## Fixes

Fixes: 

[MAASENG-4664](https://warthogs.atlassian.net/browse/MAASENG-4664)
[#2105901](https://bugs.launchpad.net/maas/+bug/2105901)
