### PR TITLE
feat(machine): Wire up DPU checkbox in Machine Add to backend MAASENG-4190

### DIFF
--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -185,6 +185,9 @@ describe("AddMachineForm", () => {
       screen.getByRole("textbox", { name: "MAC address" }),
       "11:11:11:11:11:11"
     );
+    await userEvent.click(
+      screen.getByRole("checkbox", { name: "Register as DPU" })
+    );
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: "Power type" }),
       "manual"
@@ -196,13 +199,13 @@ describe("AddMachineForm", () => {
       domain: { name: "maas" },
       extra_macs: [],
       hostname: "mean-bean",
+      is_dpu: true,
       min_hwe_kernel: "ga-16.04",
       pool: { name: "swimming" },
       power_parameters: {},
       power_type: "manual",
       pxe_mac: "11:11:11:11:11:11",
       zone: { name: "1" },
-      // TODO: Add `is_dpu` field to params https://warthogs.atlassian.net/browse/MAASENG-4186
     });
     await waitFor(() => {
       expect(
@@ -253,6 +256,7 @@ describe("AddMachineForm", () => {
       domain: { name: "maas" },
       extra_macs: [],
       hostname: "",
+      is_dpu: false,
       min_hwe_kernel: "ga-16.04",
       pool: { name: "swimming" },
       // Create action should not include power_address parameter since it does
@@ -313,6 +317,7 @@ describe("AddMachineForm", () => {
       domain: { name: "maas" },
       // There should only be one extra MAC defined.
       extra_macs: ["22:22:22:22:22:22"],
+      is_dpu: false,
       hostname: "",
       min_hwe_kernel: "ga-16.04",
       pool: { name: "swimming" },

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.tsx
@@ -87,6 +87,7 @@ export const AddMachineForm = ({
       Yup.string().matches(MAC_ADDRESS_REGEX, "Invalid MAC address")
     ),
     hostname: hostnameValidation,
+    is_dpu: Yup.boolean(),
     min_hwe_kernel: Yup.string(),
     pool: Yup.string().required("Resource pool required"),
     power_parameters: Yup.object().shape(
@@ -135,6 +136,7 @@ export const AddMachineForm = ({
             extra_macs: [],
             hostname: "",
             min_hwe_kernel: defaultMinHweKernel || "",
+            is_dpu: false,
             pool:
               (resourcePools?.data?.items?.length &&
                 resourcePools?.data.items[0].name) ||
@@ -157,6 +159,7 @@ export const AddMachineForm = ({
               domain: { name: values.domain },
               extra_macs: values.extra_macs.filter(Boolean),
               hostname: values.hostname,
+              is_dpu: values.is_dpu,
               min_hwe_kernel: values.min_hwe_kernel,
               pool: { name: values.pool },
               power_parameters: formatPowerParameters(
@@ -166,7 +169,6 @@ export const AddMachineForm = ({
               power_type: values.power_type as PowerType["name"],
               pxe_mac: values.pxe_mac,
               zone: { name: values.zone },
-              // TODO: Add `is_dpu` field to params https://warthogs.atlassian.net/browse/MAASENG-4186
             };
             dispatch(machineActions.create(params));
             setSavingMachine(values.hostname || "Machine");

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineFormFields/AddMachineFormFields.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineFormFields/AddMachineFormFields.tsx
@@ -99,9 +99,7 @@ export const AddMachineFormFields = ({ saved }: Props): React.ReactElement => {
         </Button>
       </div>
       <PowerTypeFields />
-      {import.meta.env.VITE_APP_DPU_PROVISIONING === "true" && (
-        <FormikField label="Register as DPU" name="is_dpu" type="checkbox" />
-      )}
+      <FormikField label="Register as DPU" name="is_dpu" type="checkbox" />
     </>
   );
 };

--- a/src/app/machines/components/MachineForms/AddMachine/types.ts
+++ b/src/app/machines/components/MachineForms/AddMachine/types.ts
@@ -6,6 +6,7 @@ export type AddMachineValues = {
   domain: string;
   extra_macs: string[];
   hostname: string;
+  is_dpu: boolean;
   min_hwe_kernel: string;
   pool: string;
   power_parameters: PowerParameters;

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
@@ -109,12 +109,12 @@ describe("MachineForm", () => {
       architecture: machine.architecture,
       description: "New note",
       extra_macs: machine.extra_macs,
+      is_dpu: machine.is_dpu,
       min_hwe_kernel: machine.min_hwe_kernel,
       pool: { name: machine.pool.name },
       pxe_mac: machine.pxe_mac,
       system_id: machine.system_id,
       zone: { name: machine.zone.name },
-      // TODO: add "is_dpu" here https://warthogs.atlassian.net/browse/MAASENG-4190
     });
     const actualActions = store.getActions();
     await waitFor(() => {

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { Spinner } from "@canonical/react-components";
+import { Icon, Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import type { SchemaOf } from "yup";
 import * as Yup from "yup";
@@ -20,6 +20,7 @@ import type { RootState } from "@/app/store/root/types";
 export type MachineFormValues = {
   architecture: MachineDetails["architecture"];
   description: MachineDetails["description"];
+  is_dpu: MachineDetails["is_dpu"];
   minHweKernel: MachineDetails["min_hwe_kernel"];
   pool: MachineDetails["pool"]["name"];
   zone: MachineDetails["zone"]["name"];
@@ -31,6 +32,7 @@ const MachineFormSchema: SchemaOf<MachineFormValues> = Yup.object()
   .shape({
     architecture: Yup.string().required("Architecture is required"),
     description: Yup.string(),
+    is_dpu: Yup.boolean(),
     minHweKernel: Yup.string(),
     pool: Yup.string().required("Resource pool is required"),
     zone: Yup.string().required("Zone is required"),
@@ -65,6 +67,7 @@ const MachineForm = ({ systemId }: Props): React.ReactElement | null => {
             initialValues={{
               architecture: machine.architecture || "",
               description: machine.description || "",
+              is_dpu: machine.is_dpu || false,
               minHweKernel: machine.min_hwe_kernel || "",
               pool: machine.pool?.name || "",
               zone: machine.zone?.name || "",
@@ -79,13 +82,13 @@ const MachineForm = ({ systemId }: Props): React.ReactElement | null => {
               const params = {
                 architecture: values.architecture,
                 description: values.description,
+                is_dpu: values.is_dpu,
                 extra_macs: machine.extra_macs,
                 pxe_mac: machine.pxe_mac,
                 min_hwe_kernel: values.minHweKernel,
                 pool: { name: values.pool },
                 system_id: machine.system_id,
                 zone: { name: values.zone },
-                // TODO: add "is_dpu" here https://warthogs.atlassian.net/browse/MAASENG-4190
               };
               dispatch(machineActions.update(params));
             }}
@@ -109,6 +112,10 @@ const MachineForm = ({ systemId }: Props): React.ReactElement | null => {
             />
             <Definition description={machine.zone.name} label="Zone" />
             <Definition description={machine.pool.name} label="Resource pool" />
+            <Definition
+              children={<Icon name={machine.is_dpu ? "success" : "error"} />}
+              label={"DPU"}
+            />
             <Definition description={machine.description} label="Note" />
           </div>
         )

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineFormFields/MachineFormFields.tsx
@@ -14,10 +14,7 @@ const MachineFormFields = (): React.ReactElement => {
         <MinimumKernelSelect name="minHweKernel" />
         <ZoneSelect name="zone" />
         <ResourcePoolSelect name="pool" />
-        {/* TODO: Remove feature flag https://warthogs.atlassian.net/browse/MAASENG-4186 */}
-        {import.meta.env.VITE_APP_DPU_PROVISIONING === "true" && (
-          <FormikField label="Register as DPU" name="is_dpu" type="checkbox" />
-        )}
+        <FormikField label="Register as DPU" name="is_dpu" type="checkbox" />
         <FormikField component={Textarea} label="Note" name="description" />
       </Col>
     </Row>

--- a/src/app/store/machine/types/actions.ts
+++ b/src/app/store/machine/types/actions.ts
@@ -145,6 +145,7 @@ export type CreateParams = {
   hostname?: Machine["hostname"];
   hwe_kernel?: string;
   install_rackd?: boolean;
+  is_dpu?: boolean;
   license_key?: LicenseKeys["license_key"];
   memory?: Machine["memory"];
   min_hwe_kernel?: string;

--- a/src/app/store/machine/types/base.ts
+++ b/src/app/store/machine/types/base.ts
@@ -94,6 +94,7 @@ export type MachineDetails = BaseMachine &
     installation_status: number;
     interface_test_status: TestStatus;
     interfaces: NetworkInterface[];
+    is_dpu: boolean;
     license_key: string;
     link_speeds: number[];
     memory_test_status: TestStatus;

--- a/src/testing/factories/nodes.ts
+++ b/src/testing/factories/nodes.ts
@@ -391,6 +391,7 @@ export const machineDetails = extend<BaseMachine, MachineDetails>(machine, {
   cpu_speed: 1000,
   swap_size: null,
   updated: () => timestamp("Fri, 23 Oct. 2020 05:24:41"),
+  is_dpu: false,
 });
 
 export const controller = extend<BaseNode, Controller>(node, {


### PR DESCRIPTION
## Done

- Added `is_dpu` field create machine action, and machine form types
- Removed `import.meta.env.VITE_APP_DPU_PROVISIONING` checks
- Added a placeholder DPU status display to editable machine configuration form

## QA steps

- [ ] Navigate to machines/
- [ ] Add a machine with Register as DPU checbox checked
- [ ] Navigate to the new machine's configuration page
- [ ] Verify DPU displays the success icon
- [ ] Click Edit
- [ ] Uncheck the Register as DPU checkbox
- [ ] Click Save
- [ ] Refresh page
- [ ] Verify DPU now displays the error icon

## Fixes

Resolves: 

[MAASENG-4190](https://warthogs.atlassian.net/browse/MAASENG-4190)

## Screenshots

<img width="2556" alt="Screenshot 2025-04-21 at 13 50 12" src="https://github.com/user-attachments/assets/c431e427-987f-4fd9-944b-9e798612e16c" />
<img width="2556" alt="Screenshot 2025-04-21 at 13 50 41" src="https://github.com/user-attachments/assets/65dccf7a-c818-4c3a-ad9f-ae2bdde6387a" />


## Notes

The way DPU state is being displayed is a makeshift solution, and requires design input.
