### PR TITLE
ci: use nodejs version from nvmrc in all actions that require node

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -18,6 +18,10 @@ jobs:
         uses: canonical/setup-maas@main
         with:
           maas-url: ${{env.MAAS_URL}}/MAAS
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
       - name: Install Cypress
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -27,10 +27,10 @@ jobs:
         uses: canonical/setup-maas@main
         with:
           maas-url: ${{ env.MAAS_URL }}/MAAS
-      - name: Use Node.js
+      - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version-file: ".nvmrc"
       - name: Install Cypress
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/links-checker.yml
+++ b/.github/workflows/links-checker.yml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Use Node.js from .nvmrc
+        uses: actions/setup-node@v4
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Install dependencies
         run: yarn
       - name: Install Playwright Browsers

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,6 +10,7 @@ jobs:
       MAAS_URL: localhost:5240
     steps:
       - uses: actions/checkout@v4
+      - name: Use Node.js from .nvmrc
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'


### PR DESCRIPTION
## Done
- Added step to most actions to tell it to use the NodeJS version from .nvmrc
  - This should fix the accessibility action, as that now requires NodeJS >= v20 (previously using v18)

<!--
- Itemised list of what was changed by this PR.
-->
