### PR TITLE
feat(preferences): migrate delete ssl keys to API v3 MAASENG 4623

### DIFF
--- a/src/app/api/query/sslKeys.test.ts
+++ b/src/app/api/query/sslKeys.test.ts
@@ -1,4 +1,4 @@
-import { useCreateSslKeys, useGetSslKeys } from "./sslKeys";
+import { useCreateSslKeys, useDeleteSslKey, useGetSslKeys } from "./sslKeys";
 
 import type { SslKeyRequest } from "@/app/apiclient";
 import { mockSslKeys, sslKeyResolvers } from "@/testing/resolvers/sslKeys";
@@ -10,7 +10,8 @@ import {
 
 setupMockServer(
   sslKeyResolvers.getSslKeys.handler(),
-  sslKeyResolvers.createSslKey.handler()
+  sslKeyResolvers.createSslKey.handler(),
+  sslKeyResolvers.deleteSslKey.handler()
 );
 
 describe("useGetSslKeys", () => {
@@ -28,6 +29,14 @@ describe("useCreateSslKeys", () => {
     };
     const { result } = renderHookWithProviders(() => useCreateSslKeys());
     result.current.mutate({ body: newSslKey });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe("useDeleteSslKey", () => {
+  it("should delete an SSL key", async () => {
+    const { result } = renderHookWithProviders(() => useDeleteSslKey());
+    result.current.mutate({ path: { sslkey_id: 1 } });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
 });

--- a/src/app/api/query/sslKeys.ts
+++ b/src/app/api/query/sslKeys.ts
@@ -11,12 +11,16 @@ import type {
   CreateUserSslkeyData,
   CreateUserSslkeyError,
   CreateUserSslkeyResponse,
+  DeleteUserSslkeyData,
+  DeleteUserSslkeyError,
+  DeleteUserSslkeyResponse,
   GetUserSslkeysData,
   GetUserSslkeysError,
   GetUserSslkeysResponse,
 } from "@/app/apiclient";
 import {
   createUserSslkeyMutation,
+  deleteUserSslkeyMutation,
   getUserSslkeysOptions,
   getUserSslkeysQueryKey,
 } from "@/app/apiclient/@tanstack/react-query.gen";
@@ -41,6 +45,24 @@ export const useCreateSslKeys = (
     Options<CreateUserSslkeyData>
   >({
     ...createUserSslkeyMutation(mutationOptions),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: getUserSslkeysQueryKey(),
+      });
+    },
+  });
+};
+
+export const useDeleteSslKey = (
+  mutationOptions?: Options<DeleteUserSslkeyData>
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    DeleteUserSslkeyResponse,
+    DeleteUserSslkeyError,
+    Options<DeleteUserSslkeyData>
+  >({
+    ...deleteUserSslkeyMutation(mutationOptions),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: getUserSslkeysQueryKey(),

--- a/src/app/preferences/views/SSLKeys/DeleteSSLKey/DeleteSSLKey.test.tsx
+++ b/src/app/preferences/views/SSLKeys/DeleteSSLKey/DeleteSSLKey.test.tsx
@@ -1,77 +1,38 @@
-import configureStore from "redux-mock-store";
-
 import DeleteSSLKey from "./DeleteSSLKey";
 
 import { Label as SSLKeyListLabels } from "@/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList";
-import type { RootState } from "@/app/store/root/types";
-import * as factory from "@/testing/factories";
-import { screen, renderWithBrowserRouter, userEvent } from "@/testing/utils";
+import { sslKeyResolvers } from "@/testing/resolvers/sslKeys";
+import {
+  screen,
+  renderWithBrowserRouter,
+  userEvent,
+  setupMockServer,
+  waitFor,
+} from "@/testing/utils";
 
-const mockStore = configureStore<RootState>();
+setupMockServer(sslKeyResolvers.deleteSslKey.handler());
 
-let state: RootState;
-
-beforeEach(() => {
-  state = factory.rootState({
-    sslkey: factory.sslKeyState({
-      loading: false,
-      loaded: true,
-      items: [
-        factory.sslKey({
-          id: 1,
-          key: "ssh-rsa aabb",
-        }),
-        factory.sslKey({
-          id: 2,
-          key: "ssh-rsa ccdd",
-        }),
-        factory.sslKey({
-          id: 3,
-          key: "ssh-rsa eeff",
-        }),
-        factory.sslKey({
-          id: 4,
-          key: "ssh-rsa gghh",
-        }),
-        factory.sslKey({ id: 5, key: "ssh-rsa gghh" }),
-      ],
-    }),
-  });
-});
-
-it("can show a delete confirmation", () => {
-  renderWithBrowserRouter(<DeleteSSLKey />, {
-    route: "/account/prefs/ssl-keys/1/delete",
-    routePattern: "/account/prefs/ssl-keys/:id/delete",
-    state,
-  });
-  expect(screen.getByRole("form", { name: SSLKeyListLabels.DeleteConfirm }));
-  expect(
-    screen.getByText(/Are you sure you want to delete this SSL key?/i)
-  ).toBeInTheDocument();
-});
-
-it("can delete an SSL key", async () => {
-  const store = mockStore(state);
-  renderWithBrowserRouter(<DeleteSSLKey />, {
-    route: "/account/prefs/ssl-keys/1/delete",
-    routePattern: "/account/prefs/ssl-keys/:id/delete",
-    store,
+describe("DeleteSSLKey", () => {
+  it("can show a delete confirmation", () => {
+    renderWithBrowserRouter(<DeleteSSLKey />, {
+      route: "/account/prefs/ssl-keys/1/delete",
+      routePattern: "/account/prefs/ssl-keys/:id/delete",
+    });
+    expect(screen.getByRole("form", { name: SSLKeyListLabels.DeleteConfirm }));
+    expect(
+      screen.getByText(/Are you sure you want to delete this SSL key?/i)
+    ).toBeInTheDocument();
   });
 
-  await userEvent.click(screen.getByRole("button", { name: "Delete" }));
-  expect(
-    store.getActions().find((action) => action.type === "sslkey/delete")
-  ).toEqual({
-    type: "sslkey/delete",
-    payload: {
-      params: {
-        id: 1,
-      },
-    },
-    meta: {
-      model: "sslkey",
-      method: "delete",
-    },
+  it.skip("can delete an SSL key", async () => {
+    renderWithBrowserRouter(<DeleteSSLKey />, {
+      route: "/account/prefs/ssl-keys/1/delete",
+      routePattern: "/account/prefs/ssl-keys/:id/delete",
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Delete" }));
+    await waitFor(() => {
+      expect(sslKeyResolvers.deleteSslKey.resolved).toBeTruthy();
+    });
   });
 });

--- a/src/app/preferences/views/SSLKeys/DeleteSSLKey/DeleteSSLKey.test.tsx
+++ b/src/app/preferences/views/SSLKeys/DeleteSSLKey/DeleteSSLKey.test.tsx
@@ -24,7 +24,7 @@ describe("DeleteSSLKey", () => {
     ).toBeInTheDocument();
   });
 
-  it.skip("can delete an SSL key", async () => {
+  it("can delete an SSL key", async () => {
     renderWithBrowserRouter(<DeleteSSLKey />, {
       route: "/account/prefs/ssl-keys/1/delete",
       routePattern: "/account/prefs/ssl-keys/:id/delete",

--- a/src/app/preferences/views/SSLKeys/DeleteSSLKey/DeleteSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/DeleteSSLKey/DeleteSSLKey.tsx
@@ -1,24 +1,21 @@
 import { useOnEscapePressed } from "@canonical/react-components";
-import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router";
 
+import { useDeleteSslKey } from "@/app/api/query/sslKeys";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
-import { useAddMessage, useGetURLId } from "@/app/base/hooks";
+import { useGetURLId } from "@/app/base/hooks";
 import urls from "@/app/preferences/urls";
 import { Label } from "@/app/preferences/views/SSLKeys/SSLKeyList/SSLKeyList";
-import { sslkeyActions } from "@/app/store/sslkey";
-import sslkeySelectors from "@/app/store/sslkey/selectors";
 import { isId } from "@/app/utils";
 
 const DeleteSSLKey = () => {
   const id = useGetURLId("id");
   const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const saved = useSelector(sslkeySelectors.saved);
-  const saving = useSelector(sslkeySelectors.saving);
+  const deleteSSLKey = useDeleteSslKey();
+  const saved = deleteSSLKey.isSuccess;
+  const saving = deleteSSLKey.isPending;
   const onClose = () => navigate({ pathname: urls.sslKeys.index });
   useOnEscapePressed(() => onClose());
-  useAddMessage(saved, sslkeyActions.cleanup, "SSL key removed successfully.");
 
   if (!isId(id)) {
     return <h4>SSL key not found</h4>;
@@ -30,9 +27,7 @@ const DeleteSSLKey = () => {
       initialValues={{}}
       modelType="SSL key"
       onCancel={onClose}
-      onSubmit={() => {
-        dispatch(sslkeyActions.delete(id));
-      }}
+      onSubmit={() => deleteSSLKey.mutate({ path: { sslkey_id: id } })}
       saved={saved}
       savedRedirect={urls.sslKeys.index}
       saving={saving}

--- a/src/testing/resolvers/sslKeys.ts
+++ b/src/testing/resolvers/sslKeys.ts
@@ -6,6 +6,7 @@ import { BASE_URL } from "../utils";
 
 import type {
   CreateUserSslkeyError,
+  DeleteUserSslkeyError,
   GetUserSslkeysError,
   GetUserSslkeysResponse,
 } from "@/app/apiclient";
@@ -43,6 +44,12 @@ const mockCreateSslKeysError: CreateUserSslkeyError = {
   kind: "Error",
 };
 
+const mockDeleteSslKeyError: DeleteUserSslkeyError = {
+  message: "Not found",
+  code: 404,
+  kind: "Error",
+};
+
 const sslKeyResolvers = {
   getSslKeys: {
     resolved: false,
@@ -68,6 +75,19 @@ const sslKeyResolvers = {
       http.post(`${BASE_URL}MAAS/a/v3/users/me/sslkeys`, () => {
         sslKeyResolvers.createSslKey.resolved = true;
         return HttpResponse.json(error, { status: error.code });
+      }),
+  },
+  deleteSslKey: {
+    resolved: false,
+    handler: () =>
+      http.delete(`${BASE_URL}MAAS/a/v3/users/me/sslkeys/:id`, () => {
+        sslKeyResolvers.deleteSslKey.resolved = true;
+        return HttpResponse.json({}, { status: 204 });
+      }),
+    error: (error: DeleteUserSslkeyError = mockDeleteSslKeyError) =>
+      http.delete(`${BASE_URL}MAAS/a/v3/users/me/sslkeys/:id`, () => {
+        sslKeyResolvers.deleteSslKey.resolved = true;
+        return HttpResponse.json(error, { status: 404 });
       }),
   },
 };


### PR DESCRIPTION
## Done
- updated DeleteSSLKey, DeleteSSLKey.test to use API v3 with creating and updating pools
- updated sslKeys.ts  and sslKeys.test.ts in app/api/query
- updated sslKeys.ts in resolvers

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] go to /account/prefs/ssl-keys
- [ ] click on trash icon next to ssl key you want to delete 
- [ ] click Delete button
- [ ] ensure the key is properly deleted

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-4623](https://warthogs.atlassian.net/browse/MAASENG-4623)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->

[MAASENG-4623](https://warthogs.atlassian.net/browse/MAASENG-4623)

[MAASENG-4623]: https://warthogs.atlassian.net/browse/MAASENG-4623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MAASENG-4623]: https://warthogs.atlassian.net/browse/MAASENG-4623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ