### PR TITLE
fix(images): MultiSelect auto-close in SelectUpstreamImagesForm MAASENG-4927

### DIFF
--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesSelect/SelectUpstreamImagesSelect.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import { useMemo } from "react";
+import { useCallback, useState, useMemo } from "react";
 
 import {
   Accordion,
@@ -27,6 +27,13 @@ const SelectUpstreamImagesSelect = ({
   setFieldValue,
   groupedImages,
 }: DownloadImagesSelectProps): ReactElement => {
+  const [forceRenderKey, setForceRenderKey] = useState(0);
+
+  const handleAccordionExpandedChange = useCallback(() => {
+    // Force re-render of all MultiSelect components to close any open dropdowns
+    setForceRenderKey((prev) => prev + 1);
+  }, []);
+
   const accordionSections = useMemo(
     () =>
       Object.keys(groupedImages).map((distro) => {
@@ -48,6 +55,7 @@ const SelectUpstreamImagesSelect = ({
                       <FormikField
                         component={MultiSelect}
                         items={groupedImages[distro][release]}
+                        key={`${getValueKey(distro, release)}-${forceRenderKey}`}
                         name={getValueKey(distro, release)}
                         onItemsUpdate={(items: MultiSelectItem[]) => {
                           setFieldValue(getValueKey(distro, release), items);
@@ -66,8 +74,13 @@ const SelectUpstreamImagesSelect = ({
           title: distro,
         } as Section;
       }),
-    [groupedImages, values, setFieldValue]
+    [groupedImages, forceRenderKey, values, setFieldValue]
   );
-  return <Accordion sections={accordionSections} />;
+  return (
+    <Accordion
+      onExpandedChange={handleAccordionExpandedChange}
+      sections={accordionSections}
+    />
+  );
 };
 export default SelectUpstreamImagesSelect;

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/_index.scss
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/_index.scss
@@ -1,5 +1,6 @@
 @mixin DownloadImages {
   footer.content-section__footer {
     z-index: 2;
+    margin-bottom: 100%;
   }
 }


### PR DESCRIPTION
## Done

- Added force re-render for the dropdowns on accordion state change
- added bottom margin to make the form scrollable when there is overflowing dropdown

## QA steps

- [ ] Navigate to /images
- [ ] Open "Select upstream images" side panel form
- [ ] Expand an accordion
- [ ] Click on a dropdown
- [ ] Close the accordion while the dropdown is open
- [ ] Verify the dropdown also closes

## Fixes

Fixes: 

[MAASENG-4927](https://warthogs.atlassian.net/browse/MAASENG-4927)