### PR TITLE
fix(users): Fixes for the v3 API users migration

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,6 +13,7 @@ import { Outlet } from "react-router";
 
 import packageInfo from "../../package.json";
 
+import { getMeWithSummaryQueryKey } from "./apiclient/@tanstack/react-query.gen";
 import NavigationBanner from "./base/components/AppSideNavigation/NavigationBanner";
 import PageContent from "./base/components/PageContent/PageContent";
 import SectionHeader from "./base/components/SectionHeader";
@@ -83,7 +84,10 @@ export const App = (): React.ReactElement => {
   const configErrors = useSelector(configSelectors.errors);
   const previousAuthenticated = usePrevious(authenticated, false);
 
-  const user = useGetCurrentUser();
+  const user = useGetCurrentUser(undefined, {
+    retry: false,
+    queryKey: getMeWithSummaryQueryKey(),
+  });
 
   useFetchActions([statusActions.checkAuthenticated]);
 

--- a/src/app/api/query/auth.ts
+++ b/src/app/api/query/auth.ts
@@ -20,7 +20,7 @@ import type {
 import {
   completeIntroMutation,
   getMeWithSummaryOptions,
-  listUsersWithSummaryQueryKey,
+  getMeWithSummaryQueryKey,
   loginMutation,
 } from "@/app/apiclient/@tanstack/react-query.gen";
 
@@ -30,14 +30,22 @@ export const useAuthenticate = (mutationOptions?: Options<LoginData>) => {
   });
 };
 
-export const useGetCurrentUser = (options?: Options<GetMeWithSummaryData>) => {
-  return useWebsocketAwareQuery(
-    getMeWithSummaryOptions(options) as UseQueryOptions<
-      GetMeWithSummaryResponse,
+export const useGetCurrentUser = (
+  options?: Options<GetMeWithSummaryData>,
+  queryOptions?: UseQueryOptions<
+    GetMeWithSummaryData,
+    GetMeWithSummaryError,
+    GetMeWithSummaryResponse
+  >
+) => {
+  return useWebsocketAwareQuery({
+    ...(getMeWithSummaryOptions(options) as UseQueryOptions<
+      GetMeWithSummaryData,
       GetMeWithSummaryError,
       GetMeWithSummaryResponse
-    >
-  );
+    >),
+    ...queryOptions,
+  });
 };
 
 export const useGetIsSuperUser = (options?: Options<GetMeWithSummaryData>) => {
@@ -63,7 +71,7 @@ export const useCompleteIntro = (
     ...completeIntroMutation(mutationOptions),
     onSuccess: () => {
       return queryClient.invalidateQueries({
-        queryKey: listUsersWithSummaryQueryKey(),
+        queryKey: getMeWithSummaryQueryKey(),
       });
     },
   });

--- a/src/app/api/query/users.ts
+++ b/src/app/api/query/users.ts
@@ -32,7 +32,7 @@ import {
 export const useUsers = (options?: Options<ListUsersWithSummaryData>) => {
   return useWebsocketAwareQuery(
     listUsersWithSummaryOptions(options) as UseQueryOptions<
-      ListUsersWithSummaryResponse,
+      ListUsersWithSummaryData,
       ListUsersWithSummaryError,
       ListUsersWithSummaryResponse
     >
@@ -45,7 +45,7 @@ export const useUserCount = (options?: Options<ListUsersWithSummaryData>) => {
     select: (data) => data?.total ?? 0,
   } as UseQueryOptions<
     ListUsersWithSummaryResponse,
-    ListUsersWithSummaryResponse,
+    ListUsersWithSummaryError,
     number
   >);
 };
@@ -53,7 +53,7 @@ export const useUserCount = (options?: Options<ListUsersWithSummaryData>) => {
 export const useGetUser = (options: Options<GetUserData>) => {
   return useWebsocketAwareQuery(
     getUserOptions(options) as UseQueryOptions<
-      GetUserResponse,
+      GetUserData,
       GetUserError,
       GetUserResponse
     >

--- a/src/app/intro/views/Intro.test.tsx
+++ b/src/app/intro/views/Intro.test.tsx
@@ -7,7 +7,12 @@ import { ConfigNames } from "@/app/store/config/types";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
 import { authResolvers } from "@/testing/resolvers/auth";
-import { screen, renderWithProviders, setupMockServer } from "@/testing/utils";
+import {
+  screen,
+  renderWithProviders,
+  setupMockServer,
+  waitForLoading,
+} from "@/testing/utils";
 
 const mockServer = setupMockServer(authResolvers.getCurrentUser.handler());
 
@@ -46,6 +51,29 @@ describe("Intro", () => {
           "This MAAS has not be configured. Ask an admin to log in and finish the configuration."
         )
       ).toBeInTheDocument()
+    );
+  });
+
+  it("does not display a message if the user is an admin", async () => {
+    mockServer.use(
+      authResolvers.getCurrentUser.handler(
+        factory.user({ completed_intro: false, is_superuser: true })
+      )
+    );
+    const { router } = renderWithProviders(<Intro />, {
+      initialEntries: ["/intro"],
+      state,
+    });
+    await waitFor(() =>
+      expect(router.state.location.pathname).toBe(urls.intro.index)
+    );
+    await waitForLoading();
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          "This MAAS has not be configured. Ask an admin to log in and finish the configuration."
+        )
+      ).not.toBeInTheDocument()
     );
   });
 

--- a/src/app/intro/views/Intro.tsx
+++ b/src/app/intro/views/Intro.tsx
@@ -32,7 +32,8 @@ const Intro = (): ReactElement => {
 
   const user = useGetCurrentUser();
 
-  const showIncomplete = !completedIntro && !user.data?.completed_intro;
+  const showIncomplete =
+    !completedIntro && !user.data?.completed_intro && !user.data?.is_superuser;
 
   useEffect(() => {
     if (!user.isPending && !configLoading && !showIncomplete) {

--- a/src/app/intro/views/UserIntro/UserIntro.test.tsx
+++ b/src/app/intro/views/UserIntro/UserIntro.test.tsx
@@ -1,5 +1,5 @@
 import { waitFor } from "@testing-library/react";
-import type { SpyInstance } from "vitest";
+import type { MockInstance } from "vitest";
 
 import UserIntro, { Labels as UserIntroLabels } from "./UserIntro";
 
@@ -23,7 +23,7 @@ const mockServer = setupMockServer(
 );
 
 describe("UserIntro", () => {
-  let markedIntroCompleteMock: SpyInstance;
+  let markedIntroCompleteMock: MockInstance;
   beforeEach(() => {
     markedIntroCompleteMock = vi
       .spyOn(baseHooks, "useCycled")

--- a/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -5,6 +5,7 @@ import { ActionButton, Button, Card, Icon } from "@canonical/react-components";
 import { useCompleteIntro, useGetCurrentUser } from "@/app/api/query/auth";
 import { useListSshKeys } from "@/app/api/query/sshKeys";
 import TableConfirm from "@/app/base/components/TableConfirm";
+import { useCycled } from "@/app/base/hooks";
 import IntroCard from "@/app/intro/components/IntroCard";
 import IntroSection from "@/app/intro/components/IntroSection";
 import AddSSHKey from "@/app/preferences/views/SSHKeys/components/AddSSHKey";
@@ -23,6 +24,7 @@ const UserIntro = (): React.ReactElement => {
   const user = useGetCurrentUser();
   const completeIntro = useCompleteIntro();
   const { data, isPending: sshKeyLoading } = useListSshKeys();
+  const [markedIntroComplete] = useCycled(completeIntro.isPending);
 
   const sshkeys = data?.items || [];
   const hasSSHKeys = sshkeys.length > 0;
@@ -34,7 +36,10 @@ const UserIntro = (): React.ReactElement => {
     <IntroSection
       errors={errorMessage}
       loading={user.isPending || sshKeyLoading}
-      shouldExitIntro={user.data?.completed_intro}
+      shouldExitIntro={
+        user.data?.completed_intro ||
+        (completeIntro.isSuccess && markedIntroComplete)
+      }
       windowTitle="User"
     >
       <IntroCard


### PR DESCRIPTION
## Done
- Completing the user intro redirects to the machine list instead of doing nothing
- The `IncompleteCard` is no longer shown if the user is an admin
- `me_with_summary` is only called once before the login screen is shown, instead of retrying 3 times

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

With a freshly initialised MAAS* and a new admin user:

- [ ] Open dev tools
- [ ] Go to MAAS UI
- [ ] Ensure that only one request is made to `me_with_summary`
- [ ] Log in
- [ ] Ensure you are sent to the MAAS intro
- [ ] Complete the MAAS intro
- [ ] Ensure you are sent to the user intro
- [ ] Import SSH keys from any source
- [ ] Click "Finish setup"
- [ ] Ensure you are immediately redirected to the machine list

<!-- Steps for QA. -->

## Notes

\*If you are unable to spin up a clean MAAS instance, I can provide one as needed.

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
