### PR TITLE
feat(network): Migrated NetworkTable to GenericTable MAASENG-5204

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@canonical/maas-react-components": "1.30.1",
+    "@canonical/maas-react-components": "1.33.0",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "2.14.0",
     "@redux-devtools/extension": "3.3.0",

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
@@ -134,11 +134,10 @@ describe("NetworkTable", () => {
         name: "vlan-name",
       });
       state.vlan.items = [vlan];
-      const subnets = [
+      state.subnet.items = [
         factory.subnet({ cidr: "subnet-cidr", name: "subnet-name" }),
         factory.subnet({ cidr: "subnet2-cidr", name: "subnet2-name" }),
       ];
-      state.subnet.items = subnets;
       machine = factory.machineDetails({
         interfaces: [
           factory.machineInterface({

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.test.tsx
@@ -1,19 +1,37 @@
-import NetworkTable, { Label } from "./NetworkTable";
+import type { Mock } from "vitest";
+import { describe } from "vitest";
 
+import NetworkTable from "@/app/base/components/node/networking/NetworkTable/NetworkTable";
 import { Label as PXEColumnLabel } from "@/app/base/components/node/networking/NetworkTable/PXEColumn/PXEColumn";
-import { Label as NetworkTableActionsLabel } from "@/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions/NetworkTableActions";
+import { useSidePanel } from "@/app/base/side-panel-context";
 import type { MachineDetails } from "@/app/store/machine/types";
 import type { RootState } from "@/app/store/root/types";
 import { NetworkInterfaceTypes } from "@/app/store/types/enum";
 import * as factory from "@/testing/factories";
 import {
-  userEvent,
-  screen,
-  within,
   renderWithBrowserRouter,
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+  within,
 } from "@/testing/utils";
 
+vi.mock("@/app/base/side-panel-context", async () => {
+  const actual = await vi.importActual("@/app/base/side-panel-context");
+  return {
+    ...actual,
+    useSidePanel: vi.fn(),
+  };
+});
+
 describe("NetworkTable", () => {
+  const mockSetSidePanelContent = vi.fn();
+
+  (useSidePanel as Mock).mockReturnValue({
+    setSidePanelContent: mockSetSidePanelContent,
+  });
+
   let state: RootState;
   let machine: MachineDetails;
   beforeEach(() => {
@@ -38,265 +56,226 @@ describe("NetworkTable", () => {
     });
   });
 
-  it("can display an interface that has no links", () => {
-    const fabric = factory.fabric({ name: "fabric-name" });
-    state.fabric.items = [fabric];
-    const vlan = factory.vlan({ fabric: fabric.id, vid: 2, name: "vlan-name" });
-    state.vlan.items = [vlan];
-    const subnets = [
-      factory.subnet({ cidr: "subnet-cidr", name: "subnet-name" }),
-      factory.subnet({ cidr: "subnet2-cidr", name: "subnet2-name" }),
-    ];
-    state.subnet.items = subnets;
-    machine = factory.machineDetails({
-      interfaces: [
-        factory.machineInterface({
-          discovered: null,
-          links: [],
-          type: NetworkInterfaceTypes.BOND,
-          vlan_id: vlan.id,
+  describe("display", () => {
+    it("displays a loading component if zones are loading", async () => {
+      const state = factory.rootState({
+        fabric: factory.fabricState({
+          loaded: false,
         }),
-      ],
-      system_id: "abc123",
+        machine: factory.machineState({
+          items: [machine],
+          loaded: true,
+          statuses: {
+            abc123: factory.machineStatus(),
+          },
+        }),
+      });
+      renderWithProviders(<NetworkTable node={machine} />, { state });
+
+      await waitFor(() => {
+        expect(screen.getByText("Loading...")).toBeInTheDocument();
+      });
     });
-    state.machine.items = [machine];
-    renderWithBrowserRouter(
-      <NetworkTable
-        node={machine}
-        selected={[]}
-        setExpanded={vi.fn()}
-        setSelected={vi.fn()}
-      />,
-      { state }
-    );
-    const subnetCol = screen.getByRole("gridcell", { name: Label.Subnet });
-    const subnetPrimary = within(subnetCol).getByTestId("primary");
-    expect(within(subnetPrimary).getByText("Unconfigured")).toBeInTheDocument();
-    const ipCol = screen.getByRole("gridcell", { name: Label.IP });
-    const ipPrimary = within(ipCol).getByTestId("primary");
-    expect(within(ipPrimary).getByText("Unconfigured")).toBeInTheDocument();
+
+    it("displays a message when rendering an empty list", async () => {
+      renderWithProviders(<NetworkTable node={machine} />, { state });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("No interfaces available.")
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("displays the columns correctly", () => {
+      renderWithProviders(
+        <NetworkTable
+          node={machine}
+          setExpanded={vi.fn()}
+          setSelected={vi.fn()}
+        />
+      );
+
+      [
+        "Name",
+        "PXE",
+        "Link/Interface Speed",
+        "Type",
+        "Fabric",
+        "Subnet",
+        "IP Address",
+        "DHCP",
+        "Action",
+      ].forEach((column) => {
+        expect(
+          screen.getByRole("columnheader", {
+            name: new RegExp(`^${column}`, "i"),
+          })
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("omits Action column when setExpanded is not provided", () => {
+      renderWithProviders(<NetworkTable node={machine} />);
+
+      expect(
+        screen.queryByRole("columnheader", {
+          name: new RegExp(`^Action`, "i"),
+        })
+      ).not.toBeInTheDocument();
+    });
+
+    it("can display an interface that has no links", () => {
+      const fabric = factory.fabric({ name: "fabric-name" });
+      state.fabric.items = [fabric];
+      const vlan = factory.vlan({
+        fabric: fabric.id,
+        vid: 2,
+        name: "vlan-name",
+      });
+      state.vlan.items = [vlan];
+      const subnets = [
+        factory.subnet({ cidr: "subnet-cidr", name: "subnet-name" }),
+        factory.subnet({ cidr: "subnet2-cidr", name: "subnet2-name" }),
+      ];
+      state.subnet.items = subnets;
+      machine = factory.machineDetails({
+        interfaces: [
+          factory.machineInterface({
+            discovered: null,
+            links: [],
+            type: NetworkInterfaceTypes.BOND,
+            vlan_id: vlan.id,
+          }),
+        ],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      renderWithBrowserRouter(
+        <NetworkTable
+          node={machine}
+          setExpanded={vi.fn()}
+          setSelected={vi.fn()}
+        />,
+        { state }
+      );
+
+      const row = screen.getAllByRole("row")[1];
+      const cells = within(row).getAllByRole("cell");
+      const subnetCell = cells[6];
+      expect(subnetCell).toHaveTextContent("Unconfigured");
+      const ipCell = cells[7];
+      expect(ipCell).toHaveTextContent("Unconfigured");
+    });
+
+    it("can display an interface that has a link", () => {
+      const fabric = factory.fabric({ name: "fabric-name" });
+      state.fabric.items = [fabric];
+      const vlan = factory.vlan({
+        fabric: fabric.id,
+        vid: 2,
+        name: "vlan-name",
+      });
+      state.vlan.items = [vlan];
+      const subnet = factory.subnet({
+        cidr: "subnet-cidr",
+        name: "subnet-name",
+      });
+      state.subnet.items = [subnet];
+      machine = factory.machineDetails({
+        interfaces: [
+          factory.machineInterface({
+            discovered: null,
+            links: [
+              factory.networkLink({
+                subnet_id: subnet.id,
+                ip_address: "1.2.3.99",
+              }),
+            ],
+            type: NetworkInterfaceTypes.BOND,
+            vlan_id: vlan.id,
+          }),
+        ],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      renderWithBrowserRouter(
+        <NetworkTable
+          node={machine}
+          setExpanded={vi.fn()}
+          setSelected={vi.fn()}
+        />,
+        { state }
+      );
+
+      const row = screen.getAllByRole("row")[1];
+      const cells = within(row).getAllByRole("cell");
+      const subnetCell = cells[6];
+      expect(subnetCell).toHaveTextContent("subnet-cidr");
+      const ipCell = cells[7];
+      expect(ipCell).toHaveTextContent("1.2.3.99");
+    });
+
+    it("can display an interface that is an alias", () => {
+      const fabric = factory.fabric({ name: "fabric-name" });
+      state.fabric.items = [fabric];
+      const vlan = factory.vlan({
+        fabric: fabric.id,
+        vid: 2,
+        name: "vlan-name",
+      });
+      state.vlan.items = [vlan];
+      const subnets = [
+        factory.subnet({ cidr: "subnet-cidr", name: "subnet-name" }),
+        factory.subnet({ cidr: "subnet2-cidr", name: "subnet2-name" }),
+      ];
+      const ipAddresses = ["1.2.3.99", "1.2.3.101"];
+      state.subnet.items = subnets;
+      machine = factory.machineDetails({
+        interfaces: [
+          factory.machineInterface({
+            discovered: null,
+            links: [
+              factory.networkLink({
+                subnet_id: subnets[0].id,
+                ip_address: ipAddresses[0],
+              }),
+              factory.networkLink({
+                subnet_id: subnets[1].id,
+                ip_address: ipAddresses[1],
+              }),
+            ],
+            name: "alias",
+            type: NetworkInterfaceTypes.ALIAS,
+            vlan_id: vlan.id,
+          }),
+        ],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      renderWithBrowserRouter(
+        <NetworkTable
+          node={machine}
+          setExpanded={vi.fn()}
+          setSelected={vi.fn()}
+        />,
+        { state }
+      );
+
+      const rows = screen.getAllByRole("row").slice(1);
+      rows.forEach((row, index) => {
+        const cells = within(row).getAllByRole("cell");
+        const nameCell = cells[1];
+        expect(nameCell).toHaveTextContent("alias");
+        const subnetCell = cells[6];
+        expect(subnetCell).toHaveTextContent(subnets[index].name);
+        const ipCell = cells[7];
+        expect(ipCell).toHaveTextContent(ipAddresses[index]);
+      });
+    });
   });
 
-  it("can display an interface that has a link", () => {
-    const fabric = factory.fabric({ name: "fabric-name" });
-    state.fabric.items = [fabric];
-    const vlan = factory.vlan({ fabric: fabric.id, vid: 2, name: "vlan-name" });
-    state.vlan.items = [vlan];
-    const subnet = factory.subnet({ cidr: "subnet-cidr", name: "subnet-name" });
-    state.subnet.items = [subnet];
-    machine = factory.machineDetails({
-      interfaces: [
-        factory.machineInterface({
-          discovered: null,
-          links: [
-            factory.networkLink({
-              subnet_id: subnet.id,
-              ip_address: "1.2.3.99",
-            }),
-          ],
-          type: NetworkInterfaceTypes.BOND,
-          vlan_id: vlan.id,
-        }),
-      ],
-      system_id: "abc123",
-    });
-    state.machine.items = [machine];
-    renderWithBrowserRouter(
-      <NetworkTable
-        node={machine}
-        selected={[]}
-        setExpanded={vi.fn()}
-        setSelected={vi.fn()}
-      />,
-      { state }
-    );
-    const subnetCol = screen.getByRole("gridcell", { name: Label.Subnet });
-    expect(
-      within(subnetCol).getByRole("link", { name: "subnet-cidr" })
-    ).toBeInTheDocument();
-    const ipCol = screen.getByRole("gridcell", { name: Label.IP });
-    const ipPrimary = within(ipCol).getByTestId("primary");
-    expect(within(ipPrimary).getByText("1.2.3.99")).toBeInTheDocument();
-  });
-
-  it("displays a message when empty", () => {
-    state.subnet.items = [];
-    state.fabric.items = [];
-    state.vlan.items = [];
-    state.machine.items = [machine];
-
-    renderWithBrowserRouter(
-      <NetworkTable
-        node={machine}
-        selected={[]}
-        setExpanded={vi.fn()}
-        setSelected={vi.fn()}
-      />,
-      { state }
-    );
-
-    expect(screen.getByText(Label.EmptyList)).toBeInTheDocument();
-  });
-
-  it("can display an interface that is an alias", () => {
-    const fabric = factory.fabric({ name: "fabric-name" });
-    state.fabric.items = [fabric];
-    const vlan = factory.vlan({ fabric: fabric.id, vid: 2, name: "vlan-name" });
-    state.vlan.items = [vlan];
-    const subnets = [
-      factory.subnet({ cidr: "subnet-cidr", name: "subnet-name" }),
-      factory.subnet({ cidr: "subnet2-cidr", name: "subnet2-name" }),
-    ];
-    state.subnet.items = subnets;
-    machine = factory.machineDetails({
-      interfaces: [
-        factory.machineInterface({
-          discovered: null,
-          links: [
-            factory.networkLink({
-              subnet_id: subnets[0].id,
-              ip_address: "1.2.3.99",
-            }),
-            factory.networkLink({
-              subnet_id: subnets[1].id,
-              ip_address: "1.2.3.101",
-            }),
-          ],
-          name: "alias",
-          type: NetworkInterfaceTypes.ALIAS,
-          vlan_id: vlan.id,
-        }),
-      ],
-      system_id: "abc123",
-    });
-    state.machine.items = [machine];
-    renderWithBrowserRouter(
-      <NetworkTable
-        node={machine}
-        selected={[]}
-        setExpanded={vi.fn()}
-        setSelected={vi.fn()}
-      />,
-      { state }
-    );
-    const alias = screen.getByTestId("alias:1");
-    expect(alias).toBeInTheDocument();
-    const subnetCol = within(alias).getByRole("gridcell", {
-      name: Label.Subnet,
-    });
-    expect(
-      within(subnetCol).getByRole("link", { name: "subnet2-cidr" })
-    ).toBeInTheDocument();
-    const ipCol = within(alias).getByRole("gridcell", { name: Label.IP });
-    const ipPrimary = within(ipCol).getByTestId("primary");
-    expect(within(ipPrimary).getByText("1.2.3.101")).toBeInTheDocument();
-  });
-
-  it("displays actions", () => {
-    machine = factory.machineDetails({
-      interfaces: [
-        factory.machineInterface({
-          id: 100,
-          is_boot: false,
-          name: "bond0",
-          parents: [101],
-          type: NetworkInterfaceTypes.BOND,
-        }),
-        factory.machineInterface({
-          id: 101,
-          children: [100],
-          is_boot: true,
-          name: "eth0",
-          type: NetworkInterfaceTypes.PHYSICAL,
-        }),
-        factory.machineInterface({
-          id: 102,
-          name: "eth1",
-          type: NetworkInterfaceTypes.PHYSICAL,
-        }),
-      ],
-      system_id: "abc123",
-    });
-    state.machine.items = [machine];
-    renderWithBrowserRouter(
-      <NetworkTable
-        node={machine}
-        selected={[]}
-        setExpanded={vi.fn()}
-        setSelected={vi.fn()}
-      />,
-      { state }
-    );
-    expect(
-      screen.getByRole("grid").className.includes("network-table--has-actions")
-    ).toBe(true);
-    // The check-all checkbox should be in the header.
-    expect(
-      within(screen.getByRole("columnheader", { name: Label.Name })).getByRole(
-        "checkbox"
-      )
-    ).toBeInTheDocument();
-    // There should be a checkbox for the child interface.
-    expect(
-      within(screen.getByTestId("bond0")).getByRole("checkbox")
-    ).toBeInTheDocument();
-    // There should be a checkbox for the physical nic.
-    const nic = screen.getByTestId("eth1");
-    expect(within(nic).getByRole("checkbox")).toBeInTheDocument();
-    // There should be an actions menu for the physical nic.
-    expect(
-      within(nic).getByLabelText(NetworkTableActionsLabel.Title)
-    ).toBeInTheDocument();
-  });
-
-  it("can display without actions", () => {
-    const controller = factory.controllerDetails({
-      interfaces: [
-        factory.machineInterface({
-          id: 100,
-          is_boot: false,
-          name: "bond0",
-          parents: [101],
-          type: NetworkInterfaceTypes.BOND,
-        }),
-        factory.machineInterface({
-          id: 101,
-          children: [100],
-          is_boot: true,
-          name: "eth0",
-          type: NetworkInterfaceTypes.PHYSICAL,
-        }),
-        factory.machineInterface({
-          id: 102,
-          name: "eth1",
-          type: NetworkInterfaceTypes.PHYSICAL,
-        }),
-      ],
-      system_id: "abc123",
-    });
-    state.controller.items = [controller];
-    renderWithBrowserRouter(<NetworkTable node={controller} />, {
-      state,
-    });
-    expect(
-      screen.getByRole("grid").className.includes("network-table--has-actions")
-    ).toBe(false);
-    // The check-all checkbox should not be in the header.
-    const header = screen.getByRole("columnheader", { name: Label.Name });
-    expect(within(header).queryByRole("checkbox")).not.toBeInTheDocument();
-    // There should not be a checkbox for the child interface.
-    const bond = screen.getByTestId("bond0");
-    expect(within(bond).queryByRole("checkbox")).not.toBeInTheDocument();
-    // There should not be a checkbox for the physical nic.
-    const nic = screen.getByTestId("eth1");
-    expect(within(nic).queryByRole("checkbox")).not.toBeInTheDocument();
-    // There should not be an actions menu for the physical nic.
-    expect(
-      within(nic).queryByLabelText(NetworkTableActionsLabel.Title)
-    ).not.toBeInTheDocument();
-  });
-
-  describe("bond and bridge interfaces", () => {
+  describe("subrows", () => {
     beforeEach(() => {
       machine = factory.machineDetails({
         interfaces: [
@@ -324,257 +303,71 @@ describe("NetworkTable", () => {
       renderWithBrowserRouter(
         <NetworkTable
           node={machine}
-          selected={[]}
           setExpanded={vi.fn()}
           setSelected={vi.fn()}
         />,
         { state }
       );
-      // There should be one checkbox for the child interface.
-      expect(
-        within(screen.getByTestId("bond0")).getByRole("checkbox")
-      ).toBeInTheDocument();
-      const nic = screen.getByTestId("eth0");
-      expect(within(nic).queryByRole("checkbox")).not.toBeInTheDocument();
+
+      const rows = screen.getAllByRole("row");
+      const bondRow = rows[1];
+      expect(within(bondRow).getByRole("checkbox")).toBeInTheDocument();
+      const nicRow = rows[2];
+      expect(within(nicRow).queryByRole("checkbox")).toBeDisabled();
     });
 
-    it("does not include parent interfaces in the GroupCheckbox", async () => {
+    it("does not include parent interfaces in the selection", async () => {
       const setSelected = vi.fn();
       renderWithBrowserRouter(
         <NetworkTable
           node={machine}
-          selected={[]}
           setExpanded={vi.fn()}
           setSelected={setSelected}
         />,
         { state }
       );
-      await userEvent.click(
-        within(
-          screen.getByRole("columnheader", { name: Label.Name })
-        ).getByRole("checkbox")
-      );
-      expect(setSelected).toHaveBeenCalledWith([
-        { linkId: undefined, nicId: 100 },
-      ]);
+      const rows = screen.getAllByRole("row");
+      const bondRow = rows[1];
+      await userEvent.click(within(bondRow).getByRole("checkbox"));
+      expect(setSelected).toHaveBeenCalledWith([{ linkId: null, nicId: 100 }]);
     });
 
     it("does not display a boot icon for parent interfaces", () => {
       renderWithBrowserRouter(
         <NetworkTable
           node={machine}
-          selected={[]}
           setExpanded={vi.fn()}
           setSelected={vi.fn()}
         />,
         { state }
       );
-      const row = screen.getByTestId("eth0");
+      const row = screen.getAllByRole("row")[2];
       expect(
         within(row).queryByLabelText(PXEColumnLabel.IsBoot)
       ).not.toBeInTheDocument();
     });
 
-    it("does not display a fabric column for parent interfaces", () => {
+    it("filters columns for parent interfaces", () => {
       renderWithBrowserRouter(
         <NetworkTable
           node={machine}
-          selected={[]}
           setExpanded={vi.fn()}
           setSelected={vi.fn()}
         />,
         { state }
       );
-      const row = screen.getByTestId("eth0");
-      expect(
-        within(row).queryByRole("gridcell", {
-          name: Label.Fabric,
-        })?.textContent
-      ).toBeFalsy();
-    });
-
-    it("does not display a DHCP column for parent interfaces", () => {
-      renderWithBrowserRouter(
-        <NetworkTable
-          node={machine}
-          selected={[]}
-          setExpanded={vi.fn()}
-          setSelected={vi.fn()}
-        />,
-        { state }
-      );
-      const row = screen.getByTestId("eth0");
-      expect(
-        within(row).queryByRole("gridcell", {
-          name: Label.DHCP,
-        })?.textContent
-      ).toBeFalsy();
-    });
-
-    it("does not display a subnet column for parent interfaces", () => {
-      renderWithBrowserRouter(
-        <NetworkTable
-          node={machine}
-          selected={[]}
-          setExpanded={vi.fn()}
-          setSelected={vi.fn()}
-        />,
-        { state }
-      );
-      const row = screen.getByTestId("eth0");
-      expect(
-        within(row).queryByRole("gridcell", {
-          name: Label.Subnet,
-        })?.textContent
-      ).toBeFalsy();
-    });
-
-    it("does not display an IP column for parent interfaces", () => {
-      renderWithBrowserRouter(
-        <NetworkTable
-          node={machine}
-          selected={[]}
-          setExpanded={vi.fn()}
-          setSelected={vi.fn()}
-        />,
-        { state }
-      );
-      const row = screen.getByTestId("eth0");
-      expect(
-        within(row).queryByRole("gridcell", {
-          name: Label.IP,
-        })?.textContent
-      ).toBeFalsy();
-    });
-
-    it("does not display an actions menu for parent interfaces", () => {
-      renderWithBrowserRouter(
-        <NetworkTable
-          node={machine}
-          selected={[]}
-          setExpanded={vi.fn()}
-          setSelected={vi.fn()}
-        />,
-        { state }
-      );
-      const row = screen.getByTestId("eth0");
-      expect(
-        within(row).queryByLabelText(NetworkTableActionsLabel.Title)
-      ).not.toBeInTheDocument();
-    });
-  });
-
-  describe("sorting", () => {
-    beforeEach(() => {
-      machine = factory.machineDetails({
-        interfaces: [
-          factory.machineInterface({
-            id: 100,
-            name: "bond0",
-            parents: [101, 104],
-            type: NetworkInterfaceTypes.BOND,
-          }),
-          factory.machineInterface({
-            children: [100],
-            id: 101,
-            name: "eth0",
-            type: NetworkInterfaceTypes.PHYSICAL,
-          }),
-          factory.machineInterface({
-            id: 102,
-            links: [factory.networkLink(), factory.networkLink()],
-            name: "br0",
-            parents: [103],
-            type: NetworkInterfaceTypes.BRIDGE,
-          }),
-          factory.machineInterface({
-            children: [102],
-            id: 103,
-            name: "eth1",
-            type: NetworkInterfaceTypes.PHYSICAL,
-          }),
-          factory.machineInterface({
-            id: 99,
-            name: "eth2",
-            parents: [],
-            type: NetworkInterfaceTypes.PHYSICAL,
-          }),
-          factory.machineInterface({
-            children: [100],
-            id: 104,
-            name: "eth3",
-            type: NetworkInterfaceTypes.PHYSICAL,
-          }),
-        ],
-        system_id: "abc123",
-      });
-      state.machine.items = [machine];
-    });
-
-    it("groups the bonds and bridges", () => {
-      renderWithBrowserRouter(
-        <NetworkTable
-          node={machine}
-          selected={[]}
-          setExpanded={vi.fn()}
-          setSelected={vi.fn()}
-        />,
-        { state }
-      );
-      const names = screen
-        .getAllByRole("row")
-        .map((row) => row.getAttribute("data-testid"))
-        // Remove the header.
-        .filter(Boolean);
-      expect(names).toStrictEqual([
-        // Bond group:
-        "bond0",
-        "eth0", // bond parent
-        "eth3", // bond parent
-        // Bridge group:
-        "br0",
-        "eth1", // bridge parent
-        // Alias:
-        "br0:1",
-        // Physical:
-        "eth2",
-      ]);
-    });
-
-    it("groups the bonds and bridges when in reverse order", async () => {
-      renderWithBrowserRouter(
-        <NetworkTable
-          node={machine}
-          selected={[]}
-          setExpanded={vi.fn()}
-          setSelected={vi.fn()}
-        />,
-        { state }
-      );
-
-      await userEvent.click(
-        within(
-          screen.getByRole("columnheader", { name: Label.Name })
-        ).getByRole("button", { name: `${Label.Name} (descending)` })
-      );
-      const names = screen
-        .getAllByRole("row")
-        .map((row) => row.getAttribute("data-testid"))
-        // Remove the header.
-        .filter(Boolean);
-      expect(names).toStrictEqual([
-        // Physical:
-        "eth2",
-        // Alias:
-        "br0:1",
-        // Bridge group:
-        "br0",
-        "eth1", // bridge parent
-        // Bond group (parents inside bond are in reverse order):
-        "bond0",
-        "eth3", // bond parent
-        "eth0", // bond parent
-      ]);
+      const row = screen.getAllByRole("row")[2];
+      const cells = within(row).queryAllByRole("cell");
+      const fabricCell = cells[5];
+      expect(fabricCell).toHaveTextContent("");
+      const subnetCell = cells[6];
+      expect(subnetCell).toHaveTextContent("");
+      const ipCell = cells[7];
+      expect(ipCell).toHaveTextContent("");
+      const dhcpCell = cells[8];
+      expect(dhcpCell).toHaveTextContent("");
+      const actionCell = cells[9];
+      expect(actionCell).toHaveTextContent("");
     });
   });
 });

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.tsx
@@ -1,36 +1,20 @@
-import type { ValueOf } from "@canonical/react-components";
-import { MainTable } from "@canonical/react-components";
-import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import { useEffect, useState } from "react";
+
+import { GenericTable } from "@canonical/maas-react-components";
+import type { RowSelectionState } from "@tanstack/react-table";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
 
-import IPColumn from "./IPColumn";
-import PXEColumn from "./PXEColumn";
-import SpeedColumn from "./SpeedColumn";
-
-import GroupCheckbox from "@/app/base/components/GroupCheckbox";
-import type {
-  Expanded,
-  SetExpanded,
-} from "@/app/base/components/NodeNetworkTab/NodeNetworkTab";
-import TableHeader from "@/app/base/components/TableHeader";
-import DHCPColumn from "@/app/base/components/node/networking/DHCPColumn";
-import FabricColumn from "@/app/base/components/node/networking/FabricColumn";
-import NameColumn from "@/app/base/components/node/networking/NameColumn";
-import SubnetColumn from "@/app/base/components/node/networking/SubnetColumn";
-import TypeColumn from "@/app/base/components/node/networking/TypeColumn";
+import type { SetExpanded } from "@/app/base/components/NodeNetworkTab/NodeNetworkTab";
+import useNetworkTableColumns, {
+  filterCells,
+  filterHeaders,
+} from "@/app/base/components/node/networking/NetworkTable/useNetworkTableColumns/useNetworkTableColumns";
 import type {
   Selected,
   SetSelected,
 } from "@/app/base/components/node/networking/types";
-import {
-  useFetchActions,
-  useIsAllNetworkingDisabled,
-  useTableSort,
-} from "@/app/base/hooks";
-import type { Sort } from "@/app/base/types";
-import { SortDirection } from "@/app/base/types";
-import NetworkTableActions from "@/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions";
+import { useFetchActions, useIsAllNetworkingDisabled } from "@/app/base/hooks";
 import type { ControllerDetails } from "@/app/store/controller/types";
 import { fabricActions } from "@/app/store/fabric";
 import fabricSelectors from "@/app/store/fabric/selectors";
@@ -51,14 +35,11 @@ import {
   isBondOrBridgeChild,
   isBondOrBridgeParent,
   isBootInterface,
-  nodeIsMachine,
 } from "@/app/store/utils";
 import { vlanActions } from "@/app/store/vlan";
 import vlanSelectors from "@/app/store/vlan/selectors";
 import type { VLAN } from "@/app/store/vlan/types";
 import { getDHCPStatus } from "@/app/store/vlan/utils";
-import { generateCheckboxHandlers, isComparable } from "@/app/utils";
-import type { CheckboxHandlers } from "@/app/utils/generateCheckboxHandlers";
 
 export const Label = {
   Actions: "Actions",
@@ -79,7 +60,8 @@ export const Label = {
   VLAN: "VLAN",
 } as const;
 
-type NetworkRowSortData = {
+export type Network = {
+  id: string;
   bondOrBridge: NetworkInterface["id"] | null;
   dhcp: string | null;
   fabric: string | null;
@@ -91,384 +73,171 @@ type NetworkRowSortData = {
   speed: NetworkInterface["link_speed"];
   subnet: string | null;
   type: string | null;
+  nic: NetworkInterface;
+  link: NetworkLink | null;
+  children?: Network[];
 };
-
-type NetworkRow = Omit<MainTableRow, "sortData"> & {
-  "data-testid"?: string;
-  select: Selected | null;
-  sortData: NetworkRowSortData;
-};
-
-type SortKey = keyof NetworkRowSortData;
-
-const getSortValue = (sortKey: SortKey, row: NetworkRow) => {
-  const value = row.sortData[sortKey];
-  return isComparable(value) ? value : null;
-};
-
-const generateColumnData = (
-  checkboxHandler: CheckboxHandlers<Selected> | null,
-  hasActions: boolean,
-  isABondOrBridgeParent: boolean,
-  link: NetworkLink | null,
-  nic: NetworkInterface,
-  node: ControllerDetails | MachineDetails,
-  selected: Props["selected"],
-  setExpanded?: SetExpanded,
-  setSelected?: Props["setSelected"]
-) => [
-  {
-    "aria-label": Label.Name,
-    content: (
-      <NameColumn
-        checkSelected={checkboxHandler?.checkSelected}
-        checkboxSpace={
-          // When interfaces can't be selected then we still need to add space so
-          // the parent rows appear nested under the bond or bridge.
-          (!hasActions && isABondOrBridgeParent) || isABondOrBridgeParent
-        }
-        handleRowCheckbox={checkboxHandler?.handleRowCheckbox}
-        link={link}
-        nic={nic}
-        node={node}
-        selected={selected}
-        showCheckbox={!isABondOrBridgeParent && hasActions}
-      />
-    ),
-  },
-  {
-    "aria-label": Label.PXE,
-    content: !isABondOrBridgeParent && (
-      <PXEColumn link={link} nic={nic} node={node} />
-    ),
-    className: "u-align--center",
-  },
-  {
-    "aria-label": Label.Speed,
-    content: <SpeedColumn link={link} nic={nic} node={node} />,
-  },
-  {
-    "aria-label": Label.Type,
-    content: <TypeColumn link={link} nic={nic} node={node} />,
-  },
-  {
-    "aria-label": Label.Fabric,
-    content: !isABondOrBridgeParent && (
-      <FabricColumn link={link} nic={nic} node={node} />
-    ),
-  },
-  {
-    "aria-label": Label.Subnet,
-    content: !isABondOrBridgeParent && (
-      <SubnetColumn link={link} nic={nic} node={node} />
-    ),
-  },
-  {
-    "aria-label": Label.IP,
-    content: !isABondOrBridgeParent && (
-      <IPColumn link={link} nic={nic} node={node} />
-    ),
-  },
-  {
-    "aria-label": Label.DHCP,
-    content: !isABondOrBridgeParent && <DHCPColumn nic={nic} />,
-  },
-  ...(hasActions
-    ? [
-        {
-          "aria-label": Label.Actions,
-          className: "u-align--right",
-          content:
-            !isABondOrBridgeParent && nodeIsMachine(node) && setExpanded ? (
-              <NetworkTableActions
-                link={link}
-                nic={nic}
-                selected={selected}
-                setSelected={setSelected}
-                systemId={node.system_id}
-              />
-            ) : null,
-        },
-      ]
-    : []),
-];
-
-const generateRow = (
-  checkboxHandler: CheckboxHandlers<Selected> | null,
-  fabrics: Fabric[],
-  fabricsLoaded: boolean,
-  isAllNetworkingDisabled: boolean,
-  link: NetworkLink | null,
-  node: ControllerDetails | MachineDetails,
-  nic: NetworkInterface | null,
-  selected: Props["selected"],
-  subnets: Subnet[],
-  vlans: VLAN[],
-  vlansLoaded: boolean,
-  hasActions: boolean,
-  setSelected: Props["setSelected"],
-  setExpanded?: SetExpanded
-): NetworkRow | null => {
-  if (link && !nic) {
-    [nic] = getLinkInterface(node, link);
-  }
-  if (!nic) {
-    return null;
-  }
-  const isABondOrBridgeParent = isBondOrBridgeParent(node, nic, link);
-  const isABondOrBridgeChild = isBondOrBridgeChild(node, nic, link);
-  const isBoot = isBootInterface(node, nic, link);
-  const vlan = vlans.find(({ id }) => id === nic?.vlan_id);
-  const fabric = getInterfaceFabric(node, fabrics, vlans, nic, link);
-  const name = getInterfaceName(node, nic, link);
-  const interfaceTypeDisplay = getInterfaceTypeText(node, nic, link, true);
-  const shouldShowDHCP = !isABondOrBridgeParent && fabricsLoaded && vlansLoaded;
-  const fabricContent = !isABondOrBridgeParent
-    ? fabric?.name || "Disconnected"
-    : null;
-  const subnet = getInterfaceSubnet(
-    node,
-    subnets,
-    fabrics,
-    vlans,
-    isAllNetworkingDisabled,
-    nic,
-    link
-  );
-  const columns = generateColumnData(
-    checkboxHandler,
-    hasActions,
-    isABondOrBridgeParent,
-    link,
-    nic,
-    node,
-    selected,
-    setExpanded,
-    setSelected
-  );
-
-  return {
-    className: classNames("p-table__row", {
-      "truncated-border": isABondOrBridgeParent,
-    }),
-    columns,
-    "data-testid": name,
-    key: name,
-    select:
-      !isABondOrBridgeParent && hasActions
-        ? { linkId: link?.id, nicId: nic?.id }
-        : null,
-    sortData: {
-      bondOrBridge:
-        (nic &&
-          ((isABondOrBridgeParent && nic.children[0]) ||
-            (isABondOrBridgeChild && nic.id))) ||
-        null,
-      dhcp: shouldShowDHCP ? getDHCPStatus(vlan, vlans, fabrics) : null,
-      fabric: fabricContent,
-      ip: getInterfaceIPAddressOrMode(node, fabrics, vlans, nic, link) || null,
-      isABondOrBridgeChild,
-      isABondOrBridgeParent,
-      name: name,
-      pxe: isBoot,
-      speed: nic.link_speed,
-      subnet: getSubnetDisplay(subnet),
-      type: interfaceTypeDisplay,
-    },
-  };
-};
-
-const generateRows = (
-  checkboxHandler: CheckboxHandlers<Selected> | null,
-  fabrics: Fabric[],
-  fabricsLoaded: boolean,
-  isAllNetworkingDisabled: boolean,
-  node: ControllerDetails | MachineDetails,
-  selected: Props["selected"],
-  subnets: Subnet[],
-  vlans: VLAN[],
-  vlansLoaded: boolean,
-  hasActions: boolean,
-  setSelected: Props["setSelected"],
-  setExpanded?: (expanded: Expanded | null) => void
-): NetworkRow[] => {
-  const rows: NetworkRow[] = [];
-  // Create a list of interfaces and aliases to use to generate the table rows.
-  node.interfaces.forEach((nic: NetworkInterface) => {
-    const createRow = (
-      link: NetworkLink | null,
-      nic: NetworkInterface | null
-    ) =>
-      generateRow(
-        checkboxHandler,
-        fabrics,
-        fabricsLoaded,
-        isAllNetworkingDisabled,
-        link,
-        node,
-        nic,
-        selected,
-        subnets,
-        vlans,
-        vlansLoaded,
-        hasActions,
-        setSelected,
-        setExpanded
-      );
-    if (nic.links.length === 0) {
-      const row = createRow(null, nic);
-      if (row) {
-        rows.push(row);
-      }
-    } else {
-      nic.links.forEach((link: NetworkLink) => {
-        const row = createRow(link, null);
-        if (row) {
-          rows.push(row);
-        }
-      });
-    }
-  });
-  return rows;
-};
-
-const getChild = (row: NetworkRow, rows: NetworkRow[]): NetworkRow | null => {
-  if (!row.sortData.isABondOrBridgeParent) {
-    return null;
-  }
-  return (
-    rows.find(
-      ({ sortData }) =>
-        sortData.isABondOrBridgeChild &&
-        sortData.bondOrBridge === row.sortData.bondOrBridge
-    ) || null
-  );
-};
-
-const compareValues = (
-  rowAValue: number | string | null,
-  rowBValue: number | string | null,
-  direction: ValueOf<typeof SortDirection>
-) => {
-  if (!rowAValue && !rowBValue) {
-    return 0;
-  }
-  if (
-    (rowBValue && !rowAValue) ||
-    (isComparable(rowAValue) &&
-      isComparable(rowBValue) &&
-      rowAValue < rowBValue)
-  ) {
-    return direction === SortDirection.DESCENDING ? -1 : 1;
-  }
-  if (
-    (rowAValue && !rowBValue) ||
-    (isComparable(rowAValue) &&
-      isComparable(rowBValue) &&
-      rowAValue > rowBValue)
-  ) {
-    return direction === SortDirection.DESCENDING ? 1 : -1;
-  }
-  return 0;
-};
-
-const rowSort = (
-  rowA: NetworkRow,
-  rowB: NetworkRow,
-  key: Sort<SortKey>["key"],
-  _args: unknown,
-  direction: Sort<SortKey>["direction"],
-  rows: NetworkRow[]
-) => {
-  // By default sort by bonds and bridges.
-  if (direction === SortDirection.NONE) {
-    key = "bondOrBridge";
-    direction = SortDirection.ASCENDING;
-  }
-
-  // Get the bond or bridge child rows.
-  const childA = getChild(rowA, rows);
-  const childB = getChild(rowB, rows);
-  const inSameBondOrBridge =
-    rowA.sortData.bondOrBridge === rowB.sortData.bondOrBridge;
-
-  let rowAValue = key
-    ? getSortValue(key, childA && !inSameBondOrBridge ? childA : rowA)
-    : null;
-  let rowBValue = key
-    ? getSortValue(key, childB && !inSameBondOrBridge ? childB : rowB)
-    : null;
-
-  // If the rows are in the same bond or bridge then put the child first.
-  if (inSameBondOrBridge) {
-    if (
-      rowA.sortData.isABondOrBridgeChild &&
-      !rowB.sortData.isABondOrBridgeChild
-    ) {
-      return -1;
-    }
-    if (rowB.sortData.isABondOrBridgeChild) {
-      return 0;
-    }
-  }
-
-  if (rowAValue === rowBValue) {
-    // Rows that have the same value need to be sorted by the bond or bridge id
-    // so that they don't lose their grouping.
-    rowAValue = getSortValue("bondOrBridge", rowA);
-    rowBValue = getSortValue("bondOrBridge", rowB);
-  }
-
-  return compareValues(rowAValue, rowBValue, direction);
-};
-
-export const generateUniqueId = ({ linkId, nicId }: Selected): string =>
-  `${nicId || ""}-${linkId || ""}`;
 
 type BaseProps = {
   node: ControllerDetails | MachineDetails;
 };
 
 type ActionProps = BaseProps & {
-  selected?: Selected[];
   setExpanded?: SetExpanded;
   setSelected?: SetSelected;
 };
 
 type WithoutActionProps = BaseProps & {
-  selected?: never;
   setExpanded?: never;
   setSelected?: never;
 };
 
 type Props = ActionProps | WithoutActionProps;
 
+export const generateUniqueId = ({ linkId, nicId }: Selected): string =>
+  `${nicId || ""}-${linkId || ""}`;
+
+const getNetworkTableData = (
+  fabrics: Fabric[],
+  fabricsLoaded: boolean,
+  isAllNetworkingDisabled: boolean,
+  node: ControllerDetails | MachineDetails,
+  subnets: Subnet[],
+  vlans: VLAN[],
+  vlansLoaded: boolean
+) => {
+  const flatNetworks: Network[] = [];
+  node.interfaces.forEach((nic: NetworkInterface) => {
+    const createNetwork = (
+      link: NetworkLink | null,
+      nic: NetworkInterface | null
+    ): Network | null => {
+      if (link && !nic) {
+        [nic] = getLinkInterface(node, link);
+      }
+      if (!nic) {
+        return null;
+      }
+      const isABondOrBridgeParent = isBondOrBridgeParent(node, nic, link);
+      const isABondOrBridgeChild = isBondOrBridgeChild(node, nic, link);
+      const isBoot = isBootInterface(node, nic, link);
+      const vlan = vlans.find(({ id }) => id === nic?.vlan_id);
+      const fabric = getInterfaceFabric(node, fabrics, vlans, nic, link);
+      const name = getInterfaceName(node, nic, link);
+      const interfaceTypeDisplay = getInterfaceTypeText(node, nic, link, true);
+      const shouldShowDHCP =
+        !isABondOrBridgeParent && fabricsLoaded && vlansLoaded;
+      const fabricContent = !isABondOrBridgeParent
+        ? fabric?.name || "Disconnected"
+        : null;
+      const subnet = getInterfaceSubnet(
+        node,
+        subnets,
+        fabrics,
+        vlans,
+        isAllNetworkingDisabled,
+        nic,
+        link
+      );
+      return {
+        id: generateUniqueId({ linkId: link?.id, nicId: nic?.id }),
+        bondOrBridge:
+          (nic &&
+            ((isABondOrBridgeParent && nic.children[0]) ||
+              (isABondOrBridgeChild && nic.id))) ||
+          null,
+        dhcp: shouldShowDHCP ? getDHCPStatus(vlan, vlans, fabrics) : null,
+        fabric: fabricContent,
+        ip:
+          getInterfaceIPAddressOrMode(node, fabrics, vlans, nic, link) || null,
+        isABondOrBridgeChild,
+        isABondOrBridgeParent,
+        name: name,
+        pxe: isBoot,
+        speed: nic.link_speed,
+        subnet: getSubnetDisplay(subnet),
+        type: interfaceTypeDisplay,
+        nic: nic,
+        link: link,
+      };
+    };
+    if (nic.links.length === 0) {
+      const network = createNetwork(null, nic);
+      if (network) {
+        flatNetworks.push(network);
+      }
+    } else {
+      nic.links.forEach((link: NetworkLink) => {
+        const network = createNetwork(link, null);
+        if (network) {
+          flatNetworks.push(network);
+        }
+      });
+    }
+  });
+
+  const nestedNetworks: Network[] = [];
+  const childIds = new Set<string>();
+
+  flatNetworks.forEach((network) => {
+    if (network.isABondOrBridgeChild) {
+      const children = flatNetworks.filter(
+        (n) =>
+          n.isABondOrBridgeParent && n.bondOrBridge === network.bondOrBridge
+      );
+      if (children.length > 0) {
+        network.children = children;
+        children.forEach((c) => childIds.add(c.id));
+      }
+      nestedNetworks.push(network);
+    }
+  });
+
+  flatNetworks.forEach((network) => {
+    if (!network.isABondOrBridgeChild && !childIds.has(network.id)) {
+      nestedNetworks.push(network);
+    }
+  });
+
+  return nestedNetworks;
+};
+
+const extractSelected = (
+  data: Network[],
+  rowSelection: RowSelectionState
+): Selected[] => {
+  const pick = (network: Network) => ({
+    linkId: network.link ? network.link.id : null,
+    nicId: network.nic ? network.nic.id : null,
+  });
+
+  const result: Selected[] = [];
+  const ids = Object.entries(rowSelection)
+    .filter(([_, value]) => value)
+    .map(([key]) => key);
+
+  data.forEach((item) => {
+    if (ids.includes(item.id)) {
+      result.push(pick(item));
+    }
+  });
+
+  return result;
+};
+
 const NetworkTable = ({
   node,
-  selected,
   setExpanded,
   setSelected,
 }: Props): React.ReactElement => {
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+
   const fabrics = useSelector(fabricSelectors.all);
   const subnets = useSelector(subnetSelectors.all);
   const vlans = useSelector(vlanSelectors.all);
   const fabricsLoaded = useSelector(fabricSelectors.loaded);
   const vlansLoaded = useSelector(vlanSelectors.loaded);
   const isAllNetworkingDisabled = useIsAllNetworkingDisabled(node);
-  const { currentSort, sortRows, updateSort } = useTableSort<
-    NetworkRow,
-    SortKey
-  >(
-    getSortValue,
-    {
-      key: "name",
-      direction: SortDirection.DESCENDING,
-    },
-    rowSort
-  );
-  const checkboxHandler = setSelected
-    ? generateCheckboxHandlers<Selected>(setSelected, generateUniqueId)
-    : null;
   const hasActions = !!setExpanded;
 
   useFetchActions([
@@ -477,193 +246,39 @@ const NetworkTable = ({
     vlanActions.fetch,
   ]);
 
-  const rows = generateRows(
-    checkboxHandler,
+  const columns = useNetworkTableColumns({ node, setExpanded, setSelected });
+  const data = getNetworkTableData(
     fabrics,
     fabricsLoaded,
     isAllNetworkingDisabled,
     node,
-    selected,
     subnets,
     vlans,
-    vlansLoaded,
-    hasActions,
-    setSelected,
-    setExpanded
+    vlansLoaded
   );
-  const sortedRows = sortRows(rows);
-  // Generate a list of ids for interfaces that have checkboxes.
-  const selectableIDs = rows.reduce<Selected[]>((selectable, { select }) => {
-    if (select) {
-      selectable.push(select);
+
+  useEffect(() => {
+    if (setSelected) {
+      setSelected(extractSelected(data, rowSelection));
     }
-    return selectable;
-  }, []);
+  }, [rowSelection]);
+
   return (
-    <MainTable
+    <GenericTable
+      canSelect
       className={classNames("p-table-expanding--light", "network-table", {
         "network-table--has-actions": hasActions,
       })}
-      defaultSort="name"
-      defaultSortDirection="descending"
-      emptyStateMsg={Label.EmptyList}
-      expanding
-      headers={[
-        {
-          "aria-label": Label.Name,
-          content: (
-            <div className="u-flex">
-              {hasActions && checkboxHandler && selected ? (
-                <GroupCheckbox
-                  checkAllSelected={checkboxHandler.checkAllSelected}
-                  checkSelected={checkboxHandler.checkSelected}
-                  disabled={isAllNetworkingDisabled}
-                  handleGroupCheckbox={checkboxHandler.handleGroupCheckbox}
-                  items={selectableIDs}
-                  selectedItems={selected}
-                />
-              ) : null}
-              <div>
-                <TableHeader
-                  currentSort={currentSort}
-                  onClick={() => {
-                    updateSort("name");
-                  }}
-                  sortKey="name"
-                >
-                  {Label.Name}
-                </TableHeader>
-                <TableHeader>{Label.MAC}</TableHeader>
-              </div>
-            </div>
-          ),
-        },
-        {
-          className: "u-align--center",
-          content: (
-            <>
-              <TableHeader
-                className="u-align--center"
-                currentSort={currentSort}
-                onClick={() => {
-                  updateSort("pxe");
-                }}
-                sortKey="pxe"
-              >
-                {Label.PXE}
-              </TableHeader>
-            </>
-          ),
-        },
-        {
-          content: (
-            <TableHeader
-              className="p-double-row__header-spacer"
-              currentSort={currentSort}
-              onClick={() => {
-                updateSort("speed");
-              }}
-              sortKey="speed"
-            >
-              {Label.Speed}
-            </TableHeader>
-          ),
-        },
-        {
-          "aria-label": Label.Type,
-          content: (
-            <div>
-              <TableHeader
-                className="p-double-row__header-spacer"
-                currentSort={currentSort}
-                onClick={() => {
-                  updateSort("type");
-                }}
-                sortKey="type"
-              >
-                {Label.Type}
-              </TableHeader>
-              <TableHeader className="p-double-row__header-spacer">
-                {Label.NUMA}
-              </TableHeader>
-            </div>
-          ),
-        },
-        {
-          "aria-label": Label.Fabric,
-          content: (
-            <div>
-              <TableHeader
-                currentSort={currentSort}
-                onClick={() => {
-                  updateSort("fabric");
-                }}
-                sortKey="fabric"
-              >
-                {Label.Fabric}
-              </TableHeader>
-              <TableHeader>{Label.VLAN}</TableHeader>
-            </div>
-          ),
-        },
-        {
-          "aria-label": Label.Subnet,
-          content: (
-            <div>
-              <TableHeader
-                currentSort={currentSort}
-                onClick={() => {
-                  updateSort("subnet");
-                }}
-                sortKey="subnet"
-              >
-                {Label.Subnet}
-              </TableHeader>
-              <TableHeader>{Label.SubnetName}</TableHeader>
-            </div>
-          ),
-        },
-        {
-          "aria-label": Label.IP,
-          content: (
-            <div>
-              <TableHeader
-                currentSort={currentSort}
-                onClick={() => {
-                  updateSort("ip");
-                }}
-                sortKey="ip"
-              >
-                {Label.IP}
-              </TableHeader>
-              <TableHeader>{Label.Status}</TableHeader>
-            </div>
-          ),
-        },
-        {
-          content: (
-            <TableHeader
-              className="p-double-row__header-spacer"
-              currentSort={currentSort}
-              onClick={() => {
-                updateSort("dhcp");
-              }}
-              sortKey="dhcp"
-            >
-              {Label.DHCP}
-            </TableHeader>
-          ),
-        },
-        ...(hasActions
-          ? [
-              {
-                content: Label.Actions,
-                className: "u-align--right",
-              },
-            ]
-          : []),
-      ]}
-      rows={sortedRows}
+      columns={columns}
+      data={data}
+      filterCells={filterCells}
+      filterHeaders={filterHeaders}
+      getSubRows={(originalRow) => originalRow.children}
+      isLoading={false}
+      noData={"No interfaces available."}
+      rowSelection={rowSelection}
+      setRowSelection={setRowSelection}
+      sortBy={[{ id: "name", desc: false }]}
     />
   );
 };

--- a/src/app/base/components/node/networking/NetworkTable/NetworkTable.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/NetworkTable.tsx
@@ -44,25 +44,6 @@ import vlanSelectors from "@/app/store/vlan/selectors";
 import type { VLAN } from "@/app/store/vlan/types";
 import { getDHCPStatus } from "@/app/store/vlan/utils";
 
-export const Label = {
-  Actions: "Actions",
-  ActionsMenu: "Interface actions",
-  DHCP: "DHCP",
-  EmptyList: "No interfaces available",
-  Fabric: "Fabric",
-  IP: "IP Address",
-  MAC: "MAC",
-  Name: "Name",
-  NUMA: "NUMA node",
-  PXE: "PXE",
-  Speed: "Link/interface speed",
-  Status: "Status",
-  Subnet: "Subnet",
-  SubnetName: "Name",
-  Type: "Type",
-  VLAN: "VLAN",
-} as const;
-
 export type Network = {
   id: string;
   bondOrBridge: NetworkInterface["id"] | null;
@@ -285,12 +266,13 @@ const NetworkTable = ({
 
   return (
     <GenericTable
-      canSelect
+      canSelect={(_) => !isAllNetworkingDisabled}
       className={classNames("p-table-expanding--light", "network-table", {
         "network-table--has-actions": hasActions,
       })}
       columns={columns}
       data={data}
+      disabledSelectionTooltip={"Network can't be modified for this machine."}
       filterCells={!!setExpanded ? filterCells : filterCellsAndAction}
       filterHeaders={!!setExpanded ? filterHeaders : filterHeadersAndAction}
       getSubRows={(originalRow) => originalRow.children}

--- a/src/app/base/components/node/networking/NetworkTable/_index.scss
+++ b/src/app/base/components/node/networking/NetworkTable/_index.scss
@@ -2,68 +2,131 @@
 
 @mixin NetworkTable {
   .network-table {
+    th, td {
+      &:is(.name, .pxe, .speed, .fabric, .subnet, .dhcp) {
+        text-align: left;
+      }
+
+      &.name {
+        width: 12rem;
+      }
+
+      &.pxe {
+        width: 3.5rem;
+      }
+
+      &.fabric {
+        width: 6rem;
+      }
+
+      &.action {
+        width: 4rem;
+      }
+    }
+
+    th {
+      button.p-button--table-header {
+        display: flex;
+        justify-content: left;
+        text-align: left;
+      }
+    }
+
+    tr.p-generic-table__group-row + tr.p-generic-table__individual-row {
+      display: none;
+    }
+
+    tr.p-generic-table__group-row {
+      td.p-generic-table__select {
+        display: none;
+      }
+
+      td.name {
+        width: 14rem;
+      }
+    }
+
+    .p-generic-table__select-alignment {
+      display: none;
+    }
+
     @include truncated-border(
-      $width: #{2 * map.get($icon-sizes, default) + $sph--small}
+            $width: #{2 * map.get($icon-sizes, default) + $sph--small}
     );
 
     th,
     td {
-      &:nth-child(1) {
+      &.name {
         @include breakpoint-widths(0.5, 0.5, 0.26, 0.23, 0.17, true);
       }
-      &:nth-child(2) {
+
+      &.pxe {
         @include breakpoint-widths(0, 0.06, 0.05, 0.05, 0.05, true);
       }
-      &:nth-child(3) {
+
+      &.speed {
         @include breakpoint-widths(0, 0, 0, 0.16, 0.14, true);
       }
-      &:nth-child(4) {
+
+      &.type {
         @include breakpoint-widths(0.5, 0.5, 0.2, 0.15, 0.14, true);
       }
-      &:nth-child(5) {
+
+      &.fabric {
         @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
       }
-      &:nth-child(6) {
+
+      &.subnet {
         @include breakpoint-widths(0, 0, 0, 0.13, 0.12, true);
       }
-      &:nth-child(7) {
+
+      &.ip {
         @include breakpoint-widths(0, 0, 0.17, 0.13, 0.13, true);
       }
-      &:nth-child(8) {
+
+      &.dhcp {
         @include breakpoint-widths(0, 0, 0, 0, 0.14, true);
       }
     }
-  }
 
-  .network-table--has-actions {
-    th,
-    td {
-      &:nth-child(1) {
-        @include breakpoint-widths(0.45, 0.45, 0.26, 0.2, 0.16, true);
-      }
-      &:nth-child(2) {
-        @include breakpoint-widths(0, 0.06, 0.05, 0.05, 0.05, true);
-      }
-      &:nth-child(3) {
-        @include breakpoint-widths(0, 0, 0, 0.16, 0.14, true);
-      }
-      &:nth-child(4) {
-        @include breakpoint-widths(0.45, 0.45, 0.2, 0.15, 0.14, true);
-      }
-      &:nth-child(5) {
-        @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
-      }
-      &:nth-child(6) {
-        @include breakpoint-widths(0, 0, 0, 0.13, 0.12, true);
-      }
-      &:nth-child(7) {
-        @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
-      }
-      &:nth-child(8) {
-        @include breakpoint-widths(0, 0, 0, 0, 0.12, true);
-      }
-      &:nth-child(9) {
-        @include breakpoint-widths(0, 0.1, 0.1, 0.06, 0.05, true);
+    &.network-table--has-actions {
+      th,
+      td {
+        &.name {
+          @include breakpoint-widths(0.45, 0.45, 0.26, 0.2, 0.16, true);
+        }
+
+        &.pxe {
+          @include breakpoint-widths(0, 0.06, 0.05, 0.05, 0.05, true);
+        }
+
+        &.speed {
+          @include breakpoint-widths(0, 0, 0, 0.16, 0.14, true);
+        }
+
+        &.type {
+          @include breakpoint-widths(0.45, 0.45, 0.2, 0.15, 0.14, true);
+        }
+
+        &.fabric {
+          @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
+        }
+
+        &.subnet {
+          @include breakpoint-widths(0, 0, 0, 0.13, 0.12, true);
+        }
+
+        &.ip {
+          @include breakpoint-widths(0, 0, 0.17, 0.12, 0.11, true);
+        }
+
+        &.dhcp {
+          @include breakpoint-widths(0, 0, 0, 0, 0.12, true);
+        }
+
+        &:last-child {
+          @include breakpoint-widths(0, 0.1, 0.1, 0.06, 0.05, true);
+        }
       }
     }
   }

--- a/src/app/base/components/node/networking/NetworkTable/useNetworkTableColumns/useNetworkTableColumns.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/useNetworkTableColumns/useNetworkTableColumns.tsx
@@ -1,0 +1,246 @@
+import { useMemo } from "react";
+
+import type {
+  Column,
+  ColumnDef,
+  Header,
+  Row,
+  Table,
+} from "@tanstack/react-table";
+
+import DoubleRow from "@/app/base/components/DoubleRow";
+import MacAddressDisplay from "@/app/base/components/MacAddressDisplay";
+import type { SetExpanded } from "@/app/base/components/NodeNetworkTab/NodeNetworkTab";
+import TableHeader from "@/app/base/components/TableHeader";
+import DHCPColumn from "@/app/base/components/node/networking/DHCPColumn";
+import FabricColumn from "@/app/base/components/node/networking/FabricColumn";
+import IPColumn from "@/app/base/components/node/networking/NetworkTable/IPColumn";
+import type { Network } from "@/app/base/components/node/networking/NetworkTable/NetworkTable";
+import PXEColumn from "@/app/base/components/node/networking/NetworkTable/PXEColumn";
+import SpeedColumn from "@/app/base/components/node/networking/NetworkTable/SpeedColumn";
+import SubnetColumn from "@/app/base/components/node/networking/SubnetColumn";
+import TypeColumn from "@/app/base/components/node/networking/TypeColumn";
+import type {
+  Selected,
+  SetSelected,
+} from "@/app/base/components/node/networking/types";
+import NetworkTableActions from "@/app/machines/views/MachineDetails/MachineNetwork/NetworkTable/NetworkTableActions";
+import type { ControllerDetails } from "@/app/store/controller/types";
+import type { MachineDetails } from "@/app/store/machine/types";
+import { nodeIsMachine } from "@/app/store/utils";
+
+export type NetworkColumnDef = ColumnDef<Network, Partial<Network>>;
+
+export const filterCells = (
+  _: Row<Network>,
+  column: Column<Network>
+): boolean => {
+  return !["bondOrBridge"].includes(column.id);
+};
+
+export const filterHeaders = (header: Header<Network, unknown>): boolean =>
+  header.column.id !== "bondOrBridge";
+
+const useNetworkTableColumns = ({
+  node,
+  setExpanded,
+  setSelected,
+}: {
+  node: ControllerDetails | MachineDetails;
+  setExpanded?: SetExpanded;
+  setSelected?: SetSelected;
+}): NetworkColumnDef[] => {
+  return useMemo(
+    () => [
+      {
+        id: "bondOrBridge",
+        accessorKey: "bondOrBridge",
+      },
+      {
+        id: "name",
+        accessorKey: "name",
+        enableSorting: true,
+        header: () => (
+          <div>
+            <TableHeader sortKey="name">Name</TableHeader>
+            <TableHeader>MAC</TableHeader>
+          </div>
+        ),
+        cell: ({
+          row: {
+            original: { name, nic },
+          },
+        }: {
+          row: Row<Network>;
+        }) => (
+          <DoubleRow
+            primary={<span data-testid="name">{name}</span>}
+            secondary={<MacAddressDisplay>{nic.mac_address}</MacAddressDisplay>}
+          />
+        ),
+      },
+      {
+        id: "pxe",
+        accessorKey: "pxe",
+        enableSorting: true,
+        header: "PXE",
+        cell: ({
+          row: {
+            original: { isABondOrBridgeParent, nic, link },
+          },
+        }: {
+          row: Row<Network>;
+        }) =>
+          !isABondOrBridgeParent && (
+            <PXEColumn link={link} nic={nic} node={node} />
+          ),
+      },
+      {
+        id: "speed",
+        accessorKey: "speed",
+        enableSorting: true,
+        header: () => (
+          <div className="p-double-row__header-spacer">
+            Link/Interface Speed
+          </div>
+        ),
+        cell: ({
+          row: {
+            original: { nic, link },
+          },
+        }: {
+          row: Row<Network>;
+        }) => <SpeedColumn link={link} nic={nic} node={node} />,
+      },
+      {
+        id: "type",
+        accessorKey: "type",
+        enableSorting: true,
+        header: () => (
+          <div className="p-double-row__header-spacer">
+            <TableHeader sortKey="type">Type</TableHeader>
+            <TableHeader>NUMA Node</TableHeader>
+          </div>
+        ),
+        cell: ({
+          row: {
+            original: { nic, link },
+          },
+        }: {
+          row: Row<Network>;
+        }) => <TypeColumn link={link} nic={nic} node={node} />,
+      },
+      {
+        id: "fabric",
+        accessorKey: "fabric",
+        enableSorting: true,
+        header: () => (
+          <div>
+            <TableHeader sortKey="fabric">Fabric</TableHeader>
+            <TableHeader>VLAN</TableHeader>
+          </div>
+        ),
+        cell: ({
+          row: {
+            original: { isABondOrBridgeParent, nic, link },
+          },
+        }: {
+          row: Row<Network>;
+        }) =>
+          !isABondOrBridgeParent && (
+            <FabricColumn link={link} nic={nic} node={node} />
+          ),
+      },
+      {
+        id: "subnet",
+        accessorKey: "subnet",
+        enableSorting: true,
+        header: () => (
+          <div>
+            <TableHeader sortKey="subnet">Subnet</TableHeader>
+            <TableHeader>Subnet Name</TableHeader>
+          </div>
+        ),
+        cell: ({
+          row: {
+            original: { isABondOrBridgeParent, nic, link },
+          },
+        }: {
+          row: Row<Network>;
+        }) =>
+          !isABondOrBridgeParent && (
+            <SubnetColumn link={link} nic={nic} node={node} />
+          ),
+      },
+      {
+        id: "ip",
+        accessorKey: "ip",
+        enableSorting: true,
+        header: () => (
+          <div>
+            <TableHeader sortKey="ip">IP Address</TableHeader>
+            <TableHeader>Status</TableHeader>
+          </div>
+        ),
+        cell: ({
+          row: {
+            original: { isABondOrBridgeParent, nic, link },
+          },
+        }: {
+          row: Row<Network>;
+        }) =>
+          !isABondOrBridgeParent && (
+            <IPColumn link={link} nic={nic} node={node} />
+          ),
+      },
+      {
+        id: "dhcp",
+        accessorKey: "dhcp",
+        enableSorting: true,
+        header: () => <div className="p-double-row__header-spacer">DHCP</div>,
+        cell: ({
+          row: {
+            original: { isABondOrBridgeParent, nic },
+          },
+        }: {
+          row: Row<Network>;
+        }) => !isABondOrBridgeParent && <DHCPColumn nic={nic} />,
+      },
+      {
+        id: "action",
+        accessorKey: "id",
+        enableSorting: false,
+        header: "Action",
+        cell: ({
+          row: {
+            original: { isABondOrBridgeParent, nic, link },
+          },
+          table,
+        }: {
+          row: Row<Network>;
+          table: Table<Network>;
+        }) => {
+          return !isABondOrBridgeParent &&
+            nodeIsMachine(node) &&
+            setExpanded ? (
+            <NetworkTableActions
+              link={link}
+              nic={nic}
+              selected={table.getSelectedRowModel().flatRows.map(
+                (row): Selected => ({
+                  linkId: row.original.link?.id,
+                  nicId: row.original.nic.id,
+                })
+              )}
+              setSelected={setSelected}
+              systemId={node.system_id}
+            />
+          ) : null;
+        },
+      },
+    ],
+    [node, setExpanded, setSelected]
+  );
+};
+
+export default useNetworkTableColumns;

--- a/src/app/base/components/node/networking/NetworkTable/useNetworkTableColumns/useNetworkTableColumns.tsx
+++ b/src/app/base/components/node/networking/NetworkTable/useNetworkTableColumns/useNetworkTableColumns.tsx
@@ -38,8 +38,19 @@ export const filterCells = (
   return !["bondOrBridge"].includes(column.id);
 };
 
+export const filterCellsAndAction = (
+  _: Row<Network>,
+  column: Column<Network>
+): boolean => {
+  return !["bondOrBridge", "action"].includes(column.id);
+};
+
 export const filterHeaders = (header: Header<Network, unknown>): boolean =>
   header.column.id !== "bondOrBridge";
+
+export const filterHeadersAndAction = (
+  header: Header<Network, unknown>
+): boolean => !["bondOrBridge", "action"].includes(header.column.id);
 
 const useNetworkTableColumns = ({
   node,

--- a/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
+++ b/src/app/machines/views/MachineDetails/MachineNetwork/MachineNetwork.tsx
@@ -59,7 +59,6 @@ const MachineNetwork = ({
       interfaceTable={(_, setExpanded) => (
         <NetworkTable
           node={machine}
-          selected={selected}
           setExpanded={setExpanded}
           setSelected={setSelected}
         />

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,10 +949,10 @@
     "@types/tough-cookie" "^4.0.5"
     tough-cookie "^4.1.4"
 
-"@canonical/maas-react-components@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-1.30.1.tgz#1b98ce8ce693d12daf1a261438b86d24169bcb09"
-  integrity sha512-9s3QWj1nvD0R1ojznHBxMFL1+IaRcsdzQVIU1LI5oLlEr9rkrf8wqe7cX3yl2E4Z93nER3/A6kniJ62iZtOmiQ==
+"@canonical/maas-react-components@1.33.0":
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-1.33.0.tgz#3f6d5903ea9ae5249cea397c1620cc5a1d69e827"
+  integrity sha512-QxKcLXQeHW9l1wP3uw1TcAN4ZYq0sDwNmwhcLP4vxmRL51PkC+oeX9i5+0Pyp46MgubyxwGhDmenP2kkKUXFWA==
 
 "@canonical/macaroon-bakery@1.3.2":
   version "1.3.2"
@@ -11715,16 +11715,7 @@ strict-event-emitter@^0.5.1:
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
   integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11806,14 +11797,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13032,7 +13016,8 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13045,15 +13030,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Done

- Updated maas-react-component
- Migrated NetworkTable to GenericTable
- Added a custom parser between external selection management and GenericTable's selection state
- Fixed tests

## QA steps

- [ ] Open old NetworkTable (maas-ui-demo) and this PR side by side
- [ ] Navigate to sin73l00045.maas details
- [ ] Navigate to the Network tab
- [ ] Verify the PR table loads and visually matches the old table
- [ ] Select the first checkbox (bond-NSnOV4)
- [ ] Verify the "Create bridge" button is enabled
- [ ] Play around with "Select all" and other rows' checkboxes
- [ ] Ensure states update correctly
- [ ] Open the action menu on a row
- [ ] Verify the forms open properly
- [ ] Ensure the form pre-fill information matches between the PR and old versions
- [ ] Navigate back to the machines list
- [ ] Navigate to sin73l00277.maas details
- [ ] Navigate to the Network tab
- [ ] Verify the checkboxes are disabled
- [ ] Verify hovering on the disabled checkboxes shows a tooltip
- [ ] Repeat for other random machines to make sure sin73l00045.maas is not a fluke

## Fixes

Resolves:

[MAASENG-5204](https://warthogs.atlassian.net/browse/MAASENG-5204)
