### PR TITLE
fix(images): Filter out empty selections in SelectUpstreamImagesForm onSubmit

### DIFF
--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.tsx
@@ -235,6 +235,9 @@ const SelectUpstreamImagesForm = (): ReactElement => {
             Object.entries(
               values as Record<string, { label: string; value: string }[]>
             ).forEach(([key, images]) => {
+              if (images.length === 0) {
+                return;
+              }
               const [osystem] = key.split("-", 1);
 
               if (osystem === "Ubuntu") {


### PR DESCRIPTION
## Done

- Added a filter-out empty return when parsing selected images

## QA steps

- [ ] Go to /images
- [ ] Open "Select upstream images" form
- [ ] Deselect an already selected image
- [ ] Click Submit
- [ ] Verify there are not errors, and the deselected image is removed from the list