### PR TITLE
chore(deps): maas-react-components update MAASENG-5326

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@canonical/maas-react-components": "1.33.2",
+    "@canonical/maas-react-components": "1.33.3",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "2.14.0",
     "@redux-devtools/extension": "3.3.0",

--- a/src/app/images/components/ImagesTable/ImagesTable.tsx
+++ b/src/app/images/components/ImagesTable/ImagesTable.tsx
@@ -80,6 +80,7 @@ const ImagesTable = ({
       ]}
       rowSelection={selectedRows}
       setRowSelection={setSelectedRows}
+      showChevron
       sortBy={[{ id: "release", desc: true }]}
       variant={variant}
     />

--- a/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
+++ b/src/app/images/components/ImagesTable/useImageTableColumns/useImageTableColumns.tsx
@@ -1,6 +1,5 @@
 import { type Dispatch, type SetStateAction, useMemo } from "react";
 
-import { GroupRowActions } from "@canonical/maas-react-components";
 import { Icon, Spinner } from "@canonical/react-components";
 import type {
   Column,
@@ -180,9 +179,7 @@ const useImageTableColumns = ({
               !isCommissioningImage &&
               (row.original.resource.complete ||
                 !row.original.resource.downloading);
-            return row.getIsGrouped() ? (
-              <GroupRowActions row={row} />
-            ) : (
+            return row.getIsGrouped() ? null : (
               <TableActions
                 data-testid="image-actions"
                 deleteDisabled={!canBeDeleted}

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneFormFields.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import { Col, Row } from "@canonical/react-components";
 import { useFormikContext } from "formik";
@@ -32,6 +32,7 @@ export const CloneFormFields = ({
   setSelectedMachine,
 }: Props): React.ReactElement => {
   const { setFieldValue, values } = useFormikContext<CloneFormValues>();
+  const cloneNetworkTableContainerRef = useRef<HTMLDivElement>(null);
 
   const machineInState = useSelector((state: RootState) =>
     machineSelectors.getById(state, values.source)
@@ -111,8 +112,12 @@ export const CloneFormFields = ({
                 type="checkbox"
                 wrapperClassName="u-sv2"
               />
-              <div className="clone-table-container">
+              <div
+                className="clone-table-container"
+                ref={cloneNetworkTableContainerRef}
+              >
                 <CloneNetworkTable
+                  containerRef={cloneNetworkTableContainerRef}
                   loadingMachineDetails={loadingMachineDetails}
                   machine={selectedMachine}
                   selected={values.interfaces}

--- a/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.tsx
+++ b/src/app/machines/components/MachineForms/MachineActionFormWrapper/CloneForm/CloneFormFields/CloneNetworkTable/CloneNetworkTable.tsx
@@ -1,3 +1,5 @@
+import type { RefObject } from "react";
+
 import { GenericTable } from "@canonical/maas-react-components";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
@@ -28,6 +30,7 @@ import type { VLAN } from "@/app/store/vlan/types";
 import { getDHCPStatus, getVLANDisplay } from "@/app/store/vlan/utils";
 
 type Props = {
+  containerRef?: RefObject<HTMLElement | null>;
   loadingMachineDetails?: boolean;
   machine: MachineDetails | null;
   selected: boolean;
@@ -88,6 +91,7 @@ const generateRow = ({
 };
 
 export const CloneNetworkTable = ({
+  containerRef,
   loadingMachineDetails = false,
   machine,
   selected,
@@ -167,9 +171,11 @@ export const CloneNetworkTable = ({
         "not-selected": !selected,
       })}
       columns={columns}
+      containerRef={containerRef}
       data={rows}
       isLoading={loadingMachineDetails}
       noData={machine ? "No network information detected." : null}
+      variant="full-height"
     />
   );
 };

--- a/src/app/subnets/views/Spaces/components/SpaceSubnetsTable/_index.scss
+++ b/src/app/subnets/views/Spaces/components/SpaceSubnetsTable/_index.scss
@@ -1,4 +1,4 @@
 .p-generic-table .p-generic-table__table thead th:last-child,
 .p-generic-table .p-generic-table__table tbody td:last-child {
-  text-align: left;
+  text-align: left !important;
 }

--- a/src/app/subnets/views/Spaces/components/SpaceSubnetsTable/_index.scss
+++ b/src/app/subnets/views/Spaces/components/SpaceSubnetsTable/_index.scss
@@ -1,4 +1,3 @@
-.p-generic-table .p-generic-table__table thead th:last-child,
-.p-generic-table .p-generic-table__table tbody td:last-child {
+.p-generic-table__table .fabric {
   text-align: left !important;
 }

--- a/src/app/subnets/views/Subnets/components/SubnetsTable/SubnetsTable.tsx
+++ b/src/app/subnets/views/Subnets/components/SubnetsTable/SubnetsTable.tsx
@@ -46,6 +46,7 @@ const SubnetsTable = ({
         totalItems: data.length,
       }}
       pinGroup={groupBy === "space" ? [{ value: "0", isTop: false }] : []}
+      showChevron
       variant="full-height"
     />
   );

--- a/src/app/subnets/views/Subnets/components/SubnetsTable/SubnetsTable.tsx
+++ b/src/app/subnets/views/Subnets/components/SubnetsTable/SubnetsTable.tsx
@@ -25,6 +25,7 @@ const SubnetsTable = ({
   return (
     <GenericTable
       aria-label={`Subnets by ${groupBy}`}
+      className="subnets-table"
       columns={columns}
       data={data.slice((page - 1) * size, page * size)}
       filterCells={(row, column) =>

--- a/src/app/subnets/views/Subnets/components/SubnetsTable/SubnetsTable.tsx
+++ b/src/app/subnets/views/Subnets/components/SubnetsTable/SubnetsTable.tsx
@@ -7,6 +7,8 @@ import useSubnetsTableColumns from "./useSubnetsTableColumns/useSubnetsTableColu
 import usePagination from "@/app/base/hooks/usePagination/usePagination";
 import type { SubnetGroupByProps } from "@/app/subnets/views/Subnets/components/SubnetsTable/types";
 
+import "./_index.scss";
+
 const SubnetsTable = ({
   groupBy,
   searchText,

--- a/src/app/subnets/views/Subnets/components/SubnetsTable/_index.scss
+++ b/src/app/subnets/views/Subnets/components/SubnetsTable/_index.scss
@@ -1,0 +1,3 @@
+.p-generic-table thead, tbody {
+  scrollbar-gutter: stable !important;
+}

--- a/src/app/subnets/views/Subnets/components/SubnetsTable/_index.scss
+++ b/src/app/subnets/views/Subnets/components/SubnetsTable/_index.scss
@@ -1,3 +1,3 @@
-.p-generic-table thead, tbody {
+.subnets-table,.p-generic-table thead, tbody {
   scrollbar-gutter: stable !important;
 }

--- a/src/app/subnets/views/Subnets/components/SubnetsTable/useSubnetsTableColumns/useSubnetsTableColumns.tsx
+++ b/src/app/subnets/views/Subnets/components/SubnetsTable/useSubnetsTableColumns/useSubnetsTableColumns.tsx
@@ -1,6 +1,5 @@
 import { useMemo } from "react";
 
-import { GroupRowActions } from "@canonical/maas-react-components";
 import type { ColumnDef, Row } from "@tanstack/react-table";
 import pluralize from "pluralize";
 import { Link } from "react-router";
@@ -119,9 +118,7 @@ const useSubnetsTableColumns = (groupBy: GroupByKey): SubnetsColumnDef[] => {
         enableSorting: false,
         header: "Fabric",
         cell: ({ row }) =>
-          row.getIsGrouped() ? (
-            <GroupRowActions row={row} />
-          ) : row.original.fabric ? (
+          row.getIsGrouped() ? null : row.original.fabric ? (
             <Link to={urls.fabric.index({ id: row.original.fabric.id })}>
               {getFabricDisplay(row.original.fabric)}
             </Link>
@@ -135,9 +132,7 @@ const useSubnetsTableColumns = (groupBy: GroupByKey): SubnetsColumnDef[] => {
         enableSorting: false,
         header: "Space",
         cell: ({ row }) =>
-          row.getIsGrouped() ? (
-            <GroupRowActions row={row} />
-          ) : row.original.space ? (
+          row.getIsGrouped() ? null : row.original.space ? (
             <Link to={urls.space.index({ id: row.original.space.id })}>
               {row.original.space.name}
             </Link>

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,10 +949,10 @@
     "@types/tough-cookie" "^4.0.5"
     tough-cookie "^4.1.4"
 
-"@canonical/maas-react-components@1.33.2":
-  version "1.33.2"
-  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-1.33.2.tgz#bdcda7c5c816bbdcf62dc44676c3f4fd41d26005"
-  integrity sha512-nwawUE+CSUi1hvRHLAIG6CsK07YR5Jhc2pkpP2+Q498hBHWac4NEjpfooV54BMJyE/e6SfuW9XwtGmulKcYGUg==
+"@canonical/maas-react-components@1.33.3":
+  version "1.33.3"
+  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-1.33.3.tgz#682f47ef14e9872b8b08356cdb6f392946fafb48"
+  integrity sha512-TEwpTRgPBw7BYJ7MDBtge2036NZkTieraxtQoG6YUDQNiF7k4lvrHeJpBt4fXOs4av3NxFngdZsHkBAkmYUeug==
 
 "@canonical/macaroon-bakery@1.3.2":
   version "1.3.2"
@@ -11715,16 +11715,7 @@ strict-event-emitter@^0.5.1:
   resolved "https://registry.yarnpkg.com/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz#1602ece81c51574ca39c6815e09f1a3e8550bd93"
   integrity sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11806,14 +11797,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -13032,7 +13016,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -13045,15 +13029,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Done
- Updated maas-react-components
- Added new GenericTable grouping chevron to ImagesTable and SubnetsTable
- Fixed table height bug in CloneNetworkTable
- Fixed cell alignment in SpaceSubnetsTable (broken with the update)
- Prevented cell shift on SubnetsTable when scrollbar disappears on group collapse

## QA steps

- [ ] Open this branch and maas-ui-demo side by side
- [ ] Go to /machines
- [ ] Select a machine and open the "Clone from..." form
- [ ] Verify the CloneNetwork table has one scrollbar on this branch, while demo has two
- [ ] Go to /subnets
- [ ] Verify the group rows have chevrons and can be clicked anywhere to collapse
- [ ] Increase page size so that there is a scrollbar
- [ ] Collapse enough groups so that the scrollbar disappears
- [ ] Verify the header and cells don't shift on this branch, but do on the demo
- [ ] Navigate to the details of a space
- [ ] Verify the "Fabric" column header and cells are aligned properly

## Fixes

Resolves [MAASENG-5326](https://warthogs.atlassian.net/browse/MAASENG-5326)
