### PR TITLE
feat: Generic side panel context MAASENG-5227

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -15,7 +15,7 @@ jobs:
   test-coverage-tics:
     name: Run tests with coverage and generate TiCS report
     runs-on: [ self-hosted, linux, amd64, tiobe, jammy ]
-    timeout-minutes: 180
+    timeout-minutes: 240
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/app/base/components/AppSidePanel/AppSidePanel.tsx
+++ b/src/app/base/components/AppSidePanel/AppSidePanel.tsx
@@ -4,34 +4,36 @@ import { useEffect } from "react";
 import { ContentSection } from "@canonical/maas-react-components";
 import { AppAside, useOnEscapePressed } from "@canonical/react-components";
 import classNames from "classnames";
+import { useLocation } from "react-router";
 
 import { useSidePanel } from "@/app/base/side-panel-context";
-import { history } from "@/redux-store";
 
 const useCloseSidePanelOnRouteChange = (): void => {
+  const location = useLocation();
   const { close } = useSidePanel();
 
-  // close side panel on route change
-  useEffect(() => {
-    const unlisten = history.listen(() => {
+  useEffect(
+    () => {
       close();
-    });
-
-    return () => {
-      unlisten();
-    };
-  }, [close]);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [location.pathname, location.search, location.hash]
+  );
 };
 
 const useResetSidePanelOnUnmount = (): void => {
   const { setSize } = useSidePanel();
 
   // reset side panel size to default on unmounting
-  useEffect(() => {
-    return () => {
-      setSize("regular");
-    };
-  }, [setSize]);
+  useEffect(
+    () => {
+      return () => {
+        setSize("regular");
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
 };
 
 const useCloseSidePanelOnEscPressed = (): void => {

--- a/src/app/base/components/AppSidePanel/AppSidePanel.tsx
+++ b/src/app/base/components/AppSidePanel/AppSidePanel.tsx
@@ -1,57 +1,53 @@
-import { useEffect, type ReactNode } from "react";
+import type { ReactElement } from "react";
+import { useEffect } from "react";
 
 import { ContentSection } from "@canonical/maas-react-components";
 import { AppAside, useOnEscapePressed } from "@canonical/react-components";
 import classNames from "classnames";
 
-import type { SidePanelSize } from "@/app/base/side-panel-context";
 import { useSidePanel } from "@/app/base/side-panel-context";
 import { history } from "@/redux-store";
 
-export type AppSidePanelProps = {
-  title: string | null;
-  content?: ReactNode;
-  size: SidePanelSize;
-};
-
 const useCloseSidePanelOnRouteChange = (): void => {
-  const { setSidePanelContent } = useSidePanel();
+  const { close } = useSidePanel();
 
   // close side panel on route change
   useEffect(() => {
     const unlisten = history.listen(() => {
-      setSidePanelContent(null);
+      close();
     });
 
     return () => {
       unlisten();
     };
-  }, [setSidePanelContent]);
+  }, [close]);
 };
 
 const useResetSidePanelOnUnmount = (): void => {
-  const { setSidePanelSize } = useSidePanel();
+  const { setSize } = useSidePanel();
 
-  // reset side panel size to default on unmount
+  // reset side panel size to default on unmounting
   useEffect(() => {
     return () => {
-      setSidePanelSize("regular");
+      setSize("regular");
     };
-  }, [setSidePanelSize]);
+  }, [setSize]);
 };
 
 const useCloseSidePanelOnEscPressed = (): void => {
-  const { setSidePanelContent } = useSidePanel();
+  const { close } = useSidePanel();
   useOnEscapePressed(() => {
-    setSidePanelContent(null);
+    close();
   });
 };
 
-const AppSidePanelContent = ({
-  title,
-  size,
-  content,
-}: AppSidePanelProps): React.ReactElement => {
+const AppSidePanel = (): ReactElement => {
+  useCloseSidePanelOnEscPressed();
+  useCloseSidePanelOnRouteChange();
+  useResetSidePanelOnUnmount();
+
+  const { isOpen, title, component: Component, props, size } = useSidePanel();
+
   return (
     <AppAside
       aria-label={title ?? undefined}
@@ -60,7 +56,7 @@ const AppSidePanelContent = ({
         "is-large": size === "large",
         "is-wide": size === "wide",
       })}
-      collapsed={!content}
+      collapsed={!isOpen}
       id="aside-panel"
     >
       <ContentSection>
@@ -73,21 +69,10 @@ const AppSidePanelContent = ({
             </div>
           </div>
         ) : null}
-        {content}
+        {isOpen && Component && <Component {...props} />}
       </ContentSection>
     </AppAside>
   );
-};
-
-const AppSidePanel = (
-  props: Omit<AppSidePanelProps, "size">
-): React.ReactElement => {
-  useCloseSidePanelOnEscPressed();
-  useCloseSidePanelOnRouteChange();
-  useResetSidePanelOnUnmount();
-  const { sidePanelSize } = useSidePanel();
-
-  return <AppSidePanelContent {...props} size={sidePanelSize} />;
 };
 
 export default AppSidePanel;

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -1,4 +1,4 @@
-import type { HTMLProps, ReactElement, ReactNode } from "react";
+import type { HTMLProps, ReactNode } from "react";
 
 import { AppMain } from "@canonical/react-components";
 import classNames from "classnames";
@@ -10,6 +10,8 @@ import ErrorBoundary from "../ErrorBoundary/ErrorBoundary";
 import MainContentSection from "../MainContentSection";
 import SecondaryNavigation from "../SecondaryNavigation";
 
+import type { AppSidePanelProps } from "@/app/base/components/AppSidePanel";
+import SidePanel from "@/app/base/components/SidePanel";
 import { useThemeContext } from "@/app/base/theme-context";
 import { preferencesNavItems } from "@/app/preferences/constants";
 import { settingsNavItems } from "@/app/settings/constants";
@@ -20,14 +22,21 @@ export type Props = HTMLProps<HTMLDivElement> & {
   header?: ReactNode;
   sidebar?: ReactNode;
   isNotificationListHidden?: boolean;
+  sidePanelContent: AppSidePanelProps["content"];
+  sidePanelSize?: AppSidePanelProps["size"];
+  sidePanelTitle: AppSidePanelProps["title"];
+  useNewSidePanelContext?: boolean; // TODO: remove once the new side panel context is fully migrated
 };
 
 const PageContent = ({
   children,
   header,
   sidebar,
+  sidePanelContent,
+  sidePanelTitle,
+  useNewSidePanelContext = false,
   ...props
-}: Props): ReactElement => {
+}: Props): React.ReactElement => {
   const { pathname } = useLocation();
   const isSettingsPage = !!matchPath("settings/*", pathname);
   const isPreferencesPage = !!matchPath("account/prefs/*", pathname);
@@ -57,7 +66,11 @@ const PageContent = ({
           </MainContentSection>
         </div>
       </AppMain>
-      <AppSidePanel />
+      {useNewSidePanelContext ? (
+        <SidePanel />
+      ) : (
+        <AppSidePanel content={sidePanelContent} title={sidePanelTitle} />
+      )}
     </>
   );
 };

--- a/src/app/base/components/PageContent/PageContent.tsx
+++ b/src/app/base/components/PageContent/PageContent.tsx
@@ -1,4 +1,4 @@
-import type { HTMLProps, ReactNode } from "react";
+import type { HTMLProps, ReactElement, ReactNode } from "react";
 
 import { AppMain } from "@canonical/react-components";
 import classNames from "classnames";
@@ -10,7 +10,6 @@ import ErrorBoundary from "../ErrorBoundary/ErrorBoundary";
 import MainContentSection from "../MainContentSection";
 import SecondaryNavigation from "../SecondaryNavigation";
 
-import type { AppSidePanelProps } from "@/app/base/components/AppSidePanel";
 import { useThemeContext } from "@/app/base/theme-context";
 import { preferencesNavItems } from "@/app/preferences/constants";
 import { settingsNavItems } from "@/app/settings/constants";
@@ -21,19 +20,14 @@ export type Props = HTMLProps<HTMLDivElement> & {
   header?: ReactNode;
   sidebar?: ReactNode;
   isNotificationListHidden?: boolean;
-  sidePanelContent: AppSidePanelProps["content"];
-  sidePanelSize?: AppSidePanelProps["size"];
-  sidePanelTitle: AppSidePanelProps["title"];
 };
 
 const PageContent = ({
   children,
   header,
   sidebar,
-  sidePanelContent,
-  sidePanelTitle,
   ...props
-}: Props): React.ReactElement => {
+}: Props): ReactElement => {
   const { pathname } = useLocation();
   const isSettingsPage = !!matchPath("settings/*", pathname);
   const isPreferencesPage = !!matchPath("account/prefs/*", pathname);
@@ -63,7 +57,7 @@ const PageContent = ({
           </MainContentSection>
         </div>
       </AppMain>
-      <AppSidePanel content={sidePanelContent} title={sidePanelTitle} />
+      <AppSidePanel />
     </>
   );
 };

--- a/src/app/base/components/SidePanel/SidePanel.tsx
+++ b/src/app/base/components/SidePanel/SidePanel.tsx
@@ -10,11 +10,11 @@ import { useSidePanel } from "@/app/base/side-panel-context-new";
 
 const useCloseSidePanelOnRouteChange = (): void => {
   const location = useLocation();
-  const { close } = useSidePanel();
+  const { closeSidePanel } = useSidePanel();
 
   useEffect(
     () => {
-      close();
+      closeSidePanel();
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [location.pathname, location.search, location.hash]
@@ -22,13 +22,13 @@ const useCloseSidePanelOnRouteChange = (): void => {
 };
 
 const useResetSidePanelOnUnmount = (): void => {
-  const { setSize } = useSidePanel();
+  const { setSidePanelSize } = useSidePanel();
 
   // reset side panel size to default on unmounting
   useEffect(
     () => {
       return () => {
-        setSize("regular");
+        setSidePanelSize("regular");
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -37,9 +37,9 @@ const useResetSidePanelOnUnmount = (): void => {
 };
 
 const useCloseSidePanelOnEscPressed = (): void => {
-  const { close } = useSidePanel();
+  const { closeSidePanel } = useSidePanel();
   useOnEscapePressed(() => {
-    close();
+    closeSidePanel();
   });
 };
 

--- a/src/app/base/components/SidePanel/SidePanel.tsx
+++ b/src/app/base/components/SidePanel/SidePanel.tsx
@@ -1,0 +1,80 @@
+import type { ReactElement } from "react";
+import { useEffect } from "react";
+
+import { ContentSection } from "@canonical/maas-react-components";
+import { AppAside, useOnEscapePressed } from "@canonical/react-components";
+import classNames from "classnames";
+import { useLocation } from "react-router";
+
+import { useSidePanel } from "@/app/base/side-panel-context-new";
+
+const useCloseSidePanelOnRouteChange = (): void => {
+  const location = useLocation();
+  const { close } = useSidePanel();
+
+  useEffect(
+    () => {
+      close();
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [location.pathname, location.search, location.hash]
+  );
+};
+
+const useResetSidePanelOnUnmount = (): void => {
+  const { setSize } = useSidePanel();
+
+  // reset side panel size to default on unmounting
+  useEffect(
+    () => {
+      return () => {
+        setSize("regular");
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+};
+
+const useCloseSidePanelOnEscPressed = (): void => {
+  const { close } = useSidePanel();
+  useOnEscapePressed(() => {
+    close();
+  });
+};
+
+const SidePanel = (): ReactElement => {
+  useCloseSidePanelOnEscPressed();
+  useCloseSidePanelOnRouteChange();
+  useResetSidePanelOnUnmount();
+
+  const { isOpen, title, component: Component, props, size } = useSidePanel();
+
+  return (
+    <AppAside
+      aria-label={title ?? undefined}
+      className={classNames({
+        "is-narrow": size === "narrow",
+        "is-large": size === "large",
+        "is-wide": size === "wide",
+      })}
+      collapsed={!isOpen}
+      id="aside-panel"
+    >
+      <ContentSection>
+        {title ? (
+          <div className="row section-header section-header--side-panel">
+            <div className="col-12">
+              <h3 className="section-header__title u-flex--no-shrink p-heading--4">
+                {title}
+              </h3>
+            </div>
+          </div>
+        ) : null}
+        {isOpen && Component && <Component {...props} />}
+      </ContentSection>
+    </AppAside>
+  );
+};
+
+export default SidePanel;

--- a/src/app/base/components/SidePanel/index.ts
+++ b/src/app/base/components/SidePanel/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SidePanel";

--- a/src/app/base/side-panel-context-new.tsx
+++ b/src/app/base/side-panel-context-new.tsx
@@ -17,20 +17,55 @@ interface SidePanelState<TProps = Record<string, unknown>> {
 }
 
 interface SidePanelActions {
-  open: <TProps extends Record<string, unknown> = Record<string, unknown>>(
-    component: ComponentType<TProps>,
-    title: string,
-    props?: TProps,
-    size?: SidePanelSize
-  ) => void;
-  close: () => void;
-  setSize: (size: SidePanelSize) => void;
+  openSidePanel: <
+    TProps extends Record<string, unknown> = Record<string, unknown>,
+  >(params: {
+    component: ComponentType<TProps>;
+    title: string;
+    props?: TProps;
+    size?: SidePanelSize;
+  }) => void;
+  closeSidePanel: () => void;
+  setSidePanelSize: (size: SidePanelSize) => void;
 }
 
 type SidePanelContextValue = SidePanelActions & SidePanelState;
 
 const SidePanelContext = createContext<SidePanelContextValue | null>(null);
 
+/**
+ * Hook for managing side panel state and actions.
+ *
+ * Provides methods to open/close side panels with React components and manages
+ * panel size and visibility state.
+ *
+ * @returns Object containing:
+ *   - `isOpen`: Boolean indicating if the side panel is currently open
+ *   - `title`: Current panel title string
+ *   - `size`: Current panel size ('narrow' | 'regular' | 'wide' | 'large')
+ *   - `component`: Currently rendered component
+ *   - `props`: Props passed to the current component
+ *   - `open(component, title, props?, size?)`: Opens panel with given component
+ *   - `close()`: Closes the panel and resets state
+ *   - `setSize(size)`: Changes the panel width
+ *
+ * @throws Error when used outside SidePanelProvider
+ *
+ * @example
+ * ```tsx
+ * const { open, close, isOpen } = useSidePanel();
+ *
+ * // Open a panel with a form component
+ * const handleEdit = (userId: number) => {
+ *   open(EditUserForm, 'Edit User', { userId }, 'wide');
+ * };
+ *
+ * // Close the panel
+ * const handleCancel = () => {
+ *   close();
+ * };
+ * ```
+ */
 export const useSidePanel = (): SidePanelContextValue => {
   const context = useContext(SidePanelContext);
   if (!context) {
@@ -50,14 +85,19 @@ const SidePanelContextProvider = ({
     props: {},
   });
 
-  const open = <
+  const openSidePanel = <
     TProps extends Record<string, unknown> = Record<string, unknown>,
-  >(
-    component: ComponentType<TProps>,
-    title: string,
-    props: TProps = {} as TProps,
-    size: SidePanelSize = "regular"
-  ) => {
+  >({
+    component,
+    title,
+    props = {} as TProps,
+    size = "regular",
+  }: {
+    component: ComponentType<TProps>;
+    title: string;
+    props?: TProps;
+    size?: SidePanelSize;
+  }) => {
     setState({
       isOpen: true,
       title,
@@ -67,18 +107,17 @@ const SidePanelContextProvider = ({
     });
   };
 
-  const close = () => {
-    setState((prev) => ({
-      ...prev,
+  const closeSidePanel = () => {
+    setState({
       isOpen: false,
       title: "",
       size: "regular",
       component: null,
       props: {},
-    }));
+    });
   };
 
-  const setSize = (size: SidePanelSize) => {
+  const setSidePanelSize = (size: SidePanelSize) => {
     setState((prev) => ({ ...prev, size }));
   };
 
@@ -86,9 +125,9 @@ const SidePanelContextProvider = ({
     <SidePanelContext.Provider
       value={{
         ...state,
-        open,
-        close,
-        setSize,
+        openSidePanel,
+        closeSidePanel,
+        setSidePanelSize,
       }}
     >
       {children}

--- a/src/app/base/side-panel-context-new.tsx
+++ b/src/app/base/side-panel-context-new.tsx
@@ -71,7 +71,9 @@ const SidePanelContextProvider = ({
     setState((prev) => ({
       ...prev,
       isOpen: false,
+      title: "",
       size: "regular",
+      component: null,
       props: {},
     }));
   };

--- a/src/app/base/side-panel-context-new.tsx
+++ b/src/app/base/side-panel-context-new.tsx
@@ -1,0 +1,97 @@
+import type { ComponentType, PropsWithChildren, ReactElement } from "react";
+import { useContext, createContext, useState } from "react";
+
+// This new side panel context is meant to replace the old one over time. Since migrating all
+// panels will take some time, these two contexts will live together while the migrations are
+// being carried out.
+// TODO: Once the migrations are complete, remove the old side panel context.
+
+type SidePanelSize = "large" | "narrow" | "regular" | "wide";
+
+interface SidePanelState<TProps = Record<string, unknown>> {
+  isOpen: boolean;
+  title: string;
+  size: SidePanelSize;
+  component: ComponentType<TProps> | null;
+  props: TProps;
+}
+
+interface SidePanelActions {
+  open: <TProps extends Record<string, unknown> = Record<string, unknown>>(
+    component: ComponentType<TProps>,
+    title: string,
+    props?: TProps,
+    size?: SidePanelSize
+  ) => void;
+  close: () => void;
+  setSize: (size: SidePanelSize) => void;
+}
+
+type SidePanelContextValue = SidePanelActions & SidePanelState;
+
+const SidePanelContext = createContext<SidePanelContextValue | null>(null);
+
+export const useSidePanel = (): SidePanelContextValue => {
+  const context = useContext(SidePanelContext);
+  if (!context) {
+    throw new Error("useSidePanel must be used within a SidePanelProvider");
+  }
+  return context;
+};
+
+const SidePanelContextProvider = ({
+  children,
+}: PropsWithChildren): ReactElement => {
+  const [state, setState] = useState<SidePanelState>({
+    isOpen: false,
+    title: "",
+    size: "regular",
+    component: null,
+    props: {},
+  });
+
+  const open = <
+    TProps extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    component: ComponentType<TProps>,
+    title: string,
+    props: TProps = {} as TProps,
+    size: SidePanelSize = "regular"
+  ) => {
+    setState({
+      isOpen: true,
+      title,
+      size,
+      component: component as ComponentType<Record<string, unknown>>,
+      props: props || ({} as Record<string, unknown>),
+    });
+  };
+
+  const close = () => {
+    setState((prev) => ({
+      ...prev,
+      isOpen: false,
+      size: "regular",
+      props: {},
+    }));
+  };
+
+  const setSize = (size: SidePanelSize) => {
+    setState((prev) => ({ ...prev, size }));
+  };
+
+  return (
+    <SidePanelContext.Provider
+      value={{
+        ...state,
+        open,
+        close,
+        setSize,
+      }}
+    >
+      {children}
+    </SidePanelContext.Provider>
+  );
+};
+
+export default SidePanelContextProvider;

--- a/src/app/base/side-panel-context-new.tsx
+++ b/src/app/base/side-panel-context-new.tsx
@@ -45,9 +45,9 @@ const SidePanelContext = createContext<SidePanelContextValue | null>(null);
  *   - `size`: Current panel size ('narrow' | 'regular' | 'wide' | 'large')
  *   - `component`: Currently rendered component
  *   - `props`: Props passed to the current component
- *   - `open(component, title, props?, size?)`: Opens panel with given component
- *   - `close()`: Closes the panel and resets state
- *   - `setSize(size)`: Changes the panel width
+ *   - `openSidePanel({component, title, props?, size?})`: Opens panel with given component
+ *   - `closeSidePanel()`: Closes the panel and resets state
+ *   - `setSidePanelSize(size)`: Changes the panel width
  *
  * @throws Error when used outside SidePanelProvider
  *

--- a/src/app/base/side-panel-context.tsx
+++ b/src/app/base/side-panel-context.tsx
@@ -1,91 +1,291 @@
-import type { ComponentType, PropsWithChildren, ReactElement } from "react";
-import { useContext, createContext, useState } from "react";
+import type { PropsWithChildren, ReactElement } from "react";
+import { createContext, useCallback, useContext, useState } from "react";
 
-type SidePanelSize = "large" | "narrow" | "regular" | "wide";
+import type { RepositorySidePanelContent } from "../settings/views/Repositories/constants";
+import { RepositoryActionSidePanelViews } from "../settings/views/Repositories/constants";
 
-interface SidePanelState<TProps = Record<string, unknown>> {
-  isOpen: boolean;
-  title: string;
-  size: SidePanelSize;
-  component: ComponentType<TProps> | null;
-  props: TProps;
-}
+import { ControllerSidePanelViews } from "@/app/controllers/constants";
+import type { ControllerSidePanelContent } from "@/app/controllers/types";
+import { DeviceSidePanelViews } from "@/app/devices/constants";
+import type { DeviceSidePanelContent } from "@/app/devices/types";
+import {
+  DomainDetailsSidePanelViews,
+  type DomainDetailsSidePanelContent,
+} from "@/app/domains/views/DomainDetails/constants";
+import {
+  DomainListSidePanelViews,
+  type DomainListSidePanelContent,
+} from "@/app/domains/views/DomainsList/constants";
+import { ImageSidePanelViews } from "@/app/images/constants";
+import type { ImageSidePanelContent } from "@/app/images/types";
+import { KVMSidePanelViews } from "@/app/kvm/constants";
+import type { KVMSidePanelContent } from "@/app/kvm/types";
+import { MachineSidePanelViews } from "@/app/machines/constants";
+import type { MachineSidePanelContent } from "@/app/machines/types";
+import {
+  NetworkDiscoverySidePanelViews,
+  type NetworkDiscoverySidePanelContent,
+} from "@/app/networkDiscovery/constants";
+import type { PoolSidePanelContent } from "@/app/pools/constants";
+import { PoolActionSidePanelViews } from "@/app/pools/constants";
+import type { SSHKeySidePanelContent } from "@/app/preferences/views/SSHKeys/constants";
+import { SSHKeyActionSidePanelViews } from "@/app/preferences/views/SSHKeys/constants";
+import type { SSLKeySidePanelContent } from "@/app/preferences/views/SSLKeys/constants";
+import { SSLKeyActionSidePanelViews } from "@/app/preferences/views/SSLKeys/constants";
+import { UserActionSidePanelViews } from "@/app/settings/views/Users/constants";
+import type { UserSidePanelContent } from "@/app/settings/views/Users/constants";
+import type { NodeActions } from "@/app/store/types/node";
+import { getNodeActionTitle } from "@/app/store/utils";
+import {
+  SubnetSidePanelViews,
+  type SubnetSidePanelContent,
+} from "@/app/subnets/types";
+import {
+  FabricDetailsSidePanelViews,
+  type FabricDetailsSidePanelContent,
+} from "@/app/subnets/views/FabricDetails/FabricDetailsHeader/constants";
+import {
+  SpaceDetailsSidePanelViews,
+  type SpaceDetailsSidePanelContent,
+} from "@/app/subnets/views/SpaceDetails/constants";
+import {
+  SubnetDetailsSidePanelViews,
+  type SubnetDetailsSidePanelContent,
+} from "@/app/subnets/views/SubnetDetails/constants";
+import {
+  VLANDetailsSidePanelViews,
+  type VLANDetailsSidePanelContent,
+} from "@/app/subnets/views/VLANDetails/constants";
+import { TagSidePanelViews } from "@/app/tags/constants";
+import type { TagSidePanelContent } from "@/app/tags/types";
+import {
+  ZoneActionSidePanelViews,
+  type ZoneSidePanelContent,
+} from "@/app/zones/constants";
 
-interface SidePanelActions {
-  open: <TProps extends Record<string, unknown> = Record<string, unknown>>(
-    component: ComponentType<TProps>,
-    title: string,
-    props?: TProps,
-    size?: SidePanelSize
-  ) => void;
-  close: () => void;
-  setSize: (size: SidePanelSize) => void;
-}
+export type SidePanelContent =
+  | ControllerSidePanelContent
+  | DeviceSidePanelContent
+  | DomainDetailsSidePanelContent
+  | DomainListSidePanelContent
+  | FabricDetailsSidePanelContent
+  | ImageSidePanelContent
+  | KVMSidePanelContent
+  | MachineSidePanelContent
+  | NetworkDiscoverySidePanelContent
+  | PoolSidePanelContent
+  | RepositorySidePanelContent
+  | SpaceDetailsSidePanelContent
+  | SSHKeySidePanelContent
+  | SSLKeySidePanelContent
+  | SubnetDetailsSidePanelContent
+  | SubnetSidePanelContent
+  | TagSidePanelContent
+  | UserSidePanelContent
+  | VLANDetailsSidePanelContent
+  | ZoneSidePanelContent
+  | null;
 
-type SidePanelContextValue = SidePanelActions & SidePanelState;
+export type SetSidePanelContent<T = SidePanelContent> = (
+  sidePanelContent: T | null
+) => void;
 
-const SidePanelContext = createContext<SidePanelContextValue | null>(null);
+export type SidePanelSize = "large" | "narrow" | "regular" | "wide";
+export type SidePanelContextType<T = SidePanelContent> = {
+  sidePanelContent: T | null;
+  sidePanelSize: SidePanelSize;
+};
 
-export const useSidePanel = (): SidePanelContextValue => {
-  const context = useContext(SidePanelContext);
-  if (!context) {
-    throw new Error("useSidePanel must be used within a SidePanelProvider");
+export const SidePanelViews = {
+  ...ControllerSidePanelViews,
+  ...MachineSidePanelViews,
+  ...ControllerSidePanelViews,
+  ...DeviceSidePanelViews,
+  ...KVMSidePanelViews,
+  ...TagSidePanelViews,
+  ...UserActionSidePanelViews,
+  ...ZoneActionSidePanelViews,
+  ...SubnetSidePanelViews,
+  ...DomainDetailsSidePanelViews,
+  ...DomainListSidePanelViews,
+  ...NetworkDiscoverySidePanelViews,
+  ...VLANDetailsSidePanelViews,
+  ...FabricDetailsSidePanelViews,
+  ...ImageSidePanelViews,
+  ...SSHKeyActionSidePanelViews,
+  ...SSLKeyActionSidePanelViews,
+  ...PoolActionSidePanelViews,
+  ...SubnetDetailsSidePanelViews,
+  ...SpaceDetailsSidePanelViews,
+  ...RepositoryActionSidePanelViews,
+} as const;
+
+const sidePanelTitleMap: Record<string, string> = {
+  [SidePanelViews.ADD_ALIAS[1]]: "Add alias",
+  [SidePanelViews.ADD_BOND[1]]: "Create bond",
+  [SidePanelViews.ADD_BRIDGE[1]]: "Create bridge",
+  [SidePanelViews.ADD_CONTROLLER[1]]: "Add controller",
+  [SidePanelViews.ADD_CHASSIS[1]]: "Add chassis",
+  [SidePanelViews.ADD_DISCOVERY[1]]: "Add discovery",
+  [SidePanelViews.ADD_DOMAIN[1]]: "Add domains",
+  [SidePanelViews.ADD_INTERFACE[1]]: "Add interface",
+  [SidePanelViews.ADD_MACHINE[1]]: "Add machine",
+  [SidePanelViews.ADD_DEVICE[1]]: "Add device",
+  [SidePanelViews.ADD_SPECIAL_FILESYSTEM[1]]: "Add special filesystem",
+  [SidePanelViews.ADD_SSH_KEY[1]]: "Add SSH key",
+  [SidePanelViews.DELETE_SSH_KEY[1]]: "Delete SSH key",
+  [SidePanelViews.ADD_SSL_KEY[1]]: "Add SSL key",
+  [SidePanelViews.DELETE_SSL_KEY[1]]: "Delete SSL key",
+  [SidePanelViews.AddTag[1]]: "Create new tag",
+  [SidePanelViews.ADD_VLAN[1]]: "Add VLAN",
+  [SidePanelViews.APPLY_STORAGE_LAYOUT[1]]: "Change storage layout",
+  [SidePanelViews.CLEAR_ALL_DISCOVERIES[1]]: "Clear all discoveries",
+  [SidePanelViews.CREATE_BCACHE[1]]: "Create bcache",
+  [SidePanelViews.CREATE_CACHE_SET[1]]: "Create cache set",
+  [SidePanelViews.CREATE_DATASTORE[1]]: "Create datastore",
+  [SidePanelViews.CREATE_LOGICAL_VOLUME[1]]: "Create logical volume",
+  [SidePanelViews.CREATE_PARTITION[1]]: "Create partition",
+  [SidePanelViews.CREATE_RAID[1]]: "Create raid",
+  [SidePanelViews.CREATE_VOLUME_GROUP[1]]: "Create volume group",
+  [SidePanelViews.DELETE_DISCOVERY[1]]: "Delete discovery",
+  [SidePanelViews.DELETE_DISK[1]]: "Delete disk",
+  [SidePanelViews.DELETE_FILESYSTEM[1]]: "Delete filesystem",
+  [SidePanelViews.DELETE_SPECIAL_FILESYSTEM[1]]: "Delete special filesystem",
+  [SidePanelViews.DeleteTag[1]]: "Delete tag",
+  [SidePanelViews.DELETE_VOLUME_GROUP[1]]: "Delete volume group",
+  [SidePanelViews.DOWNLOAD_IMAGE[1]]: "Select upstream images to sync",
+  [SidePanelViews.EDIT_INTERFACE[1]]: "Edit interface",
+  [SidePanelViews.CREATE_ZONE[1]]: "Add AZ",
+  [SidePanelViews.EDIT_ZONE[1]]: "Edit AZ",
+  [SidePanelViews.DELETE_ZONE[1]]: "Delete AZ",
+  [SidePanelViews.EDIT_DISK[1]]: "Edit disk",
+  [SidePanelViews.EDIT_PARTITION[1]]: "Edit partition",
+  [SidePanelViews.EDIT_PHYSICAL[1]]: "Edit physical",
+  [SidePanelViews.DELETE_IMAGE[1]]: "Delete image",
+  [SidePanelViews.DELETE_MULTIPLE_IMAGES[1]]: "Delete multiple images",
+  [SidePanelViews.DELETE_SPACE[1]]: "Delete space",
+  [SidePanelViews.DELETE_FABRIC[1]]: "Delete fabric",
+  [SidePanelViews.MARK_CONNECTED[1]]: "Mark as connected",
+  [SidePanelViews.MARK_DISCONNECTED[1]]: "Mark as disconnected",
+  [SidePanelViews.REMOVE_INTERFACE[1]]: "Remove interface",
+  [SidePanelViews.REMOVE_PARTITION[1]]: "Remove partition",
+  [SidePanelViews.REMOVE_PHYSICAL[1]]: "Remove physical",
+  [SidePanelViews.SET_BOOT_DISK[1]]: "Set boot disk",
+  [SidePanelViews.SET_DEFAULT[1]]: "Set default",
+  [SidePanelViews.UNMOUNT_FILESYSTEM[1]]: "Unmount filesystem",
+  [SidePanelViews.UPDATE_DATASTORE[1]]: "Update datastore",
+  [SidePanelViews.UpdateTag[1]]: "Update Tag",
+  [SidePanelViews.CREATE_POOL[1]]: "Add pool",
+  [SidePanelViews.EDIT_POOL[1]]: "Edit pool",
+  [SidePanelViews.DELETE_POOL[1]]: "Delete pool",
+  [SidePanelViews.CREATE_USER[1]]: "Add user",
+  [SidePanelViews.EDIT_USER[1]]: "Edit user",
+  [SidePanelViews.DELETE_USER[1]]: "Delete user",
+  [SidePanelViews.ADD_REPOSITORY[1]]: "Add repository",
+  [SidePanelViews.ADD_PPA[1]]: "Add PPA",
+  [SidePanelViews.EDIT_REPOSITORY[1]]: "Edit repository",
+  [SidePanelViews.DELETE_REPOSITORY[1]]: "Delete repository",
+};
+
+/**
+ * Get title depending on side panel content.
+ * @param defaultTitle - Title to show if no header content open.
+ * @param sidePanelContent - The name of the header content to check.
+ * @returns Header title string.
+ */
+export const getSidePanelTitle = (
+  defaultTitle: string,
+  sidePanelContent: SidePanelContent | null
+): string => {
+  if (sidePanelContent) {
+    const [, name] = sidePanelContent.view;
+    return (
+      sidePanelTitleMap[name] ||
+      getNodeActionTitle(name as NodeActions) ||
+      defaultTitle
+    );
   }
-  return context;
+  return defaultTitle;
+};
+
+export type SetSidePanelContextType = {
+  setSidePanelContent: SetSidePanelContent;
+  setSidePanelSize: (size: SidePanelSize) => void;
+};
+
+export type SidePanelContentTypes<T = SidePanelContent> = {
+  sidePanelContent: T | null;
+  setSidePanelContent: SetSidePanelContent<T>;
+};
+
+const SidePanelContext = createContext<SidePanelContextType>({
+  sidePanelContent: null,
+  sidePanelSize: "regular",
+});
+
+const SetSidePanelContext = createContext<SetSidePanelContextType>({
+  setSidePanelContent: () => {},
+  setSidePanelSize: () => {},
+});
+
+const useSidePanelContext = (): SidePanelContextType =>
+  useContext(SidePanelContext);
+
+const useSetSidePanelContext = (): SetSidePanelContextType =>
+  useContext(SetSidePanelContext);
+
+export const useSidePanel = (): SetSidePanelContextType &
+  SidePanelContextType => {
+  const { sidePanelSize, sidePanelContent } = useSidePanelContext();
+  const { setSidePanelContent, setSidePanelSize } = useSetSidePanelContext();
+  const setSidePanelContentWithSizeReset = useCallback(
+    (content: SidePanelContent | null): void => {
+      if (content === null) {
+        setSidePanelSize("regular");
+      }
+      setSidePanelContent(content);
+    },
+    [setSidePanelContent, setSidePanelSize]
+  );
+
+  return {
+    sidePanelContent,
+    setSidePanelContent: setSidePanelContentWithSizeReset,
+    sidePanelSize,
+    setSidePanelSize,
+  };
 };
 
 const SidePanelContextProvider = ({
   children,
-}: PropsWithChildren): ReactElement => {
-  const [state, setState] = useState<SidePanelState>({
-    isOpen: false,
-    title: "",
-    size: "regular",
-    component: null,
-    props: {},
-  });
-
-  const open = <
-    TProps extends Record<string, unknown> = Record<string, unknown>,
-  >(
-    component: ComponentType<TProps>,
-    title: string,
-    props: TProps = {} as TProps,
-    size: SidePanelSize = "regular"
-  ) => {
-    setState({
-      isOpen: true,
-      title,
-      size,
-      component: component as ComponentType<Record<string, unknown>>,
-      props: props || ({} as Record<string, unknown>),
-    });
-  };
-
-  const close = () => {
-    setState((prev) => ({
-      ...prev,
-      isOpen: false,
-      size: "regular",
-      props: {},
-    }));
-  };
-
-  const setSize = (size: SidePanelSize) => {
-    setState((prev) => ({ ...prev, size }));
-  };
+  initialSidePanelContent = null,
+  initialSidePanelSize = "regular",
+}: PropsWithChildren<{
+  initialSidePanelContent?: SidePanelContent;
+  initialSidePanelSize?: SidePanelSize;
+}>): ReactElement => {
+  const [sidePanelContent, setSidePanelContent] = useState<SidePanelContent>(
+    initialSidePanelContent
+  );
+  const [sidePanelSize, setSidePanelSize] =
+    useState<SidePanelSize>(initialSidePanelSize);
 
   return (
-    <SidePanelContext.Provider
+    <SetSidePanelContext.Provider
       value={{
-        ...state,
-        open,
-        close,
-        setSize,
+        setSidePanelContent,
+        setSidePanelSize,
       }}
     >
-      {children}
-    </SidePanelContext.Provider>
+      <SidePanelContext.Provider
+        value={{
+          sidePanelContent,
+          sidePanelSize,
+        }}
+      >
+        {children}
+      </SidePanelContext.Provider>
+    </SetSidePanelContext.Provider>
   );
 };
 

--- a/src/app/base/side-panel-context.tsx
+++ b/src/app/base/side-panel-context.tsx
@@ -1,291 +1,91 @@
-import type { PropsWithChildren, ReactElement } from "react";
-import { createContext, useCallback, useContext, useState } from "react";
+import type { ComponentType, PropsWithChildren, ReactElement } from "react";
+import { useContext, createContext, useState } from "react";
 
-import type { RepositorySidePanelContent } from "../settings/views/Repositories/constants";
-import { RepositoryActionSidePanelViews } from "../settings/views/Repositories/constants";
+type SidePanelSize = "large" | "narrow" | "regular" | "wide";
 
-import { ControllerSidePanelViews } from "@/app/controllers/constants";
-import type { ControllerSidePanelContent } from "@/app/controllers/types";
-import { DeviceSidePanelViews } from "@/app/devices/constants";
-import type { DeviceSidePanelContent } from "@/app/devices/types";
-import {
-  DomainDetailsSidePanelViews,
-  type DomainDetailsSidePanelContent,
-} from "@/app/domains/views/DomainDetails/constants";
-import {
-  DomainListSidePanelViews,
-  type DomainListSidePanelContent,
-} from "@/app/domains/views/DomainsList/constants";
-import { ImageSidePanelViews } from "@/app/images/constants";
-import type { ImageSidePanelContent } from "@/app/images/types";
-import { KVMSidePanelViews } from "@/app/kvm/constants";
-import type { KVMSidePanelContent } from "@/app/kvm/types";
-import { MachineSidePanelViews } from "@/app/machines/constants";
-import type { MachineSidePanelContent } from "@/app/machines/types";
-import {
-  NetworkDiscoverySidePanelViews,
-  type NetworkDiscoverySidePanelContent,
-} from "@/app/networkDiscovery/constants";
-import type { PoolSidePanelContent } from "@/app/pools/constants";
-import { PoolActionSidePanelViews } from "@/app/pools/constants";
-import type { SSHKeySidePanelContent } from "@/app/preferences/views/SSHKeys/constants";
-import { SSHKeyActionSidePanelViews } from "@/app/preferences/views/SSHKeys/constants";
-import type { SSLKeySidePanelContent } from "@/app/preferences/views/SSLKeys/constants";
-import { SSLKeyActionSidePanelViews } from "@/app/preferences/views/SSLKeys/constants";
-import { UserActionSidePanelViews } from "@/app/settings/views/Users/constants";
-import type { UserSidePanelContent } from "@/app/settings/views/Users/constants";
-import type { NodeActions } from "@/app/store/types/node";
-import { getNodeActionTitle } from "@/app/store/utils";
-import {
-  SubnetSidePanelViews,
-  type SubnetSidePanelContent,
-} from "@/app/subnets/types";
-import {
-  FabricDetailsSidePanelViews,
-  type FabricDetailsSidePanelContent,
-} from "@/app/subnets/views/FabricDetails/FabricDetailsHeader/constants";
-import {
-  SpaceDetailsSidePanelViews,
-  type SpaceDetailsSidePanelContent,
-} from "@/app/subnets/views/SpaceDetails/constants";
-import {
-  SubnetDetailsSidePanelViews,
-  type SubnetDetailsSidePanelContent,
-} from "@/app/subnets/views/SubnetDetails/constants";
-import {
-  VLANDetailsSidePanelViews,
-  type VLANDetailsSidePanelContent,
-} from "@/app/subnets/views/VLANDetails/constants";
-import { TagSidePanelViews } from "@/app/tags/constants";
-import type { TagSidePanelContent } from "@/app/tags/types";
-import {
-  ZoneActionSidePanelViews,
-  type ZoneSidePanelContent,
-} from "@/app/zones/constants";
+interface SidePanelState<TProps = Record<string, unknown>> {
+  isOpen: boolean;
+  title: string;
+  size: SidePanelSize;
+  component: ComponentType<TProps> | null;
+  props: TProps;
+}
 
-export type SidePanelContent =
-  | ControllerSidePanelContent
-  | DeviceSidePanelContent
-  | DomainDetailsSidePanelContent
-  | DomainListSidePanelContent
-  | FabricDetailsSidePanelContent
-  | ImageSidePanelContent
-  | KVMSidePanelContent
-  | MachineSidePanelContent
-  | NetworkDiscoverySidePanelContent
-  | PoolSidePanelContent
-  | RepositorySidePanelContent
-  | SpaceDetailsSidePanelContent
-  | SSHKeySidePanelContent
-  | SSLKeySidePanelContent
-  | SubnetDetailsSidePanelContent
-  | SubnetSidePanelContent
-  | TagSidePanelContent
-  | UserSidePanelContent
-  | VLANDetailsSidePanelContent
-  | ZoneSidePanelContent
-  | null;
+interface SidePanelActions {
+  open: <TProps extends Record<string, unknown> = Record<string, unknown>>(
+    component: ComponentType<TProps>,
+    title: string,
+    props?: TProps,
+    size?: SidePanelSize
+  ) => void;
+  close: () => void;
+  setSize: (size: SidePanelSize) => void;
+}
 
-export type SetSidePanelContent<T = SidePanelContent> = (
-  sidePanelContent: T | null
-) => void;
+type SidePanelContextValue = SidePanelActions & SidePanelState;
 
-export type SidePanelSize = "large" | "narrow" | "regular" | "wide";
-export type SidePanelContextType<T = SidePanelContent> = {
-  sidePanelContent: T | null;
-  sidePanelSize: SidePanelSize;
-};
+const SidePanelContext = createContext<SidePanelContextValue | null>(null);
 
-export const SidePanelViews = {
-  ...ControllerSidePanelViews,
-  ...MachineSidePanelViews,
-  ...ControllerSidePanelViews,
-  ...DeviceSidePanelViews,
-  ...KVMSidePanelViews,
-  ...TagSidePanelViews,
-  ...UserActionSidePanelViews,
-  ...ZoneActionSidePanelViews,
-  ...SubnetSidePanelViews,
-  ...DomainDetailsSidePanelViews,
-  ...DomainListSidePanelViews,
-  ...NetworkDiscoverySidePanelViews,
-  ...VLANDetailsSidePanelViews,
-  ...FabricDetailsSidePanelViews,
-  ...ImageSidePanelViews,
-  ...SSHKeyActionSidePanelViews,
-  ...SSLKeyActionSidePanelViews,
-  ...PoolActionSidePanelViews,
-  ...SubnetDetailsSidePanelViews,
-  ...SpaceDetailsSidePanelViews,
-  ...RepositoryActionSidePanelViews,
-} as const;
-
-const sidePanelTitleMap: Record<string, string> = {
-  [SidePanelViews.ADD_ALIAS[1]]: "Add alias",
-  [SidePanelViews.ADD_BOND[1]]: "Create bond",
-  [SidePanelViews.ADD_BRIDGE[1]]: "Create bridge",
-  [SidePanelViews.ADD_CONTROLLER[1]]: "Add controller",
-  [SidePanelViews.ADD_CHASSIS[1]]: "Add chassis",
-  [SidePanelViews.ADD_DISCOVERY[1]]: "Add discovery",
-  [SidePanelViews.ADD_DOMAIN[1]]: "Add domains",
-  [SidePanelViews.ADD_INTERFACE[1]]: "Add interface",
-  [SidePanelViews.ADD_MACHINE[1]]: "Add machine",
-  [SidePanelViews.ADD_DEVICE[1]]: "Add device",
-  [SidePanelViews.ADD_SPECIAL_FILESYSTEM[1]]: "Add special filesystem",
-  [SidePanelViews.ADD_SSH_KEY[1]]: "Add SSH key",
-  [SidePanelViews.DELETE_SSH_KEY[1]]: "Delete SSH key",
-  [SidePanelViews.ADD_SSL_KEY[1]]: "Add SSL key",
-  [SidePanelViews.DELETE_SSL_KEY[1]]: "Delete SSL key",
-  [SidePanelViews.AddTag[1]]: "Create new tag",
-  [SidePanelViews.ADD_VLAN[1]]: "Add VLAN",
-  [SidePanelViews.APPLY_STORAGE_LAYOUT[1]]: "Change storage layout",
-  [SidePanelViews.CLEAR_ALL_DISCOVERIES[1]]: "Clear all discoveries",
-  [SidePanelViews.CREATE_BCACHE[1]]: "Create bcache",
-  [SidePanelViews.CREATE_CACHE_SET[1]]: "Create cache set",
-  [SidePanelViews.CREATE_DATASTORE[1]]: "Create datastore",
-  [SidePanelViews.CREATE_LOGICAL_VOLUME[1]]: "Create logical volume",
-  [SidePanelViews.CREATE_PARTITION[1]]: "Create partition",
-  [SidePanelViews.CREATE_RAID[1]]: "Create raid",
-  [SidePanelViews.CREATE_VOLUME_GROUP[1]]: "Create volume group",
-  [SidePanelViews.DELETE_DISCOVERY[1]]: "Delete discovery",
-  [SidePanelViews.DELETE_DISK[1]]: "Delete disk",
-  [SidePanelViews.DELETE_FILESYSTEM[1]]: "Delete filesystem",
-  [SidePanelViews.DELETE_SPECIAL_FILESYSTEM[1]]: "Delete special filesystem",
-  [SidePanelViews.DeleteTag[1]]: "Delete tag",
-  [SidePanelViews.DELETE_VOLUME_GROUP[1]]: "Delete volume group",
-  [SidePanelViews.DOWNLOAD_IMAGE[1]]: "Select upstream images to sync",
-  [SidePanelViews.EDIT_INTERFACE[1]]: "Edit interface",
-  [SidePanelViews.CREATE_ZONE[1]]: "Add AZ",
-  [SidePanelViews.EDIT_ZONE[1]]: "Edit AZ",
-  [SidePanelViews.DELETE_ZONE[1]]: "Delete AZ",
-  [SidePanelViews.EDIT_DISK[1]]: "Edit disk",
-  [SidePanelViews.EDIT_PARTITION[1]]: "Edit partition",
-  [SidePanelViews.EDIT_PHYSICAL[1]]: "Edit physical",
-  [SidePanelViews.DELETE_IMAGE[1]]: "Delete image",
-  [SidePanelViews.DELETE_MULTIPLE_IMAGES[1]]: "Delete multiple images",
-  [SidePanelViews.DELETE_SPACE[1]]: "Delete space",
-  [SidePanelViews.DELETE_FABRIC[1]]: "Delete fabric",
-  [SidePanelViews.MARK_CONNECTED[1]]: "Mark as connected",
-  [SidePanelViews.MARK_DISCONNECTED[1]]: "Mark as disconnected",
-  [SidePanelViews.REMOVE_INTERFACE[1]]: "Remove interface",
-  [SidePanelViews.REMOVE_PARTITION[1]]: "Remove partition",
-  [SidePanelViews.REMOVE_PHYSICAL[1]]: "Remove physical",
-  [SidePanelViews.SET_BOOT_DISK[1]]: "Set boot disk",
-  [SidePanelViews.SET_DEFAULT[1]]: "Set default",
-  [SidePanelViews.UNMOUNT_FILESYSTEM[1]]: "Unmount filesystem",
-  [SidePanelViews.UPDATE_DATASTORE[1]]: "Update datastore",
-  [SidePanelViews.UpdateTag[1]]: "Update Tag",
-  [SidePanelViews.CREATE_POOL[1]]: "Add pool",
-  [SidePanelViews.EDIT_POOL[1]]: "Edit pool",
-  [SidePanelViews.DELETE_POOL[1]]: "Delete pool",
-  [SidePanelViews.CREATE_USER[1]]: "Add user",
-  [SidePanelViews.EDIT_USER[1]]: "Edit user",
-  [SidePanelViews.DELETE_USER[1]]: "Delete user",
-  [SidePanelViews.ADD_REPOSITORY[1]]: "Add repository",
-  [SidePanelViews.ADD_PPA[1]]: "Add PPA",
-  [SidePanelViews.EDIT_REPOSITORY[1]]: "Edit repository",
-  [SidePanelViews.DELETE_REPOSITORY[1]]: "Delete repository",
-};
-
-/**
- * Get title depending on side panel content.
- * @param defaultTitle - Title to show if no header content open.
- * @param sidePanelContent - The name of the header content to check.
- * @returns Header title string.
- */
-export const getSidePanelTitle = (
-  defaultTitle: string,
-  sidePanelContent: SidePanelContent | null
-): string => {
-  if (sidePanelContent) {
-    const [, name] = sidePanelContent.view;
-    return (
-      sidePanelTitleMap[name] ||
-      getNodeActionTitle(name as NodeActions) ||
-      defaultTitle
-    );
+export const useSidePanel = (): SidePanelContextValue => {
+  const context = useContext(SidePanelContext);
+  if (!context) {
+    throw new Error("useSidePanel must be used within a SidePanelProvider");
   }
-  return defaultTitle;
-};
-
-export type SetSidePanelContextType = {
-  setSidePanelContent: SetSidePanelContent;
-  setSidePanelSize: (size: SidePanelSize) => void;
-};
-
-export type SidePanelContentTypes<T = SidePanelContent> = {
-  sidePanelContent: T | null;
-  setSidePanelContent: SetSidePanelContent<T>;
-};
-
-const SidePanelContext = createContext<SidePanelContextType>({
-  sidePanelContent: null,
-  sidePanelSize: "regular",
-});
-
-const SetSidePanelContext = createContext<SetSidePanelContextType>({
-  setSidePanelContent: () => {},
-  setSidePanelSize: () => {},
-});
-
-const useSidePanelContext = (): SidePanelContextType =>
-  useContext(SidePanelContext);
-
-const useSetSidePanelContext = (): SetSidePanelContextType =>
-  useContext(SetSidePanelContext);
-
-export const useSidePanel = (): SetSidePanelContextType &
-  SidePanelContextType => {
-  const { sidePanelSize, sidePanelContent } = useSidePanelContext();
-  const { setSidePanelContent, setSidePanelSize } = useSetSidePanelContext();
-  const setSidePanelContentWithSizeReset = useCallback(
-    (content: SidePanelContent | null): void => {
-      if (content === null) {
-        setSidePanelSize("regular");
-      }
-      setSidePanelContent(content);
-    },
-    [setSidePanelContent, setSidePanelSize]
-  );
-
-  return {
-    sidePanelContent,
-    setSidePanelContent: setSidePanelContentWithSizeReset,
-    sidePanelSize,
-    setSidePanelSize,
-  };
+  return context;
 };
 
 const SidePanelContextProvider = ({
   children,
-  initialSidePanelContent = null,
-  initialSidePanelSize = "regular",
-}: PropsWithChildren<{
-  initialSidePanelContent?: SidePanelContent;
-  initialSidePanelSize?: SidePanelSize;
-}>): ReactElement => {
-  const [sidePanelContent, setSidePanelContent] = useState<SidePanelContent>(
-    initialSidePanelContent
-  );
-  const [sidePanelSize, setSidePanelSize] =
-    useState<SidePanelSize>(initialSidePanelSize);
+}: PropsWithChildren): ReactElement => {
+  const [state, setState] = useState<SidePanelState>({
+    isOpen: false,
+    title: "",
+    size: "regular",
+    component: null,
+    props: {},
+  });
+
+  const open = <
+    TProps extends Record<string, unknown> = Record<string, unknown>,
+  >(
+    component: ComponentType<TProps>,
+    title: string,
+    props: TProps = {} as TProps,
+    size: SidePanelSize = "regular"
+  ) => {
+    setState({
+      isOpen: true,
+      title,
+      size,
+      component: component as ComponentType<Record<string, unknown>>,
+      props: props || ({} as Record<string, unknown>),
+    });
+  };
+
+  const close = () => {
+    setState((prev) => ({
+      ...prev,
+      isOpen: false,
+      size: "regular",
+      props: {},
+    }));
+  };
+
+  const setSize = (size: SidePanelSize) => {
+    setState((prev) => ({ ...prev, size }));
+  };
 
   return (
-    <SetSidePanelContext.Provider
+    <SidePanelContext.Provider
       value={{
-        setSidePanelContent,
-        setSidePanelSize,
+        ...state,
+        open,
+        close,
+        setSize,
       }}
     >
-      <SidePanelContext.Provider
-        value={{
-          sidePanelContent,
-          sidePanelSize,
-        }}
-      >
-        {children}
-      </SidePanelContext.Provider>
-    </SetSidePanelContext.Provider>
+      {children}
+    </SidePanelContext.Provider>
   );
 };
 

--- a/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.test.tsx
@@ -31,9 +31,9 @@ describe("AddSSHKey", () => {
       size: "regular",
       component: null,
       props: {},
-      open: vi.fn(),
-      close: mockClose,
-      setSize: vi.fn(),
+      openSidePanel: vi.fn(),
+      closeSidePanel: mockClose,
+      setSidePanelSize: vi.fn(),
     });
   });
   it("runs closeForm function when the cancel button is clicked", async () => {

--- a/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.test.tsx
@@ -14,18 +14,37 @@ const mockServer = setupMockServer(
   sshKeyResolvers.importSshKey.handler(),
   sshKeyResolvers.createSshKey.handler()
 );
+const mockUseSidePanel = vi.spyOn(
+  await import("@/app/base/side-panel-context-new"),
+  "useSidePanel"
+);
 
 describe("AddSSHKey", () => {
+  const mockClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseSidePanel.mockReturnValue({
+      isOpen: false,
+      title: "",
+      size: "regular",
+      component: null,
+      props: {},
+      open: vi.fn(),
+      close: mockClose,
+      setSize: vi.fn(),
+    });
+  });
   it("runs closeForm function when the cancel button is clicked", async () => {
-    const closeForm = vi.fn();
-    renderWithProviders(<AddSSHKey closeForm={closeForm} />);
+    renderWithProviders(<AddSSHKey />);
 
     await userEvent.click(screen.getByRole("button", { name: /Cancel/i }));
-    expect(closeForm).toHaveBeenCalled();
+    expect(mockClose).toHaveBeenCalled();
   });
 
   it("calls the import endpoint on save button click when LP or GH is chosen", async () => {
-    renderWithProviders(<AddSSHKey closeForm={vi.fn()} />);
+    renderWithProviders(<AddSSHKey />);
 
     await userEvent.selectOptions(screen.getByRole("combobox"), "lp");
 
@@ -44,7 +63,7 @@ describe("AddSSHKey", () => {
   });
 
   it("calls the create endpoint on save button click when Upload is chosen", async () => {
-    renderWithProviders(<AddSSHKey closeForm={vi.fn()} />);
+    renderWithProviders(<AddSSHKey />);
 
     await userEvent.selectOptions(screen.getByRole("combobox"), "upload");
 
@@ -67,7 +86,7 @@ describe("AddSSHKey", () => {
       sshKeyResolvers.importSshKey.error({ code: 400, message: "Uh oh!" })
     );
 
-    renderWithProviders(<AddSSHKey closeForm={vi.fn()} />);
+    renderWithProviders(<AddSSHKey />);
 
     await userEvent.selectOptions(screen.getByRole("combobox"), "lp");
 

--- a/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.tsx
@@ -11,7 +11,7 @@ import type {
   SshKeysProtocolType,
 } from "@/app/apiclient";
 import FormikForm from "@/app/base/components/FormikForm";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 import SSHKeyFormFields from "@/app/preferences/views/SSHKeys/components/AddSSHKey/SSHKeyFormFields";
 
 export type SSHKeyFormValues = {

--- a/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.tsx
@@ -11,11 +11,8 @@ import type {
   SshKeysProtocolType,
 } from "@/app/apiclient";
 import FormikForm from "@/app/base/components/FormikForm";
+import { useSidePanel } from "@/app/base/side-panel-context";
 import SSHKeyFormFields from "@/app/preferences/views/SSHKeys/components/AddSSHKey/SSHKeyFormFields";
-
-type AddSSHKeyProps = {
-  closeForm?: () => void;
-};
 
 export type SSHKeyFormValues = {
   protocol: SshKeyImportFromSourceRequest["protocol"] | "" | "upload";
@@ -35,7 +32,8 @@ const SSHKeySchema = Yup.object().shape({
   }),
 });
 
-const AddSSHKey = ({ closeForm }: AddSSHKeyProps): ReactElement => {
+const AddSSHKey = (): ReactElement => {
+  const { close } = useSidePanel();
   const uploadSshKey = useCreateSshKeys();
   const importSshKey = useImportSshKeys();
 
@@ -47,7 +45,7 @@ const AddSSHKey = ({ closeForm }: AddSSHKeyProps): ReactElement => {
       aria-label="Add SSH key"
       errors={uploadSshKey.error || importSshKey.error}
       initialValues={{ auth_id: "", protocol: "", key: "" }}
-      onCancel={closeForm}
+      onCancel={close}
       onSaveAnalytics={{
         action: "Saved",
         category: "SSH keys preferences",
@@ -69,7 +67,7 @@ const AddSSHKey = ({ closeForm }: AddSSHKeyProps): ReactElement => {
           });
         }
       }}
-      onSuccess={closeForm}
+      onSuccess={close}
       resetOnSave={true}
       saved={uploadSshKey.isSuccess || importSshKey.isSuccess}
       saving={uploadSshKey.isPending || importSshKey.isPending}

--- a/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/components/AddSSHKey/AddSSHKey.tsx
@@ -33,7 +33,7 @@ const SSHKeySchema = Yup.object().shape({
 });
 
 const AddSSHKey = (): ReactElement => {
-  const { close } = useSidePanel();
+  const { closeSidePanel } = useSidePanel();
   const uploadSshKey = useCreateSshKeys();
   const importSshKey = useImportSshKeys();
 
@@ -45,7 +45,7 @@ const AddSSHKey = (): ReactElement => {
       aria-label="Add SSH key"
       errors={uploadSshKey.error || importSshKey.error}
       initialValues={{ auth_id: "", protocol: "", key: "" }}
-      onCancel={close}
+      onCancel={closeSidePanel}
       onSaveAnalytics={{
         action: "Saved",
         category: "SSH keys preferences",
@@ -67,7 +67,7 @@ const AddSSHKey = (): ReactElement => {
           });
         }
       }}
-      onSuccess={close}
+      onSuccess={closeSidePanel}
       resetOnSave={true}
       saved={uploadSshKey.isSuccess || importSshKey.isSuccess}
       saving={uploadSshKey.isPending || importSshKey.isPending}

--- a/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.test.tsx
@@ -11,10 +11,31 @@ import {
 } from "@/testing/utils";
 
 const mockServer = setupMockServer(sshKeyResolvers.deleteSshKey.handler());
+const mockUseSidePanel = vi.spyOn(
+  await import("@/app/base/side-panel-context-new"),
+  "useSidePanel"
+);
 
 describe("DeleteSSHKey", () => {
+  const mockClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseSidePanel.mockReturnValue({
+      isOpen: false,
+      title: "",
+      size: "regular",
+      component: null,
+      props: {},
+      open: vi.fn(),
+      close: mockClose,
+      setSize: vi.fn(),
+    });
+  });
+
   it("renders", () => {
-    renderWithProviders(<DeleteSSHKey closeForm={vi.fn()} ids={[2, 3]} />);
+    renderWithProviders(<DeleteSSHKey ids={[2, 3]} />);
     expect(
       screen.getByRole("form", { name: "Confirm SSH key deletion" })
     ).toBeInTheDocument();
@@ -24,15 +45,14 @@ describe("DeleteSSHKey", () => {
   });
 
   it("calls closeForm on cancel click", async () => {
-    const closeForm = vi.fn();
-    renderWithProviders(<DeleteSSHKey closeForm={closeForm} ids={[2]} />);
+    renderWithProviders(<DeleteSSHKey ids={[2]} />);
 
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(closeForm).toHaveBeenCalled();
+    expect(mockClose).toHaveBeenCalled();
   });
 
   it("can delete a group of SSH keys", async () => {
-    renderWithProviders(<DeleteSSHKey closeForm={vi.fn()} ids={[2, 3]} />);
+    renderWithProviders(<DeleteSSHKey ids={[2, 3]} />);
     await userEvent.click(screen.getByRole("button", { name: /delete/i }));
 
     await waitFor(() => {
@@ -44,7 +64,7 @@ describe("DeleteSSHKey", () => {
     mockServer.use(
       sshKeyResolvers.deleteSshKey.error({ message: "Uh oh!", code: 404 })
     );
-    renderWithProviders(<DeleteSSHKey closeForm={vi.fn()} ids={[2, 3]} />);
+    renderWithProviders(<DeleteSSHKey ids={[2, 3]} />);
 
     await userEvent.click(screen.getByRole("button", { name: /delete/i }));
 

--- a/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.test.tsx
+++ b/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.test.tsx
@@ -28,9 +28,9 @@ describe("DeleteSSHKey", () => {
       size: "regular",
       component: null,
       props: {},
-      open: vi.fn(),
-      close: mockClose,
-      setSize: vi.fn(),
+      openSidePanel: vi.fn(),
+      closeSidePanel: mockClose,
+      setSidePanelSize: vi.fn(),
     });
   });
 

--- a/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.tsx
@@ -9,7 +9,7 @@ type DeleteSSHKeyProps = {
 };
 
 const DeleteSSHKey = ({ ids }: DeleteSSHKeyProps): ReactElement => {
-  const { close } = useSidePanel();
+  const { closeSidePanel } = useSidePanel();
   const deleteSshKey = useDeleteSshKey();
 
   return (
@@ -21,13 +21,13 @@ const DeleteSSHKey = ({ ids }: DeleteSSHKeyProps): ReactElement => {
         ids.length > 1 ? "these SSH keys" : "this SSH key"
       }?`}
       modelType="SSH key"
-      onCancel={close}
+      onCancel={closeSidePanel}
       onSubmit={() => {
         ids.forEach((id) => {
           deleteSshKey.mutate({ path: { id } });
         });
       }}
-      onSuccess={close}
+      onSuccess={closeSidePanel}
       saved={deleteSshKey.isSuccess}
       saving={deleteSshKey.isPending}
     />

--- a/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.tsx
@@ -2,13 +2,14 @@ import type { ReactElement } from "react";
 
 import { useDeleteSshKey } from "@/app/api/query/sshKeys";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { useSidePanel } from "@/app/base/side-panel-context";
 
 type DeleteSSHKeyProps = {
   ids: number[];
-  closeForm: () => void;
 };
 
-const DeleteSSHKey = ({ ids, closeForm }: DeleteSSHKeyProps): ReactElement => {
+const DeleteSSHKey = ({ ids }: DeleteSSHKeyProps): ReactElement => {
+  const { close } = useSidePanel();
   const deleteSshKey = useDeleteSshKey();
 
   return (
@@ -20,13 +21,13 @@ const DeleteSSHKey = ({ ids, closeForm }: DeleteSSHKeyProps): ReactElement => {
         ids.length > 1 ? "these SSH keys" : "this SSH key"
       }?`}
       modelType="SSH key"
-      onCancel={closeForm}
+      onCancel={close}
       onSubmit={() => {
         ids.forEach((id) => {
           deleteSshKey.mutate({ path: { id } });
         });
       }}
-      onSuccess={closeForm}
+      onSuccess={close}
       saved={deleteSshKey.isSuccess}
       saving={deleteSshKey.isPending}
     />

--- a/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.tsx
+++ b/src/app/preferences/views/SSHKeys/components/DeleteSSHKey/DeleteSSHKey.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 
 import { useDeleteSshKey } from "@/app/api/query/sshKeys";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 
 type DeleteSSHKeyProps = {
   ids: number[];

--- a/src/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable.test.tsx
+++ b/src/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable.test.tsx
@@ -1,12 +1,7 @@
-import userEvent from "@testing-library/user-event";
-import type { Mock } from "vitest";
 import { describe } from "vitest";
 
 import SSHKeysTable from "./SSHKeysTable";
 
-import { useSidePanel } from "@/app/base/side-panel-context";
-import { SSHKeyActionSidePanelViews } from "@/app/preferences/views/SSHKeys/constants";
-import * as factory from "@/testing/factories";
 import { sshKeyResolvers } from "@/testing/resolvers/sshKeys";
 import {
   renderWithProviders,
@@ -18,21 +13,7 @@ import {
 
 const mockServer = setupMockServer(sshKeyResolvers.listSshKeys.handler());
 
-vi.mock("@/app/base/side-panel-context", async () => {
-  const actual = await vi.importActual("@/app/base/side-panel-context");
-  return {
-    ...actual,
-    useSidePanel: vi.fn(),
-  };
-});
-
 describe("SSHKeysTable", () => {
-  const mockSetSidePanelContent = vi.fn();
-
-  (useSidePanel as Mock).mockReturnValue({
-    setSidePanelContent: mockSetSidePanelContent,
-  });
-
   describe("display", () => {
     it("displays a loading component if SSH keys are loading", async () => {
       mockIsPending();
@@ -71,62 +52,5 @@ describe("SSHKeysTable", () => {
     it.skip("enables the action buttons with correct permissions");
 
     it.skip("disables the action buttons without permissions");
-  });
-
-  describe("actions", () => {
-    it("opens add SSH key side panel form", async () => {
-      renderWithProviders(<SSHKeysTable isIntro={false} />);
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: "Import SSH key" })
-        ).toBeInTheDocument();
-      });
-
-      await userEvent.click(
-        screen.getByRole("button", { name: "Import SSH key" })
-      );
-
-      await waitFor(() => {
-        expect(mockSetSidePanelContent).toHaveBeenCalledWith({
-          view: SSHKeyActionSidePanelViews.ADD_SSH_KEY,
-        });
-      });
-    });
-
-    it("opens delete SSH key side panel form", async () => {
-      mockServer.use(
-        sshKeyResolvers.listSshKeys.handler({
-          items: [
-            factory.sshKey({
-              id: 1,
-            }),
-            factory.sshKey({
-              id: 2,
-            }),
-          ],
-          total: 2,
-        })
-      );
-
-      renderWithProviders(<SSHKeysTable isIntro={false} />);
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: "Delete" })
-        ).toBeInTheDocument();
-      });
-
-      await userEvent.click(screen.getByRole("button", { name: "Delete" }));
-
-      await waitFor(() => {
-        expect(mockSetSidePanelContent).toHaveBeenCalledWith({
-          view: SSHKeyActionSidePanelViews.DELETE_SSH_KEY,
-          extras: {
-            sshKeyIds: [1, 2],
-          },
-        });
-      });
-    });
   });
 });

--- a/src/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable.tsx
+++ b/src/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable.tsx
@@ -10,7 +10,7 @@ import { Button, Notification } from "@canonical/react-components";
 import { useListSshKeys } from "@/app/api/query/sshKeys";
 import type { SshKeyResponse } from "@/app/apiclient";
 import docsUrls from "@/app/base/docsUrls";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 import { AddSSHKey } from "@/app/preferences/views/SSHKeys/components";
 import useSSHKeysTableColumns from "@/app/preferences/views/SSHKeys/components/SSHKeysTable/useSSHKeysTableColumns/useSSHKeysTableColumns";
 

--- a/src/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable.tsx
+++ b/src/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable.tsx
@@ -11,8 +11,8 @@ import { useListSshKeys } from "@/app/api/query/sshKeys";
 import type { SshKeyResponse } from "@/app/apiclient";
 import docsUrls from "@/app/base/docsUrls";
 import { useSidePanel } from "@/app/base/side-panel-context";
+import { AddSSHKey } from "@/app/preferences/views/SSHKeys/components";
 import useSSHKeysTableColumns from "@/app/preferences/views/SSHKeys/components/SSHKeysTable/useSSHKeysTableColumns/useSSHKeysTableColumns";
-import { SSHKeyActionSidePanelViews } from "@/app/preferences/views/SSHKeys/constants";
 
 type SSHKeysTableProps = {
   isIntro: boolean;
@@ -58,7 +58,7 @@ const groupBySource = (sshKeys: SshKeyResponse[]): SSHKeyValue[] => {
 };
 
 const SSHKeysTable = ({ isIntro = false }: SSHKeysTableProps): ReactElement => {
-  const { setSidePanelContent } = useSidePanel();
+  const { open } = useSidePanel();
   const { data, failureReason, isPending } = useListSshKeys();
   const sshKeys = groupBySource(data?.items ?? []);
 
@@ -76,9 +76,7 @@ const SSHKeysTable = ({ isIntro = false }: SSHKeysTableProps): ReactElement => {
           <MainToolbar.Controls>
             <Button
               onClick={() => {
-                setSidePanelContent({
-                  view: SSHKeyActionSidePanelViews.ADD_SSH_KEY,
-                });
+                open(AddSSHKey, "Add SSH key");
               }}
             >
               Import SSH key

--- a/src/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable.tsx
+++ b/src/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable.tsx
@@ -58,7 +58,7 @@ const groupBySource = (sshKeys: SshKeyResponse[]): SSHKeyValue[] => {
 };
 
 const SSHKeysTable = ({ isIntro = false }: SSHKeysTableProps): ReactElement => {
-  const { open } = useSidePanel();
+  const { openSidePanel } = useSidePanel();
   const { data, failureReason, isPending } = useListSshKeys();
   const sshKeys = groupBySource(data?.items ?? []);
 
@@ -76,7 +76,7 @@ const SSHKeysTable = ({ isIntro = false }: SSHKeysTableProps): ReactElement => {
           <MainToolbar.Controls>
             <Button
               onClick={() => {
-                open(AddSSHKey, "Add SSH key");
+                openSidePanel({ component: AddSSHKey, title: "Add SSH key" });
               }}
             >
               Import SSH key

--- a/src/app/preferences/views/SSHKeys/components/SSHKeysTable/useSSHKeysTableColumns/useSSHKeysTableColumns.tsx
+++ b/src/app/preferences/views/SSHKeys/components/SSHKeysTable/useSSHKeysTableColumns/useSSHKeysTableColumns.tsx
@@ -4,7 +4,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 
 import type { SshKeyResponse } from "@/app/apiclient";
 import TableActions from "@/app/base/components/TableActions";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 import { DeleteSSHKey } from "@/app/preferences/views/SSHKeys/components";
 import type { SSHKeyValue } from "@/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable";
 

--- a/src/app/preferences/views/SSHKeys/components/SSHKeysTable/useSSHKeysTableColumns/useSSHKeysTableColumns.tsx
+++ b/src/app/preferences/views/SSHKeys/components/SSHKeysTable/useSSHKeysTableColumns/useSSHKeysTableColumns.tsx
@@ -5,8 +5,8 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { SshKeyResponse } from "@/app/apiclient";
 import TableActions from "@/app/base/components/TableActions";
 import { useSidePanel } from "@/app/base/side-panel-context";
+import { DeleteSSHKey } from "@/app/preferences/views/SSHKeys/components";
 import type { SSHKeyValue } from "@/app/preferences/views/SSHKeys/components/SSHKeysTable/SSHKeysTable";
-import { SSHKeyActionSidePanelViews } from "@/app/preferences/views/SSHKeys/constants";
 
 type SSHKeysColumnDef = ColumnDef<SSHKeyValue, Partial<SSHKeyValue>>;
 
@@ -19,7 +19,7 @@ const formatKey = (key: SshKeyResponse["key"]) => {
 };
 
 const useSSHKeysTableColumns = (): SSHKeysColumnDef[] => {
-  const { setSidePanelContent } = useSidePanel();
+  const { open } = useSidePanel();
   return useMemo(
     () =>
       [
@@ -73,11 +73,8 @@ const useSSHKeysTableColumns = (): SSHKeysColumnDef[] => {
               <TableActions
                 data-testid="ssh-key-actions"
                 onDelete={() => {
-                  setSidePanelContent({
-                    view: SSHKeyActionSidePanelViews.DELETE_SSH_KEY,
-                    extras: {
-                      sshKeyIds: keys.map((key) => key.id),
-                    },
+                  open(DeleteSSHKey, "Delete SSH keys", {
+                    ids: keys.map((key) => key.id),
                   });
                 }}
               />
@@ -85,7 +82,7 @@ const useSSHKeysTableColumns = (): SSHKeysColumnDef[] => {
           },
         },
       ] as SSHKeysColumnDef[],
-    [setSidePanelContent]
+    [open]
   );
 };
 

--- a/src/app/preferences/views/SSHKeys/components/SSHKeysTable/useSSHKeysTableColumns/useSSHKeysTableColumns.tsx
+++ b/src/app/preferences/views/SSHKeys/components/SSHKeysTable/useSSHKeysTableColumns/useSSHKeysTableColumns.tsx
@@ -19,7 +19,7 @@ const formatKey = (key: SshKeyResponse["key"]) => {
 };
 
 const useSSHKeysTableColumns = (): SSHKeysColumnDef[] => {
-  const { open } = useSidePanel();
+  const { openSidePanel } = useSidePanel();
   return useMemo(
     () =>
       [
@@ -73,8 +73,12 @@ const useSSHKeysTableColumns = (): SSHKeysColumnDef[] => {
               <TableActions
                 data-testid="ssh-key-actions"
                 onDelete={() => {
-                  open(DeleteSSHKey, "Delete SSH keys", {
-                    ids: keys.map((key) => key.id),
+                  openSidePanel({
+                    component: DeleteSSHKey,
+                    title: "Delete SSH keys",
+                    props: {
+                      ids: keys.map((key) => key.id),
+                    },
                   });
                 }}
               />
@@ -82,7 +86,7 @@ const useSSHKeysTableColumns = (): SSHKeysColumnDef[] => {
           },
         },
       ] as SSHKeysColumnDef[],
-    [open]
+    [openSidePanel]
   );
 };
 

--- a/src/app/preferences/views/SSHKeys/views/SSHKeysList.test.tsx
+++ b/src/app/preferences/views/SSHKeys/views/SSHKeysList.test.tsx
@@ -1,5 +1,5 @@
-import type { SSHKeySidePanelContent } from "@/app/preferences/views/SSHKeys/constants";
-import { SSHKeyActionSidePanelViews } from "@/app/preferences/views/SSHKeys/constants";
+import { waitFor } from "@testing-library/react";
+
 import SSHKeysList from "@/app/preferences/views/SSHKeys/views/SSHKeysList";
 import { sshKeyResolvers } from "@/testing/resolvers/sshKeys";
 import {
@@ -11,61 +11,39 @@ import {
 
 setupMockServer(sshKeyResolvers.listSshKeys.handler());
 
-let mockSidePanelContent: SSHKeySidePanelContent | null = null;
-const mockSetSidePanelContent = vi.fn();
-
-vi.mock("@/app/base/side-panel-context", async () => {
-  const actual = await vi.importActual("@/app/base/side-panel-context");
-  return {
-    ...actual,
-    useSidePanel: () => ({
-      sidePanelContent: mockSidePanelContent,
-      setSidePanelContent: mockSetSidePanelContent,
-      sidePanelSize: "regular",
-      setSidePanelSize: vi.fn(),
-    }),
-  };
-});
-
 describe("SSHKeysList", () => {
-  beforeEach(() => {
-    mockSetSidePanelContent.mockClear();
-    mockSidePanelContent = null;
-  });
-
-  it("renders AddSSHKey when view is ADD_SSH_KEY", () => {
-    mockSidePanelContent = {
-      view: SSHKeyActionSidePanelViews.ADD_SSH_KEY,
-    };
-
+  it("renders AddSSHKey", async () => {
     renderWithProviders(<SSHKeysList />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Import SSH key" })
+    );
     expect(
       screen.getByRole("complementary", { name: "Add SSH key" })
     ).toBeInTheDocument();
   });
 
-  it("renders DeleteSSHKey when view is DELETE_SSH_KEY and valid sshKeyIds are provided", () => {
-    mockSidePanelContent = {
-      view: SSHKeyActionSidePanelViews.DELETE_SSH_KEY,
-      extras: { sshKeyIds: [42] },
-    };
-
+  it("renders DeleteSSHKey when valid sshKeyIds are provided", async () => {
     renderWithProviders(<SSHKeysList />);
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Delete" }));
+    });
+    await userEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
     expect(
-      screen.getByRole("complementary", { name: "Delete SSH key" })
+      screen.getByRole("complementary", { name: "Delete SSH keys" })
     ).toBeInTheDocument();
   });
 
   it("closes side panel form when canceled", async () => {
-    mockSidePanelContent = {
-      view: SSHKeyActionSidePanelViews.ADD_SSH_KEY,
-    };
-
     renderWithProviders(<SSHKeysList />);
+    await userEvent.click(
+      screen.getByRole("button", { name: "Import SSH key" })
+    );
     expect(
       screen.getByRole("complementary", { name: "Add SSH key" })
     ).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(mockSetSidePanelContent).toHaveBeenCalledWith(null);
+    expect(
+      screen.queryByRole("complementary", { name: "Add SSH key" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/preferences/views/SSHKeys/views/SSHKeysList.tsx
+++ b/src/app/preferences/views/SSHKeys/views/SSHKeysList.tsx
@@ -1,63 +1,22 @@
 import type { ReactElement } from "react";
-import { useEffect } from "react";
 
 import PageContent from "@/app/base/components/PageContent";
 import { useWindowTitle } from "@/app/base/hooks";
-import { getSidePanelTitle, useSidePanel } from "@/app/base/side-panel-context";
-import {
-  AddSSHKey,
-  DeleteSSHKey,
-  SSHKeysTable,
-} from "@/app/preferences/views/SSHKeys/components";
-import { SSHKeyActionSidePanelViews } from "@/app/preferences/views/SSHKeys/constants";
-import { isId } from "@/app/utils";
+import { SSHKeysTable } from "@/app/preferences/views/SSHKeys/components";
 
 type SSHKeysListProps = {
   isIntro?: boolean;
 };
 
 const SSHKeysList = ({ isIntro = false }: SSHKeysListProps): ReactElement => {
-  const { sidePanelContent, setSidePanelContent } = useSidePanel();
-
   useWindowTitle("SSH Keys");
-
-  const closeForm = () => {
-    setSidePanelContent(null);
-  };
-
-  useEffect(() => {
-    setSidePanelContent(null);
-  }, [setSidePanelContent]);
-
-  let content = null;
-
-  if (
-    sidePanelContent &&
-    sidePanelContent.view === SSHKeyActionSidePanelViews.ADD_SSH_KEY
-  ) {
-    content = <AddSSHKey closeForm={closeForm} key="add-ssh-key-form" />;
-  } else if (
-    sidePanelContent &&
-    sidePanelContent.view === SSHKeyActionSidePanelViews.DELETE_SSH_KEY
-  ) {
-    const sshKeyIds: number[] =
-      sidePanelContent.extras && "sshKeyIds" in sidePanelContent.extras
-        ? sidePanelContent.extras.sshKeyIds
-        : [];
-    content = sshKeyIds.every((id) => isId(id)) ? (
-      <DeleteSSHKey closeForm={closeForm} ids={sshKeyIds} />
-    ) : null;
-  }
 
   return (
     <>
       {isIntro ? (
         <SSHKeysTable isIntro={true} />
       ) : (
-        <PageContent
-          sidePanelContent={content}
-          sidePanelTitle={getSidePanelTitle("SSH keys", sidePanelContent)}
-        >
+        <PageContent>
           <SSHKeysTable isIntro={false} />
         </PageContent>
       )}

--- a/src/app/preferences/views/SSHKeys/views/SSHKeysList.tsx
+++ b/src/app/preferences/views/SSHKeys/views/SSHKeysList.tsx
@@ -16,7 +16,11 @@ const SSHKeysList = ({ isIntro = false }: SSHKeysListProps): ReactElement => {
       {isIntro ? (
         <SSHKeysTable isIntro={true} />
       ) : (
-        <PageContent>
+        <PageContent
+          sidePanelContent={undefined}
+          sidePanelTitle={null}
+          useNewSidePanelContext={true}
+        >
           <SSHKeysTable isIntro={false} />
         </PageContent>
       )}

--- a/src/app/preferences/views/SSLKeys/components/AddSSLKey/AddSSLKey.test.tsx
+++ b/src/app/preferences/views/SSLKeys/components/AddSSLKey/AddSSLKey.test.tsx
@@ -13,14 +13,14 @@ setupMockServer(sslKeyResolvers.createSslKey.handler());
 
 describe("AddSSLKey", () => {
   it("can render", () => {
-    renderWithProviders(<AddSSLKey closeForm={vi.fn()} />);
+    renderWithProviders(<AddSSLKey />);
     expect(
       screen.getByRole("form", { name: "Add SSL key" })
     ).toBeInTheDocument();
   });
 
   it("can create a SSL key", async () => {
-    renderWithProviders(<AddSSLKey closeForm={vi.fn()} />);
+    renderWithProviders(<AddSSLKey />);
     await userEvent.type(
       screen.getByRole("textbox", { name: "SSL key" }),
       "--- begin cert ---..."

--- a/src/app/preferences/views/SSLKeys/components/AddSSLKey/AddSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/components/AddSSLKey/AddSSLKey.tsx
@@ -8,7 +8,7 @@ import { useCreateSslKeys } from "@/app/api/query/sslKeys";
 import type { CreateUserSslkeyError, SslKeyRequest } from "@/app/apiclient";
 import FormikField from "@/app/base/components/FormikField";
 import FormikForm from "@/app/base/components/FormikForm";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 
 // This can be removed when the autoComplete prop is supported:
 // https://github.com/canonical/react-components/issues/571

--- a/src/app/preferences/views/SSLKeys/components/AddSSLKey/AddSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/components/AddSSLKey/AddSSLKey.tsx
@@ -21,7 +21,7 @@ const SSLKeySchema = Yup.object().shape({
 });
 
 export const AddSSLKey = (): ReactElement => {
-  const { close } = useSidePanel();
+  const { closeSidePanel } = useSidePanel();
   const uploadSslKey = useCreateSslKeys();
 
   return (
@@ -29,7 +29,7 @@ export const AddSSLKey = (): ReactElement => {
       aria-label="Add SSL key"
       errors={uploadSslKey.error}
       initialValues={{ key: "" }}
-      onCancel={close}
+      onCancel={closeSidePanel}
       onSaveAnalytics={{
         action: "Saved",
         category: "SSL keys preferences",
@@ -44,7 +44,7 @@ export const AddSSLKey = (): ReactElement => {
           });
         }
       }}
-      onSuccess={close}
+      onSuccess={closeSidePanel}
       resetOnSave={true}
       saved={uploadSslKey.isSuccess}
       saving={uploadSslKey.isPending}

--- a/src/app/preferences/views/SSLKeys/components/AddSSLKey/AddSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/components/AddSSLKey/AddSSLKey.tsx
@@ -8,10 +8,7 @@ import { useCreateSslKeys } from "@/app/api/query/sslKeys";
 import type { CreateUserSslkeyError, SslKeyRequest } from "@/app/apiclient";
 import FormikField from "@/app/base/components/FormikField";
 import FormikForm from "@/app/base/components/FormikForm";
-
-type AddSSLKeyProps = {
-  closeForm: () => void;
-};
+import { useSidePanel } from "@/app/base/side-panel-context";
 
 // This can be removed when the autoComplete prop is supported:
 // https://github.com/canonical/react-components/issues/571
@@ -23,7 +20,8 @@ const SSLKeySchema = Yup.object().shape({
   key: Yup.string().required("SSL key is required"),
 });
 
-export const AddSSLKey = ({ closeForm }: AddSSLKeyProps): ReactElement => {
+export const AddSSLKey = (): ReactElement => {
+  const { close } = useSidePanel();
   const uploadSslKey = useCreateSslKeys();
 
   return (
@@ -31,7 +29,7 @@ export const AddSSLKey = ({ closeForm }: AddSSLKeyProps): ReactElement => {
       aria-label="Add SSL key"
       errors={uploadSslKey.error}
       initialValues={{ key: "" }}
-      onCancel={closeForm}
+      onCancel={close}
       onSaveAnalytics={{
         action: "Saved",
         category: "SSL keys preferences",
@@ -46,7 +44,7 @@ export const AddSSLKey = ({ closeForm }: AddSSLKeyProps): ReactElement => {
           });
         }
       }}
-      onSuccess={closeForm}
+      onSuccess={close}
       resetOnSave={true}
       saved={uploadSslKey.isSuccess}
       saving={uploadSslKey.isPending}

--- a/src/app/preferences/views/SSLKeys/components/DeleteSSLKey/DeleteSSLKey.test.tsx
+++ b/src/app/preferences/views/SSLKeys/components/DeleteSSLKey/DeleteSSLKey.test.tsx
@@ -3,17 +3,17 @@ import DeleteSSLKey from "./DeleteSSLKey";
 import { sslKeyResolvers } from "@/testing/resolvers/sslKeys";
 import {
   screen,
-  renderWithBrowserRouter,
   userEvent,
   setupMockServer,
   waitFor,
+  renderWithProviders,
 } from "@/testing/utils";
 
 setupMockServer(sslKeyResolvers.deleteSslKey.handler());
 
 describe("DeleteSSLKey", () => {
   it("can show a delete confirmation", () => {
-    renderWithBrowserRouter(<DeleteSSLKey closeForm={vi.fn()} id={1} />);
+    renderWithProviders(<DeleteSSLKey id={1} />);
     expect(screen.getByRole("form", { name: "Confirm SSL key deletion" }));
     expect(
       screen.getByText(/Are you sure you want to delete this SSL key?/i)
@@ -21,7 +21,7 @@ describe("DeleteSSLKey", () => {
   });
 
   it("can delete an SSL key", async () => {
-    renderWithBrowserRouter(<DeleteSSLKey closeForm={vi.fn()} id={1} />);
+    renderWithProviders(<DeleteSSLKey id={1} />);
 
     await userEvent.click(screen.getByRole("button", { name: "Delete" }));
     await waitFor(() => {

--- a/src/app/preferences/views/SSLKeys/components/DeleteSSLKey/DeleteSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/components/DeleteSSLKey/DeleteSSLKey.tsx
@@ -2,13 +2,14 @@ import type { ReactElement } from "react";
 
 import { useDeleteSslKey } from "@/app/api/query/sslKeys";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { useSidePanel } from "@/app/base/side-panel-context";
 
 type DeleteSSLKeyProps = {
   id: number;
-  closeForm: () => void;
 };
 
-const DeleteSSLKey = ({ id, closeForm }: DeleteSSLKeyProps): ReactElement => {
+const DeleteSSLKey = ({ id }: DeleteSSLKeyProps): ReactElement => {
+  const { close } = useSidePanel();
   const deleteSSLKey = useDeleteSslKey();
 
   return (
@@ -18,11 +19,11 @@ const DeleteSSLKey = ({ id, closeForm }: DeleteSSLKeyProps): ReactElement => {
       initialValues={{}}
       message="Are you sure you want to delete this SSL key?"
       modelType="SSL key"
-      onCancel={closeForm}
+      onCancel={close}
       onSubmit={() => {
         deleteSSLKey.mutate({ path: { sslkey_id: id } });
       }}
-      onSuccess={closeForm}
+      onSuccess={close}
       saved={deleteSSLKey.isSuccess}
       saving={deleteSSLKey.isPending}
     />

--- a/src/app/preferences/views/SSLKeys/components/DeleteSSLKey/DeleteSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/components/DeleteSSLKey/DeleteSSLKey.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from "react";
 
 import { useDeleteSslKey } from "@/app/api/query/sslKeys";
 import ModelActionForm from "@/app/base/components/ModelActionForm";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 
 type DeleteSSLKeyProps = {
   id: number;

--- a/src/app/preferences/views/SSLKeys/components/DeleteSSLKey/DeleteSSLKey.tsx
+++ b/src/app/preferences/views/SSLKeys/components/DeleteSSLKey/DeleteSSLKey.tsx
@@ -9,7 +9,7 @@ type DeleteSSLKeyProps = {
 };
 
 const DeleteSSLKey = ({ id }: DeleteSSLKeyProps): ReactElement => {
-  const { close } = useSidePanel();
+  const { closeSidePanel } = useSidePanel();
   const deleteSSLKey = useDeleteSslKey();
 
   return (
@@ -19,11 +19,11 @@ const DeleteSSLKey = ({ id }: DeleteSSLKeyProps): ReactElement => {
       initialValues={{}}
       message="Are you sure you want to delete this SSL key?"
       modelType="SSL key"
-      onCancel={close}
+      onCancel={closeSidePanel}
       onSubmit={() => {
         deleteSSLKey.mutate({ path: { sslkey_id: id } });
       }}
-      onSuccess={close}
+      onSuccess={closeSidePanel}
       saved={deleteSSLKey.isSuccess}
       saving={deleteSSLKey.isPending}
     />

--- a/src/app/preferences/views/SSLKeys/components/SSLKeysTable/SSLKeysTable.test.tsx
+++ b/src/app/preferences/views/SSLKeys/components/SSLKeysTable/SSLKeysTable.test.tsx
@@ -1,12 +1,7 @@
-import userEvent from "@testing-library/user-event";
-import type { Mock } from "vitest";
 import { describe } from "vitest";
 
 import SSLKeysTable from "./SSLKeysTable";
 
-import { useSidePanel } from "@/app/base/side-panel-context";
-import { SSLKeyActionSidePanelViews } from "@/app/preferences/views/SSLKeys/constants";
-import * as factory from "@/testing/factories";
 import { sslKeyResolvers } from "@/testing/resolvers/sslKeys";
 import {
   renderWithProviders,
@@ -18,21 +13,7 @@ import {
 
 const mockServer = setupMockServer(sslKeyResolvers.listSslKeys.handler());
 
-vi.mock("@/app/base/side-panel-context", async () => {
-  const actual = await vi.importActual("@/app/base/side-panel-context");
-  return {
-    ...actual,
-    useSidePanel: vi.fn(),
-  };
-});
-
 describe("SSLKeysTable", () => {
-  const mockSetSidePanelContent = vi.fn();
-
-  (useSidePanel as Mock).mockReturnValue({
-    setSidePanelContent: mockSetSidePanelContent,
-  });
-
   describe("display", () => {
     it("displays a loading component if SSL keys are loading", async () => {
       mockIsPending();
@@ -63,60 +44,6 @@ describe("SSLKeysTable", () => {
             name: new RegExp(`^${column}`, "i"),
           })
         ).toBeInTheDocument();
-      });
-    });
-  });
-
-  describe("actions", () => {
-    it("opens add SSL key side panel form", async () => {
-      renderWithProviders(<SSLKeysTable />);
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: "Add SSL key" })
-        ).toBeInTheDocument();
-      });
-
-      await userEvent.click(
-        screen.getByRole("button", { name: "Add SSL key" })
-      );
-
-      await waitFor(() => {
-        expect(mockSetSidePanelContent).toHaveBeenCalledWith({
-          view: SSLKeyActionSidePanelViews.ADD_SSL_KEY,
-        });
-      });
-    });
-
-    it("opens delete SSL key side panel form", async () => {
-      mockServer.use(
-        sslKeyResolvers.listSslKeys.handler({
-          items: [
-            factory.sslKey({
-              id: 1,
-            }),
-          ],
-          total: 1,
-        })
-      );
-
-      renderWithProviders(<SSLKeysTable />);
-
-      await waitFor(() => {
-        expect(
-          screen.getByRole("button", { name: "Delete" })
-        ).toBeInTheDocument();
-      });
-
-      await userEvent.click(screen.getByRole("button", { name: "Delete" }));
-
-      await waitFor(() => {
-        expect(mockSetSidePanelContent).toHaveBeenCalledWith({
-          view: SSLKeyActionSidePanelViews.DELETE_SSL_KEY,
-          extras: {
-            sslKeyId: 1,
-          },
-        });
       });
     });
   });

--- a/src/app/preferences/views/SSLKeys/components/SSLKeysTable/SSLKeysTable.tsx
+++ b/src/app/preferences/views/SSLKeys/components/SSLKeysTable/SSLKeysTable.tsx
@@ -1,13 +1,15 @@
+import type { ReactElement } from "react";
+
 import { GenericTable, MainToolbar } from "@canonical/maas-react-components";
 import { Button, Notification } from "@canonical/react-components";
 
 import { useGetSslKeys } from "@/app/api/query/sslKeys";
 import { useSidePanel } from "@/app/base/side-panel-context";
+import { AddSSLKey } from "@/app/preferences/views/SSLKeys/components";
 import useSSLKeysTableColumns from "@/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns";
-import { SSLKeyActionSidePanelViews } from "@/app/preferences/views/SSLKeys/constants";
 
-const SSLKeysTable = (): React.ReactElement => {
-  const { setSidePanelContent } = useSidePanel();
+const SSLKeysTable = (): ReactElement => {
+  const { open } = useSidePanel();
   const { data, failureReason, isPending } = useGetSslKeys();
   const sslKeys = data?.items ?? [];
 
@@ -24,9 +26,7 @@ const SSLKeysTable = (): React.ReactElement => {
         <MainToolbar.Controls>
           <Button
             onClick={() => {
-              setSidePanelContent({
-                view: SSLKeyActionSidePanelViews.ADD_SSL_KEY,
-              });
+              open(AddSSLKey, "Add SSL key");
             }}
           >
             Add SSL key

--- a/src/app/preferences/views/SSLKeys/components/SSLKeysTable/SSLKeysTable.tsx
+++ b/src/app/preferences/views/SSLKeys/components/SSLKeysTable/SSLKeysTable.tsx
@@ -9,7 +9,7 @@ import { AddSSLKey } from "@/app/preferences/views/SSLKeys/components";
 import useSSLKeysTableColumns from "@/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns";
 
 const SSLKeysTable = (): ReactElement => {
-  const { open } = useSidePanel();
+  const { openSidePanel } = useSidePanel();
   const { data, failureReason, isPending } = useGetSslKeys();
   const sslKeys = data?.items ?? [];
 
@@ -26,7 +26,7 @@ const SSLKeysTable = (): ReactElement => {
         <MainToolbar.Controls>
           <Button
             onClick={() => {
-              open(AddSSLKey, "Add SSL key");
+              openSidePanel({ component: AddSSLKey, title: "Add SSL key" });
             }}
           >
             Add SSL key

--- a/src/app/preferences/views/SSLKeys/components/SSLKeysTable/SSLKeysTable.tsx
+++ b/src/app/preferences/views/SSLKeys/components/SSLKeysTable/SSLKeysTable.tsx
@@ -4,7 +4,7 @@ import { GenericTable, MainToolbar } from "@canonical/maas-react-components";
 import { Button, Notification } from "@canonical/react-components";
 
 import { useGetSslKeys } from "@/app/api/query/sslKeys";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 import { AddSSLKey } from "@/app/preferences/views/SSLKeys/components";
 import useSSLKeysTableColumns from "@/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns";
 

--- a/src/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns.tsx
+++ b/src/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns.tsx
@@ -5,12 +5,12 @@ import type { ColumnDef } from "@tanstack/react-table";
 import type { SslKeyResponse } from "@/app/apiclient";
 import TableActions from "@/app/base/components/TableActions";
 import { useSidePanel } from "@/app/base/side-panel-context";
-import { SSLKeyActionSidePanelViews } from "@/app/preferences/views/SSLKeys/constants";
+import { DeleteSSLKey } from "@/app/preferences/views/SSLKeys/components";
 
 type SSLKeysColumnDef = ColumnDef<SslKeyResponse, Partial<SslKeyResponse>>;
 
 const useSSLKeysTableColumns = (): SSLKeysColumnDef[] => {
-  const { setSidePanelContent } = useSidePanel();
+  const { open } = useSidePanel();
   return useMemo(
     () =>
       [
@@ -43,19 +43,14 @@ const useSSLKeysTableColumns = (): SSLKeysColumnDef[] => {
               <TableActions
                 data-testid="ssh-key-actions"
                 onDelete={() => {
-                  setSidePanelContent({
-                    view: SSLKeyActionSidePanelViews.DELETE_SSL_KEY,
-                    extras: {
-                      sslKeyId: id,
-                    },
-                  });
+                  open(DeleteSSLKey, "Delete SSL key", { id });
                 }}
               />
             );
           },
         },
       ] as SSLKeysColumnDef[],
-    [setSidePanelContent]
+    [open]
   );
 };
 

--- a/src/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns.tsx
+++ b/src/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns.tsx
@@ -10,7 +10,7 @@ import { DeleteSSLKey } from "@/app/preferences/views/SSLKeys/components";
 type SSLKeysColumnDef = ColumnDef<SslKeyResponse, Partial<SslKeyResponse>>;
 
 const useSSLKeysTableColumns = (): SSLKeysColumnDef[] => {
-  const { open } = useSidePanel();
+  const { openSidePanel } = useSidePanel();
   return useMemo(
     () =>
       [
@@ -43,14 +43,18 @@ const useSSLKeysTableColumns = (): SSLKeysColumnDef[] => {
               <TableActions
                 data-testid="ssh-key-actions"
                 onDelete={() => {
-                  open(DeleteSSLKey, "Delete SSL key", { id });
+                  openSidePanel({
+                    component: DeleteSSLKey,
+                    title: "Delete SSL key",
+                    props: { id },
+                  });
                 }}
               />
             );
           },
         },
       ] as SSLKeysColumnDef[],
-    [open]
+    [openSidePanel]
   );
 };
 

--- a/src/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns.tsx
+++ b/src/app/preferences/views/SSLKeys/components/SSLKeysTable/useSSLKeysTableColumns/useSSLKeysTableColumns.tsx
@@ -4,7 +4,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 
 import type { SslKeyResponse } from "@/app/apiclient";
 import TableActions from "@/app/base/components/TableActions";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 import { DeleteSSLKey } from "@/app/preferences/views/SSLKeys/components";
 
 type SSLKeysColumnDef = ColumnDef<SslKeyResponse, Partial<SslKeyResponse>>;

--- a/src/app/preferences/views/SSLKeys/views/SSLKeysList.test.tsx
+++ b/src/app/preferences/views/SSLKeys/views/SSLKeysList.test.tsx
@@ -1,5 +1,5 @@
-import type { SSLKeySidePanelContent } from "@/app/preferences/views/SSLKeys/constants";
-import { SSLKeyActionSidePanelViews } from "@/app/preferences/views/SSLKeys/constants";
+import { waitFor } from "@testing-library/react";
+
 import SSLKeysList from "@/app/preferences/views/SSLKeys/views/SSLKeysList";
 import { sslKeyResolvers } from "@/testing/resolvers/sslKeys";
 import {
@@ -11,61 +11,35 @@ import {
 
 setupMockServer(sslKeyResolvers.listSslKeys.handler());
 
-let mockSidePanelContent: SSLKeySidePanelContent | null = null;
-const mockSetSidePanelContent = vi.fn();
-
-vi.mock("@/app/base/side-panel-context", async () => {
-  const actual = await vi.importActual("@/app/base/side-panel-context");
-  return {
-    ...actual,
-    useSidePanel: () => ({
-      sidePanelContent: mockSidePanelContent,
-      setSidePanelContent: mockSetSidePanelContent,
-      sidePanelSize: "regular",
-      setSidePanelSize: vi.fn(),
-    }),
-  };
-});
-
 describe("SSLKeysList", () => {
-  beforeEach(() => {
-    mockSetSidePanelContent.mockClear();
-    mockSidePanelContent = null;
-  });
-
-  it("renders AddSSLKey when view is ADD_SSL_KEY", () => {
-    mockSidePanelContent = {
-      view: SSLKeyActionSidePanelViews.ADD_SSL_KEY,
-    };
-
+  it("renders AddSSLKey", async () => {
     renderWithProviders(<SSLKeysList />);
+    await userEvent.click(screen.getByRole("button", { name: "Add SSL key" }));
     expect(
       screen.getByRole("complementary", { name: "Add SSL key" })
     ).toBeInTheDocument();
   });
 
-  it("renders DeleteSSLKey when view is DELETE_SSL_KEY and valid sslKeyIds are provided", () => {
-    mockSidePanelContent = {
-      view: SSLKeyActionSidePanelViews.DELETE_SSL_KEY,
-      extras: { sslKeyId: 42 },
-    };
-
+  it("renders DeleteSSLKey when valid sslKeyIds are provided", async () => {
     renderWithProviders(<SSLKeysList />);
+    await waitFor(() => {
+      expect(screen.getAllByRole("button", { name: "Delete" }));
+    });
+    await userEvent.click(screen.getAllByRole("button", { name: "Delete" })[0]);
     expect(
       screen.getByRole("complementary", { name: "Delete SSL key" })
     ).toBeInTheDocument();
   });
 
   it("closes side panel form when canceled", async () => {
-    mockSidePanelContent = {
-      view: SSLKeyActionSidePanelViews.ADD_SSL_KEY,
-    };
-
     renderWithProviders(<SSLKeysList />);
+    await userEvent.click(screen.getByRole("button", { name: "Add SSL key" }));
     expect(
       screen.getByRole("complementary", { name: "Add SSL key" })
     ).toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(mockSetSidePanelContent).toHaveBeenCalledWith(null);
+    expect(
+      screen.queryByRole("complementary", { name: "Add SSL key" })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/preferences/views/SSLKeys/views/SSLKeysList.tsx
+++ b/src/app/preferences/views/SSLKeys/views/SSLKeysList.tsx
@@ -8,7 +8,11 @@ const SSLKeysList = (): ReactElement => {
   useWindowTitle("SSL keys");
 
   return (
-    <PageContent>
+    <PageContent
+      sidePanelContent={undefined}
+      sidePanelTitle={null}
+      useNewSidePanelContext={true}
+    >
       <SSLKeysTable />
     </PageContent>
   );

--- a/src/app/preferences/views/SSLKeys/views/SSLKeysList.tsx
+++ b/src/app/preferences/views/SSLKeys/views/SSLKeysList.tsx
@@ -1,55 +1,14 @@
 import type { ReactElement } from "react";
-import { useEffect } from "react";
 
 import PageContent from "@/app/base/components/PageContent";
 import { useWindowTitle } from "@/app/base/hooks";
-import { getSidePanelTitle, useSidePanel } from "@/app/base/side-panel-context";
-import {
-  AddSSLKey,
-  DeleteSSLKey,
-  SSLKeysTable,
-} from "@/app/preferences/views/SSLKeys/components";
-import { SSLKeyActionSidePanelViews } from "@/app/preferences/views/SSLKeys/constants";
-import { isId } from "@/app/utils";
+import { SSLKeysTable } from "@/app/preferences/views/SSLKeys/components";
 
 const SSLKeysList = (): ReactElement => {
-  const { sidePanelContent, setSidePanelContent } = useSidePanel();
-
   useWindowTitle("SSL keys");
 
-  const closeForm = () => {
-    setSidePanelContent(null);
-  };
-
-  useEffect(() => {
-    setSidePanelContent(null);
-  }, [setSidePanelContent]);
-
-  let content = null;
-
-  if (
-    sidePanelContent &&
-    sidePanelContent.view === SSLKeyActionSidePanelViews.ADD_SSL_KEY
-  ) {
-    content = <AddSSLKey closeForm={closeForm} key="add-ssl-key-form" />;
-  } else if (
-    sidePanelContent &&
-    sidePanelContent.view === SSLKeyActionSidePanelViews.DELETE_SSL_KEY
-  ) {
-    const sslKeyId =
-      sidePanelContent.extras && "sslKeyId" in sidePanelContent.extras
-        ? sidePanelContent.extras.sslKeyId
-        : null;
-    content = isId(sslKeyId) ? (
-      <DeleteSSLKey closeForm={closeForm} id={sslKeyId} />
-    ) : null;
-  }
-
   return (
-    <PageContent
-      sidePanelContent={content}
-      sidePanelTitle={getSidePanelTitle("SSL keys", sidePanelContent)}
-    >
+    <PageContent>
       <SSLKeysTable />
     </PageContent>
   );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -12,6 +12,7 @@ import { createQueryClient } from "./app/api/query-client";
 import { store } from "./redux-store";
 
 import SidePanelContextProvider from "@/app/base/side-panel-context";
+import NewSidePanelContextProvider from "@/app/base/side-panel-context-new";
 import { WebSocketProvider } from "@/app/base/websocket-context";
 import "./scss/index.scss";
 import { router } from "@/router";
@@ -23,9 +24,11 @@ export const Root = () => {
     <Provider store={store}>
       <WebSocketProvider>
         <QueryClientProvider client={queryClient}>
-          <SidePanelContextProvider>
-            <RouterProvider router={router} />
-          </SidePanelContextProvider>
+          <NewSidePanelContextProvider>
+            <SidePanelContextProvider>
+              <RouterProvider router={router} />
+            </SidePanelContextProvider>
+          </NewSidePanelContextProvider>
           <ReactQueryDevtools
             buttonPosition="bottom-left"
             initialIsOpen={

--- a/src/testing/utils.tsx
+++ b/src/testing/utils.tsx
@@ -30,6 +30,7 @@ import type {
   SidePanelSize,
 } from "@/app/base/side-panel-context";
 import SidePanelContextProvider from "@/app/base/side-panel-context";
+import NewSidePanelContextProvider from "@/app/base/side-panel-context-new";
 import { WebSocketProvider } from "@/app/base/websocket-context";
 import { ConfigNames } from "@/app/store/config/types";
 import type { RootState } from "@/app/store/root/types";
@@ -563,9 +564,11 @@ export const renderWithProviders = (
     result: render(
       <QueryClientProvider client={queryClient}>
         <WebSocketProvider>
-          <Provider store={store}>
-            <RouterProvider router={router} />
-          </Provider>
+          <NewSidePanelContextProvider>
+            <Provider store={store}>
+              <RouterProvider router={router} />
+            </Provider>
+          </NewSidePanelContextProvider>
         </WebSocketProvider>
       </QueryClientProvider>,
       options


### PR DESCRIPTION
## Done

- Created 'side-panel-context-new.tsx*
- Migrated SSH and SSL key tables
- Added new provider to 'renderWithProviders'
- Removed no longer applicable tests

## QA steps

- [ ] Navigate to SSH keys
- [ ] Open any form
- [ ] Close the form
- [ ] Re-open the form, and switch to SSL keys
- [ ] Verify form is automatically closed
- [ ] Repeat for SSL keys
- [ ] Try auto-closing for old side panel context views e.g. open an SSH keys form, navigate to Pools and vice versa

## Fixes

Resolves:

[MAASENG-5227](https://warthogs.atlassian.net/browse/MAASENG-5227)

[MAASENG-5227]: https://warthogs.atlassian.net/browse/MAASENG-5227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ