### PR TITLE
refactor(subnets): use GenericTable for ReservedRanges Table MAASENG-5280

### DIFF
--- a/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
+++ b/src/app/subnets/components/ReservedRanges/ReservedRanges.tsx
@@ -74,10 +74,7 @@ const ReservedRanges = ({
 
   useFetchActions([ipRangeActions.fetch]);
 
-  const columns = useReservedRangesColumns(
-    showSubnetColumn,
-    setSidePanelContent
-  );
+  const columns = useReservedRangesColumns(showSubnetColumn);
 
   const data: ReservedRangesTableData[] = ipRanges.map((ipRange) => ({
     id: ipRange.id,
@@ -156,7 +153,7 @@ const ReservedRanges = ({
         isLoading={ipRangeLoading}
         noData={`No IP ranges have been reserved for this ${isSubnet ? "subnet" : "VLAN"}.`}
         role="table"
-        sortBy={[{ id: "name", desc: true }]}
+        sortBy={[{ id: "startIp", desc: false }]}
       />
       <ExternalLink to={docsUrls.ipRanges}>About IP ranges</ExternalLink>
     </TitledSection>

--- a/src/app/subnets/components/ReservedRanges/useReservedRangesColumns/useReservedRangesColumns.tsx
+++ b/src/app/subnets/components/ReservedRanges/useReservedRangesColumns/useReservedRangesColumns.tsx
@@ -6,7 +6,7 @@ import { Labels } from "../ReservedRanges";
 
 import SubnetLink from "@/app/base/components/SubnetLink";
 import TableActions from "@/app/base/components/TableActions";
-import type { SetSidePanelContent } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context";
 import {
   SubnetActionTypes,
   SubnetDetailsSidePanelViews,
@@ -29,9 +29,9 @@ export type ReservedRangesColumnsDef = ColumnDef<
 >;
 
 const useReservedRangesColumns = (
-  showSubnetColumn: boolean,
-  setSidePanelContent: SetSidePanelContent
+  showSubnetColumn: boolean
 ): ReservedRangesColumnsDef[] => {
+  const { setSidePanelContent } = useSidePanel();
   return useMemo((): ReservedRangesColumnsDef[] => {
     const columns: ReservedRangesColumnsDef[] = [
       {

--- a/src/app/subnets/components/ReservedRanges/useReservedRangesColumns/useReservedRangesColumns.tsx
+++ b/src/app/subnets/components/ReservedRanges/useReservedRangesColumns/useReservedRangesColumns.tsx
@@ -1,0 +1,108 @@
+import { useMemo } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import { Labels } from "../ReservedRanges";
+
+import SubnetLink from "@/app/base/components/SubnetLink";
+import TableActions from "@/app/base/components/TableActions";
+import type { SetSidePanelContent } from "@/app/base/side-panel-context";
+import {
+  SubnetActionTypes,
+  SubnetDetailsSidePanelViews,
+} from "@/app/subnets/views/SubnetDetails/constants";
+
+export type ReservedRangesTableData = {
+  id: number | string;
+  ipRangeId?: number;
+  subnet: number | null;
+  startIp: string;
+  endIp: string;
+  owner: string;
+  type: string;
+  comment: string;
+};
+
+export type ReservedRangesColumnsDef = ColumnDef<
+  ReservedRangesTableData,
+  Partial<ReservedRangesTableData>
+>;
+
+const useReservedRangesColumns = (
+  showSubnetColumn: boolean,
+  setSidePanelContent: SetSidePanelContent
+): ReservedRangesColumnsDef[] => {
+  return useMemo((): ReservedRangesColumnsDef[] => {
+    const columns: ReservedRangesColumnsDef[] = [
+      {
+        accessorKey: "startIp",
+        header: Labels.StartIP,
+      },
+      {
+        accessorKey: "endIp",
+        header: Labels.EndIP,
+      },
+      {
+        accessorKey: "owner",
+        header: Labels.Owner,
+      },
+      {
+        accessorKey: "type",
+        header: Labels.Type,
+      },
+      {
+        accessorKey: "comment",
+        header: Labels.Comment,
+      },
+      {
+        accessorKey: "actions",
+        header: Labels.Actions,
+        enableSorting: false,
+        cell: ({
+          row: {
+            original: { ipRangeId },
+          },
+        }) => (
+          <TableActions
+            onDelete={() => {
+              setSidePanelContent({
+                view: SubnetDetailsSidePanelViews[
+                  SubnetActionTypes.DeleteReservedRange
+                ],
+                extras: {
+                  ipRangeId: ipRangeId,
+                },
+              });
+            }}
+            onEdit={() => {
+              setSidePanelContent({
+                view: SubnetDetailsSidePanelViews[
+                  SubnetActionTypes.ReserveRange
+                ],
+                extras: {
+                  ipRangeId: ipRangeId,
+                },
+              });
+            }}
+          />
+        ),
+      },
+    ];
+
+    // When viewing a VLAN, include Subnet as the first column
+    if (showSubnetColumn) {
+      columns.unshift({
+        accessorKey: "subnet",
+        header: Labels.Subnet,
+        cell: ({
+          row: {
+            original: { subnet },
+          },
+        }) => <SubnetLink id={subnet} />,
+      });
+    }
+    return columns;
+  }, [setSidePanelContent, showSubnetColumn]);
+};
+
+export default useReservedRangesColumns;


### PR DESCRIPTION
## Done

- Refactored the original ```MainTable``` in ```ReservedRanges.tsx``` to ```GenericTable```.
- Created a custom hook (```useReservedRangesColumns```) for generating table columns.
- Updated ```ReservedRanges.test.tsx``` to reflect the component refactoring:
  - Some tests were incorrectly querying elements by their accessible name (e.g. using column headers like ```Labels.Type```, ```Labels.Owner``` etc.). The accessible name of a ```<td>``` should only reflect its content (e.g. for ```<td>Value here</td>``` the accessible name should be "Value here"), so the tests now assert against the cell’s actual value instead. [Read more here](https://developer.mozilla.org/en-US/docs/Glossary/Accessible_name).
  - Changed ```render(...)``` to ```renderWithProviders(...)```.

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

For subnets, first navigate to the "Address reservation" page for any subnet (e.g. ```{BASE_URL}/subnet/1/address-reservation```), and observe the "Reserved ranges" section:
- [x] Ensure a table is rendered with 6 columns (start IP, end IP, owner, type, comment & actions)
- [x] Ensure the "actions" column __cannot__ be sorted, and all other columns __can__ be sorted
- [x] Ensure that the owner is "MAAS" when the type of reserved range is "Dynamic"
- [x] Ensure that the text "No IP ranges have been reserved for this subnet." is visible, when the table is empty

For VLANs, first navigate to any VLAN (e.g. ```{BASE_URL}/vlan/5001```), and observe the "Reserved ranges" section:
- [x] Ensure a table is rendered with 7 columns (subnet, start IP, end IP, owner, type, comment & actions)
- [x] Ensure the "actions" column __cannot__ be sorted, and all other columns __can__ be sorted
- [x] Ensure that the owner is "MAAS" when the type of reserved range is "Dynamic"
- [x] Ensure that the text "No IP ranges have been reserved for this VLAN." is visible, when the table is empty

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-5280](https://warthogs.atlassian.net/browse/MAASENG-5280)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-5280]: https://warthogs.atlassian.net/browse/MAASENG-5280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ