### PR TITLE
fix: DPU QA fixes

### DIFF
--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -190,7 +190,7 @@ describe("AddMachineForm", () => {
       "11:11:11:11:11:11"
     );
     await userEvent.click(
-      screen.getByRole("checkbox", { name: "Register as DPU" })
+      screen.getByRole("checkbox", { name: /Register as DPU/i })
     );
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: "Power type" }),

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineFormFields/AddMachineFormFields.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineFormFields/AddMachineFormFields.tsx
@@ -12,6 +12,7 @@ import MacAddressField from "@/app/base/components/MacAddressField";
 import MinimumKernelSelect from "@/app/base/components/MinimumKernelSelect";
 import PowerTypeFields from "@/app/base/components/PowerTypeFields";
 import ResourcePoolSelect from "@/app/base/components/ResourcePoolSelect";
+import TooltipButton from "@/app/base/components/TooltipButton";
 import ZoneSelect from "@/app/base/components/ZoneSelect";
 import { PowerTypeNames } from "@/app/store/general/constants";
 import type { MachineState } from "@/app/store/machine/types";
@@ -101,7 +102,21 @@ export const AddMachineFormFields = ({ saved }: Props): React.ReactElement => {
         </Button>
       </div>
       <PowerTypeFields />
-      <FormikField label="Register as DPU" name="is_dpu" type="checkbox" />
+      <FormikField
+        label={
+          <>
+            Register as DPU{" "}
+            <TooltipButton
+              iconName="help"
+              message="This option registers the machine as a DPU which will affect how MAAS handles the lifecycle of the machine."
+              position="btm-left"
+              positionElementClassName="u-display--inline"
+            />
+          </>
+        }
+        name="is_dpu"
+        type="checkbox"
+      />
     </>
   );
 };

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.test.tsx
@@ -9,15 +9,12 @@ import {
   userEvent,
   screen,
   waitFor,
-  renderWithBrowserRouter,
+  renderWithProviders,
 } from "@/testing/utils";
 
 const mockStore = configureStore();
 describe("MachineForm", () => {
   let state: ReturnType<typeof factory.rootState>;
-  const queryData = {
-    zones: [factory.zone()],
-  };
 
   beforeEach(() => {
     state = factory.rootState({
@@ -42,10 +39,9 @@ describe("MachineForm", () => {
 
   it("is not editable if machine does not have edit permission", () => {
     state.machine.items[0].permissions = [];
-    renderWithBrowserRouter(<MachineForm systemId="abc123" />, {
+    renderWithProviders(<MachineForm systemId="abc123" />, {
       state,
-      queryData,
-      route: "/machine/abc123",
+      initialEntries: ["/machine/abc123"],
     });
 
     expect(
@@ -55,10 +51,9 @@ describe("MachineForm", () => {
 
   it("is editable if machine has edit permission", () => {
     state.machine.items[0].permissions = ["edit"];
-    renderWithBrowserRouter(<MachineForm systemId="abc123" />, {
+    renderWithProviders(<MachineForm systemId="abc123" />, {
       state,
-      queryData,
-      route: "/machine/abc123",
+      initialEntries: ["/machine/abc123"],
     });
 
     expect(
@@ -67,10 +62,9 @@ describe("MachineForm", () => {
   });
 
   it("renders read-only text fields until edit button is pressed", async () => {
-    renderWithBrowserRouter(<MachineForm systemId="abc123" />, {
+    renderWithProviders(<MachineForm systemId="abc123" />, {
       state,
-      queryData,
-      route: "/machine/abc123",
+      initialEntries: ["/machine/abc123"],
     });
 
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
@@ -82,6 +76,36 @@ describe("MachineForm", () => {
     expect(screen.getByRole("textbox")).toBeInTheDocument();
   });
 
+  it("displays 'True' if the machine is a DPU", () => {
+    const machine = factory.machineDetails({
+      is_dpu: true,
+      system_id: "abc123",
+    });
+    state.machine.items = [machine];
+
+    renderWithProviders(<MachineForm systemId="abc123" />, {
+      state,
+      initialEntries: ["/machine/abc123"],
+    });
+
+    expect(screen.getByText("True")).toBeInTheDocument();
+  });
+
+  it("displays 'False' if the machine is not a DPU", () => {
+    const machine = factory.machineDetails({
+      is_dpu: false,
+      system_id: "abc123",
+    });
+    state.machine.items = [machine];
+
+    renderWithProviders(<MachineForm systemId="abc123" />, {
+      state,
+      initialEntries: ["/machine/abc123"],
+    });
+
+    expect(screen.getByText("False")).toBeInTheDocument();
+  });
+
   it("correctly dispatches an action to update a machine", async () => {
     const machine = factory.machineDetails({
       architecture: "amd64",
@@ -91,10 +115,9 @@ describe("MachineForm", () => {
     state.machine.items = [machine];
     const store = mockStore(state);
 
-    renderWithBrowserRouter(<MachineForm systemId="abc123" />, {
+    renderWithProviders(<MachineForm systemId="abc123" />, {
       store,
-      queryData,
-      route: "/machine/abc123",
+      initialEntries: ["/machine/abc123"],
     });
 
     await userEvent.click(

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/MachineForm/MachineForm.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 
-import { Icon, Spinner } from "@canonical/react-components";
+import { Spinner } from "@canonical/react-components";
 import { useDispatch, useSelector } from "react-redux";
 import type { SchemaOf } from "yup";
 import * as Yup from "yup";
@@ -117,8 +117,8 @@ const MachineForm = ({ systemId }: Props): React.ReactElement | null => {
             <Definition description={machine.zone.name} label="Zone" />
             <Definition description={machine.pool.name} label="Resource pool" />
             <Definition
-              children={<Icon name={machine.is_dpu ? "success" : "error"} />}
-              label={"DPU"}
+              children={machine.is_dpu ? "True" : "False"}
+              label={"Registered as DPU"}
             />
             <Definition description={machine.description} label="Note" />
           </div>


### PR DESCRIPTION
## Done
- added help tooltip for DPU field in "Add Machine" form
- improved display of `is_dpu` value in machine configuration

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to machine list
- [x] Click "Add hardware" --> "Add Machine"
- [x] Ensure "Register as DPU" field has a tooltip button with help text matching design
- [x] Go to machine configuration of a DPU
- [x] Ensure "Registeredas DPU" reads "True"
- [x] Go to machine configuration of a normal machine
- [x] Ensure "Registeredas DPU" reads "False"

<!-- Steps for QA. -->


<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

[Design](https://www.figma.com/design/48QccxasITNNR6OsFOANXz/MAAS-DPU-deployment?node-id=11-30281&t=TBqBHei8c6etFY4M-0)

### Add Machine
#### Before
![image](https://github.com/user-attachments/assets/2885ddb7-f3e2-46f9-9cdd-e4f1d99966e0)

#### After
![image](https://github.com/user-attachments/assets/ef6064bf-70ff-432c-a2cf-af6f19c5215b)

### Machine configuration

#### Before
![image](https://github.com/user-attachments/assets/94538be5-c025-4143-84f5-691924159f60)

#### After
![image](https://github.com/user-attachments/assets/0c55779a-d25b-4f66-91aa-92b854129b0b)

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->
