### PR TITLE
feat(base): Add pagination to GenericTable MAASENG-4588

### DIFF
--- a/src/app/api/query/pools.test.ts
+++ b/src/app/api/query/pools.test.ts
@@ -38,7 +38,7 @@ describe("usePoolCount", () => {
     expect(result.current.data).toBe(3);
   });
 
-  it("should return 0 when no zones exist", async () => {
+  it("should return 0 when no pools exist", async () => {
     mockServer.use(poolsResolvers.listPools.handler({ items: [], total: 0 }));
     const { result } = renderHookWithProviders(() => usePoolCount());
     await waitFor(() => expect(result.current.isSuccess).toBe(true));

--- a/src/app/api/query/pools.test.ts
+++ b/src/app/api/query/pools.test.ts
@@ -39,9 +39,7 @@ describe("usePoolCount", () => {
   });
 
   it("should return 0 when no zones exist", async () => {
-    mockServer.use(
-      poolsResolvers.listPools.handler({ ...mockPools, items: [] })
-    );
+    mockServer.use(poolsResolvers.listPools.handler({ items: [], total: 0 }));
     const { result } = renderHookWithProviders(() => usePoolCount());
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBe(0);

--- a/src/app/api/query/pools.ts
+++ b/src/app/api/query/pools.ts
@@ -47,7 +47,7 @@ export const usePoolCount = (
 ) => {
   return useWebsocketAwareQuery({
     ...listResourcePoolsWithSummaryOptions(options),
-    select: (data) => data?.items.length ?? 0,
+    select: (data) => data?.total ?? 0,
   } as UseQueryOptions<
     ListResourcePoolsWithSummaryResponse,
     ListResourcePoolsWithSummaryResponse,

--- a/src/app/api/query/zones.test.ts
+++ b/src/app/api/query/zones.test.ts
@@ -38,9 +38,7 @@ describe("useZoneCount", () => {
   });
 
   it("should return 0 when no zones exist", async () => {
-    mockServer.use(
-      zoneResolvers.listZones.handler({ ...mockZones, items: [] })
-    );
+    mockServer.use(zoneResolvers.listZones.handler({ items: [], total: 0 }));
     const { result } = renderHookWithProviders(() => useZoneCount());
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBe(0);

--- a/src/app/api/query/zones.ts
+++ b/src/app/api/query/zones.ts
@@ -42,7 +42,7 @@ export const useZones = (options?: Options<ListZonesWithSummaryData>) => {
 export const useZoneCount = (options?: Options<ListZonesWithSummaryData>) => {
   return useWebsocketAwareQuery({
     ...listZonesWithSummaryOptions(options),
-    select: (data) => data?.items.length ?? 0,
+    select: (data) => data?.total ?? 0,
   } as UseQueryOptions<
     ListZonesWithSummaryResponse,
     ListZonesWithSummaryResponse,

--- a/src/app/base/components/GenericTable/ColumnHeader/ColumnHeader.tsx
+++ b/src/app/base/components/GenericTable/ColumnHeader/ColumnHeader.tsx
@@ -9,7 +9,7 @@ type TableHeaderProps<T> = {
   header: Header<T, unknown>;
 };
 
-const TableHeader = <T,>({ header }: TableHeaderProps<T>) => {
+const ColumnHeader = <T,>({ header }: TableHeaderProps<T>) => {
   return (
     <th className={classNames(`${header.column.id}`)} key={header.id}>
       {header.column.getCanSort() ? (
@@ -29,4 +29,4 @@ const TableHeader = <T,>({ header }: TableHeaderProps<T>) => {
   );
 };
 
-export default TableHeader;
+export default ColumnHeader;

--- a/src/app/base/components/GenericTable/ColumnHeader/index.ts
+++ b/src/app/base/components/GenericTable/ColumnHeader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ColumnHeader";

--- a/src/app/base/components/GenericTable/GenericTable.test.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.test.tsx
@@ -2,6 +2,7 @@ import { vi } from "vitest";
 
 import GenericTable from "./GenericTable";
 
+import type { PaginationBarProps } from "@/app/base/components/GenericTable/PaginationBar/PaginationBar";
 import type { Image } from "@/app/images/types";
 import type { UtcDatetime } from "@/app/store/types/model";
 import * as factory from "@/testing/factories";
@@ -89,6 +90,15 @@ describe("GenericTable", () => {
 
   it("can change pages", async () => {
     const setPagination = vi.fn();
+    const pagination: PaginationBarProps = {
+      currentPage: 1,
+      dataContext: "",
+      handlePageSizeChange: vi.fn,
+      isPending: false,
+      itemsPerPage: 10,
+      setCurrentPage: setPagination,
+      totalItems: 100,
+    };
     render(
       <GenericTable
         columns={columns}
@@ -96,9 +106,8 @@ describe("GenericTable", () => {
         filterCells={mockFilterCells}
         filterHeaders={mockFilterHeaders}
         noData={<span>No data</span>}
-        pagination={{ page: 1, size: 1, total: 2 }}
+        pagination={pagination}
         rowSelection={{}}
-        setPagination={setPagination}
         setRowSelection={vi.fn}
       />
     );

--- a/src/app/base/components/GenericTable/GenericTable.test.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.test.tsx
@@ -87,6 +87,31 @@ describe("GenericTable", () => {
     expect(screen.getByText("18.04 LTS")).toBeInTheDocument();
   });
 
+  it("can change pages", async () => {
+    const setPagination = vi.fn();
+    render(
+      <GenericTable
+        columns={columns}
+        data={[]}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        noData={<span>No data</span>}
+        pagination={{ page: 1, size: 1, total: 2 }}
+        rowSelection={{}}
+        setPagination={setPagination}
+        setRowSelection={vi.fn}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Next page" })
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Next page" }));
+
+    expect(setPagination).toHaveBeenCalled();
+  });
+
   it('displays "No data" when the data array is empty', () => {
     render(
       <GenericTable

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import type { Dispatch, ReactNode, SetStateAction, ChangeEvent } from "react";
 
 import { DynamicTable, Pagination } from "@canonical/maas-react-components";
@@ -263,16 +263,22 @@ const GenericTable = <T extends { id: string | number }>({
               {headerGroup.headers
                 .filter(filterHeaders)
                 .map((header, index) => (
-                  <>
-                    <TableHeader header={header} key={header.id} />
+                  <Fragment key={header.id}>
+                    <TableHeader header={header} />
                     {index === 2 ? <th className="select-alignment" /> : null}
-                  </>
+                  </Fragment>
                 ))}
             </tr>
           ))}
         </thead>
         {table.getRowModel().rows.length < 1 ? (
-          noData
+          <tbody>
+            <tr>
+              <td colSpan={columns.length} style={{ textAlign: "center" }}>
+                {noData}
+              </td>
+            </tr>
+          </tbody>
         ) : (
           <DynamicTable.Body>
             {table.getRowModel().rows.map((row) => {

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -1,12 +1,7 @@
-import {
-  type Dispatch,
-  type ReactNode,
-  type SetStateAction,
-  useMemo,
-  useState,
-} from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Dispatch, ReactNode, SetStateAction, ChangeEvent } from "react";
 
-import { DynamicTable } from "@canonical/maas-react-components";
+import { DynamicTable, Pagination } from "@canonical/maas-react-components";
 import type {
   Column,
   Row,
@@ -29,6 +24,8 @@ import classNames from "classnames";
 
 import TableCheckbox from "@/app/base/components/GenericTable/TableCheckbox";
 import TableHeader from "@/app/base/components/GenericTable/TableHeader";
+import { DEFAULT_DEBOUNCE_INTERVAL } from "@/app/machines/views/MachineList/MachineListTable/MachineListPagination/MachineListPagination";
+import PageSizeSelect from "@/app/machines/views/MachineList/MachineListTable/PageSizeSelect";
 
 import "./_index.scss";
 
@@ -40,7 +37,11 @@ type GenericTableProps<T extends { id: string | number }> = {
   filterHeaders?: (header: Header<T, unknown>) => boolean;
   groupBy?: string[];
   noData?: ReactNode;
-  pin?: { value: string; isTop: boolean }[];
+  pagination?: { page: number; size: number; total: number };
+  setPagination?: Dispatch<
+    SetStateAction<{ page: number; size: number; total: number }>
+  >;
+  pinGroup?: { value: string; isTop: boolean }[];
   sortBy?: ColumnSort[];
   rowSelection?: RowSelectionState;
   setRowSelection?: Dispatch<SetStateAction<RowSelectionState>>;
@@ -55,15 +56,32 @@ const GenericTable = <T extends { id: string | number }>({
   filterHeaders = () => true,
   groupBy,
   noData,
-  pin,
+  pagination,
+  setPagination,
+  pinGroup,
   sortBy,
   rowSelection,
   setRowSelection,
   variant = "full-height",
 }: GenericTableProps<T>) => {
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
   const [grouping, setGrouping] = useState<GroupingState>(groupBy ?? []);
   const [expanded, setExpanded] = useState<ExpandedState>(true);
   const [sorting, setSorting] = useState<SortingState>(sortBy ?? []);
+
+  const [currentPage, setCurrentPage] = useState<number | undefined>(
+    pagination?.page
+  );
+  const [paginationError, setPaginationError] = useState<string>("");
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) {
+        clearTimeout(intervalRef.current);
+      }
+    };
+  }, []);
 
   if (canSelect) {
     columns = [
@@ -93,10 +111,18 @@ const GenericTable = <T extends { id: string | number }>({
     }
   }
 
+  let totalPages = 0;
+  if (pagination) {
+    totalPages =
+      (pagination.total - (pagination.total % pagination.size)) /
+        pagination.size +
+      (pagination.total % pagination.size > 0 ? 1 : 0);
+  }
+
   data = useMemo(() => {
     return [...data].sort((a, b) => {
-      if (pin && pin.length > 0 && grouping.length > 0) {
-        for (const { value, isTop } of pin) {
+      if (pinGroup && pinGroup.length > 0 && grouping.length > 0) {
+        for (const { value, isTop } of pinGroup) {
           const groupId = grouping[0];
           const aValue = a[groupId as keyof typeof a];
           const bValue = b[groupId as keyof typeof b];
@@ -133,7 +159,7 @@ const GenericTable = <T extends { id: string | number }>({
       }
       return 0;
     });
-  }, [data, sorting, grouping, pin]);
+  }, [data, sorting, grouping, pinGroup]);
 
   const table = useReactTable<T>({
     data,
@@ -163,53 +189,123 @@ const GenericTable = <T extends { id: string | number }>({
   });
 
   return (
-    <DynamicTable className="p-generic-table" variant={variant}>
-      <thead>
-        {table.getHeaderGroups().map((headerGroup) => (
-          <tr key={headerGroup.id}>
-            {headerGroup.headers.filter(filterHeaders).map((header, index) => (
-              <>
-                <TableHeader header={header} key={header.id} />
-                {index === 2 ? <th className="select-alignment" /> : null}
-              </>
-            ))}
-          </tr>
-        ))}
-      </thead>
-      {table.getRowModel().rows.length < 1 ? (
-        noData
-      ) : (
-        <DynamicTable.Body>
-          {table.getRowModel().rows.map((row) => {
-            const { getIsGrouped, id, getVisibleCells } = row;
-            const isIndividualRow = !getIsGrouped();
-            return (
-              <tr
-                className={classNames({
-                  "individual-row": isIndividualRow,
-                  "group-row": !isIndividualRow,
-                })}
-                key={id}
-              >
-                {getVisibleCells()
-                  .filter((cell) => filterCells(row, cell.column))
-                  .map((cell) => {
-                    const { column, id: cellId } = cell;
-                    return (
-                      <td
-                        className={classNames(`${cell.column.id}`)}
-                        key={cellId}
-                      >
-                        {flexRender(column.columnDef.cell, cell.getContext())}
-                      </td>
+    <>
+      {pagination && setPagination != undefined ? (
+        <span className="u-flex--end">
+          <Pagination
+            className="u-nudge-left--x-large"
+            currentPage={currentPage}
+            error={paginationError}
+            onInputBlur={() => {
+              setCurrentPage(pagination?.page);
+              setPaginationError("");
+            }}
+            onInputChange={function (e: ChangeEvent<HTMLInputElement>): void {
+              if (e.target.value) {
+                setCurrentPage(e.target.valueAsNumber);
+                if (intervalRef.current) {
+                  clearTimeout(intervalRef.current);
+                }
+                intervalRef.current = setTimeout(() => {
+                  if (
+                    e.target.valueAsNumber > totalPages ||
+                    e.target.valueAsNumber < 1
+                  ) {
+                    setPaginationError(
+                      `"${e.target.valueAsNumber}" is not a valid page number.`
                     );
+                  } else {
+                    setPaginationError("");
+                    setPagination((prevState) => {
+                      return { ...prevState, page: e.target.valueAsNumber };
+                    });
+                  }
+                }, DEFAULT_DEBOUNCE_INTERVAL);
+              } else {
+                setCurrentPage(undefined);
+                setPaginationError("Enter a page number.");
+              }
+            }}
+            onNextClick={function (): void {
+              setCurrentPage((prevState) => Number(prevState) + 1);
+              setPagination((prevState) => {
+                return { ...prevState, page: prevState.page + 1 };
+              });
+            }}
+            onPreviousClick={function (): void {
+              setCurrentPage((prevState) => Number(prevState) - 1);
+              setPagination((prevState) => {
+                return { ...prevState, page: prevState.page - 1 };
+              });
+            }}
+            totalPages={totalPages}
+          />
+          <PageSizeSelect
+            pageSize={pagination.size}
+            paginate={function (page: number): void {
+              setCurrentPage(page);
+              setPagination((prevState) => {
+                return { ...prevState, page };
+              });
+            }}
+            setPageSize={function (pageSize: number): void {
+              setPagination((prevState) => {
+                return { ...prevState, size: pageSize };
+              });
+            }}
+          />
+        </span>
+      ) : null}
+      <DynamicTable className="p-generic-table" variant={variant}>
+        <thead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <tr key={headerGroup.id}>
+              {headerGroup.headers
+                .filter(filterHeaders)
+                .map((header, index) => (
+                  <>
+                    <TableHeader header={header} key={header.id} />
+                    {index === 2 ? <th className="select-alignment" /> : null}
+                  </>
+                ))}
+            </tr>
+          ))}
+        </thead>
+        {table.getRowModel().rows.length < 1 ? (
+          noData
+        ) : (
+          <DynamicTable.Body>
+            {table.getRowModel().rows.map((row) => {
+              const { getIsGrouped, id, getVisibleCells } = row;
+              const isIndividualRow = !getIsGrouped();
+              return (
+                <tr
+                  className={classNames({
+                    "individual-row": isIndividualRow,
+                    "group-row": !isIndividualRow,
                   })}
-              </tr>
-            );
-          })}
-        </DynamicTable.Body>
-      )}
-    </DynamicTable>
+                  key={id}
+                >
+                  {getVisibleCells()
+                    .filter((cell) => filterCells(row, cell.column))
+                    .map((cell) => {
+                      const { column, id: cellId } = cell;
+                      return (
+                        <td
+                          className={classNames(`${cell.column.id}`)}
+                          key={cellId}
+                        >
+                          {flexRender(column.columnDef.cell, cell.getContext())}
+                        </td>
+                      );
+                    })}
+                </tr>
+              );
+            })}
+          </DynamicTable.Body>
+        )}
+      </DynamicTable>
+    </>
   );
 };
 

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -25,8 +25,8 @@ import {
 } from "@tanstack/react-table";
 import classNames from "classnames";
 
+import ColumnHeader from "@/app/base/components/GenericTable/ColumnHeader";
 import TableCheckbox from "@/app/base/components/GenericTable/TableCheckbox";
-import TableHeader from "@/app/base/components/GenericTable/TableHeader";
 import PageSizeSelect from "@/app/machines/views/MachineList/MachineListTable/PageSizeSelect";
 
 import "./_index.scss";
@@ -212,7 +212,7 @@ const GenericTable = <T extends { id: string | number }>({
                 .filter(filterHeaders)
                 .map((header, index) => (
                   <Fragment key={header.id}>
-                    <TableHeader header={header} />
+                    <ColumnHeader header={header} />
                     {index === 2 ? <th className="select-alignment" /> : null}
                   </Fragment>
                 ))}

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -1,10 +1,7 @@
 import { Fragment, useMemo, useState } from "react";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
 
-import {
-  DynamicTable,
-  PaginationContainer,
-} from "@canonical/maas-react-components";
+import { DynamicTable } from "@canonical/maas-react-components";
 import type {
   Column,
   Row,
@@ -26,8 +23,9 @@ import {
 import classNames from "classnames";
 
 import ColumnHeader from "@/app/base/components/GenericTable/ColumnHeader";
+import type { PaginationBarProps } from "@/app/base/components/GenericTable/PaginationBar/PaginationBar";
+import PaginationBar from "@/app/base/components/GenericTable/PaginationBar/PaginationBar";
 import TableCheckbox from "@/app/base/components/GenericTable/TableCheckbox";
-import PageSizeSelect from "@/app/machines/views/MachineList/MachineListTable/PageSizeSelect";
 
 import "./_index.scss";
 
@@ -39,10 +37,7 @@ type GenericTableProps<T extends { id: string | number }> = {
   filterHeaders?: (header: Header<T, unknown>) => boolean;
   groupBy?: string[];
   noData?: ReactNode;
-  pagination?: { page: number; size: number; total: number };
-  setPagination?: Dispatch<
-    SetStateAction<{ page: number; size: number; total: number }>
-  >;
+  pagination?: PaginationBarProps;
   pinGroup?: { value: string; isTop: boolean }[];
   sortBy?: ColumnSort[];
   rowSelection?: RowSelectionState;
@@ -59,7 +54,6 @@ const GenericTable = <T extends { id: string | number }>({
   groupBy,
   noData,
   pagination,
-  setPagination,
   pinGroup,
   sortBy,
   rowSelection,
@@ -96,14 +90,6 @@ const GenericTable = <T extends { id: string | number }>({
         ...columns,
       ];
     }
-  }
-
-  let totalPages = 0;
-  if (pagination) {
-    totalPages =
-      (pagination.total - (pagination.total % pagination.size)) /
-        pagination.size +
-      (pagination.total % pagination.size > 0 ? 1 : 0);
   }
 
   data = useMemo(() => {
@@ -177,32 +163,16 @@ const GenericTable = <T extends { id: string | number }>({
 
   return (
     <>
-      {pagination && setPagination != undefined ? (
-        <span className="u-flex--end">
-          <PaginationContainer
-            currentPage={pagination.page}
-            disabled={false}
-            paginate={function (page: number): void {
-              setPagination((prevState) => {
-                return { ...prevState, page };
-              });
-            }}
-            totalPages={totalPages}
-          />
-          <PageSizeSelect
-            pageSize={pagination.size}
-            paginate={function (page: number): void {
-              setPagination((prevState) => {
-                return { ...prevState, page };
-              });
-            }}
-            setPageSize={function (pageSize: number): void {
-              setPagination((prevState) => {
-                return { ...prevState, size: pageSize };
-              });
-            }}
-          />
-        </span>
+      {pagination ? (
+        <PaginationBar
+          currentPage={pagination.currentPage}
+          dataContext={pagination.dataContext}
+          handlePageSizeChange={pagination.handlePageSizeChange}
+          isPending={pagination.isPending}
+          itemsPerPage={pagination.itemsPerPage}
+          setCurrentPage={pagination.setCurrentPage}
+          totalItems={pagination.totalItems}
+        />
       ) : null}
       <DynamicTable className="p-generic-table" variant={variant}>
         <thead>

--- a/src/app/base/components/GenericTable/PaginationBar/ControlsBar/ControlsBar.tsx
+++ b/src/app/base/components/GenericTable/PaginationBar/ControlsBar/ControlsBar.tsx
@@ -1,0 +1,26 @@
+import type { PropsWithChildren } from "react";
+
+const ControlsBar = ({ children }: PropsWithChildren<object>) => {
+  return (
+    <section className="controls-bar u-flex u-flex--justify-between u-flex--wrap">
+      <div className="p-form p-form--inline">{children}</div>
+    </section>
+  );
+};
+
+const ControlsBarLeft = ({ children }: PropsWithChildren<object>) => {
+  return <strong className="controls-bar__description">{children}</strong>;
+};
+
+const ControlsBarRight = ({ children }: PropsWithChildren<object>) => {
+  return (
+    <div className="u-flex u-flex--wrap u-flex--column-x-small controls-bar__right">
+      {children}
+    </div>
+  );
+};
+
+ControlsBar.Left = ControlsBarLeft;
+ControlsBar.Right = ControlsBarRight;
+
+export default ControlsBar;

--- a/src/app/base/components/GenericTable/PaginationBar/PaginationBar.tsx
+++ b/src/app/base/components/GenericTable/PaginationBar/PaginationBar.tsx
@@ -1,0 +1,81 @@
+import type { ChangeEvent } from "react";
+import { useMemo } from "react";
+
+import { PaginationContainer } from "@canonical/maas-react-components";
+import { Select } from "@canonical/react-components";
+
+import ControlsBar from "@/app/base/components/GenericTable/PaginationBar/ControlsBar/ControlsBar";
+
+export type PaginationBarProps = {
+  currentPage: number;
+  itemsPerPage: number;
+  totalItems: number;
+  handlePageSizeChange: (size: number) => void;
+  dataContext: string;
+  setCurrentPage: (page: number) => void;
+  isPending: boolean;
+};
+export const pageSizes: Array<number> = [20, 30, 50, 100];
+
+const PaginationBar = ({
+  currentPage,
+  itemsPerPage,
+  totalItems,
+  handlePageSizeChange,
+  dataContext,
+  setCurrentPage,
+  isPending,
+}: PaginationBarProps) => {
+  const pageCounts = useMemo(() => pageSizes, []);
+  const pageOptions = useMemo(
+    () =>
+      pageCounts.map((pageCount) => ({
+        label: `${pageCount}/page`,
+        value: pageCount,
+      })),
+    [pageCounts]
+  );
+
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  const handleSizeChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const { value } = e.target;
+    handlePageSizeChange(Number(value));
+  };
+
+  const getDisplayedDataCount = () => {
+    if (currentPage === totalPages) {
+      return itemsPerPage - (totalPages * itemsPerPage - totalItems);
+    } else if (currentPage < totalPages) {
+      return itemsPerPage;
+    } else {
+      return 0;
+    }
+  };
+
+  return (
+    <ControlsBar>
+      <ControlsBar.Left>
+        Showing {getDisplayedDataCount()} out of {totalItems} {dataContext}
+      </ControlsBar.Left>
+      <ControlsBar.Right>
+        <PaginationContainer
+          currentPage={currentPage}
+          disabled={isPending}
+          paginate={setCurrentPage}
+          totalPages={totalPages}
+        />
+        <Select
+          aria-label="Items per page"
+          className="u-no-margin--bottom"
+          name="Items per page"
+          onChange={handleSizeChange}
+          options={pageOptions}
+          value={itemsPerPage}
+        />
+      </ControlsBar.Right>
+    </ControlsBar>
+  );
+};
+
+export default PaginationBar;

--- a/src/app/base/components/GenericTable/TableCheckbox/TableCheckbox.test.tsx
+++ b/src/app/base/components/GenericTable/TableCheckbox/TableCheckbox.test.tsx
@@ -59,13 +59,11 @@ const getMockRow = (rowProps: Partial<Row<Image>> = {}) => {
 describe("TableCheckbox.All", () => {
   const renderSelectAllCheckbox = (tableProps?: {
     getSelectedRowModel: Mock<[], { rows: object[] }>;
-    getRowCount: Mock<[], number>;
-    getGroupedRowModel: Mock<[], { rows: never[] }>;
+    getCoreRowModel: Mock<[], { rows: object[] }>;
   }) => {
     const mockTable = {
       getSelectedRowModel: vi.fn(() => ({ rows: [] })),
-      getRowCount: vi.fn(() => 10),
-      getGroupedRowModel: vi.fn(() => ({ rows: [] })),
+      getCoreRowModel: vi.fn(() => ({ rows: [] })),
       toggleAllPageRowsSelected: vi.fn(),
       getIsAllPageRowsSelected: vi.fn(() => false),
       ...tableProps,
@@ -86,8 +84,7 @@ describe("TableCheckbox.All", () => {
   it("displays 'mixed' state when some rows are selected", () => {
     renderSelectAllCheckbox({
       getSelectedRowModel: vi.fn(() => ({ rows: [{}] })), // 1 row selected
-      getRowCount: vi.fn(() => 10),
-      getGroupedRowModel: vi.fn(() => ({ rows: [] })),
+      getCoreRowModel: vi.fn(() => ({ rows: [{}, {}] })),
     });
     expect(screen.getByRole("checkbox")).toHaveAttribute(
       "aria-checked",
@@ -98,8 +95,7 @@ describe("TableCheckbox.All", () => {
   it("displays 'checked' when all rows are selected", () => {
     renderSelectAllCheckbox({
       getSelectedRowModel: vi.fn(() => ({ rows: [{}] })), // Simulate all rows selected
-      getRowCount: vi.fn(() => 1),
-      getGroupedRowModel: vi.fn(() => ({ rows: [] })),
+      getCoreRowModel: vi.fn(() => ({ rows: [{}] })),
     });
     expect(screen.getByRole("checkbox")).toHaveAttribute(
       "aria-checked",

--- a/src/app/base/components/GenericTable/TableCheckbox/TableCheckbox.tsx
+++ b/src/app/base/components/GenericTable/TableCheckbox/TableCheckbox.tsx
@@ -16,7 +16,7 @@ const TableAllCheckbox = <T,>({ table, ...props }: TableCheckboxProps<T>) => {
     checked = "false";
   } else if (
     table.getSelectedRowModel().rows.length <
-    table.getRowCount() - table.getGroupedRowModel().rows.length
+    table.getCoreRowModel().rows.length
   ) {
     checked = "mixed";
   } else {

--- a/src/app/base/components/GenericTable/TableHeader/index.ts
+++ b/src/app/base/components/GenericTable/TableHeader/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./TableHeader";

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -1,5 +1,4 @@
 .p-generic-table {
-
   thead,
   tbody {
     display: table-row-group;
@@ -15,4 +14,8 @@
   th.select {
     display: none;
   }
+}
+
+.p-pagination {
+  z-index: 2;
 }

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -20,3 +20,30 @@
   z-index: 2;
   padding-right: 2rem;
 }
+
+.controls-bar {
+  border-top: 1px solid #d9d9d9;
+  border-bottom: 1px solid #d9d9d9;
+  align-items: center;
+  padding: 0.5rem 0;
+  margin-top: 1rem;
+
+  .p-form--inline {
+    width: 100%;
+  }
+
+  .controls-bar__left {
+    margin: 0;
+    padding: 0;
+  }
+
+  .controls-bar__right {
+    width: 100%;
+    margin-left: auto;
+    margin-right: 0;
+
+    @media screen and (min-width: 620px) {
+      width: auto;
+    }
+  }
+}

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -18,4 +18,5 @@
 
 .p-pagination {
   z-index: 2;
+  padding-right: 2rem;
 }

--- a/src/app/base/constants.ts
+++ b/src/app/base/constants.ts
@@ -44,3 +44,5 @@ export const COLOURS = {
 // global keyboard shortcuts
 export const KEYBOARD_SHORTCUTS = ["[", "/"] as const;
 export type KeyboardShortcut = (typeof KEYBOARD_SHORTCUTS)[number];
+
+export const DEFAULT_PAGE_SIZE = 50;

--- a/src/app/base/hooks/useDebouncedValue/useDebouncedValue.ts
+++ b/src/app/base/hooks/useDebouncedValue/useDebouncedValue.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+
+const DEFAULT_DELAY = 500;
+
+function useDebouncedValue<T>(value: T, delay = DEFAULT_DELAY): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => setDebouncedValue(value), delay);
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+export default useDebouncedValue;

--- a/src/app/base/hooks/usePagination/usePagination.ts
+++ b/src/app/base/hooks/usePagination/usePagination.ts
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+import useDebouncedValue from "@/app/base/hooks/useDebouncedValue/useDebouncedValue";
+
+function usePagination(pageSize: number) {
+  const [page, setPage] = useState(1);
+  const [size, setSize] = useState(pageSize);
+  const debouncedPage = useDebouncedValue(page);
+
+  const handleNextClick = () => {
+    setPage((prev) => prev + 1);
+  };
+
+  const handlePreviousClick = () => {
+    setPage((prev) => prev - 1);
+  };
+
+  const resetPageCount = () => setPage(1);
+
+  const handlePageSizeChange = (size: number) => {
+    setSize(size);
+    resetPageCount();
+  };
+
+  return {
+    page: page,
+    size,
+    setPage,
+    debouncedPage: debouncedPage,
+    handleNextClick,
+    handlePreviousClick,
+    handlePageSizeChange,
+  };
+}
+
+export default usePagination;

--- a/src/app/base/hooks/usePagination/usePagination.ts
+++ b/src/app/base/hooks/usePagination/usePagination.ts
@@ -1,8 +1,9 @@
 import { useState } from "react";
 
+import { DEFAULT_PAGE_SIZE } from "@/app/base/constants";
 import useDebouncedValue from "@/app/base/hooks/useDebouncedValue/useDebouncedValue";
 
-function usePagination(pageSize: number) {
+function usePagination(pageSize: number = DEFAULT_PAGE_SIZE) {
   const [page, setPage] = useState(1);
   const [size, setSize] = useState(pageSize);
   const debouncedPage = useDebouncedValue(page);

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -94,7 +94,7 @@ const ImagesTable = ({
           </TableCaption.Description>
         </TableCaption>
       }
-      pin={[
+      pinGroup={[
         { value: "Ubuntu", isTop: true },
         { value: "Other", isTop: false },
       ]}

--- a/src/app/pools/components/PoolsTable/PoolsTable.tsx
+++ b/src/app/pools/components/PoolsTable/PoolsTable.tsx
@@ -1,16 +1,28 @@
+import { useState } from "react";
+
 import usePoolsTableColumns from "./usePoolsTableColumns/usePoolsTableColumns";
 
-import { usePools } from "@/app/api/query/pools";
+import { usePoolCount, usePools } from "@/app/api/query/pools";
 import GenericTable from "@/app/base/components/GenericTable";
 
 const PoolsTable = () => {
-  const listPools = usePools();
+  const { data: poolCount } = usePoolCount();
+  const [pagination, setPagination] = useState({
+    page: 1,
+    size: 50,
+    total: poolCount ?? 0,
+  });
+
+  const listPools = usePools({ query: pagination });
   const resourcePools = listPools.data?.items || [];
+
   return (
     <GenericTable
       columns={usePoolsTableColumns()}
       data={resourcePools}
       noData="No pools found."
+      pagination={pagination}
+      setPagination={setPagination}
       variant="full-height"
     />
   );

--- a/src/app/pools/components/PoolsTable/PoolsTable.tsx
+++ b/src/app/pools/components/PoolsTable/PoolsTable.tsx
@@ -6,7 +6,7 @@ import usePagination from "@/app/base/hooks/usePagination/usePagination";
 
 const PoolsTable = () => {
   const { page, debouncedPage, size, handlePageSizeChange, setPage } =
-    usePagination(50);
+    usePagination();
 
   const pools = usePools({
     query: { page: debouncedPage, size },

--- a/src/app/pools/components/PoolsTable/PoolsTable.tsx
+++ b/src/app/pools/components/PoolsTable/PoolsTable.tsx
@@ -1,28 +1,32 @@
-import { useState } from "react";
-
 import usePoolsTableColumns from "./usePoolsTableColumns/usePoolsTableColumns";
 
-import { usePoolCount, usePools } from "@/app/api/query/pools";
+import { usePools } from "@/app/api/query/pools";
 import GenericTable from "@/app/base/components/GenericTable";
+import usePagination from "@/app/base/hooks/usePagination/usePagination";
 
 const PoolsTable = () => {
-  const { data: poolCount } = usePoolCount();
-  const [pagination, setPagination] = useState({
-    page: 1,
-    size: 50,
-    total: poolCount ?? 0,
-  });
+  const { page, debouncedPage, size, handlePageSizeChange, setPage } =
+    usePagination(50);
 
-  const listPools = usePools({ query: pagination });
-  const resourcePools = listPools.data?.items || [];
+  const pools = usePools({
+    query: { page: debouncedPage, size },
+  });
 
   return (
     <GenericTable
       columns={usePoolsTableColumns()}
-      data={resourcePools}
+      data={pools.data?.items ?? []}
       noData="No pools found."
-      pagination={pagination}
-      setPagination={setPagination}
+      pagination={{
+        currentPage: page,
+        dataContext: "pools",
+        handlePageSizeChange: handlePageSizeChange,
+        isPending: pools.isPending,
+        itemsPerPage: size,
+        setCurrentPage: setPage,
+        totalItems: pools.data?.total ?? 0,
+      }}
+      sortBy={[{ id: "machine_ready_count", desc: true }]}
       variant="full-height"
     />
   );

--- a/src/app/pools/components/PoolsTable/usePoolsTableColumns/usePoolsTableColumns.test.tsx
+++ b/src/app/pools/components/PoolsTable/usePoolsTableColumns/usePoolsTableColumns.test.tsx
@@ -35,7 +35,7 @@ it("returns the correct number of columns", () => {
   expect(result.current).toBeInstanceOf(Array);
   expect(result.current.map((column) => column.id)).toStrictEqual([
     "name",
-    "machines",
+    "machine_ready_count",
     "description",
     "actions",
   ]);

--- a/src/app/pools/components/PoolsTable/usePoolsTableColumns/usePoolsTableColumns.tsx
+++ b/src/app/pools/components/PoolsTable/usePoolsTableColumns/usePoolsTableColumns.tsx
@@ -38,8 +38,8 @@ const usePoolsTableColumns = () => {
           header: "Name",
         },
         {
-          id: "machines",
-          accessorKey: "machine_total_count",
+          id: "machine_ready_count",
+          accessorKey: "machine_ready_count",
           enableSorting: true,
           header: "Machines",
           cell: ({ row }) => {

--- a/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
@@ -16,7 +16,7 @@ import "./_index.scss";
 const ZonesListTable: React.FC = () => {
   const { setSidePanelContent } = useSidePanel();
   const { page, debouncedPage, size, handlePageSizeChange, setPage } =
-    usePagination(50);
+    usePagination();
   const zones = useZones({
     query: { page: debouncedPage, size },
   });

--- a/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 
 import { useZones } from "@/app/api/query/zones";
 import GenericTable from "@/app/base/components/GenericTable";
+import usePagination from "@/app/base/hooks/usePagination/usePagination";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import authSelectors from "@/app/store/auth/selectors";
 import { ZoneActionSidePanelViews } from "@/app/zones/constants";
@@ -14,7 +15,11 @@ import "./_index.scss";
 
 const ZonesListTable: React.FC = () => {
   const { setSidePanelContent } = useSidePanel();
-  const zones = useZones();
+  const { page, debouncedPage, size, handlePageSizeChange, setPage } =
+    usePagination(50);
+  const zones = useZones({
+    query: { page: debouncedPage, size },
+  });
 
   const isAdmin = useSelector(authSelectors.isAdmin);
   const columns = useZonesTableColumns({
@@ -42,6 +47,16 @@ const ZonesListTable: React.FC = () => {
       columns={columns}
       data={zones.data?.items ?? []}
       noData={<TableCaption>No zones available.</TableCaption>}
+      pagination={{
+        currentPage: page,
+        dataContext: "zones",
+        handlePageSizeChange: handlePageSizeChange,
+        isPending: zones.isPending,
+        itemsPerPage: size,
+        setCurrentPage: setPage,
+        totalItems: zones.data?.total ?? 0,
+      }}
+      sortBy={[{ id: "machines_count", desc: true }]}
     />
   );
 };

--- a/src/app/zones/views/ZonesList/ZonesListTable/useZonesTableColumns/useZonesTableColumns.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/useZonesTableColumns/useZonesTableColumns.tsx
@@ -45,7 +45,7 @@ const useZonesTableColumns = ({
       header: "Description",
     },
     {
-      id: "machines",
+      id: "machines_count",
       accessorKey: "machines_count",
       enableSorting: true,
       header: "Machines",
@@ -61,7 +61,7 @@ const useZonesTableColumns = ({
       },
     },
     {
-      id: "devices",
+      id: "devices_count",
       accessorKey: "devices_count",
       enableSorting: true,
       header: "Devices",
@@ -77,7 +77,7 @@ const useZonesTableColumns = ({
       },
     },
     {
-      id: "controllers",
+      id: "controllers_count",
       accessorKey: "controllers_count",
       enableSorting: true,
       header: "Controllers",


### PR DESCRIPTION
## Done

- Added pagination support to `GenericTable`
- Implemented pagination for `PoolsTable`
- Fixed unique key and validateDOM warnings for `GenericTable`
- Fixed the mixed select bug for `TableCheckbox.All`
- Fixed `usePoolCount` and `useZoneCount` hooks to use `data.total`, instead of the paginated `data.items.length`

## QA steps

- [ ] Navigate to `pools/`
- [ ] Verify that there is a pagination controller at the top-right of the table
- [ ] Go to `src/app/pools/components/PoolsTable/PoolsTable.tsx` line 12
- [ ] Change `50` to `5`
- [ ] Refresh page
- [ ] Verify the pagination is 1 out of 2 pages, and only 5 rows are visible in the table
- [ ] Ensure pages can be changed by both the arrows and the text field
- [ ] Verify changing page size to 100/page brings all the rows and drops the total pages to 1
- [ ] Revert your code change
- [ ] Open Inspect>Console
- [ ] Refresh page
- [ ] Verify there are no console warnings

## Fixes

Resolves: 

[MAASENG-4588](https://warthogs.atlassian.net/browse/MAASENG-4588)

## Screenshots

<img width="1791" alt="Screenshot 2025-04-03 at 16 00 51" src="https://github.com/user-attachments/assets/35ba6b0e-bbd8-4af8-8ed9-f0703232f7c9" />

[MAASENG-4588]: https://warthogs.atlassian.net/browse/MAASENG-4588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ