### PR TITLE
chore(machines): Convert CloneNetworkTable to GenericTable MAASENG-5212

### DIFF
--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/useCloneNetworkTableColumns/useCloneNetworkTableColumns.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/useCloneNetworkTableColumns/useCloneNetworkTableColumns.tsx
@@ -1,0 +1,108 @@
+import { useMemo } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import DoubleRow from "@/app/base/components/DoubleRow";
+import type { NetworkInterface } from "@/app/store/types/node";
+
+export type CloneNetworkRowData = {
+  id: NetworkInterface["id"];
+  name: string;
+  subnet?: string;
+  fabric?: string;
+  vlan: string | null;
+  type: string | null;
+  numaNodes?: string;
+  dhcp?: string;
+  isParent?: boolean;
+};
+
+export type CloneNetworkColumnDef = ColumnDef<
+  CloneNetworkRowData,
+  Partial<CloneNetworkRowData>
+>;
+
+const useCloneNetworkTableColumns = (): CloneNetworkColumnDef[] => {
+  return useMemo(
+    (): CloneNetworkColumnDef[] => [
+      {
+        id: "name",
+        accessorKey: "name",
+        enableSorting: false,
+        header: () => (
+          <span className="name-col">
+            <div>Interface</div>
+            <div>Subnet</div>
+          </span>
+        ),
+        cell: ({
+          row: {
+            original: { name, subnet, isParent },
+          },
+        }) => (
+          <DoubleRow
+            primary={name}
+            primaryTitle={name}
+            secondary={!isParent ? subnet : null}
+            secondaryTitle={subnet}
+          />
+        ),
+      },
+      {
+        id: "fabric",
+        accessorKey: "fabric",
+        enableSorting: false,
+        header: () => (
+          <span className="fabric-col">
+            <div>Fabric</div>
+            <div>VLAN</div>
+          </span>
+        ),
+        cell: ({
+          row: {
+            original: { fabric, vlan },
+          },
+        }) => (
+          <DoubleRow
+            primary={fabric}
+            primaryTitle={fabric}
+            secondary={vlan}
+            secondaryTitle={vlan}
+          />
+        ),
+      },
+      {
+        id: "type",
+        accessorKey: "type",
+        enableSorting: false,
+        header: () => (
+          <span className="type-col">
+            <div>Type</div>
+            <div>NUMA node</div>
+          </span>
+        ),
+        cell: ({
+          row: {
+            original: { type, numaNodes },
+          },
+        }) => (
+          <DoubleRow
+            primary={type}
+            primaryTitle={type}
+            secondary={numaNodes}
+            secondaryTitle={numaNodes}
+          />
+        ),
+      },
+      {
+        id: "dhcp",
+        accessorKey: "dhcp",
+        enableSorting: false,
+        header: () => <span className="dhcp-col">DHCP</span>,
+      },
+    ],
+    []
+  );
+};
+
+export default useCloneNetworkTableColumns;


### PR DESCRIPTION
## Done
- Converted CloneNetworkTable to GenericTable
- Replaced `renderWithMockStore` with `renderWithProviders` in tests

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Open this PR and maas-ui-demo.internal side by side
- [ ] Go to the machine list
- [ ] Select a machine
- [ ] In the "Actions" dropdown, click "Clone from"
- [ ] Select a machine to clone from
- [ ] Ensure the network table loads interface data about that machine
- [ ] Ensure the data is correct and matches what is shown in maas-ui-demo
- [ ] Ensure clicking the checkbox next to the network table makes the table enabled

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-5212](https://warthogs.atlassian.net/browse/MAASENG-5212)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->
