### PR TITLE
refactor(base): FilesystemsTable to GenericTable MAASENG-5261

### DIFF
--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.test.tsx
@@ -1,15 +1,22 @@
-import { Provider } from "react-redux";
-import { MemoryRouter } from "react-router";
-import configureStore from "redux-mock-store";
+import userEvent from "@testing-library/user-event";
+import { describe } from "vitest";
 
 import FilesystemsTable from "./FilesystemsTable";
 
 import * as sidePanelHooks from "@/app/base/side-panel-context";
 import { MachineSidePanelViews } from "@/app/machines/constants";
+import type { ControllerDetails } from "@/app/store/controller/types";
+import type { MachineDetails } from "@/app/store/machine/types";
+import type { RootState } from "@/app/store/root/types";
+import type { Disk, Filesystem, Partition } from "@/app/store/types/node";
 import * as factory from "@/testing/factories";
-import { userEvent, render, screen } from "@/testing/utils";
+import {
+  mockIsPending,
+  renderWithProviders,
+  screen,
+  waitFor,
+} from "@/testing/utils";
 
-const mockStore = configureStore();
 const setSidePanelContent = vi.fn();
 beforeEach(() => {
   vi.spyOn(sidePanelHooks, "useSidePanel").mockReturnValue({
@@ -23,384 +30,379 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-it("can show an empty message", () => {
-  const machine = factory.machineDetails({
-    disks: [
-      factory.nodeDisk({
-        filesystem: null,
-        partitions: [factory.nodePartition({ filesystem: null })],
+describe("FilesystemsTable", () => {
+  let state: RootState;
+  let machine: MachineDetails;
+  let controller: ControllerDetails;
+  let disk: Disk;
+  let partition: Partition;
+  let filesystem: Filesystem;
+
+  beforeEach(() => {
+    filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
+    partition = factory.nodePartition({ filesystem });
+    disk = factory.nodeDisk({
+      filesystem: null,
+      partitions: [partition],
+    });
+    controller = factory.controllerDetails({
+      disks: [disk],
+      system_id: "abc123",
+    });
+    machine = factory.machineDetails({
+      disks: [
+        factory.nodeDisk({
+          filesystem: null,
+          partitions: [factory.nodePartition({ filesystem: null })],
+        }),
+      ],
+      system_id: "abc123",
+    });
+    state = factory.rootState({
+      machine: factory.machineState({
+        items: [machine],
       }),
-    ],
-    system_id: "abc123",
+      controller: factory.controllerState({
+        items: [controller],
+      }),
+    });
   });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
 
-  expect(screen.getByTestId("no-filesystems")).toHaveTextContent(
-    "No filesystems defined."
-  );
-});
+  describe("display", () => {
+    // TODO: enable test once filesystems are fetched through v3
+    it.skip("displays a loading component if filesystems are loading", async () => {
+      mockIsPending();
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
 
-it("can show filesystems associated with disks", () => {
-  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
-  const machine = factory.machineDetails({
-    disks: [factory.nodeDisk({ filesystem, name: "disk-fs", partitions: [] })],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
+      await waitFor(() => {
+        expect(screen.getByText("Loading...")).toBeInTheDocument();
+      });
+    });
 
-  expect(screen.getByRole("gridcell", { name: "Name" })).toHaveTextContent(
-    "disk-fs"
-  );
-  expect(
-    screen.getByRole("gridcell", { name: "Mount point" })
-  ).toHaveTextContent("/disk-fs/path");
-});
+    it("displays a message when rendering an empty list", async () => {
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
 
-it("can show filesystems associated with partitions", () => {
-  const filesystem = factory.nodeFilesystem({
-    mount_point: "/partition-fs/path",
-  });
-  const machine = factory.machineDetails({
-    disks: [
-      factory.nodeDisk({
-        filesystem: null,
-        partitions: [
-          factory.nodePartition({ filesystem, name: "partition-fs" }),
+      await waitFor(() => {
+        expect(screen.getByText("No filesystems defined.")).toBeInTheDocument();
+      });
+    });
+
+    describe("displays the columns correctly", () => {
+      it("shows an action column if node is a machine", () => {
+        renderWithProviders(
+          <FilesystemsTable canEditStorage node={machine} />,
+          { state }
+        );
+
+        [
+          "Name",
+          "Size",
+          "Filesystem",
+          "Mount point",
+          "Mount options",
+          "Actions",
+        ].forEach((column) => {
+          expect(
+            screen.getByRole("columnheader", {
+              name: new RegExp(`^${column}`, "i"),
+            })
+          ).toBeInTheDocument();
+        });
+      });
+
+      it("does not show action column if node is a controller", () => {
+        renderWithProviders(
+          <FilesystemsTable canEditStorage node={controller} />,
+          { state }
+        );
+
+        ["Name", "Size", "Filesystem", "Mount point", "Mount options"].forEach(
+          (column) => {
+            expect(
+              screen.getByRole("columnheader", {
+                name: new RegExp(`^${column}`, "i"),
+              })
+            ).toBeInTheDocument();
+          }
+        );
+
+        expect(
+          screen.queryByRole("columnheader", { name: "Actions" })
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it("can show filesystems associated with disks", () => {
+      const filesystem = factory.nodeFilesystem({
+        mount_point: "/disk-fs/path",
+      });
+      const machine = factory.machineDetails({
+        disks: [
+          factory.nodeDisk({ filesystem, name: "disk-fs", partitions: [] }),
         ],
-      }),
-    ],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
 
-  expect(screen.getByRole("gridcell", { name: "Name" })).toHaveTextContent(
-    "partition-fs"
-  );
-  expect(
-    screen.getByRole("gridcell", { name: "Mount point" })
-  ).toHaveTextContent("/partition-fs/path");
-});
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
 
-it("can show special filesystems", () => {
-  const specialFilesystem = factory.nodeFilesystem({
-    mount_point: "/special-fs/path",
-    fstype: "tmpfs",
-  });
-  const machine = factory.machineDetails({
-    disks: [factory.nodeDisk()],
-    special_filesystems: [specialFilesystem],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
+      expect(screen.getByRole("cell", { name: "disk-fs" })).toHaveClass("name");
+      expect(screen.getByRole("cell", { name: "/disk-fs/path" })).toHaveClass(
+        "mountPoint"
+      );
+    });
 
-  expect(screen.getByRole("gridcell", { name: "Name" })).toHaveTextContent("—");
-  expect(
-    screen.getByRole("gridcell", { name: "Mount point" })
-  ).toHaveTextContent("/special-fs/path");
-});
+    it("can show filesystems associated with partitions", () => {
+      const filesystem = factory.nodeFilesystem({
+        mount_point: "/partition-fs/path",
+      });
+      const machine = factory.machineDetails({
+        disks: [
+          factory.nodeDisk({
+            filesystem: null,
+            partitions: [
+              factory.nodePartition({ filesystem, name: "partition-fs" }),
+            ],
+          }),
+        ],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
 
-it("does not show action column if node is a controller", () => {
-  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
-  const partition = factory.nodePartition({ filesystem });
-  const disk = factory.nodeDisk({ filesystem: null, partitions: [partition] });
-  const controller = factory.controllerDetails({
-    disks: [disk],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    controller: factory.controllerState({
-      items: [controller],
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={controller} />
-      </MemoryRouter>
-    </Provider>
-  );
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
 
-  expect(
-    screen.queryByRole("columnheader", { name: "Actions" })
-  ).not.toBeInTheDocument();
-});
+      expect(screen.getByRole("cell", { name: "partition-fs" })).toHaveClass(
+        "name"
+      );
+      expect(
+        screen.getByRole("cell", { name: "/partition-fs/path" })
+      ).toHaveClass("mountPoint");
+    });
 
-it("shows an action column if node is a machine", () => {
-  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
-  const partition = factory.nodePartition({ filesystem });
-  const disk = factory.nodeDisk({ filesystem: null, partitions: [partition] });
-  const machine = factory.machineDetails({
-    disks: [disk],
-    system_id: "abc123",
+    it("can show special filesystems", () => {
+      const specialFilesystem = factory.nodeFilesystem({
+        mount_point: "/special-fs/path",
+        fstype: "tmpfs",
+      });
+      const machine = factory.machineDetails({
+        disks: [factory.nodeDisk()],
+        special_filesystems: [specialFilesystem],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
+
+      expect(screen.getAllByRole("cell", { name: "—" })[0]).toHaveClass("name");
+      expect(
+        screen.getByRole("cell", { name: "/special-fs/path" })
+      ).toHaveClass("mountPoint");
+    });
   });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-      statuses: factory.machineStatuses({
+
+  describe("actions", () => {
+    it("disables the action menu if node is a machine and storage can't be edited", () => {
+      const filesystem = factory.nodeFilesystem({
+        mount_point: "/disk-fs/path",
+      });
+      const partition = factory.nodePartition({ filesystem });
+      const disk = factory.nodeDisk({
+        filesystem: null,
+        partitions: [partition],
+      });
+      const machine = factory.machineDetails({
+        disks: [disk],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      state.machine.statuses = factory.machineStatuses({
         abc123: factory.machineStatus(),
-      }),
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
+      });
 
-  expect(
-    screen.getByRole("columnheader", { name: "Actions" })
-  ).toBeInTheDocument();
-});
+      renderWithProviders(
+        <FilesystemsTable canEditStorage={false} node={machine} />,
+        {
+          state,
+        }
+      );
 
-it("disables the action menu if node is a machine and storage can't be edited", () => {
-  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
-  const partition = factory.nodePartition({ filesystem });
-  const disk = factory.nodeDisk({ filesystem: null, partitions: [partition] });
-  const machine = factory.machineDetails({
-    disks: [disk],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-      statuses: factory.machineStatuses({
+      expect(
+        screen.getByRole("button", { name: /Take action/ })
+      ).toBeAriaDisabled();
+    });
+
+    it("can remove a disk's filesystem if node is a machine", async () => {
+      const filesystem = factory.nodeFilesystem({
+        mount_point: "/disk-fs/path",
+      });
+      const disk = factory.nodeDisk({ filesystem, partitions: [] });
+      const machine = factory.machineDetails({
+        disks: [disk],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      state.machine.statuses = factory.machineStatuses({
         abc123: factory.machineStatus(),
-      }),
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage={false} node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
-  expect(
-    screen.getByRole("button", { name: /Take action/ })
-  ).toBeAriaDisabled();
-});
+      });
 
-it("can remove a disk's filesystem if node is a machine", async () => {
-  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
-  const disk = factory.nodeDisk({ filesystem, partitions: [] });
-  const machine = factory.machineDetails({
-    disks: [disk],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-      statuses: factory.machineStatuses({
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /Take action/ })
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Remove filesystem..." })
+      );
+      expect(setSidePanelContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          view: MachineSidePanelViews.DELETE_FILESYSTEM,
+        })
+      );
+    });
+
+    it("can remove a partition's filesystem if node is a machine", async () => {
+      const filesystem = factory.nodeFilesystem({
+        mount_point: "/disk-fs/path",
+      });
+      const partition = factory.nodePartition({ filesystem });
+      const disk = factory.nodeDisk({
+        filesystem: null,
+        partitions: [partition],
+      });
+      const machine = factory.machineDetails({
+        disks: [disk],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      state.machine.statuses = factory.machineStatuses({
         abc123: factory.machineStatus(),
-      }),
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
+      });
 
-  await userEvent.click(screen.getByRole("button", { name: /Take action/ }));
-  await userEvent.click(
-    screen.getByRole("button", { name: "Remove filesystem..." })
-  );
-  expect(setSidePanelContent).toHaveBeenCalledWith(
-    expect.objectContaining({ view: MachineSidePanelViews.DELETE_FILESYSTEM })
-  );
-});
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
 
-it("can remove a partition's filesystem if node is a machine", async () => {
-  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
-  const partition = factory.nodePartition({ filesystem });
-  const disk = factory.nodeDisk({ filesystem: null, partitions: [partition] });
-  const machine = factory.machineDetails({
-    disks: [disk],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-      statuses: factory.machineStatuses({
+      await userEvent.click(
+        screen.getByRole("button", { name: /Take action/ })
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Remove filesystem..." })
+      );
+      expect(setSidePanelContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          view: MachineSidePanelViews.DELETE_FILESYSTEM,
+        })
+      );
+    });
+
+    it("can remove a special filesystem if node is a machine", async () => {
+      const filesystem = factory.nodeFilesystem({
+        fstype: "tmpfs",
+        mount_point: "/disk-fs/path",
+      });
+      const machine = factory.machineDetails({
+        disks: [],
+        special_filesystems: [filesystem],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      state.machine.statuses = factory.machineStatuses({
         abc123: factory.machineStatus(),
-      }),
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
+      });
 
-  await userEvent.click(screen.getByRole("button", { name: /Take action/ }));
-  await userEvent.click(
-    screen.getByRole("button", { name: "Remove filesystem..." })
-  );
-  expect(setSidePanelContent).toHaveBeenCalledWith(
-    expect.objectContaining({ view: MachineSidePanelViews.DELETE_FILESYSTEM })
-  );
-});
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
 
-it("can remove a special filesystem if node is a machine", async () => {
-  const filesystem = factory.nodeFilesystem({
-    fstype: "tmpfs",
-    mount_point: "/disk-fs/path",
-  });
-  const machine = factory.machineDetails({
-    disks: [],
-    special_filesystems: [filesystem],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-      statuses: factory.machineStatuses({
+      await userEvent.click(
+        screen.getByRole("button", { name: /Take action/ })
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Remove filesystem..." })
+      );
+      expect(setSidePanelContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          view: MachineSidePanelViews.DELETE_SPECIAL_FILESYSTEM,
+        })
+      );
+    });
+
+    it("can unmount a disk's filesystem if node is a machine", async () => {
+      const filesystem = factory.nodeFilesystem({
+        mount_point: "/disk-fs/path",
+      });
+      const disk = factory.nodeDisk({ filesystem, partitions: [] });
+      const machine = factory.machineDetails({
+        disks: [disk],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      state.machine.statuses = factory.machineStatuses({
         abc123: factory.machineStatus(),
-      }),
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
+      });
 
-  await userEvent.click(screen.getByRole("button", { name: /Take action/ }));
-  await userEvent.click(
-    screen.getByRole("button", { name: "Remove filesystem..." })
-  );
-  expect(setSidePanelContent).toHaveBeenCalledWith(
-    expect.objectContaining({
-      view: MachineSidePanelViews.DELETE_SPECIAL_FILESYSTEM,
-    })
-  );
-});
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
 
-it("can unmount a disk's filesystem if node is a machine", async () => {
-  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
-  const disk = factory.nodeDisk({ filesystem, partitions: [] });
-  const machine = factory.machineDetails({
-    disks: [disk],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-      statuses: factory.machineStatuses({
+      await userEvent.click(
+        screen.getByRole("button", { name: /Take action/ })
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Unmount filesystem..." })
+      );
+      expect(setSidePanelContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          view: MachineSidePanelViews.UNMOUNT_FILESYSTEM,
+        })
+      );
+    });
+
+    it("can unmount a partition's filesystem if node is a machine", async () => {
+      const filesystem = factory.nodeFilesystem({
+        mount_point: "/disk-fs/path",
+      });
+      const partition = factory.nodePartition({ filesystem });
+      const disk = factory.nodeDisk({
+        filesystem: null,
+        partitions: [partition],
+      });
+      const machine = factory.machineDetails({
+        disks: [disk],
+        system_id: "abc123",
+      });
+      state.machine.items = [machine];
+      state.machine.statuses = factory.machineStatuses({
         abc123: factory.machineStatus(),
-      }),
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
+      });
 
-  await userEvent.click(screen.getByRole("button", { name: /Take action/ }));
-  await userEvent.click(
-    screen.getByRole("button", { name: "Unmount filesystem..." })
-  );
-  expect(setSidePanelContent).toHaveBeenCalledWith(
-    expect.objectContaining({ view: MachineSidePanelViews.UNMOUNT_FILESYSTEM })
-  );
-});
+      renderWithProviders(<FilesystemsTable canEditStorage node={machine} />, {
+        state,
+      });
 
-it("can unmount a partition's filesystem if node is a machine", async () => {
-  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
-  const partition = factory.nodePartition({ filesystem });
-  const disk = factory.nodeDisk({ filesystem: null, partitions: [partition] });
-  const machine = factory.machineDetails({
-    disks: [disk],
-    system_id: "abc123",
+      await userEvent.click(
+        screen.getByRole("button", { name: /Take action/ })
+      );
+      await userEvent.click(
+        screen.getByRole("button", { name: "Unmount filesystem..." })
+      );
+      expect(setSidePanelContent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          view: MachineSidePanelViews.UNMOUNT_FILESYSTEM,
+        })
+      );
+    });
   });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-      statuses: factory.machineStatuses({
-        abc123: factory.machineStatus(),
-      }),
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <FilesystemsTable canEditStorage node={machine} />
-      </MemoryRouter>
-    </Provider>
-  );
-
-  await userEvent.click(screen.getByRole("button", { name: /Take action/ }));
-  await userEvent.click(
-    screen.getByRole("button", { name: "Unmount filesystem..." })
-  );
-  expect(setSidePanelContent).toHaveBeenCalledWith(
-    expect.objectContaining({ view: MachineSidePanelViews.UNMOUNT_FILESYSTEM })
-  );
 });

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.tsx
@@ -16,7 +16,7 @@ export enum FilesystemAction {
   UNMOUNT = "unmountFilesystem",
 }
 
-type Props = {
+type FilesystemsTableProps = {
   canEditStorage: boolean;
   node: ControllerDetails | MachineDetails;
 };
@@ -75,14 +75,14 @@ const generateFilesystemRowData = (
   return data;
 };
 
-const FilesystemsTable = ({ canEditStorage, node }: Props): ReactElement => {
+const FilesystemsTable = ({
+  canEditStorage,
+  node,
+}: FilesystemsTableProps): ReactElement => {
   const isMachine = nodeIsMachine(node);
   const { setSidePanelContent } = useSidePanel();
 
-  const columns = useFileSystemsTableColumns(
-    canEditStorage,
-    nodeIsMachine(node)
-  );
+  const columns = useFileSystemsTableColumns(canEditStorage, isMachine);
   const data = generateFilesystemRowData(node);
 
   return (

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.tsx
@@ -1,19 +1,15 @@
-import { Button, MainTable, Tooltip } from "@canonical/react-components";
-import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import type { ReactElement } from "react";
 
-import TableActionsDropdown from "@/app/base/components/TableActionsDropdown";
+import { GenericTable } from "@canonical/maas-react-components";
+import { Button, Tooltip } from "@canonical/react-components";
+
+import useFileSystemsTableColumns from "@/app/base/components/node/StorageTables/FilesystemsTable/useFilesystemsTableColumns/useFileSystemsTableColumns";
 import { useSidePanel } from "@/app/base/side-panel-context";
-import type { SetSidePanelContent } from "@/app/base/side-panel-context";
 import { MachineSidePanelViews } from "@/app/machines/constants";
 import type { ControllerDetails } from "@/app/store/controller/types";
 import type { MachineDetails } from "@/app/store/machine/types";
-import type { Filesystem, Disk, Partition } from "@/app/store/types/node";
-import {
-  formatSize,
-  isMounted,
-  nodeIsMachine,
-  usesStorage,
-} from "@/app/store/utils";
+import type { Disk, Partition } from "@/app/store/types/node";
+import { isMounted, nodeIsMachine } from "@/app/store/utils";
 
 export enum FilesystemAction {
   DELETE = "deleteFilesystem",
@@ -25,201 +21,80 @@ type Props = {
   node: ControllerDetails | MachineDetails;
 };
 
-const headers = [
-  {
-    content: "Name",
-    sortKey: "name",
-  },
-  {
-    content: "Size",
-    sortKey: "size",
-  },
-  {
-    content: "Filesystem",
-    sortKey: "fstype",
-  },
-  {
-    content: "Mount point",
-    sortKey: "mountPoint",
-  },
-  {
-    content: "Mount options",
-  },
-  {
-    content: "Actions",
-    className: "u-align--right",
-  },
-];
-
-/**
- * Normalise rendered row data so that both disk and partition filesystems can
- * be displayed.
- * @param rowId - the row ID of the filesystem.
- * @param fs - the filesystem to normalise.
- * @param storageDevice - the storage device the filesystem belongs to.
- * @param canEditStorage - the boolean for whether storage is editable.
- * @param isMachine - whether the node is a machine or not.
- * @param node - the node that the file system is on.
- * @param setSidePanelContent - the context setter for the side panel.
- * @returns normalised row data
- */
-const normaliseRowData = (
-  rowId: string,
-  fs: Filesystem,
-  storageDevice: Disk | Partition | null,
-  canEditStorage: Props["canEditStorage"],
-  isMachine: boolean,
-  node: Props["node"],
-  setSidePanelContent: SetSidePanelContent
-) => {
-  return {
-    columns: [
-      { content: storageDevice?.name || "—" },
-      { content: storageDevice ? formatSize(storageDevice.size) : "—" },
-      { content: fs.fstype },
-      { content: fs.mount_point },
-      { content: fs.mount_options },
-      ...(isMachine
-        ? [
-            {
-              className: "u-align--right",
-              content: (
-                <TableActionsDropdown
-                  actions={[
-                    {
-                      label: "Unmount filesystem...",
-                      show: usesStorage(fs.fstype),
-                      type: FilesystemAction.UNMOUNT,
-                      view: MachineSidePanelViews.UNMOUNT_FILESYSTEM,
-                    },
-                    {
-                      label: "Remove filesystem...",
-                      type: FilesystemAction.DELETE,
-                      view:
-                        node.special_filesystems && !storageDevice
-                          ? MachineSidePanelViews.DELETE_SPECIAL_FILESYSTEM
-                          : MachineSidePanelViews.DELETE_FILESYSTEM,
-                    },
-                  ]}
-                  disabled={!canEditStorage}
-                  onActionClick={(_, view) => {
-                    if (view) {
-                      if (
-                        node.special_filesystems &&
-                        view === MachineSidePanelViews.DELETE_SPECIAL_FILESYSTEM
-                      ) {
-                        setSidePanelContent({
-                          view,
-                          extras: {
-                            systemId: node.system_id,
-                            mountPoint: fs.mount_point,
-                          },
-                        });
-                        return;
-                      }
-                      setSidePanelContent({
-                        view,
-                        extras: {
-                          systemId: node.system_id,
-                          storageDevice,
-                        },
-                      });
-                    }
-                  }}
-                />
-              ),
-            },
-          ]
-        : []),
-    ].map((column, i) => ({ ...column, "aria-label": headers[i].content })),
-    key: rowId,
-  };
+export type FilesystemRow = {
+  id: string;
+  name?: string;
+  size?: number;
+  node: ControllerDetails | MachineDetails;
+  storage?: Disk | Partition;
+  fstype: string;
+  is_format_fstype: boolean;
+  label: string;
+  mount_options: string | null;
+  mount_point: string;
+  used_for: string;
 };
 
-const FilesystemsTable = ({
-  canEditStorage,
-  node,
-}: Props): React.ReactElement | null => {
-  const isMachine = nodeIsMachine(node);
-  const { setSidePanelContent } = useSidePanel();
+const generateFilesystemRowData = (
+  node: ControllerDetails | MachineDetails
+): FilesystemRow[] => {
+  const data: FilesystemRow[] = [];
 
-  const rows = node.disks.reduce<MainTableRow[]>((rows, disk) => {
-    const diskFs = disk.filesystem;
+  const addFilesystem = (storage: Disk | Partition) => {
+    if (!isMounted(storage.filesystem)) return;
+    data.push({
+      name: storage?.name,
+      size: storage?.size,
+      node,
+      storage,
+      ...storage.filesystem,
+      id: `${storage.filesystem.fstype}-${storage.filesystem.id}`,
+    });
+  };
 
-    if (isMounted(diskFs)) {
-      const rowId = `${diskFs.fstype}-${diskFs.id}`;
-
-      rows.push({
-        ...normaliseRowData(
-          rowId,
-          diskFs,
-          disk,
-          canEditStorage,
-          isMachine,
-          node,
-          setSidePanelContent
-        ),
-      });
-    }
+  node.disks.forEach((disk) => {
+    addFilesystem(disk);
 
     if (disk.partitions) {
       disk.partitions.forEach((partition) => {
-        const partitionFs = partition.filesystem;
-
-        if (isMounted(partitionFs)) {
-          const rowId = `${partitionFs.fstype}-${partitionFs.id}`;
-
-          rows.push({
-            ...normaliseRowData(
-              rowId,
-              partitionFs,
-              partition,
-              canEditStorage,
-              isMachine,
-              node,
-              setSidePanelContent
-            ),
-          });
-        }
+        addFilesystem(partition);
       });
     }
-    return rows;
-  }, []);
+  });
 
   if (node.special_filesystems) {
-    node.special_filesystems.forEach((specialFs) => {
-      const rowId = `${specialFs.fstype}-${specialFs.id}`;
-
-      rows.push({
-        ...normaliseRowData(
-          rowId,
-          specialFs,
-          null,
-          canEditStorage,
-          isMachine,
-          node,
-          setSidePanelContent
-        ),
+    node.special_filesystems.forEach((specialFilesystem) => {
+      data.push({
+        node,
+        ...specialFilesystem,
+        id: `${specialFilesystem.fstype}-${specialFilesystem.id}`,
       });
     });
   }
 
+  return data;
+};
+
+const FilesystemsTable = ({ canEditStorage, node }: Props): ReactElement => {
+  const isMachine = nodeIsMachine(node);
+  const { setSidePanelContent } = useSidePanel();
+
+  const columns = useFileSystemsTableColumns(
+    canEditStorage,
+    nodeIsMachine(node)
+  );
+  const data = generateFilesystemRowData(node);
+
   return (
     <>
-      <MainTable
-        className="p-table-expanding--light"
-        defaultSort="name"
-        defaultSortDirection="ascending"
-        expanding
-        headers={isMachine ? headers : headers.slice(0, -1)}
-        responsive
-        rows={rows}
+      <GenericTable
+        columns={columns}
+        data={data}
+        isLoading={false}
+        noData="No filesystems defined."
+        sortBy={[{ id: "name", desc: false }]}
+        style={{ marginBottom: "1.5rem" }}
       />
-      {rows.length === 0 && (
-        <p className="u-nudge-right--small u-sv1" data-testid="no-filesystems">
-          No filesystems defined.
-        </p>
-      )}
       {canEditStorage && (
         <Tooltip message="Create a tmpfs or ramfs filesystem.">
           <Button

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/useFilesystemsTableColumns/useFileSystemsTableColumns.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/useFilesystemsTableColumns/useFileSystemsTableColumns.tsx
@@ -1,0 +1,136 @@
+import { useMemo } from "react";
+
+import type { ColumnDef, Row } from "@tanstack/react-table";
+
+import TableActionsDropdown from "@/app/base/components/TableActionsDropdown";
+import type { FilesystemRow } from "@/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable";
+import { FilesystemAction } from "@/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable";
+import { useSidePanel } from "@/app/base/side-panel-context";
+import { MachineSidePanelViews } from "@/app/machines/constants";
+import { formatSize, usesStorage } from "@/app/store/utils";
+
+export type FilesystemsColumnDef = ColumnDef<
+  FilesystemRow,
+  Partial<FilesystemRow>
+>;
+
+const useFileSystemsTableColumns = (
+  canEditStorage: boolean,
+  isMachine: boolean
+): FilesystemsColumnDef[] => {
+  const { setSidePanelContent } = useSidePanel();
+  return useMemo(
+    () =>
+      [
+        {
+          id: "name",
+          accessorKey: "name",
+          enableSorting: true,
+          header: "Name",
+          cell: ({
+            row: {
+              original: { name },
+            },
+          }: {
+            row: Row<FilesystemRow>;
+          }) => name ?? "—",
+        },
+        {
+          id: "size",
+          accessorKey: "size",
+          enableSorting: true,
+          header: "Size",
+          cell: ({
+            row: {
+              original: { size },
+            },
+          }: {
+            row: Row<FilesystemRow>;
+          }) => (size ? formatSize(size) : "—"),
+        },
+        {
+          id: "fstype",
+          accessorKey: "fstype",
+          enableSorting: true,
+          header: "Filesystem",
+        },
+        {
+          id: "mountPoint",
+          accessorKey: "mount_point",
+          enableSorting: true,
+          header: "Mount point",
+        },
+        {
+          id: "mountOptions",
+          accessorKey: "mount_options",
+          enableSorting: false,
+          header: "Mount options",
+        },
+        ...(isMachine
+          ? [
+              {
+                id: "Actions",
+                accessorKey: "id",
+                enableSorting: false,
+                header: "Actions",
+                cell: ({
+                  row: {
+                    original: { fstype, mount_point, node, storage },
+                  },
+                }: {
+                  row: Row<FilesystemRow>;
+                }) => (
+                  <TableActionsDropdown
+                    actions={[
+                      {
+                        label: "Unmount filesystem...",
+                        show: usesStorage(fstype),
+                        type: FilesystemAction.UNMOUNT,
+                        view: MachineSidePanelViews.UNMOUNT_FILESYSTEM,
+                      },
+                      {
+                        label: "Remove filesystem...",
+                        type: FilesystemAction.DELETE,
+                        view:
+                          node.special_filesystems && !storage
+                            ? MachineSidePanelViews.DELETE_SPECIAL_FILESYSTEM
+                            : MachineSidePanelViews.DELETE_FILESYSTEM,
+                      },
+                    ]}
+                    disabled={!canEditStorage}
+                    onActionClick={(_, view) => {
+                      if (view) {
+                        if (
+                          node.special_filesystems &&
+                          view ===
+                            MachineSidePanelViews.DELETE_SPECIAL_FILESYSTEM
+                        ) {
+                          setSidePanelContent({
+                            view,
+                            extras: {
+                              systemId: node.system_id,
+                              mountPoint: mount_point,
+                            },
+                          });
+                          return;
+                        }
+                        setSidePanelContent({
+                          view,
+                          extras: {
+                            systemId: node.system_id,
+                            storageDevice: storage,
+                          },
+                        });
+                      }
+                    }}
+                  />
+                ),
+              },
+            ]
+          : []),
+      ] as FilesystemsColumnDef[],
+    [canEditStorage, isMachine, setSidePanelContent]
+  );
+};
+
+export default useFileSystemsTableColumns;

--- a/src/app/zones/components/ZonesTable/ZonesTable.test.tsx
+++ b/src/app/zones/components/ZonesTable/ZonesTable.test.tsx
@@ -53,7 +53,7 @@ describe("ZonesTable", () => {
         "Machines",
         "Devices",
         "Controllers",
-        "Action",
+        "Actions",
       ].forEach((column) => {
         expect(
           screen.getByRole("columnheader", {


### PR DESCRIPTION
## Done

- Refactored FilesystemsTable to use GenericTable
- Added table row representation type for joined fields
- Fixed tests

## QA steps

- [x] Navigate to the details page of a machine with filesystems that is _NOT_ Ready (e.g. sin73l00045.maas)
- [x] Go to the Storage tab
- [x] Verify filesystems table has entries displayed correctly
- [x] Verify the row actions are disabled
- [x] Navigate to the details page of a machine with filesystems that IS Ready (e.g. sin73l00001.maas)
- [x] Go to the Storage tab
- [x] Verify filesystems table has entries displayed correctly
- [x] Verify the row actions are available
- [x] Verify the actions open the correct side panel forms
- [x] Navigate to the details page of a controller
- [x] Go to the Storage tab
- [x] Verify the filesystems table has no "Action" column
- [x] Verify filesystems table has entries displayed correctly
- [x] Verify "No filesystems defined." is displayed when the table is empty

## Fixes

Resolves [MAASENG-5261](https://warthogs.atlassian.net/browse/MAASENG-5261)

[MAASENG-5261]: https://warthogs.atlassian.net/browse/MAASENG-5261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ