### PR TITLE
feat: migrate settings storage to API v3 MAASENG-5006

### DIFF
--- a/src/app/settings/utils.test.ts
+++ b/src/app/settings/utils.test.ts
@@ -1,4 +1,6 @@
-import { simpleObjectEquality } from "./utils";
+import type { PublicConfigName } from "../apiclient";
+
+import { getConfigsFromResponse, simpleObjectEquality } from "./utils";
 
 describe("settings utils", () => {
   describe("simpleObjectEquality", () => {
@@ -6,6 +8,28 @@ describe("settings utils", () => {
       const obj1 = { key1: "value1", key2: "value2" };
       const obj2 = { key1: "value1", key2: "value2" };
       expect(simpleObjectEquality(obj1, obj2)).toBe(true);
+    });
+  });
+  describe("getConfigsFromResponse", () => {
+    it("returns an object with the specified configuration names and their values", () => {
+      const items = [
+        { name: "config1", value: "value1" },
+        { name: "config2", value: "value2" },
+        { name: "config3", value: "value3" },
+      ];
+      const names = ["config1", "config3"];
+      const result = getConfigsFromResponse(items, names as PublicConfigName[]);
+      expect(result).toEqual({
+        config1: "value1",
+        config3: "value3",
+      });
+    });
+
+    it("returns an empty object if no matching configurations are found", () => {
+      const items = [{ name: "config1", value: "value1" }];
+      const names = ["config2"];
+      const result = getConfigsFromResponse(items, names as PublicConfigName[]);
+      expect(result).toEqual({});
     });
   });
 });

--- a/src/app/settings/utils.ts
+++ b/src/app/settings/utils.ts
@@ -1,3 +1,5 @@
+import type { ConfigurationResponse, PublicConfigName } from "../apiclient";
+
 import type { AnyObject } from "@/app/base/types";
 
 /**
@@ -14,4 +16,22 @@ const simpleObjectEquality = <O = AnyObject>(obj1: O, obj2: O): boolean => {
   return false;
 };
 
-export { simpleObjectEquality };
+/**
+ * Extracts configuration values from the API response.
+ * @param items - The API response items.
+ * @param names - The names of the configurations to extract.
+ * @returns An object containing the extracted configuration values.
+ */
+const getConfigsFromResponse = (
+  items: ConfigurationResponse[],
+  names: PublicConfigName[]
+): Record<PublicConfigName, unknown> => {
+  return items.reduce<Record<string, unknown>>((acc, item) => {
+    if (names.includes(item.name as PublicConfigName)) {
+      acc[item.name] = item.value;
+    }
+    return acc;
+  }, {});
+};
+
+export { simpleObjectEquality, getConfigsFromResponse };

--- a/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
+++ b/src/app/settings/views/Storage/StorageForm/StorageFormFields/StorageFormFields.test.tsx
@@ -1,16 +1,19 @@
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router";
-import configureStore from "redux-mock-store";
-
 import StorageForm from "../StorageForm";
 
 import { ConfigNames } from "@/app/store/config/types";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
-import { userEvent, screen, render, waitFor } from "@/testing/utils";
+import { configurationsResolvers } from "@/testing/resolvers/configurations";
+import {
+  userEvent,
+  screen,
+  waitFor,
+  setupMockServer,
+  renderWithProviders,
+  waitForLoading,
+} from "@/testing/utils";
 
-const mockStore = configureStore();
-
+setupMockServer(configurationsResolvers.listConfigurations.handler());
 describe("StorageFormFields", () => {
   let state: RootState;
 
@@ -30,32 +33,14 @@ describe("StorageFormFields", () => {
               ["vmfs6", "VMFS6 layout"],
             ],
           },
-          {
-            name: ConfigNames.ENABLE_DISK_ERASING_ON_RELEASE,
-            value: false,
-          },
-          {
-            name: ConfigNames.DISK_ERASE_WITH_SECURE_ERASE,
-            value: false,
-          },
-          {
-            name: ConfigNames.DISK_ERASE_WITH_QUICK_ERASE,
-            value: false,
-          },
         ],
       }),
     });
   });
 
   it("displays a warning if blank storage layout chosen", async () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <StorageForm />
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithProviders(<StorageForm />, { state });
+    await waitForLoading();
 
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: "Default storage layout" }),
@@ -69,14 +54,9 @@ describe("StorageFormFields", () => {
   });
 
   it("displays a warning if a VMFS storage layout chosen", async () => {
-    const store = mockStore(state);
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <StorageForm />
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithProviders(<StorageForm />, { state });
+    await waitForLoading();
+
     await userEvent.selectOptions(
       screen.getByRole("combobox", { name: "Default storage layout" }),
       "VMFS6 layout"


### PR DESCRIPTION
## Done
- updated StorageForm to use API v3
- updated StorageForm.test
- added function in utils.ts and wrote a test for it
- updated StorageFormFields.test

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] go to Settings/Storage
- [ ] check if fetching data uses API v3
- [ ] update values
- [ ] check if values get correctly updated
- [ ] check if update endpoint used API v3

<!-- Steps for QA. -->

## Fixes

Resolves: [MAASENG-5006](https://warthogs.atlassian.net/browse/MAASENG-5006)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes
[MAASENG-5006](https://warthogs.atlassian.net/browse/MAASENG-5006)
<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
