### PR TITLE
feat: Exchange backend notifications to toast notifications MAASENG-5095

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "@canonical/maas-react-components": "1.30.1",
     "@canonical/macaroon-bakery": "1.3.2",
-    "@canonical/react-components": "2.5.1",
+    "@canonical/react-components": "2.11.0",
     "@redux-devtools/extension": "3.3.0",
     "@reduxjs/toolkit": "2.7.0",
     "@sentry/browser": "7.119.1",

--- a/src/app/api/query/notifications.ts
+++ b/src/app/api/query/notifications.ts
@@ -1,0 +1,117 @@
+import { useEffect } from "react";
+
+import { useToastNotification } from "@canonical/react-components";
+import {
+  useMutation,
+  useQueryClient,
+  type UseQueryOptions,
+} from "@tanstack/react-query";
+
+import { useWebsocketAwareQuery } from "./base";
+
+import type {
+  DismissNotificationError,
+  DismissNotificationResponse,
+  DismissNotificationData,
+  ListNotificationsData,
+  ListNotificationsError,
+  ListNotificationsResponse,
+  Options,
+} from "@/app/apiclient";
+import {
+  dismissNotificationMutation,
+  listNotificationsOptions,
+  listNotificationsQueryKey,
+} from "@/app/apiclient/@tanstack/react-query.gen";
+
+export const useListNotifications = (
+  options?: Options<ListNotificationsData>
+) => {
+  return useWebsocketAwareQuery(
+    listNotificationsOptions(options) as UseQueryOptions<
+      ListNotificationsData,
+      ListNotificationsError,
+      ListNotificationsResponse
+    >
+  );
+};
+
+export const useNotifications = () => {
+  const backendNotifications = useListNotifications();
+  const items = backendNotifications.data?.items;
+  const notifications = useToastNotification();
+  const dismissMutatation = useDismissNotification();
+  useEffect(() => {
+    if (items === undefined) return;
+    items.forEach((item) => {
+      switch (item.category) {
+        case "success":
+          notifications.success(item.message, [
+            {
+              label: "Dismiss",
+              onClick: () => {
+                dismissMutatation.mutate({
+                  path: { notification_id: item.id },
+                });
+              },
+            },
+          ]);
+          break;
+        case "error":
+          notifications.failure(item.message, [
+            {
+              label: "Dismiss",
+              onClick: () => {
+                dismissMutatation.mutate({
+                  path: { notification_id: item.id },
+                });
+              },
+            },
+          ]);
+          break;
+        case "warning":
+          notifications.caution(item.message, [
+            {
+              label: "Dismiss",
+              onClick: () => {
+                dismissMutatation.mutate({
+                  path: { notification_id: item.id },
+                });
+              },
+            },
+          ]);
+          break;
+        case "info":
+          notifications.info(item.message, "", [
+            {
+              label: "Dismiss",
+              onClick: () => {
+                dismissMutatation.mutate({
+                  path: { notification_id: item.id },
+                });
+              },
+            },
+          ]);
+          break;
+      }
+    });
+  }, [items]);
+};
+
+export const useDismissNotification = (
+  mutationOptions?: Options<DismissNotificationData>
+) => {
+  const queryClient = useQueryClient();
+  return useMutation<
+    DismissNotificationResponse,
+    DismissNotificationError,
+    Options<DismissNotificationData>
+  >({
+    ...dismissNotificationMutation(mutationOptions),
+    onSuccess: () => {
+      return queryClient.invalidateQueries({
+        queryKey: listNotificationsQueryKey(),
+      });
+    },
+  });
+};

--- a/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/src/app/base/components/StatusBar/StatusBar.tsx
@@ -17,6 +17,7 @@ import { useSelector } from "react-redux";
 
 import TooltipButton from "../TooltipButton";
 
+import { useNotifications } from "@/app/api/query/notifications";
 import { useFetchActions, useUsabilla } from "@/app/base/hooks";
 import configSelectors from "@/app/store/config/selectors";
 import controllerSelectors from "@/app/store/controller/selectors";
@@ -118,6 +119,7 @@ export const StatusBar = (): React.ReactElement | null => {
   const { toggleListView, notifications, countBySeverity, isListView } =
     useToastNotification();
 
+  useNotifications();
   useEventListener("keydown", (e: KeyboardEvent) => {
     // Close notifications list if Escape pressed
     if (e.code === "Escape" && isListView) {
@@ -239,20 +241,20 @@ Site Manager as its upstream image source."
             {status}
           </div>
         )}
-        {hasNotifications && (
-          <Button
-            aria-label="Expand notifications list"
-            className={classNames("u-no-margin expand-button", {
-              "button-active": isListView,
-            })}
-            onClick={toggleListView}
-          >
-            {notificationIcons}
-            <span className="total-count">{notifications.length}</span>
-            <Icon name={isListView ? ICONS.chevronDown : ICONS.chevronUp} />
-          </Button>
-        )}
       </div>
+      {hasNotifications && (
+        <Button
+          aria-label="Expand notifications list"
+          className={classNames("u-no-margin expand-button", {
+            "button-active": isListView,
+          })}
+          onClick={toggleListView}
+        >
+          {notificationIcons}
+          <span className="total-count">{notifications.length}</span>
+          <Icon name={isListView ? ICONS.chevronDown : ICONS.chevronUp} />
+        </Button>
+      )}
     </AppStatus>
   );
 };

--- a/src/scss/_patterns_status-bar.scss
+++ b/src/scss/_patterns_status-bar.scss
@@ -7,6 +7,8 @@
     position: sticky;
     right: 0;
     z-index: 1;
+    display: flex;
+    justify-content: space-between;
 
     .expand-button {
      align-items: center;
@@ -14,6 +16,7 @@
      display: flex;
      gap: $sph--x-small;
      padding: 0 $sph--small !important;
+     background: none;
 
      .total-count {
        margin-left: 0.2rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,10 +962,10 @@
     "@types/sjcl" "1.0.30"
     macaroon "3.0.4"
 
-"@canonical/react-components@2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-2.5.1.tgz#4ce4734c44fd75c45ea74865a0e877540f33c934"
-  integrity sha512-9LW9U1UNILsuf2pxJPYjXuf+UGCgB+zIgMYO51RHDVWkzRGixJFPaxPgwDvquIGVrtkwB3mFiwK6uF8YlOzc8g==
+"@canonical/react-components@2.11.0":
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/@canonical/react-components/-/react-components-2.11.0.tgz#33fc07f962f1863a65b1959607521fdce616038e"
+  integrity sha512-erO67V4frwTQ3nna3KPW19y5qSyg+HFBhodKq0CKKjI2S5ZFEQe55cwWuUhP6oO7stfV+13C8tsUWmNUZvBjPw==
   dependencies:
     "@types/jest" "29.5.14"
     "@types/node" "20.17.19"
@@ -4393,11 +4393,6 @@
   dependencies:
     "@typescript-eslint/types" "8.28.0"
     eslint-visitor-keys "^4.2.0"
-
-"@use-it/event-listener@0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@use-it/event-listener/-/event-listener-0.1.7.tgz#443a9b6df87f2f2961b74d42997ce723a7078623"
-  integrity sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q==
 
 "@vitejs/plugin-react-swc@3.8.0":
   version "3.8.0"


### PR DESCRIPTION
## Done
- migrated list and dismiss notifications endpoint to API v3
- created hook that goes through backend notifications and created toast notifications of them
- fixed status bar notifications section 

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] go to Maas
- [ ] see if there is notifications section in status bar
- [ ] see if clicking notifications section opens the notifications center
- [ ] see if Notifications center works like it's described in specification 

<!-- Steps for QA. -->

## Fixes

Resolves: [MAASENG-5095](https://warthogs.atlassian.net/browse/MAASENG-5095)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots
<img width="1512" height="982" alt="Screenshot 2025-07-29 at 09 19 51" src="https://github.com/user-attachments/assets/e6892237-31cf-4461-b2c2-7b8148b7c6d5" />

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes
- dismissing doesn't work for now as it is supposed to. It will be done in next story
- position of notifications section in status bar was discussed and we will move react query dev tools button
[MAASENG-5095](https://warthogs.atlassian.net/browse/MAASENG-5095)
<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
