### PR TITLE
feat(base): Add sticky header to GenericTable MAASENG-4718

### DIFF
--- a/src/app/base/components/GenericTable/GenericTable.test.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.test.tsx
@@ -1,3 +1,6 @@
+import { useRef } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
 import { vi } from "vitest";
 
 import GenericTable from "./GenericTable";
@@ -8,8 +11,17 @@ import type { UtcDatetime } from "@/app/store/types/model";
 import * as factory from "@/testing/factories";
 import { userEvent, screen, render } from "@/testing/utils";
 
+// Mock the ResizeObserver
+class ResizeObserverMock {
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+global.ResizeObserver = ResizeObserverMock as never;
+
 describe("GenericTable", () => {
-  const columns = [
+  const columns: ColumnDef<Image, Partial<Image>>[] = [
     {
       id: "release",
       accessorKey: "release",
@@ -29,6 +41,7 @@ describe("GenericTable", () => {
       header: () => "Size",
     },
   ];
+
   const data: Image[] = [
     {
       id: 0,
@@ -76,8 +89,9 @@ describe("GenericTable", () => {
         data={data}
         filterCells={mockFilterCells}
         filterHeaders={mockFilterHeaders}
+        isLoading={false}
         rowSelection={{}}
-        setRowSelection={vi.fn}
+        setRowSelection={vi.fn()}
       />
     );
 
@@ -93,7 +107,7 @@ describe("GenericTable", () => {
     const pagination: PaginationBarProps = {
       currentPage: 1,
       dataContext: "",
-      handlePageSizeChange: vi.fn,
+      handlePageSizeChange: vi.fn(),
       isPending: false,
       itemsPerPage: 10,
       setCurrentPage: setPagination,
@@ -105,10 +119,11 @@ describe("GenericTable", () => {
         data={[]}
         filterCells={mockFilterCells}
         filterHeaders={mockFilterHeaders}
+        isLoading={false}
         noData={<span>No data</span>}
         pagination={pagination}
         rowSelection={{}}
-        setRowSelection={vi.fn}
+        setRowSelection={vi.fn()}
       />
     );
 
@@ -128,9 +143,10 @@ describe("GenericTable", () => {
         data={[]}
         filterCells={mockFilterCells}
         filterHeaders={mockFilterHeaders}
+        isLoading={false}
         noData={<span>No data</span>}
         rowSelection={{}}
-        setRowSelection={vi.fn}
+        setRowSelection={vi.fn()}
       />
     );
 
@@ -144,8 +160,9 @@ describe("GenericTable", () => {
         data={data}
         filterCells={mockFilterCells}
         filterHeaders={mockFilterHeaders}
+        isLoading={false}
         rowSelection={{}}
-        setRowSelection={vi.fn}
+        setRowSelection={vi.fn()}
       />
     );
 
@@ -154,5 +171,286 @@ describe("GenericTable", () => {
     const rows = screen.getAllByRole("row");
     expect(rows[1]).toHaveTextContent("16.04 LTS");
     expect(rows[2]).toHaveTextContent("18.04 LTS");
+  });
+
+  // New tests to cover more features
+
+  it("renders loading state correctly", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={true}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // Table should have aria-busy attribute when loading
+    const table = screen.getByRole("grid");
+    expect(table).toHaveAttribute("aria-busy", "true");
+
+    // Should render placeholders
+    const placeholders = screen.getAllByText("XXXxxxx.xxxxxxxxx");
+    expect(placeholders.length).toBeGreaterThan(0);
+  });
+
+  it("supports row selection when canSelect is true", async () => {
+    const mockSetRowSelection = vi.fn();
+    render(
+      <GenericTable
+        canSelect={true}
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={mockSetRowSelection}
+      />
+    );
+
+    // Should render checkboxes
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes.length).toBeGreaterThan(0);
+
+    // Click on a checkbox should trigger selection change
+    await userEvent.click(checkboxes[1]); // Click first row checkbox
+    expect(mockSetRowSelection).toHaveBeenCalled();
+  });
+
+  it("uses custom class names when provided", () => {
+    render(
+      <GenericTable
+        className="custom-table-class"
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    const tableWrapper =
+      screen.getByTestId("p-generic-table") ||
+      screen.getByRole("grid").closest(".p-generic-table");
+    expect(tableWrapper).toHaveClass("custom-table-class");
+  });
+
+  it("supports grouping rows by specified columns", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        groupBy={["release"]}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // Check if grouped rows are rendered correctly
+    const groupRows = screen
+      .getAllByRole("row")
+      .filter((row) => row.classList.contains("p-generic-table__group-row"));
+    expect(groupRows.length).toBeGreaterThan(0);
+  });
+
+  it("supports expanded/collapsed state for grouped rows", async () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        groupBy={["name"]}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // Find expand/collapse buttons and click one
+    const expandButtons = screen
+      .getAllByRole("button")
+      .filter(
+        (button) =>
+          button.getAttribute("aria-label")?.includes("expand") ||
+          button.getAttribute("aria-label")?.includes("collapse")
+      );
+
+    if (expandButtons.length) {
+      const initialRows = screen.getAllByRole("row").length;
+      await userEvent.click(expandButtons[0]);
+      const rowsAfterClick = screen.getAllByRole("row").length;
+
+      // Number of visible rows should change when expanding/collapsing
+      expect(rowsAfterClick).not.toEqual(initialRows);
+    }
+  });
+
+  it("applies initial sortBy configuration", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+        sortBy={[{ id: "release", desc: true }]}
+      />
+    );
+
+    // With desc: true, 18.04 should appear before 16.04
+    const rows = screen.getAllByRole("row");
+    const firstDataRow = rows[1];
+    expect(firstDataRow).toHaveTextContent("18.04 LTS");
+  });
+
+  it("applies variant styles correctly", () => {
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+        variant="regular"
+      />
+    );
+
+    const table = screen.getByRole("grid");
+    expect(table).not.toHaveClass("p-generic-table__is-full-height");
+
+    // Render with full-height variant
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+        variant="full-height"
+      />
+    );
+
+    const fullHeightTable = screen.getAllByRole("grid")[1];
+    expect(fullHeightTable).toHaveClass("p-generic-table__is-full-height");
+  });
+
+  it("handles pin groups correctly", () => {
+    // Create data with different architectures for testing pinning
+    const extendedData = [
+      ...data,
+      {
+        id: 2,
+        release: "20.04 LTS",
+        architecture: "armhf",
+        name: "Ubuntu",
+        size: "1.5 MB",
+        lastSynced: "Mon, 06 Jan. 2025 10:45:24",
+        canDeployToMemory: true,
+        status: "Synced",
+        lastDeployed: "Thu, 15 Aug. 2019 06:21:39" as UtcDatetime,
+        machines: 1,
+        resource: factory.bootResource({
+          name: "ubuntu/focal",
+          arch: "armhf",
+          title: "20.04 LTS",
+        }),
+      },
+    ];
+
+    render(
+      <GenericTable
+        columns={columns}
+        data={extendedData}
+        filterCells={mockFilterCells}
+        filterHeaders={mockFilterHeaders}
+        groupBy={["architecture"]}
+        isLoading={false}
+        pinGroup={[{ value: "arm64", isTop: true }]}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // The arm64 groups should be pinned to the top
+    const rows = screen.getAllByRole("row");
+    expect(rows[1]).toHaveTextContent("arm64"); // First group row should be arm64
+  });
+
+  it("uses containerRef for calculating table height", () => {
+    // Create a component that uses the containerRef
+    const TestComponent = () => {
+      const containerRef = useRef<HTMLDivElement>(null);
+
+      return (
+        <div ref={containerRef} style={{ height: "500px" }}>
+          <GenericTable
+            columns={columns}
+            containerRef={containerRef}
+            data={data}
+            filterCells={mockFilterCells}
+            filterHeaders={mockFilterHeaders}
+            isLoading={false}
+            rowSelection={{}}
+            setRowSelection={vi.fn()}
+          />
+        </div>
+      );
+    };
+
+    render(<TestComponent />);
+
+    // Verify the table renders correctly with the containerRef
+    expect(screen.getByRole("grid")).toBeInTheDocument();
+
+    // The ResizeObserver should have been called
+    expect(ResizeObserverMock.prototype.observe).toHaveBeenCalled();
+  });
+
+  it("applies filter functions for cells and headers", () => {
+    const customFilterCells = vi.fn(
+      (_row, column) => column.id !== "size" // Filter out the size column cells
+    );
+
+    const customFilterHeaders = vi.fn(
+      (header) => header.id !== "size" // Filter out the size column header
+    );
+
+    render(
+      <GenericTable
+        columns={columns}
+        data={data}
+        filterCells={customFilterCells}
+        filterHeaders={customFilterHeaders}
+        isLoading={false}
+        rowSelection={{}}
+        setRowSelection={vi.fn()}
+      />
+    );
+
+    // Size header should not be rendered
+    expect(screen.queryByText("Size")).not.toBeInTheDocument();
+
+    // Size cell values should not be rendered
+    expect(screen.queryByText("1.3 MB")).not.toBeInTheDocument();
+
+    // Other columns should still be visible
+    expect(screen.getByText("Release title")).toBeInTheDocument();
+    expect(screen.getByText("Architecture")).toBeInTheDocument();
   });
 });

--- a/src/app/base/components/GenericTable/GenericTable.test.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.test.tsx
@@ -198,8 +198,7 @@ describe("GenericTable", () => {
     expect(table).toHaveAttribute("aria-busy", "true");
 
     // Should render placeholders
-    const placeholders = screen.getAllByText("XXXxxxx.xxxxxxxxx");
-    expect(placeholders.length).toBeGreaterThan(0);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
   });
 
   it("supports row selection when canSelect is true", async () => {

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   Dispatch,
   ReactNode,
@@ -129,7 +129,7 @@ const GenericTable = <T extends { id: string | number }>({
   const [sorting, setSorting] = useState<SortingState>(sortBy ?? []);
 
   // Update table height based on available space
-  useEffect(() => {
+  useLayoutEffect(() => {
     const updateHeight = () => {
       const wrapper = tableRef.current;
       if (!wrapper) return;

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -1,5 +1,11 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
-import type { Dispatch, ReactNode, SetStateAction, RefObject } from "react";
+import type {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  RefObject,
+  ReactElement,
+} from "react";
 
 import { Placeholder } from "@canonical/maas-react-components";
 import type {
@@ -35,7 +41,7 @@ type GenericTableProps<T extends { id: string | number }> = {
   className?: string;
   canSelect?: boolean;
   columns: ColumnDef<T, Partial<T>>[];
-  containerRef?: RefObject<HTMLElement>;
+  containerRef?: RefObject<HTMLElement | null>;
   data: T[];
   filterCells?: (row: Row<T>, column: Column<T>) => boolean;
   filterHeaders?: (header: Header<T, unknown>) => boolean;
@@ -50,6 +56,53 @@ type GenericTableProps<T extends { id: string | number }> = {
   variant?: "full-height" | "regular";
 };
 
+/**
+ * GenericTable - A flexible and feature-rich table component for React applications
+ *
+ * A highly customizable table component that supports sorting, grouping, selection,
+ * auto-sizing, and pagination. Built on top of TanStack Table with enhanced features
+ * for enterprise applications.
+ *
+ * @template T - The data type for table rows, must include an 'id' property
+ *
+ * @param {Object} props - Component props
+ * @param {string} [props.className] - Additional CSS class for the table wrapper
+ * @param {boolean} [props.canSelect=false] - Enable row selection with checkboxes
+ * @param {ColumnDef<T, Partial<T>>[]} props.columns - Column definitions
+ * @param {RefObject<HTMLElement | null>} [props.containerRef] - Reference to container for size calculations
+ * @param {T[]} props.data - Table data array
+ * @param {Function} [props.filterCells] - Function to filter which cells should be displayed
+ * @param {Function} [props.filterHeaders] - Function to filter which headers should be displayed
+ * @param {string[]} [props.groupBy] - Column IDs to group rows by
+ * @param {boolean} props.isLoading - Loading state to display placeholder content
+ * @param {ReactNode} [props.noData] - Content to display when no data is available
+ * @param {PaginationBarProps} [props.pagination] - Pagination configuration
+ * @param {{ value: string; isTop: boolean }[]} [props.pinGroup] - Group pinning configuration
+ * @param {ColumnSort[]} [props.sortBy] - Initial sort configuration
+ * @param {RowSelectionState} [props.rowSelection] - Selected rows state
+ * @param {Dispatch<SetStateAction<RowSelectionState>>} [props.setRowSelection] - Selection state setter
+ * @param {"full-height" | "regular"} [props.variant="full-height"] - Table layout variant
+ *
+ * @returns {ReactElement} - The rendered table component
+ *
+ * @example
+ * <GenericTable
+ *   columns={columns}
+ *   data={products}
+ *   isLoading={isLoading}
+ *   canSelect={true}
+ *   groupBy={["category"]}
+ *   rowSelection={selectedRows}
+ *   setRowSelection={setSelectedRows}
+ *   pagination={{
+ *     currentPage: page,
+ *     setCurrentPage: setPage,
+ *     itemsPerPage: pageSize,
+ *     totalItems: totalCount,
+ *     handlePageSizeChange: handlePageSizeChange
+ *   }}
+ * />
+ */
 const GenericTable = <T extends { id: string | number }>({
   className,
   canSelect = false,
@@ -67,7 +120,7 @@ const GenericTable = <T extends { id: string | number }>({
   rowSelection,
   setRowSelection,
   variant = "full-height",
-}: GenericTableProps<T>) => {
+}: GenericTableProps<T>): ReactElement => {
   const tableRef = useRef<HTMLTableSectionElement>(null);
   const [maxHeight, setMaxHeight] = useState("auto");
 
@@ -303,7 +356,10 @@ const GenericTable = <T extends { id: string | number }>({
   };
 
   return (
-    <div className={classNames("p-generic-table", className)}>
+    <div
+      className={classNames("p-generic-table", className)}
+      data-testid="p-generic-table"
+    >
       {pagination && (
         <PaginationBar
           currentPage={pagination.currentPage}

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import type { Dispatch, ReactNode, SetStateAction } from "react";
 
+import { Placeholder } from "@canonical/maas-react-components";
 import type {
   Column,
   Row,
@@ -36,6 +37,7 @@ type GenericTableProps<T extends { id: string | number }> = {
   filterCells?: (row: Row<T>, column: Column<T>) => boolean;
   filterHeaders?: (header: Header<T, unknown>) => boolean;
   groupBy?: string[];
+  isLoading: boolean;
   noData?: ReactNode;
   pagination?: PaginationBarProps;
   pinGroup?: { value: string; isTop: boolean }[];
@@ -53,6 +55,7 @@ const GenericTable = <T extends { id: string | number }>({
   filterCells = () => true,
   filterHeaders = () => true,
   groupBy,
+  isLoading,
   noData,
   pagination,
   pinGroup,
@@ -225,12 +228,28 @@ const GenericTable = <T extends { id: string | number }>({
             maxHeight,
           }}
         >
-          {table.getRowModel().rows.length < 1 ? (
-            <tr>
-              <td colSpan={columns.length} style={{ textAlign: "center" }}>
-                {noData}
-              </td>
-            </tr>
+          {isLoading ? (
+            Array.from({ length: 10 }, (_, index) => {
+              return (
+                <tr aria-hidden="true" key={index}>
+                  {columns.map((column, columnIndex) => {
+                    return (
+                      <td
+                        className={classNames(
+                          column.id,
+                          "u-text-overflow-clip"
+                        )}
+                        key={columnIndex}
+                      >
+                        <Placeholder isPending text="XXXxxxx.xxxxxxxxx" />
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })
+          ) : table.getRowModel().rows.length < 1 ? (
+            <tr>{noData}</tr>
           ) : (
             table.getRowModel().rows.map((row) => {
               const { getIsGrouped, id, getVisibleCells } = row;

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -91,7 +91,7 @@ const GenericTable = <T extends { id: string | number }>({
     return () => window.removeEventListener("resize", updateHeight);
   }, []);
 
-  if (canSelect) {
+  if (canSelect && !isLoading) {
     columns = [
       {
         id: "select",
@@ -234,13 +234,7 @@ const GenericTable = <T extends { id: string | number }>({
                 <tr aria-hidden="true" key={index}>
                   {columns.map((column, columnIndex) => {
                     return (
-                      <td
-                        className={classNames(
-                          column.id,
-                          "u-text-overflow-clip"
-                        )}
-                        key={columnIndex}
-                      >
+                      <td className={column.id} key={columnIndex}>
                         <Placeholder isPending text="XXXxxxx.xxxxxxxxx" />
                       </td>
                     );
@@ -249,7 +243,9 @@ const GenericTable = <T extends { id: string | number }>({
               );
             })
           ) : table.getRowModel().rows.length < 1 ? (
-            <tr>{noData}</tr>
+            <tr>
+              <td className="p-generic-table__no-data">{noData}</td>
+            </tr>
           ) : (
             table.getRowModel().rows.map((row) => {
               const { getIsGrouped, id, getVisibleCells } = row;

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -7,7 +7,7 @@ import type {
   ReactElement,
 } from "react";
 
-import { Placeholder } from "@canonical/maas-react-components";
+import { Spinner } from "@canonical/react-components";
 import type {
   Column,
   Row,
@@ -288,15 +288,17 @@ const GenericTable = <T extends { id: string | number }>({
 
   // Render loading placeholder rows
   const renderLoadingRows = () => {
-    return Array.from({ length: 10 }, (_, index) => (
-      <tr aria-hidden="true" key={index}>
-        {columns.map((column, columnIndex) => (
-          <td className={column.id} key={columnIndex}>
-            <Placeholder isPending text="XXXxxxx.xxxxxxxxx" />
-          </td>
-        ))}
+    return (
+      <tr>
+        <td
+          className="p-generic-table__loading"
+          colSpan={columns.length}
+          role="cell"
+        >
+          <Spinner text="Loading..." />
+        </td>
       </tr>
-    ));
+    );
   };
 
   // Render data rows

--- a/src/app/base/components/GenericTable/GenericTable.tsx
+++ b/src/app/base/components/GenericTable/GenericTable.tsx
@@ -102,7 +102,7 @@ const GenericTable = <T extends { id: string | number }>({
 
     const selectionColumns = [
       {
-        id: "select",
+        id: "p-generic-table__select",
         accessorKey: "id",
         enableSorting: false,
         header: "",
@@ -115,7 +115,7 @@ const GenericTable = <T extends { id: string | number }>({
     if (groupBy) {
       return [
         {
-          id: "group-select",
+          id: "p-generic-table__group-select",
           accessorKey: "id",
           enableSorting: false,
           header: ({ table }: HeaderContext<T, Partial<T>>) => (
@@ -236,13 +236,20 @@ const GenericTable = <T extends { id: string | number }>({
       return (
         <tr
           className={classNames({
-            "individual-row": isIndividualRow,
-            "group-row": !isIndividualRow,
+            "p-generic-table__individual-row": isIndividualRow,
+            "p-generic-table__group-row": !isIndividualRow,
           })}
           key={id}
         >
           {getVisibleCells()
-            .filter((cell) => filterCells(row, cell.column))
+            .filter((cell) => {
+              if (
+                !isIndividualRow &&
+                cell.column.id === "p-generic-table__group-select"
+              )
+                return true;
+              return filterCells(row, cell.column);
+            })
             .map((cell) => (
               <td className={classNames(`${cell.column.id}`)} key={cell.id}>
                 {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -269,8 +276,8 @@ const GenericTable = <T extends { id: string | number }>({
 
       <table
         className={classNames("p-generic-table__table", {
-          "is-full-height": variant === "full-height",
-          "is-selectable": canSelect,
+          "p-generic-table__is-full-height": variant === "full-height",
+          "p-generic-table__is-selectable": canSelect,
         })}
       >
         <thead>
@@ -281,7 +288,9 @@ const GenericTable = <T extends { id: string | number }>({
                 .map((header, index) => (
                   <Fragment key={header.id}>
                     <ColumnHeader header={header} />
-                    {index === 2 ? <th className="select-alignment" /> : null}
+                    {index === 2 ? (
+                      <th className="p-generic-table__select-alignment" />
+                    ) : null}
                   </Fragment>
                 ))}
             </tr>

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -1,50 +1,117 @@
+@import "vanilla-framework";
+
 .p-generic-table {
-  thead,
-  tbody {
-    display: block;
-    overflow: hidden auto;
-    width: 100%;
+  .controls-bar {
+    border-top: 1px solid #d9d9d9;
+    border-bottom: 1px solid #d9d9d9;
+    align-items: center;
+    padding: 0.5rem 0;
+    margin-top: 1rem;
+
+    .p-form--inline {
+      width: 100%;
+    }
+
+    .controls-bar__left {
+      margin: 0;
+      padding: 0;
+    }
+
+    .controls-bar__right {
+      width: 100%;
+      margin-left: auto;
+      margin-right: 0;
+
+      .p-pagination {
+        z-index: 2;
+        padding-right: 2rem;
+      }
+
+      @media screen and (min-width: 620px) {
+        width: auto;
+      }
+    }
   }
 
-  .group-select,
-  .select,
-  .select-alignment {
-    width: 2rem;
-  }
+  .p-generic-table__table {
+    margin-bottom: 0;
 
-  th.select {
-    display: none;
-  }
-}
+    // Hide "Loading" visually but keep it accessible to screenreaders
+    &__loading {
+      position: absolute !important;
+      height: 1px !important;
+      width: 1px !important;
+      overflow: hidden !important;
+      clip: rect(1px, 1px, 1px, 1px) !important;
+      white-space: nowrap !important;
+    }
 
-.p-pagination {
-  z-index: 2;
-  padding-right: 2rem;
-}
+    thead,
+    tbody {
+      display: block;
+      overflow: hidden auto;
+    }
 
-.controls-bar {
-  border-top: 1px solid #d9d9d9;
-  border-bottom: 1px solid #d9d9d9;
-  align-items: center;
-  padding: 0.5rem 0;
-  margin-top: 1rem;
+    thead {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      background-color: white;
+    }
 
-  .p-form--inline {
-    width: 100%;
-  }
+    &.is-full-height {
+      thead {
+        scrollbar-gutter: stable;
+      }
+    }
 
-  .controls-bar__left {
-    margin: 0;
-    padding: 0;
-  }
+    thead tr,
+    tbody tr {
+      display: table;
+      table-layout: fixed;
+      width: 100%;
+    }
 
-  .controls-bar__right {
-    width: 100%;
-    margin-left: auto;
-    margin-right: 0;
+    tbody {
+      height: auto;
+      min-height: auto;
+    }
 
-    @media screen and (min-width: 620px) {
-      width: auto;
+    &:not([aria-busy="true"]) tbody:not([aria-busy="true"]) {
+      tr:hover,
+      tr:focus-within {
+        @include vf-transition($property: #{background}, $duration: fast);
+
+        background-color: $colors--light-theme--background-hover;
+      }
+    }
+
+    thead th:last-child,
+    tbody td:last-child {
+      text-align: right;
+    }
+
+    thead th button {
+      padding-top: 0;
+      margin-bottom: 0;
+    }
+
+    thead,
+    tbody {
+      display: block;
+      overflow: hidden auto;
+      width: 100%;
+    }
+
+    .group-select,
+    .select,
+    .select-alignment {
+      width: 2rem;
+    }
+
+    th.select {
+      display: none;
     }
   }
 }
+

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -114,8 +114,8 @@
       display: none;
     }
 
-    // Empty state
-    td.p-generic-table__no-data {
+    // Empty and loading states
+    td.p-generic-table__no-data, td.p-generic-table__loading {
       padding: 2rem;
       text-align: center !important;
     }

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -36,16 +36,6 @@
   .p-generic-table__table {
     margin-bottom: 0;
 
-    // Hide "Loading" visually but keep it accessible to screenreaders
-    &__loading {
-      position: absolute !important;
-      height: 1px !important;
-      width: 1px !important;
-      overflow: hidden !important;
-      clip: rect(1px, 1px, 1px, 1px) !important;
-      white-space: nowrap !important;
-    }
-
     thead,
     tbody {
       display: block;
@@ -111,6 +101,11 @@
 
     th.select, &:not(.is-selectable)>* .select-alignment {
       display: none;
+    }
+
+    td.p-generic-table__no-data {
+      padding: 2rem;
+      text-align: center !important;
     }
   }
 }

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -109,7 +109,7 @@
       width: 2rem;
     }
 
-    th.select {
+    th.select, &:not(.is-selectable)>* .select-alignment {
       display: none;
     }
   }

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -1,7 +1,8 @@
 .p-generic-table {
   thead,
   tbody {
-    display: table-row-group;
+    display: block;
+    overflow: hidden auto;
     width: 100%;
   }
 

--- a/src/app/base/components/GenericTable/_index.scss
+++ b/src/app/base/components/GenericTable/_index.scss
@@ -1,23 +1,26 @@
 @import "vanilla-framework";
 
+// Generic Table main component
 .p-generic-table {
+  // Pagination and controls section
   .controls-bar {
-    border-top: 1px solid #d9d9d9;
-    border-bottom: 1px solid #d9d9d9;
+    display: flex;
     align-items: center;
     padding: 0.5rem 0;
     margin-top: 1rem;
+    border-top: 1px solid #d9d9d9;
+    border-bottom: 1px solid #d9d9d9;
 
     .p-form--inline {
       width: 100%;
     }
 
-    .controls-bar__left {
+    &__left {
       margin: 0;
       padding: 0;
     }
 
-    .controls-bar__right {
+    &__right {
       width: 100%;
       margin-left: auto;
       margin-right: 0;
@@ -33,28 +36,45 @@
     }
   }
 
+  // Table structure and layout
   .p-generic-table__table {
     margin-bottom: 0;
 
+    // Common styles for thead and tbody
     thead,
     tbody {
       display: block;
-      overflow: hidden auto;
+      overflow: auto;
+      width: 100%;
     }
 
+    // Header styling
     thead {
       position: sticky;
       top: 0;
       z-index: 1;
       background-color: white;
+
+      th {
+        button {
+          padding-top: 0;
+          margin-bottom: 0;
+        }
+
+        &:last-child {
+          text-align: right;
+        }
+      }
     }
 
-    &.is-full-height {
+    // Full-height variant
+    &.p-generic-table__is-full-height {
       thead {
         scrollbar-gutter: stable;
       }
     }
 
+    // Row layout
     thead tr,
     tbody tr {
       display: table;
@@ -62,51 +82,42 @@
       width: 100%;
     }
 
+    // Body styling
     tbody {
       height: auto;
       min-height: auto;
+
+      td:last-child {
+        text-align: right;
+      }
     }
 
+    // Row hover effects
     &:not([aria-busy="true"]) tbody:not([aria-busy="true"]) {
       tr:hover,
       tr:focus-within {
-        @include vf-transition($property: #{background}, $duration: fast);
-
+        @include vf-transition($property: background, $duration: fast);
         background-color: $colors--light-theme--background-hover;
       }
     }
 
-    thead th:last-child,
-    tbody td:last-child {
-      text-align: right;
-    }
-
-    thead th button {
-      padding-top: 0;
-      margin-bottom: 0;
-    }
-
-    thead,
-    tbody {
-      display: block;
-      overflow: hidden auto;
-      width: 100%;
-    }
-
-    .group-select,
-    .select,
-    .select-alignment {
+    // Selection column styling
+    .p-generic-table__group-select,
+    .p-generic-table__select,
+    .p-generic-table__select-alignment {
       width: 2rem;
     }
 
-    th.select, &:not(.is-selectable)>* .select-alignment {
+    // Hide selection columns when not selectable
+    th.p-generic-table__select,
+    &:not(.p-generic-table__is-selectable) > * .p-generic-table__select-alignment {
       display: none;
     }
 
+    // Empty state
     td.p-generic-table__no-data {
       padding: 2rem;
       text-align: center !important;
     }
   }
 }
-

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -50,6 +50,7 @@ const ImagesTable = ({
   variant,
 }: SMImagesTableProps) => {
   const resources = useSelector(bootResourceSelectors.resources);
+  const isPolling = useSelector(bootResourceSelectors.polling);
   const images = getImages(resources);
 
   const { setSidePanelContent } = useSidePanel();
@@ -84,6 +85,7 @@ const ImagesTable = ({
       filterCells={filterCells}
       filterHeaders={filterHeaders}
       groupBy={["name"]}
+      isLoading={isPolling && images.length === 0}
       noData={
         <TableCaption>
           <TableCaption.Title>No images</TableCaption.Title>

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -87,14 +87,11 @@ const ImagesTable = ({
       groupBy={["name"]}
       isLoading={isPolling && images.length === 0}
       noData={
-        <TableCaption>
-          <TableCaption.Title>No images</TableCaption.Title>
-          <TableCaption.Description>
-            There are no images stored in Site Manager at the moment. You can
-            either upload images, or connect to an upstream image source to
-            download images from.
-          </TableCaption.Description>
-        </TableCaption>
+        <TableCaption.Description>
+          There are no images stored in Site Manager at the moment. You can
+          either upload images, or connect to an upstream image source to
+          download images from.
+        </TableCaption.Description>
       }
       pinGroup={[
         { value: "Ubuntu", isTop: true },

--- a/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
+++ b/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
@@ -21,7 +21,7 @@ export type ImageColumnDef = ColumnDef<Image, Partial<Image>>;
 
 export const filterCells = (row: Row<Image>, column: Column<Image>) => {
   if (row.getIsGrouped()) {
-    return ["group-select", "name", "action"].includes(column.id);
+    return ["name", "action"].includes(column.id);
   } else {
     return !["name"].includes(column.id);
   }

--- a/src/app/pools/components/PoolsTable/PoolsTable.tsx
+++ b/src/app/pools/components/PoolsTable/PoolsTable.tsx
@@ -16,6 +16,7 @@ const PoolsTable = () => {
     <GenericTable
       columns={usePoolsTableColumns()}
       data={pools.data?.items ?? []}
+      isLoading={pools.isPending}
       noData="No pools found."
       pagination={{
         currentPage: page,

--- a/src/app/zones/views/ZonesList/ZonesList.test.tsx
+++ b/src/app/zones/views/ZonesList/ZonesList.test.tsx
@@ -2,31 +2,33 @@ import ZonesList from "./ZonesListTable/ZonesListTable";
 
 import { zoneResolvers } from "@/testing/resolvers/zones";
 import {
-  renderWithBrowserRouter,
+  renderWithProviders,
   screen,
   setupMockServer,
+  waitFor,
 } from "@/testing/utils";
 
-setupMockServer(zoneResolvers.listZones.handler());
+const mockServer = setupMockServer(zoneResolvers.listZones.handler());
 
 describe("ZonesList", () => {
   it("correctly fetches the necessary data", async () => {
-    renderWithBrowserRouter(<ZonesList />, {
-      route: "/zones",
-    });
+    renderWithProviders(<ZonesList />);
 
     expect(await screen.findByText("zone-1")).toBeInTheDocument();
   });
 
   it("shows a zones table if there are any zones", async () => {
-    renderWithBrowserRouter(<ZonesList />, { route: "/zones" });
+    renderWithProviders(<ZonesList />);
 
-    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("grid")).toBeInTheDocument();
   });
 
   it("shows a message if there are no zones", async () => {
-    renderWithBrowserRouter(<ZonesList />, { route: "/zones" });
+    mockServer.use(zoneResolvers.listZones.handler({ items: [], total: 0 }));
+    renderWithProviders(<ZonesList />);
 
-    expect(screen.getByText("No zones available.")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByText("No zones available.")).toBeInTheDocument()
+    );
   });
 });

--- a/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
+++ b/src/app/zones/views/ZonesList/ZonesListTable/ZonesListTable.tsx
@@ -46,6 +46,7 @@ const ZonesListTable: React.FC = () => {
     <GenericTable
       columns={columns}
       data={zones.data?.items ?? []}
+      isLoading={zones.isPending}
       noData={<TableCaption>No zones available.</TableCaption>}
       pagination={{
         currentPage: page,


### PR DESCRIPTION
## Done

- Made table body scrollable
- Removed `DynamicTable` import, incorporated fully
- Added dynamic height sizing
- Added loading state and skeleton rows
- Refactored code, added accessibility attributes

## QA steps

- [x] Navigate to `images/`
- [x] Verify loading skeleton rows are displayed when polling data
- [x] Verify the grouping and selection checkboxes work as intended
- [x] Navigate to `pools/`
- [x] Verify loading skeleton rows are displayed when querying data
- [x] Verify sorting works as intended 
- [x] Ensure pagination works properly
- [x] Verify the table height is fit into the main section such that the window is not scrollable
- [x] Verify the table body (rows) are scrollable, and the table header and pagination stay fixed during scrolling

## Fixes

Resolves: 

[MAASENG-4718](https://warthogs.atlassian.net/browse/MAASENG-4718)

## Screenshots

<img width="2556" alt="Screenshot 2025-04-17 at 14 53 37" src="https://github.com/user-attachments/assets/c90d7e16-0376-4d63-90f4-2f462ec8b1bc" />

## Notes

With this PR, GenericTable can be evaluated for upstreaming to https://github.com/canonical/maas-react-components


[MAASENG-4718]: https://warthogs.atlassian.net/browse/MAASENG-4718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ