### PR TITLE
refactor(images): use new side-panel-context for /images route MAASENG-5234

### DIFF
--- a/src/app/images/components/ImagesForms/ImagesForms.test.tsx
+++ b/src/app/images/components/ImagesForms/ImagesForms.test.tsx
@@ -3,7 +3,7 @@ import ImagesForms from "./ImagesForms";
 import { ImageSidePanelViews } from "@/app/images/constants";
 import type { ImageSidePanelContent } from "@/app/images/types";
 import * as factory from "@/testing/factories";
-import { renderWithBrowserRouter, screen } from "@/testing/utils";
+import { renderWithProviders, screen } from "@/testing/utils";
 
 describe("ImagesForms", () => {
   it("renders DeleteImage form", () => {
@@ -11,7 +11,7 @@ describe("ImagesForms", () => {
       view: ImageSidePanelViews.DELETE_IMAGE,
       extras: { bootResource: factory.bootResource() },
     };
-    renderWithBrowserRouter(
+    renderWithProviders(
       <ImagesForms
         setSidePanelContent={vi.fn()}
         sidePanelContent={sidePanelContent}
@@ -31,7 +31,7 @@ describe("ImagesForms", () => {
         setRowSelection: vi.fn,
       },
     };
-    renderWithBrowserRouter(
+    renderWithProviders(
       <ImagesForms
         setSidePanelContent={vi.fn()}
         sidePanelContent={sidePanelContent}
@@ -47,7 +47,7 @@ describe("ImagesForms", () => {
     const sidePanelContent: ImageSidePanelContent = {
       view: ImageSidePanelViews.DOWNLOAD_IMAGE,
     };
-    renderWithBrowserRouter(
+    renderWithProviders(
       <ImagesForms
         setSidePanelContent={vi.fn()}
         sidePanelContent={sidePanelContent}

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.test.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.test.tsx
@@ -1,6 +1,3 @@
-import { render } from "@testing-library/react";
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router";
 import configureStore from "redux-mock-store";
 
 import SelectUpstreamImagesForm from "@/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm";
@@ -96,13 +93,9 @@ describe("SelectUpstreamImagesForm", () => {
   });
 
   it("can dispatch an action to save ubuntu images", async () => {
-    render(
-      <Provider store={store}>
-        <MemoryRouter>
-          <SelectUpstreamImagesForm />
-        </MemoryRouter>
-      </Provider>
-    );
+    renderWithProviders(<SelectUpstreamImagesForm />, {
+      store,
+    });
 
     await userEvent.click(
       screen.getByRole("button", { name: "Save and sync" })

--- a/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.tsx
+++ b/src/app/images/components/ImagesForms/SelectUpstreamImagesForm/SelectUpstreamImagesForm.tsx
@@ -9,7 +9,7 @@ import SelectUpstreamImagesSelect from "./SelectUpstreamImagesSelect";
 import type { DownloadImagesSelectProps } from "./SelectUpstreamImagesSelect/SelectUpstreamImagesSelect";
 
 import FormikForm from "@/app/base/components/FormikForm";
-import { useSidePanel } from "@/app/base/side-panel-context";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 import { bootResourceActions } from "@/app/store/bootresource";
 import bootResourceSelectors from "@/app/store/bootresource/selectors";
 import type {
@@ -198,10 +198,10 @@ const SelectUpstreamImagesForm = (): ReactElement => {
     };
   }, [dispatch]);
 
-  const { setSidePanelContent } = useSidePanel();
+  const { closeSidePanel } = useSidePanel();
 
   const resetForm = () => {
-    setSidePanelContent(null);
+    closeSidePanel();
   };
 
   return (

--- a/src/app/images/views/ImageList/ImageList.test.tsx
+++ b/src/app/images/views/ImageList/ImageList.test.tsx
@@ -5,7 +5,7 @@ import ImageList, { Labels as ImageListLabels } from "./ImageList";
 import { ConfigNames } from "@/app/store/config/types";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
-import { screen, renderWithBrowserRouter } from "@/testing/utils";
+import { screen, renderWithProviders } from "@/testing/utils";
 
 const mockStore = configureStore<RootState>();
 
@@ -23,11 +23,10 @@ describe("ImageList", () => {
       }),
     });
     const store = mockStore(state);
-    const { unmount } = renderWithBrowserRouter(<ImageList />, {
-      route: "/images",
+    const { result } = renderWithProviders(<ImageList />, {
       store,
     });
-    unmount();
+    result.unmount();
     expect(
       store
         .getActions()
@@ -47,8 +46,7 @@ describe("ImageList", () => {
         loaded: true,
       }),
     });
-    renderWithBrowserRouter(<ImageList />, {
-      route: "/images",
+    renderWithProviders(<ImageList />, {
       state,
     });
 

--- a/src/app/images/views/ImageList/ImageList.tsx
+++ b/src/app/images/views/ImageList/ImageList.tsx
@@ -9,8 +9,7 @@ import ImageListHeader from "./ImageListHeader";
 
 import PageContent from "@/app/base/components/PageContent";
 import { useWindowTitle } from "@/app/base/hooks";
-import { getSidePanelTitle, useSidePanel } from "@/app/base/side-panel-context";
-import ImagesForms from "@/app/images/components/ImagesForms";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
 import ImagesTable from "@/app/images/components/ImagesTable";
 import { bootResourceActions } from "@/app/store/bootresource";
 import { configActions } from "@/app/store/config";
@@ -22,22 +21,22 @@ export enum Labels {
 
 const ImageList = (): ReactElement => {
   const dispatch = useDispatch();
-  const { sidePanelContent, setSidePanelContent } = useSidePanel();
   const autoImport = useSelector(configSelectors.bootImagesAutoImport);
   const configLoaded = useSelector(configSelectors.loaded);
+  const { closeSidePanel } = useSidePanel();
 
   const [selectedRows, setSelectedRows] = useState<RowSelectionState>({});
 
   useWindowTitle("Images");
 
   useEffect(() => {
-    setSidePanelContent(null);
+    closeSidePanel();
     dispatch(bootResourceActions.poll({ continuous: true }));
     dispatch(configActions.fetch());
     return () => {
       dispatch(bootResourceActions.pollStop());
     };
-  }, [dispatch, setSidePanelContent]);
+  }, [dispatch]);
 
   return (
     <PageContent
@@ -47,15 +46,9 @@ const ImageList = (): ReactElement => {
           setSelectedRows={setSelectedRows}
         />
       }
-      sidePanelContent={
-        sidePanelContent && (
-          <ImagesForms
-            setSidePanelContent={setSidePanelContent}
-            sidePanelContent={sidePanelContent}
-          />
-        )
-      }
-      sidePanelTitle={getSidePanelTitle("Images", sidePanelContent)}
+      sidePanelContent={null}
+      sidePanelTitle={null}
+      useNewSidePanelContext={true}
     >
       {configLoaded && (
         <>

--- a/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
+++ b/src/app/images/views/ImageList/ImageListHeader/ImageListHeader.tsx
@@ -7,8 +7,9 @@ import type { RowSelectionState } from "@tanstack/react-table";
 import { useDispatch, useSelector } from "react-redux";
 
 import { useFetchActions, useCycled } from "@/app/base/hooks";
-import { useSidePanel } from "@/app/base/side-panel-context";
-import { ImageSidePanelViews } from "@/app/images/constants";
+import { useSidePanel } from "@/app/base/side-panel-context-new";
+import DeleteMultipleImagesForm from "@/app/images/components/ImagesForms/DeleteMultipleImagesForm";
+import SelectUpstreamImagesForm from "@/app/images/components/ImagesForms/SelectUpstreamImagesForm";
 import { bootResourceActions } from "@/app/store/bootresource";
 import bootResourceSelectors from "@/app/store/bootresource/selectors";
 import { BootResourceSourceType } from "@/app/store/bootresource/types";
@@ -63,7 +64,7 @@ const ImageListHeader = ({
   const canStopImport = (saving || imagesDownloading) && !stoppingImport;
   const cleanup = useCallback(() => bootResourceActions.cleanup(), []);
 
-  const { setSidePanelContent } = useSidePanel();
+  const { openSidePanel, closeSidePanel } = useSidePanel();
   const isDeleteDisabled = Object.keys(selectedRows).length <= 0;
 
   const sources = ubuntu?.sources || [];
@@ -124,12 +125,16 @@ const ImageListHeader = ({
             disabled={isDeleteDisabled}
             hasIcon
             onClick={() => {
-              setSidePanelContent({
-                view: ImageSidePanelViews.DELETE_MULTIPLE_IMAGES,
-                extras: {
+              openSidePanel({
+                component: DeleteMultipleImagesForm,
+                props: {
+                  closeForm: () => {
+                    closeSidePanel();
+                  },
                   rowSelection: selectedRows,
                   setRowSelection: setSelectedRows,
                 },
+                title: "Delete multiple images",
               });
             }}
             type="button"
@@ -141,8 +146,9 @@ const ImageListHeader = ({
             disabled={canStopImport || stoppingImport}
             hasIcon
             onClick={() => {
-              setSidePanelContent({
-                view: ImageSidePanelViews.DOWNLOAD_IMAGE,
+              openSidePanel({
+                component: SelectUpstreamImagesForm,
+                title: "Select upstream images to sync",
               });
             }}
             type="button"


### PR DESCRIPTION
## Done
Refactored the /images route’s side panel context calls to use the new side panel context.

Changed files breakdown:

1. ```ImageList.tsx```, ```ImageListHeader.tsx```, ```SelectUpstreamImagesForm.tsx```
  - Updated to use the new ```useSidePanel()``` context
2. ```ImagesForms.test.tsx```, ```SelectUpstreamImagesForm.tsx```, ```ImageList.test.tsx```, ```ImageListHeader.tsx```
  - Refactored tests to use ```renderWithProviders(...)``` instead of ```renderWithBrowserRouter(...)``` or ```render(...)```

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps
Head over to ```{BASE_URL}/images``` and observe the table.

- [ ] Verify no side panel is visible initially
- [ ] Verify clicking **Delete** (after selecting an image) opens a delete confirmation side panel  
- [ ] Verify clicking **Cancel** closes the delete confirmation side panel  
- [ ] Verify clicking **Select upstream images** opens a side panel with the image selection form  
- [ ] Verify clicking **Cancel** closes the image selection side panel  


<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-5234](https://warthogs.atlassian.net/browse/MAASENG-5234)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
