### PR TITLE
fix: fix image table placeholder to have max width

### DIFF
--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/_index.scss
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/_index.scss
@@ -37,3 +37,11 @@
 .multi-select__dropdown {
   margin-top: 20px;
 }
+
+.multi-select__condensed-text {
+  margin-right: 1.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 250px;
+}


### PR DESCRIPTION
## Done
- fix image table placeholder so that is has max width (so that adding more architectures wouldn't push it outside of frame)

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] go to images and see if width doesn't go over 250px

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-4628](https://warthogs.atlassian.net/jira/software/c/projects/MAASENG/boards/1423?selectedIssue=MAASENG-4628)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
<img width="1512" alt="Screenshot 2025-04-04 at 13 45 49" src="https://github.com/user-attachments/assets/0cc42eb2-61f8-49af-b6a8-1b79c5373d2f" />
<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
[MAASENG-4628](https://warthogs.atlassian.net/jira/software/c/projects/MAASENG/boards/1423?selectedIssue=MAASENG-4628)



[MAASENG-4628]: https://warthogs.atlassian.net/browse/MAASENG-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAASENG-4628]: https://warthogs.atlassian.net/browse/MAASENG-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ