### PR TITLE
fix: add missing 'l' to link in CI chip in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## MAAS UI
 
-[![CI](https://github.com/canonical/maas-ui/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/test.ym?query=branch%3Amain)
+[![CI](https://github.com/canonical/maas-ui/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/test.yml?query=branch%3Amain)
 [![Playwright Tests](https://github.com/canonical/maas-ui/actions/workflows/playwright.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/playwright.yml?query=branch%3Amain)
 [![Accessibility](https://github.com/canonical/maas-ui/actions/workflows/accessibility.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/accessibility.yml?query=branch%3Amain)
 [![Cypress](https://github.com/canonical/maas-ui/actions/workflows/cypress.yml/badge.svg?branch=main)](https://github.com/canonical/maas-ui/actions/workflows/cypress.yml?query=branch%3Amain)


### PR DESCRIPTION
## Done
- fixed status link for CI chip in readme

<!--
- Itemised list of what was changed by this PR.
-->

