### PR TITLE
refactor(base): DatastoresTable to GenericTable MAASENG-5262

### DIFF
--- a/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.tsx
@@ -1,139 +1,71 @@
-import { useState } from "react";
+import type { ReactElement } from "react";
 
-import { MainTable } from "@canonical/react-components";
-import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
-import { useDispatch } from "react-redux";
+import { GenericTable } from "@canonical/maas-react-components";
 
-import TableActionsDropdown from "@/app/base/components/TableActionsDropdown";
-import ActionConfirm from "@/app/base/components/node/ActionConfirm";
+import useDatastoresTableColumns from "@/app/base/components/node/StorageTables/DatastoresTable/useDatastoresTableColumns/useDatastoresTableColumns";
 import type { ControllerDetails } from "@/app/store/controller/types";
-import { machineActions } from "@/app/store/machine";
 import type { MachineDetails } from "@/app/store/machine/types";
-import { formatSize, isDatastore, nodeIsMachine } from "@/app/store/utils";
+import type { Disk } from "@/app/store/types/node";
+import { isDatastore, nodeIsMachine } from "@/app/store/utils";
 
 export enum DatastoreAction {
   DELETE = "deleteDisk",
 }
-
-type Expanded = {
-  content: DatastoreAction;
-  id: string;
-};
 
 type Props = {
   canEditStorage: boolean;
   node: ControllerDetails | MachineDetails;
 };
 
-const DatastoresTable = ({
-  canEditStorage,
-  node,
-}: Props): React.ReactElement => {
-  const dispatch = useDispatch();
-  const [expanded, setExpanded] = useState<Expanded | null>(null);
-  const isMachine = nodeIsMachine(node);
-  const closeExpanded = () => {
-    setExpanded(null);
-  };
+export type DatastoreRow = {
+  id: string;
+  name: string;
+  size: number;
+  fstype: string;
+  mount_point: string;
+  disk: Disk;
+  systemId: string;
+};
 
-  const headers = [
-    { content: "Name" },
-    { content: "Filesystem" },
-    { content: "Size" },
-    { content: "Mount point" },
-    {
-      content: "Actions",
-      className: "u-align--right",
-    },
-  ];
+const generateDatastoreRowData = (
+  node: ControllerDetails | MachineDetails
+): DatastoreRow[] => {
+  const data: DatastoreRow[] = [];
 
-  const rows = node.disks.reduce<MainTableRow[]>((rows, disk) => {
-    if (disk.filesystem && isDatastore(disk.filesystem)) {
-      const fs = disk.filesystem;
-      const rowId = `${fs.fstype}-${fs.id}`;
-      const isExpanded = expanded?.id === rowId && Boolean(expanded?.content);
-      rows.push({
-        className: isExpanded ? "p-table__row is-active" : null,
-        columns: [
-          { content: disk.name },
-          { content: fs.fstype },
-          { content: formatSize(disk.size) },
-          { content: fs.mount_point },
-          ...(isMachine
-            ? [
-                {
-                  content: (
-                    <TableActionsDropdown
-                      actions={[
-                        {
-                          label: "Remove datastore...",
-                          type: DatastoreAction.DELETE,
-                        },
-                      ]}
-                      disabled={!canEditStorage}
-                      onActionClick={(action: DatastoreAction) => {
-                        setExpanded({ content: action, id: rowId });
-                      }}
-                    />
-                  ),
-                  className: "u-align--right",
-                },
-              ]
-            : []),
-        ].map((column, i) => ({
-          ...column,
-          "aria-label": headers[i].content,
-        })),
-        expanded: isExpanded,
-        expandedContent: isMachine ? (
-          <div className="u-flex--grow">
-            {expanded?.content === "deleteDisk" && (
-              <ActionConfirm
-                closeExpanded={closeExpanded}
-                confirmLabel="Remove datastore"
-                eventName="deleteDisk"
-                message="Are you sure you want to remove this datastore? ESXi requires at least one VMFS datastore to deploy."
-                onConfirm={() => {
-                  dispatch(machineActions.cleanup());
-                  dispatch(
-                    machineActions.deleteDisk({
-                      blockId: disk.id,
-                      systemId: node.system_id,
-                    })
-                  );
-                }}
-                onSaveAnalytics={{
-                  action: "Delete datastore",
-                  category: "Machine storage",
-                  label: "Remove datastore",
-                }}
-                statusKey="deletingDisk"
-                systemId={node.system_id}
-              />
-            )}
-          </div>
-        ) : null,
-        key: rowId,
-      });
+  node.disks.forEach((disk) => {
+    if (!disk.filesystem || !isDatastore(disk.filesystem)) {
+      return;
     }
-    return rows;
-  }, []);
+
+    data.push({
+      id: `${disk.filesystem.fstype}-${disk.filesystem.id}`,
+      name: disk.name,
+      size: disk.size,
+      fstype: disk.filesystem.fstype,
+      mount_point: disk.filesystem.mount_point,
+      disk,
+      systemId: node.system_id,
+    });
+  });
+
+  return data;
+};
+
+const DatastoresTable = ({ canEditStorage, node }: Props): ReactElement => {
+  const isMachine = nodeIsMachine(node);
+
+  const columns = useDatastoresTableColumns(canEditStorage, isMachine);
+  const data = generateDatastoreRowData(node);
 
   return (
-    <>
-      <MainTable
-        className="p-table-expanding--light"
-        expanding
-        headers={isMachine ? headers : headers.slice(0, -1)}
-        responsive
-        rows={rows}
-      />
-      {rows.length === 0 && (
-        <div className="u-nudge-right--small" data-testid="no-datastores">
-          No datastores detected.
-        </div>
-      )}
-    </>
+    <GenericTable
+      columns={columns}
+      data={data}
+      isLoading={false}
+      noData="No datastores detected."
+      sortBy={[{ id: "name", desc: false }]}
+      style={{ marginBottom: "1.5rem" }}
+    />
   );
 };
 

--- a/src/app/base/components/node/StorageTables/DatastoresTable/RemoveDatastore/RemoveDatastore.test.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/RemoveDatastore/RemoveDatastore.test.tsx
@@ -1,0 +1,63 @@
+import configureStore from "redux-mock-store";
+
+import RemoveDatastore from "@/app/base/components/node/StorageTables/DatastoresTable/RemoveDatastore/RemoveDatastore";
+import { machineActions } from "@/app/store/machine";
+import type { RootState } from "@/app/store/root/types";
+import * as factory from "@/testing/factories";
+import { renderWithBrowserRouter, screen, userEvent } from "@/testing/utils";
+
+const mockStore = configureStore<RootState>();
+
+describe("RemoveDatastore", () => {
+  const filesystem = factory.nodeFilesystem({ mount_point: "/disk-fs/path" });
+  const disk = factory.nodeDisk({ filesystem, partitions: [] });
+  const machine = factory.machineDetails({
+    disks: [disk],
+    system_id: "abc123",
+  });
+  const state = factory.rootState({
+    machine: factory.machineState({
+      items: [machine],
+      statuses: factory.machineStatuses({
+        abc123: factory.machineStatus(),
+      }),
+    }),
+  });
+
+  it("renders a delete confirmation form", () => {
+    renderWithBrowserRouter(
+      <RemoveDatastore diskId={disk.id} systemId="abc123" />,
+      { state }
+    );
+
+    expect(
+      screen.getByRole("form", { name: "Remove datastore" })
+    ).toBeInTheDocument();
+  });
+
+  it("can remove a disk's filesystem", async () => {
+    const store = mockStore(state);
+    renderWithBrowserRouter(
+      <RemoveDatastore diskId={disk.id} systemId="abc123" />,
+      { store }
+    );
+
+    expect(
+      screen.getByRole("form", { name: "Remove datastore" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Are you sure you want to remove this datastore? ESXi requires at least one VMFS datastore to deploy."
+      )
+    ).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+
+    const expectedAction = machineActions.deleteDisk({
+      blockId: disk.id,
+      systemId: machine.system_id,
+    });
+    expect(
+      store.getActions().find((action) => action.type === expectedAction.type)
+    ).toStrictEqual(expectedAction);
+  });
+});

--- a/src/app/base/components/node/StorageTables/DatastoresTable/RemoveDatastore/RemoveDatastore.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/RemoveDatastore/RemoveDatastore.tsx
@@ -1,0 +1,57 @@
+import type { ReactElement } from "react";
+
+import { useDispatch } from "react-redux";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { useSidePanel } from "@/app/base/side-panel-context";
+import { machineActions } from "@/app/store/machine";
+import type { Machine } from "@/app/store/machine/types";
+import type { Disk } from "@/app/store/types/node";
+
+type Props = {
+  systemId: Machine["system_id"];
+  diskId: Disk["id"];
+};
+
+const RemoveDatastore = ({ systemId, diskId }: Props): ReactElement => {
+  const { setSidePanelContent } = useSidePanel();
+  const dispatch = useDispatch();
+
+  const closeForm = () => {
+    setSidePanelContent(null);
+  };
+
+  return (
+    <ModelActionForm
+      aria-label="Remove datastore"
+      initialValues={{}}
+      message={
+        <>
+          Are you sure you want to remove this datastore? ESXi requires at least
+          one VMFS datastore to deploy.
+        </>
+      }
+      modelType="datastore"
+      onCancel={closeForm}
+      onSaveAnalytics={{
+        action: "Delete datastore",
+        category: "Machine storage",
+        label: "Remove datastore",
+      }}
+      onSubmit={() => {
+        dispatch(machineActions.cleanup());
+        dispatch(
+          machineActions.deleteDisk({
+            blockId: diskId,
+            systemId: systemId,
+          })
+        );
+      }}
+      onSuccess={closeForm}
+      submitAppearance="negative"
+      submitLabel="Remove"
+    />
+  );
+};
+
+export default RemoveDatastore;

--- a/src/app/base/components/node/StorageTables/DatastoresTable/RemoveDatastore/index.ts
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/RemoveDatastore/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RemoveDatastore";

--- a/src/app/base/components/node/StorageTables/DatastoresTable/useDatastoresTableColumns/useDatastoresTableColumns.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/useDatastoresTableColumns/useDatastoresTableColumns.tsx
@@ -1,0 +1,94 @@
+import { useMemo } from "react";
+
+import type { ColumnDef, Row } from "@tanstack/react-table";
+
+import TableActionsDropdown from "@/app/base/components/TableActionsDropdown";
+import type { DatastoreRow } from "@/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable";
+import { DatastoreAction } from "@/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable";
+import { useSidePanel } from "@/app/base/side-panel-context";
+import { MachineSidePanelViews } from "@/app/machines/constants";
+import { formatSize } from "@/app/store/utils";
+
+export type DatastoresColumnDef = ColumnDef<
+  DatastoreRow,
+  Partial<DatastoreRow>
+>;
+
+const useDatastoresTableColumns = (
+  canEditStorage: boolean,
+  isMachine: boolean
+): DatastoresColumnDef[] => {
+  const { setSidePanelContent } = useSidePanel();
+  return useMemo(
+    () =>
+      [
+        {
+          id: "name",
+          accessorKey: "name",
+          enableSorting: true,
+          header: "Name",
+        },
+        {
+          id: "size",
+          accessorKey: "size",
+          enableSorting: true,
+          header: "Size",
+          cell: ({
+            row: {
+              original: { size },
+            },
+          }: {
+            row: Row<DatastoreRow>;
+          }) => formatSize(size),
+        },
+        {
+          id: "fstype",
+          accessorKey: "fstype",
+          enableSorting: true,
+          header: "Filesystem",
+        },
+        {
+          id: "mountPoint",
+          accessorKey: "mount_point",
+          enableSorting: true,
+          header: "Mount point",
+        },
+        ...(isMachine
+          ? [
+              {
+                id: "Actions",
+                accessorKey: "id",
+                enableSorting: false,
+                header: "Actions",
+                cell: ({
+                  row: {
+                    original: { disk, systemId },
+                  },
+                }: {
+                  row: Row<DatastoreRow>;
+                }) => (
+                  <TableActionsDropdown
+                    actions={[
+                      {
+                        label: "Remove datastore...",
+                        type: DatastoreAction.DELETE,
+                      },
+                    ]}
+                    disabled={!canEditStorage}
+                    onActionClick={() => {
+                      setSidePanelContent({
+                        view: MachineSidePanelViews.REMOVE_DATASTORE,
+                        extras: { disk, systemId: systemId },
+                      });
+                    }}
+                  />
+                ),
+              },
+            ]
+          : []),
+      ] as DatastoresColumnDef[],
+    [canEditStorage, isMachine, setSidePanelContent]
+  );
+};
+
+export default useDatastoresTableColumns;

--- a/src/app/base/side-panel-context.tsx
+++ b/src/app/base/side-panel-context.tsx
@@ -71,6 +71,7 @@ const sidePanelTitleMap: Record<string, string> = {
   [SidePanelViews.SET_BOOT_DISK[1]]: "Set boot disk",
   [SidePanelViews.UNMOUNT_FILESYSTEM[1]]: "Unmount filesystem",
   [SidePanelViews.UPDATE_DATASTORE[1]]: "Update datastore",
+  [SidePanelViews.REMOVE_DATASTORE[1]]: "Remove datastore",
   [SidePanelViews.UpdateTag[1]]: "Update Tag",
 };
 

--- a/src/app/machines/components/MachineForms/MachineForms.tsx
+++ b/src/app/machines/components/MachineForms/MachineForms.tsx
@@ -24,6 +24,7 @@ import DeleteVolumeGroup from "@/app/base/components/node/StorageTables/Availabl
 import EditDisk from "@/app/base/components/node/StorageTables/AvailableStorageTable/EditDisk";
 import EditPartition from "@/app/base/components/node/StorageTables/AvailableStorageTable/EditPartition";
 import SetBootDisk from "@/app/base/components/node/StorageTables/AvailableStorageTable/SetBootDisk";
+import RemoveDatastore from "@/app/base/components/node/StorageTables/DatastoresTable/RemoveDatastore/RemoveDatastore";
 import AddSpecialFilesystem from "@/app/base/components/node/StorageTables/FilesystemsTable/AddSpecialFilesystem";
 import DeleteFilesystem from "@/app/base/components/node/StorageTables/FilesystemsTable/DeleteFilesystem";
 import DeleteSpecialFilesystem from "@/app/base/components/node/StorageTables/FilesystemsTable/DeleteSpecialFilesystem";
@@ -386,6 +387,10 @@ export const MachineForms = ({
           systemId={systemId}
         />
       );
+    }
+    case MachineSidePanelViews.REMOVE_DATASTORE: {
+      if (!disk || !systemId) return null;
+      return <RemoveDatastore diskId={disk.id} systemId={systemId} />;
     }
 
     default:

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -64,6 +64,7 @@ export const MachineNonActionSidePanelViews = {
   SET_BOOT_DISK: ["machineNonActionForm", "setBootDisk"],
   UNMOUNT_FILESYSTEM: ["machineNonActionForm", "unmountFilesystem"],
   UPDATE_DATASTORE: ["machineNonActionForm", "updateDatastore"],
+  REMOVE_DATASTORE: ["machineNonActionForm", "removeDatastore"],
 } as const;
 
 export const MachineSidePanelViews = {


### PR DESCRIPTION
## Done

- Converted in-table "Remove datastore" confirmation to a side panel form (old context)
- Refactored DatastoresTable to GenericTable
- Added and fixed tests

## QA steps

- [ ] Navigate to an LXD machine (e.g. sin73l00114.maas)
- [ ] Go to the Storage tab
- [ ] Verify the datastores table is being displayed instead of the filesystems table
- [ ] If not, change storage layout to VMFS6 or VMFS7
- [ ] Verify the datastores table is rendered correctly
- [ ] Verify the actions open the correct side panel forms
- [ ] Remove a datastore
- [ ] Verify "No datastores detected." is displayed when the table is empty
- [ ] Navigate to the details page of a controller (make sure it is VMFS& or VMFS7)
- [ ] Go to the Storage tab
- [ ] Verify the filesystems table has no "Action" column

## Fixes

Resolves [MAASENG-5262](https://warthogs.atlassian.net/browse/MAASENG-5262)
