### PR TITLE
fix(intro): User intro cannot be skipped MAASENG-5201

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@
 
 ## Fixes
 
-Resolves [MAASENG-XXXX](https://warthogs.atlassian.net/browse/NAASENG-XXXX)
+Resolves [MAASENG-XXXX](https://warthogs.atlassian.net/browse/MAASENG-XXXX)
 
 <!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,6 @@
 ## Done
-- 
+
+-
 
 <!--
 - Itemised list of what was changed by this PR.
@@ -7,15 +8,15 @@
 
 ## QA steps
 
-- [ ] 
+- [ ]
 
 <!-- Steps for QA. -->
 
 ## Fixes
 
-Fixes: 
+Resolves [MAASENG-XXXX](https://warthogs.atlassian.net/browse/NAASENG-XXXX)
 
-<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->
+<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->
 
 ## Screenshots
 

--- a/src/app/intro/views/UserIntro/UserIntro.tsx
+++ b/src/app/intro/views/UserIntro/UserIntro.tsx
@@ -83,10 +83,7 @@ const UserIntro = (): React.ReactElement => {
             confirmLabel={Labels.Skip}
             errors={completeIntro.error?.message}
             finished={completeIntro.isSuccess}
-            inProgress={
-              !(user.data?.completed_intro || completeIntro.isSuccess) &&
-              showSkip
-            }
+            inProgress={completeIntro.isPending && showSkip}
             message={
               <>
                 <Icon className="is-inline" name="warning" />


### PR DESCRIPTION
## Done
- Fixed `inProgress` button state in user intro skip confirmation
  - The button should now be enabled and clickable when the confirmation is first shown, instead of showing a spinner

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Create a new user and log in as that user
- [x] When you arrive at the intro, click the skip button
- [x] Ensure the confirmation dialogue appears
- [x] Ensure the skip button is not disabled, and shows the correct text
- [x] Click the skip button
- [x] Ensure the button state changes to a spinner
- [x] Ensure you are redirected to the machine list

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-5201](https://warthogs.atlassian.net/browse/MAASENG-5201)

<!-- If there's an existing JIRA/launchpad issue/bug for your change, please link to it above. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-5201]: https://warthogs.atlassian.net/browse/MAASENG-5201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ