### PR TITLE
chore(devices): Convert DeviceNetworkTable to GenericTable MAASENG-5211

### DIFF
--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.test.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetwork.test.tsx
@@ -4,7 +4,7 @@ import DeviceNetwork from "./DeviceNetwork";
 
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
-import { screen, renderWithBrowserRouter } from "@/testing/utils";
+import { renderWithBrowserRouter, screen } from "@/testing/utils";
 
 const mockStore = configureStore<RootState>();
 
@@ -38,9 +38,7 @@ describe("DeviceNetwork", () => {
     });
     expect(screen.getByLabelText("Device network")).toBeInTheDocument();
     expect(screen.getByRole("grid", { name: /DHCP/ })).toBeInTheDocument();
-    expect(
-      screen.getByRole("grid", { name: /Interfaces/ })
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Interfaces")).toBeInTheDocument();
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
   });
 });

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
@@ -1,20 +1,11 @@
-import { MainTable, Spinner } from "@canonical/react-components";
-import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import { GenericTable } from "@canonical/maas-react-components";
+import { Spinner } from "@canonical/react-components";
 import { useSelector } from "react-redux";
 
-import MacAddressDisplay from "@/app/base/components/MacAddressDisplay";
-import TableHeader from "@/app/base/components/TableHeader";
-import TableMenu from "@/app/base/components/TableMenu";
-import SubnetColumn from "@/app/base/components/node/networking/SubnetColumn";
-import {
-  useFetchActions,
-  useIsAllNetworkingDisabled,
-  useTableSort,
-} from "@/app/base/hooks";
-import type { SetSidePanelContent } from "@/app/base/side-panel-context";
-import { useSidePanel } from "@/app/base/side-panel-context";
-import { SortDirection } from "@/app/base/types";
-import { DeviceSidePanelViews } from "@/app/devices/constants";
+import type { DeviceNetworkRowData } from "./useDeviceNetworkTableColumns/useDeviceNetworkTableColumns";
+import useDeviceNetworkTableColumns from "./useDeviceNetworkTableColumns/useDeviceNetworkTableColumns";
+
+import { useFetchActions, useIsAllNetworkingDisabled } from "@/app/base/hooks";
 import deviceSelectors from "@/app/store/device/selectors";
 import type { Device, DeviceMeta } from "@/app/store/device/types";
 import { isDeviceDetails } from "@/app/store/device/utils";
@@ -25,174 +16,81 @@ import type { RootState } from "@/app/store/root/types";
 import { subnetActions } from "@/app/store/subnet";
 import subnetSelectors from "@/app/store/subnet/selectors";
 import type { Subnet } from "@/app/store/subnet/types";
-import { getSubnetDisplay } from "@/app/store/subnet/utils";
-import type { NetworkInterface, NetworkLink } from "@/app/store/types/node";
+import type { NetworkInterface } from "@/app/store/types/node";
 import {
   getInterfaceIPAddress,
-  getInterfaceName,
   getInterfaceSubnet,
-  getInterfaceTypeText,
   getLinkInterface,
   getLinkModeDisplay,
 } from "@/app/store/utils";
 import { vlanActions } from "@/app/store/vlan";
 import vlanSelectors from "@/app/store/vlan/selectors";
 import type { VLAN } from "@/app/store/vlan/types";
-import { isComparable } from "@/app/utils";
-
-type NetworkRowSortData = {
-  ip_address: string | null;
-  ip_mode: string | null;
-  mac_address: NetworkInterface["mac_address"];
-  subnet: string | null;
-};
-
-type NetworkRow = Omit<MainTableRow, "sortData"> & {
-  sortData: NetworkRowSortData;
-};
-
-type SortKey = keyof NetworkRowSortData;
 
 type Props = {
   systemId: Device[DeviceMeta.PK];
 };
 
-const getSortValue = (sortKey: SortKey, row: NetworkRow) => {
-  const value = row.sortData[sortKey];
-  return isComparable(value) ? value : null;
-};
+const generateRowData = ({
+  device,
+  fabrics,
+  vlans,
+  subnets,
+  isAllNetworkingDisabled,
+}: {
+  device: Device;
+  fabrics: Fabric[];
+  vlans: VLAN[];
+  subnets: Subnet[];
+  isAllNetworkingDisabled: boolean;
+}) => {
+  if (!isDeviceDetails(device)) return [];
 
-const generateRow = (
-  fabrics: Fabric[],
-  isAllNetworkingDisabled: boolean,
-  link: NetworkLink | null,
-  device: Device,
-  nic: NetworkInterface | null,
-  subnets: Subnet[],
-  vlans: VLAN[],
-  setSidePanelContent: SetSidePanelContent
-): NetworkRow | null => {
-  if (link && !nic) {
-    [nic] = getLinkInterface(device, link);
-  }
-  if (!nic) {
-    return null;
-  }
-  const name = getInterfaceName(device, nic, link);
-  const subnet = getInterfaceSubnet(
-    device,
-    subnets,
-    fabrics,
-    vlans,
-    isAllNetworkingDisabled,
-    nic,
-    link
-  );
-  const typeDisplay = getInterfaceTypeText(device, nic, link);
+  const rows: DeviceNetworkRowData[] = [];
 
-  return {
-    className: "p-table__row",
-    columns: [
-      {
-        content: <MacAddressDisplay>{nic.mac_address}</MacAddressDisplay>,
-      },
-      {
-        content: <SubnetColumn link={link} nic={nic} node={device} />,
-      },
-      {
-        content: (
-          <span data-testid="ip-address">
-            {getInterfaceIPAddress(device, fabrics, vlans, nic, link)}
-          </span>
-        ),
-      },
-      {
-        content: <span data-testid="ip-mode">{getLinkModeDisplay(link)}</span>,
-      },
-      {
-        className: "u-align--right",
-        content: (
-          <TableMenu
-            disabled={isAllNetworkingDisabled}
-            links={[
-              {
-                children: `Edit ${typeDisplay}`,
-                onClick: () => {
-                  setSidePanelContent({
-                    view: DeviceSidePanelViews.EDIT_INTERFACE,
-                    extras: { linkId: link?.id, nicId: nic?.id },
-                  });
-                },
-              },
-              {
-                children: `Remove ${typeDisplay}`,
-                onClick: () => {
-                  setSidePanelContent({
-                    view: DeviceSidePanelViews.REMOVE_INTERFACE,
-                    extras: { linkId: link?.id, nicId: nic?.id },
-                  });
-                },
-              },
-            ]}
-            position="right"
-            title="Take action:"
-          />
-        ),
-      },
-    ],
-    key: name,
-    sortData: {
-      ip_address:
-        getInterfaceIPAddress(device, fabrics, vlans, nic, link) || null,
-      ip_mode: getLinkModeDisplay(link) || null,
-      mac_address: nic.mac_address,
-      subnet: getSubnetDisplay(subnet),
-    },
-  };
-};
-
-const generateRows = (
-  fabrics: Fabric[],
-  isAllNetworkingDisabled: boolean,
-  device: Device,
-  subnets: Subnet[],
-  vlans: VLAN[],
-  setSidePanelContent: SetSidePanelContent
-): NetworkRow[] => {
-  if (!isDeviceDetails(device)) {
-    return [];
-  }
-  const rows: NetworkRow[] = [];
-  // Create a list of interfaces and aliases to use to generate the table rows.
   device.interfaces.forEach((nic: NetworkInterface) => {
-    const createRow = (
-      link: NetworkLink | null,
-      nic: NetworkInterface | null
-    ) =>
-      generateRow(
-        fabrics,
-        isAllNetworkingDisabled,
-        link,
-        device,
-        nic,
-        subnets,
-        vlans,
-        setSidePanelContent
-      );
-    if (nic.links.length === 0) {
-      const row = createRow(null, nic);
-      if (row) {
-        rows.push(row);
-      }
+    if (nic.links.length > 0) {
+      nic.links.forEach((link) => {
+        const [linkNic] = getLinkInterface(device, link);
+        const subnet = getInterfaceSubnet(
+          device,
+          subnets,
+          fabrics,
+          vlans,
+          isAllNetworkingDisabled,
+          nic,
+          link
+        );
+        rows.push({
+          id: link.id,
+          nic: linkNic,
+          link,
+          ip_address: getInterfaceIPAddress(device, fabrics, vlans, nic, link),
+          ip_mode: getLinkModeDisplay(link),
+          subnet,
+          device,
+        });
+      });
     } else {
-      nic.links.forEach((link: NetworkLink) => {
-        const row = createRow(link, null);
-        if (row) {
-          rows.push(row);
-        }
+      const subnet = getInterfaceSubnet(
+        device,
+        subnets,
+        fabrics,
+        vlans,
+        isAllNetworkingDisabled,
+        nic
+      );
+      rows.push({
+        id: nic.id,
+        nic,
+        ip_address: getInterfaceIPAddress(device, fabrics, vlans, nic),
+        ip_mode: getLinkModeDisplay(null),
+        subnet,
+        device,
       });
     }
   });
+
   return rows;
 };
 
@@ -200,18 +98,11 @@ const DeviceNetworkTable = ({ systemId }: Props): React.ReactElement => {
   const device = useSelector((state: RootState) =>
     deviceSelectors.getById(state, systemId)
   );
+  const loading = useSelector(deviceSelectors.loading);
   const fabrics = useSelector(fabricSelectors.all);
   const subnets = useSelector(subnetSelectors.all);
   const vlans = useSelector(vlanSelectors.all);
-  const { setSidePanelContent } = useSidePanel();
   const isAllNetworkingDisabled = useIsAllNetworkingDisabled(device);
-  const { currentSort, sortRows, updateSort } = useTableSort<
-    NetworkRow,
-    SortKey
-  >(getSortValue, {
-    key: "mac_address",
-    direction: SortDirection.DESCENDING,
-  });
 
   useFetchActions([
     fabricActions.fetch,
@@ -219,87 +110,31 @@ const DeviceNetworkTable = ({ systemId }: Props): React.ReactElement => {
     vlanActions.fetch,
   ]);
 
+  const columns = useDeviceNetworkTableColumns({ isAllNetworkingDisabled });
+
   if (!isDeviceDetails(device)) {
     return <Spinner text="Loading..." />;
   }
 
-  const rows = generateRows(
-    fabrics,
-    isAllNetworkingDisabled,
+  const rowData = generateRowData({
     device,
-    subnets,
+    fabrics,
     vlans,
-    setSidePanelContent
-  );
-  const sortedRows = sortRows(rows);
+    subnets,
+    isAllNetworkingDisabled,
+  });
+
   return (
-    <MainTable
-      aria-label="Interfaces"
-      className="p-table-expanding--light device-network-table"
-      defaultSort="name"
-      defaultSortDirection="descending"
-      emptyStateMsg="No interfaces available."
-      expanding
-      headers={[
-        {
-          content: (
-            <TableHeader
-              currentSort={currentSort}
-              onClick={() => {
-                updateSort("mac_address");
-              }}
-              sortKey="mac_address"
-            >
-              Mac
-            </TableHeader>
-          ),
-        },
-        {
-          content: (
-            <TableHeader
-              currentSort={currentSort}
-              onClick={() => {
-                updateSort("subnet");
-              }}
-              sortKey="subnet"
-            >
-              Subnet
-            </TableHeader>
-          ),
-        },
-        {
-          content: (
-            <TableHeader
-              currentSort={currentSort}
-              onClick={() => {
-                updateSort("ip_address");
-              }}
-              sortKey="ip_address"
-            >
-              IP Address
-            </TableHeader>
-          ),
-        },
-        {
-          content: (
-            <TableHeader
-              currentSort={currentSort}
-              onClick={() => {
-                updateSort("ip_mode");
-              }}
-              sortKey="ip_mode"
-            >
-              IP assignment
-            </TableHeader>
-          ),
-        },
-        {
-          content: "Actions",
-          className: "u-align--right",
-        },
-      ]}
-      rows={sortedRows}
-    />
+    <>
+      <GenericTable
+        className="device-network-table"
+        columns={columns}
+        data={rowData}
+        isLoading={loading && !device}
+        noData="No interfaces available."
+        sortBy={[{ id: "mac_address", desc: true }]}
+      />
+    </>
   );
 };
 

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
@@ -129,6 +129,7 @@ const DeviceNetworkTable = ({ systemId }: Props): React.ReactElement => {
   return (
     <>
       <GenericTable
+        aria-label="Interfaces"
         className="device-network-table"
         columns={columns}
         data={rowData}

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/DeviceNetworkTable.tsx
@@ -64,6 +64,7 @@ const generateRowData = ({
         rows.push({
           id: link.id,
           nic: linkNic,
+          mac_address: linkNic?.mac_address,
           link,
           ip_address: getInterfaceIPAddress(device, fabrics, vlans, nic, link),
           ip_mode: getLinkModeDisplay(link),
@@ -82,6 +83,7 @@ const generateRowData = ({
       );
       rows.push({
         id: nic.id,
+        mac_address: nic.mac_address,
         nic,
         ip_address: getInterfaceIPAddress(device, fabrics, vlans, nic),
         ip_mode: getLinkModeDisplay(null),

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/useDeviceNetworkTableColumns/useDeviceNetworkTableColumns.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/useDeviceNetworkTableColumns/useDeviceNetworkTableColumns.tsx
@@ -14,6 +14,7 @@ import type { NetworkInterface, NetworkLink } from "@/app/store/types/node";
 export type DeviceNetworkRowData = {
   id: NetworkInterface["id"];
   nic: NetworkInterface | null;
+  mac_address?: string;
   link?: NetworkLink;
   ip_address?: string | null;
   ip_mode: string | null;
@@ -42,9 +43,9 @@ const useDeviceNetworkTableColumns = ({
         enableSorting: true,
         cell: ({
           row: {
-            original: { nic },
+            original: { mac_address },
           },
-        }) => <MacAddressDisplay>{nic?.mac_address}</MacAddressDisplay>,
+        }) => <MacAddressDisplay>{mac_address}</MacAddressDisplay>,
       },
       {
         id: "subnet",

--- a/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/useDeviceNetworkTableColumns/useDeviceNetworkTableColumns.tsx
+++ b/src/app/devices/views/DeviceDetails/DeviceNetwork/DeviceNetworkTable/useDeviceNetworkTableColumns/useDeviceNetworkTableColumns.tsx
@@ -1,0 +1,104 @@
+import { useMemo } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import MacAddressDisplay from "@/app/base/components/MacAddressDisplay";
+import TableActions from "@/app/base/components/TableActions";
+import SubnetColumn from "@/app/base/components/node/networking/SubnetColumn";
+import { useSidePanel } from "@/app/base/side-panel-context";
+import { DeviceSidePanelViews } from "@/app/devices/constants";
+import type { Device } from "@/app/store/device/types";
+import type { Subnet } from "@/app/store/subnet/types";
+import type { NetworkInterface, NetworkLink } from "@/app/store/types/node";
+
+export type DeviceNetworkRowData = {
+  id: NetworkInterface["id"];
+  nic: NetworkInterface | null;
+  link?: NetworkLink;
+  ip_address?: string | null;
+  ip_mode: string | null;
+  subnet: Subnet | null;
+  device: Device;
+};
+
+export type DeviceNetworkTableColumnDef = ColumnDef<
+  DeviceNetworkRowData,
+  Partial<DeviceNetworkRowData>
+>;
+
+const useDeviceNetworkTableColumns = ({
+  isAllNetworkingDisabled,
+}: {
+  isAllNetworkingDisabled: boolean;
+}): DeviceNetworkTableColumnDef[] => {
+  const { setSidePanelContent } = useSidePanel();
+
+  return useMemo(
+    (): DeviceNetworkTableColumnDef[] => [
+      {
+        id: "mac_address",
+        accessorKey: "mac_address",
+        header: "Mac",
+        enableSorting: true,
+        cell: ({
+          row: {
+            original: { nic },
+          },
+        }) => <MacAddressDisplay>{nic?.mac_address}</MacAddressDisplay>,
+      },
+      {
+        id: "subnet",
+        accessorKey: "subnet",
+        header: "Subnet",
+        enableSorting: true,
+        cell: ({
+          row: {
+            original: { nic, link, device },
+          },
+        }) => <SubnetColumn link={link} nic={nic} node={device} />,
+      },
+      {
+        id: "ip_address",
+        accessorKey: "ip_address",
+        header: "IP address",
+        enableSorting: true,
+      },
+      {
+        id: "ip_mode",
+        accessorKey: "ip_mode",
+        header: "IP assignment",
+        enableSorting: true,
+      },
+      {
+        id: "actions",
+        header: "Actions",
+        enableSorting: false,
+        cell: ({
+          row: {
+            original: { nic, link },
+          },
+        }) => (
+          <TableActions
+            deleteDisabled={isAllNetworkingDisabled}
+            editDisabled={isAllNetworkingDisabled}
+            onDelete={() => {
+              setSidePanelContent({
+                view: DeviceSidePanelViews.REMOVE_INTERFACE,
+                extras: { nicId: nic?.id, linkId: link?.id },
+              });
+            }}
+            onEdit={() => {
+              setSidePanelContent({
+                view: DeviceSidePanelViews.EDIT_INTERFACE,
+                extras: { nicId: nic?.id, linkId: link?.id },
+              });
+            }}
+          />
+        ),
+      },
+    ],
+    [isAllNetworkingDisabled, setSidePanelContent]
+  );
+};
+
+export default useDeviceNetworkTableColumns;


### PR DESCRIPTION
## Done
- Converted DeviceNetworkTable to GenericTable
- Migrated tests to use `renderWithProviders`

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Open maas-ui-demo.internal and this PR side-by-side, to `/device/q3ctsx/network`
- [ ] Ensure the table sorts by mac address (desc) by default*
- [x] Ensure the table can be sorted by all headers (except actions)
- [x] Ensure any links to subnets work as intended
- [x] Ensure clicking on the action buttons opens the relevant side panels (with the correct pre-fill data)

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-5211](https://warthogs.atlassian.net/browse/MAASENG-5211)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

*the descending order is interpreted differently by tanstack table compared to our internal functions - tanstack puts letters first, internally we put numbers first. I think we should follow the tanstack convention here for simplicity.

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-5211]: https://warthogs.atlassian.net/browse/MAASENG-5211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ