### PR TITLE
fix(base): prevent keypress from focusing searchbox if a textarea is focused

### DIFF
--- a/src/app/base/hooks/base.ts
+++ b/src/app/base/hooks/base.ts
@@ -235,8 +235,11 @@ export const useGlobalKeyShortcut = (
     if (event.ctrlKey || event.altKey || event.metaKey) {
       return;
     }
-    // ignore keyboard events from input elements
-    if ((event.target as Element).nodeName !== "INPUT") {
+    // ignore keyboard events from input elements and textareas
+    if (
+      (event.target as Element).nodeName !== "INPUT" &&
+      (event.target as Element).nodeName !== "TEXTAREA"
+    ) {
       onAfterPressed(event);
     }
   });


### PR DESCRIPTION
## Done
- Ignored keyboard events from textarea elements in `useGlobalKeyShortcut`
- Added tests for `useGlobalKeyShortcut` and `useOnKeyPressed`

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to tags
- [x] Create a new tag
- [x] Type `/` in the "Definiton" field
- [x] Ensure the `/` appears in the textarea
- [x] Ensure the textarea remains focused, and the searchbox does not get focused

<!-- Steps for QA. -->

