### PR TITLE
feat: remove power on/off if DPU MAASENG-3947

### DIFF
--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.test.tsx
@@ -37,8 +37,8 @@ describe("NodeActionMenuGroup", () => {
 
   it("only shows actions that can be performed by the nodes", async () => {
     const nodes = [
-      factory.machine({ actions: [NodeActions.DELETE] }),
-      factory.machine({ actions: [NodeActions.SET_ZONE] }),
+      factory.machine({ actions: [NodeActions.DELETE], is_dpu: false }),
+      factory.machine({ actions: [NodeActions.SET_ZONE], is_dpu: false }),
     ];
     render(
       <NodeActionMenuGroup
@@ -86,7 +86,9 @@ describe("NodeActionMenuGroup", () => {
 
   it(`can be made to always show lifecycle actions, disabling the actions that
       cannot be performed`, async () => {
-    const nodes = [factory.machine({ actions: [NodeActions.DEPLOY] })];
+    const nodes = [
+      factory.machine({ actions: [NodeActions.DEPLOY], is_dpu: false }),
+    ];
     render(
       <NodeActionMenuGroup
         alwaysShowLifecycle
@@ -115,7 +117,9 @@ describe("NodeActionMenuGroup", () => {
   });
 
   it(`disables the actions that cannot be performed when nodes are provided`, async () => {
-    const nodes = [factory.machine({ actions: [NodeActions.DEPLOY] })];
+    const nodes = [
+      factory.machine({ actions: [NodeActions.DEPLOY], is_dpu: false }),
+    ];
     render(
       <NodeActionMenuGroup
         alwaysShowLifecycle
@@ -182,12 +186,15 @@ describe("NodeActionMenuGroup", () => {
           NodeActions.RELEASE,
           NodeActions.DEPLOY,
         ],
+        is_dpu: false,
       }),
       factory.machine({
         actions: [NodeActions.COMMISSION, NodeActions.RELEASE],
+        is_dpu: false,
       }),
       factory.machine({
         actions: [NodeActions.COMMISSION],
+        is_dpu: false,
       }),
     ];
     render(
@@ -217,6 +224,7 @@ describe("NodeActionMenuGroup", () => {
     const nodes = [
       factory.machine({
         actions: [NodeActions.DEPLOY],
+        is_dpu: false,
       }),
     ];
     const onActionClick = vi.fn();
@@ -240,6 +248,7 @@ describe("NodeActionMenuGroup", () => {
     const nodes = [
       factory.machine({
         actions: [NodeActions.DEPLOY, NodeActions.DELETE],
+        is_dpu: false,
       }),
     ];
     render(
@@ -285,6 +294,7 @@ describe("NodeActionMenuGroup", () => {
     const nodes = [
       factory.machine({
         actions: [NodeActions.TAG],
+        is_dpu: false,
       }),
     ];
     render(

--- a/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
+++ b/src/app/base/components/NodeActionMenuGroup/NodeActionMenuGroup.tsx
@@ -10,6 +10,7 @@ import {
 } from "@canonical/react-components";
 
 import type { DataTestElement } from "@/app/base/types";
+import type { MachineDetails } from "@/app/store/machine/types";
 import type { Node } from "@/app/store/types/node";
 import { NodeActions } from "@/app/store/types/node";
 import { canOpenActionForm, getNodeActionTitle } from "@/app/store/utils";
@@ -117,6 +118,9 @@ const generateActionMenus = (
   singleNode?: boolean
 ) => {
   return actionGroups.reduce<React.ReactElement[]>((menus, group) => {
+    //if (nodes && (nodes[0] as MachineDetails).is_dpu) {
+    //  console.log(group);
+    //}
     const groupLinks = group.actions.reduce<ActionLink[]>(
       (groupLinks, action) => {
         if (excludeActions.includes(action)) {
@@ -189,8 +193,15 @@ const generateActionMenus = (
       },
       []
     );
-
-    if (groupLinks.length > 0) {
+    if (
+      (groupLinks.length > 0 && nodes === undefined) ||
+      (groupLinks.length > 0 && nodes && nodes.length === 0) ||
+      (groupLinks.length > 0 &&
+        nodes !== undefined &&
+        nodes.length > 0 &&
+        (((nodes![0] as MachineDetails).is_dpu && group.name !== "power") ||
+          (nodes![0] as MachineDetails).is_dpu === false))
+    ) {
       menus.push(
         <ContextualMenu
           dropdownProps={{ "aria-label": `${group.title} submenu` }}

--- a/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
+++ b/src/app/machines/views/MachineList/MachineListControls/MachineListControls.test.tsx
@@ -28,6 +28,7 @@ describe("MachineListControls", () => {
         factory.machine({
           fqdn: "abc123",
           system_id: "abc123",
+          is_dpu: false,
         }),
       ],
     });


### PR DESCRIPTION
## Done
- added condition that if machine is DPU don't show Power on/off button
- changed tests accordingly to new condition

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] go to /machines
- [x] click a machine that is not DPU 
- [x] check if there is still a Power button
- [x] go back
- [x] click a machine that is a DPU
- [x] check if there is not a Power button

<!-- Steps for QA. -->

## Fixes

Fixes: [MAASENG-3947](https://warthogs.atlassian.net/browse/MAASENG-3947)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
<img width="1512" alt="Screenshot 2025-05-15 at 13 15 10" src="https://github.com/user-attachments/assets/51006d4c-d7d8-4e72-bcc8-ee492ce6e113" />
<img width="1512" alt="Screenshot 2025-05-15 at 13 15 25" src="https://github.com/user-attachments/assets/e76f8265-998c-4429-b6ec-f7a322418ce7" />

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-3947]: https://warthogs.atlassian.net/browse/MAASENG-3947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ