### PR TITLE
fix(images): Filtered out unsupported archs per image MAASENG-5391

### DIFF
--- a/src/app/images/components/SelectUpstreamImagesForm/SelectUpstreamImagesForm.tsx
+++ b/src/app/images/components/SelectUpstreamImagesForm/SelectUpstreamImagesForm.tsx
@@ -49,7 +49,10 @@ export const getDownloadableImages = (
     .filter((release) => !release.deleted)
     .map((image) => {
       return ubuntuArches
-        .filter((arche) => !arche.deleted)
+        .filter(
+          (arche) =>
+            !arche.deleted && !image.unsupported_arches.includes(arche.name)
+        )
         .map((arch) => {
           return {
             id: `ubuntu-${image.name}-${image.title}-${arch.name}`,


### PR DESCRIPTION
## Done

- Excluded unsupported archs from image form options

## QA steps

- [ ] Navigate to images/
- [ ] Open the "Select upstream images to sync" form
- [ ] Verify unsupported archs are not listed (you can check the data with console logs, or verify that some Ubuntu images do not have i386)

## Fixes

Resolves [MAASENG-5391](https://warthogs.atlassian.net/browse/MAASENG-5391)


[MAASENG-5391]: https://warthogs.atlassian.net/browse/MAASENG-5391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ