### PR TITLE
refactor(base): UsedStorageTable to GenericTable MAASENG-5265

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@canonical/maas-react-components": "1.33.3",
+    "@canonical/maas-react-components": "1.33.4",
     "@canonical/macaroon-bakery": "1.3.2",
     "@canonical/react-components": "2.14.0",
     "@redux-devtools/extension": "3.3.0",

--- a/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/DatastoresTable.tsx
@@ -65,6 +65,7 @@ const DatastoresTable = ({ canEditStorage, node }: Props): ReactElement => {
       noData="No datastores detected."
       sortBy={[{ id: "name", desc: false }]}
       style={{ marginBottom: "1.5rem" }}
+      variant="regular"
     />
   );
 };

--- a/src/app/base/components/node/StorageTables/DatastoresTable/useDatastoresTableColumns/useDatastoresTableColumns.tsx
+++ b/src/app/base/components/node/StorageTables/DatastoresTable/useDatastoresTableColumns/useDatastoresTableColumns.tsx
@@ -25,13 +25,13 @@ const useDatastoresTableColumns = (
         {
           id: "name",
           accessorKey: "name",
-          enableSorting: true,
+          enableSorting: false,
           header: "Name",
         },
         {
           id: "size",
           accessorKey: "size",
-          enableSorting: true,
+          enableSorting: false,
           header: "Size",
           cell: ({
             row: {
@@ -44,13 +44,13 @@ const useDatastoresTableColumns = (
         {
           id: "fstype",
           accessorKey: "fstype",
-          enableSorting: true,
+          enableSorting: false,
           header: "Filesystem",
         },
         {
           id: "mountPoint",
           accessorKey: "mount_point",
-          enableSorting: true,
+          enableSorting: false,
           header: "Mount point",
         },
         ...(isMachine

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/FilesystemsTable.tsx
@@ -94,6 +94,7 @@ const FilesystemsTable = ({
         noData="No filesystems defined."
         sortBy={[{ id: "name", desc: false }]}
         style={{ marginBottom: "1.5rem" }}
+        variant="regular"
       />
       {canEditStorage && (
         <Tooltip message="Create a tmpfs or ramfs filesystem.">

--- a/src/app/base/components/node/StorageTables/FilesystemsTable/useFilesystemsTableColumns/useFileSystemsTableColumns.tsx
+++ b/src/app/base/components/node/StorageTables/FilesystemsTable/useFilesystemsTableColumns/useFileSystemsTableColumns.tsx
@@ -25,7 +25,7 @@ const useFileSystemsTableColumns = (
         {
           id: "name",
           accessorKey: "name",
-          enableSorting: true,
+          enableSorting: false,
           header: "Name",
           cell: ({
             row: {
@@ -38,7 +38,7 @@ const useFileSystemsTableColumns = (
         {
           id: "size",
           accessorKey: "size",
-          enableSorting: true,
+          enableSorting: false,
           header: "Size",
           cell: ({
             row: {
@@ -51,13 +51,13 @@ const useFileSystemsTableColumns = (
         {
           id: "fstype",
           accessorKey: "fstype",
-          enableSorting: true,
+          enableSorting: false,
           header: "Filesystem",
         },
         {
           id: "mountPoint",
           accessorKey: "mount_point",
-          enableSorting: true,
+          enableSorting: false,
           header: "Mount point",
         },
         {

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.tsx
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.tsx
@@ -1,206 +1,55 @@
-import { MainTable } from "@canonical/react-components";
-import type { MainTableRow } from "@canonical/react-components/dist/components/MainTable/MainTable";
+import type { ReactElement } from "react";
 
-import DoubleRow from "@/app/base/components/DoubleRow";
-import TagLinks from "@/app/base/components/TagLinks";
-import DiskBootStatus from "@/app/base/components/node/DiskBootStatus";
-import DiskNumaNodes from "@/app/base/components/node/DiskNumaNodes";
-import DiskTestStatus from "@/app/base/components/node/DiskTestStatus";
-import urls from "@/app/base/urls";
+import { GenericTable } from "@canonical/maas-react-components";
+
+import useUsedStorageTableColumns from "@/app/base/components/node/StorageTables/UsedStorageTable/useUsedStorageTableColumns/useUsedStorageTableColumns";
 import type { ControllerDetails } from "@/app/store/controller/types";
-import { FilterControllers } from "@/app/store/controller/utils";
 import type { MachineDetails } from "@/app/store/machine/types";
-import { FilterMachines } from "@/app/store/machine/utils";
 import type { Disk, Partition } from "@/app/store/types/node";
 import {
   diskAvailable,
-  formatType,
-  formatSize,
   partitionAvailable,
   nodeIsMachine,
 } from "@/app/store/utils";
 
-type Props = {
+type UsedStorageTableProps = {
   node: ControllerDetails | MachineDetails;
 };
 
-const normaliseColumns = (
-  storageDevice: Disk | Partition,
-  node: Props["node"]
-) => {
-  return [
-    {
-      content: (
-        <DoubleRow
-          primary={storageDevice.name}
-          secondary={"serial" in storageDevice && storageDevice.serial}
-        />
-      ),
-      "aria-label": "Name & serial",
-    },
-    {
-      content: (
-        <DoubleRow
-          primary={"model" in storageDevice ? storageDevice.model : "—"}
-          secondary={
-            "firmware_version" in storageDevice &&
-            storageDevice.firmware_version
-          }
-        />
-      ),
-      "aria-label": "Model & firmware",
-    },
-    {
-      content: (
-        <DoubleRow
-          primary={
-            "is_boot" in storageDevice ? (
-              <DiskBootStatus disk={storageDevice} />
-            ) : (
-              "—"
-            )
-          }
-        />
-      ),
-      "aria-label": "Boot",
-    },
-    {
-      content: <DoubleRow primary={formatSize(storageDevice.size)} />,
-      "aria-label": "Size",
-    },
-    {
-      content: (
-        <DoubleRow
-          data-testid="type"
-          primary={formatType(storageDevice)}
-          secondary={
-            ("numa_node" in storageDevice || "numa_nodes" in storageDevice) && (
-              <DiskNumaNodes disk={storageDevice} />
-            )
-          }
-        />
-      ),
-      "aria-label": "Type & NUMA node",
-    },
-    {
-      content: (
-        <DoubleRow
-          data-testid="health"
-          primary={
-            "test_status" in storageDevice ? (
-              <DiskTestStatus testStatus={storageDevice.test_status} />
-            ) : (
-              "—"
-            )
-          }
-          secondary={
-            <TagLinks
-              getLinkURL={(tag) => {
-                if (nodeIsMachine(node)) {
-                  const filter = FilterMachines.filtersToQueryString({
-                    storage_tags: [`=${tag}`],
-                  });
-                  return `${urls.machines.index}${filter}`;
-                }
-                const filter = FilterControllers.filtersToQueryString({
-                  storage_tags: [`=${tag}`],
-                });
-                return `${urls.controllers.index}${filter}`;
-              }}
-              tags={storageDevice.tags}
-            />
-          }
-        />
-      ),
-      "aria-label": "Health & Tags",
-    },
-    {
-      "aria-label": "Used for",
-      className: "u-break-spaces",
-      content: storageDevice.used_for,
-    },
-  ];
-};
+export type UsedStorage = Disk | Partition;
 
-const UsedStorageTable = ({ node }: Props): React.ReactElement | null => {
-  const rows: MainTableRow[] = [];
+const generateUsedStorageData = (node: ControllerDetails | MachineDetails) => {
+  const data: UsedStorage[] = [];
 
   node.disks.forEach((disk) => {
     if (!diskAvailable(disk)) {
-      const rowId = `${disk.type}-${disk.id}`;
-      rows.push({
-        columns: normaliseColumns(disk, node),
-        key: rowId,
-      });
+      data.push(disk);
     }
 
     if (disk.partitions) {
       disk.partitions.forEach((partition) => {
         if (!partitionAvailable(partition)) {
-          const rowId = `${partition.type}-${partition.id}`;
-          rows.push({
-            columns: normaliseColumns(partition, node),
-            key: rowId,
-          });
+          data.push(partition);
         }
       });
     }
   });
 
+  return data;
+};
+
+const UsedStorageTable = ({ node }: UsedStorageTableProps): ReactElement => {
+  const columns = useUsedStorageTableColumns(nodeIsMachine(node));
+  const data = generateUsedStorageData(node);
+
   return (
-    <>
-      <MainTable
-        className="p-table-expanding--light"
-        headers={[
-          {
-            content: (
-              <>
-                <div>Name</div>
-                <div>Serial</div>
-              </>
-            ),
-          },
-          {
-            content: (
-              <>
-                <div>Model</div>
-                <div>Firmware</div>
-              </>
-            ),
-          },
-          {
-            content: <div>Boot</div>,
-          },
-          { content: <div>Size</div> },
-          {
-            content: (
-              <>
-                <div>Type</div>
-                <div>NUMA node</div>
-              </>
-            ),
-          },
-          {
-            content: (
-              <>
-                <div>Health</div>
-                <div>Tags</div>
-              </>
-            ),
-          },
-          {
-            content: "Used for",
-          },
-        ]}
-        responsive
-        rows={rows}
-      />
-      {rows.length === 0 && (
-        <div className="u-nudge-right--small" data-testid="no-used">
-          No disk or partition has been fully utilised.
-        </div>
-      )}
-    </>
+    <GenericTable
+      columns={columns}
+      data={data}
+      isLoading={false}
+      noData="No disk or partition has been fully utilised."
+      variant="regular"
+    />
   );
 };
 

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.tsx
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable.tsx
@@ -12,6 +12,8 @@ import {
   nodeIsMachine,
 } from "@/app/store/utils";
 
+import "./_index.scss";
+
 type UsedStorageTableProps = {
   node: ControllerDetails | MachineDetails;
 };
@@ -46,6 +48,7 @@ const UsedStorageTable = ({ node }: UsedStorageTableProps): ReactElement => {
     <GenericTable
       columns={columns}
       data={data}
+      id="used-storage-table"
       isLoading={false}
       noData="No disk or partition has been fully utilised."
       variant="regular"

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/_index.scss
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/_index.scss
@@ -1,0 +1,5 @@
+#used-storage-table {
+  .used_for {
+    text-align: left;
+  }
+}

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/useUsedStorageTableColumns/useUsedStorageTableColumns.tsx
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/useUsedStorageTableColumns/useUsedStorageTableColumns.tsx
@@ -1,0 +1,155 @@
+import { useMemo } from "react";
+
+import type { ColumnDef, Row } from "@tanstack/react-table";
+
+import DoubleRow from "@/app/base/components/DoubleRow";
+import TableHeader from "@/app/base/components/TableHeader";
+import TagLinks from "@/app/base/components/TagLinks";
+import DiskBootStatus from "@/app/base/components/node/DiskBootStatus";
+import DiskNumaNodes from "@/app/base/components/node/DiskNumaNodes";
+import DiskTestStatus from "@/app/base/components/node/DiskTestStatus";
+import type { UsedStorage } from "@/app/base/components/node/StorageTables/UsedStorageTable/UsedStorageTable";
+import urls from "@/app/base/urls";
+import { FilterControllers } from "@/app/store/controller/utils";
+import { FilterMachines } from "@/app/store/machine/utils";
+import { formatSize, formatType } from "@/app/store/utils";
+
+export type UsedStorageColumnDef = ColumnDef<UsedStorage, Partial<UsedStorage>>;
+
+const useUsedStorageTableColumns = (
+  isMachine: boolean
+): UsedStorageColumnDef[] => {
+  return useMemo(
+    () =>
+      [
+        {
+          id: "name",
+          accessorKey: "name",
+          enableSorting: true,
+          header: () => (
+            <div className="p-double-row__header-spacer">
+              <TableHeader sortKey="name">Name</TableHeader>
+              <TableHeader>Serial</TableHeader>
+            </div>
+          ),
+          cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) => (
+            <DoubleRow
+              primary={storage.name}
+              secondary={"serial" in storage && storage.serial}
+            />
+          ),
+        },
+        {
+          id: "model",
+          accessorKey: "model",
+          enableSorting: true,
+          header: () => (
+            <div className="p-double-row__header-spacer">
+              <TableHeader sortKey="model">Model</TableHeader>
+              <TableHeader>Firmware</TableHeader>
+            </div>
+          ),
+          cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) => (
+            <DoubleRow
+              primary={"model" in storage ? storage.model : "—"}
+              secondary={
+                "firmware_version" in storage && storage.firmware_version
+              }
+            />
+          ),
+        },
+        {
+          id: "boot",
+          accessorKey: "boot",
+          enableSorting: true,
+          header: "Boot",
+          cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) =>
+            "is_boot" in storage ? <DiskBootStatus disk={storage} /> : "—",
+        },
+        {
+          id: "size",
+          accessorKey: "size",
+          enableSorting: true,
+          header: "Size",
+          cell: ({
+            row: {
+              original: { size },
+            },
+          }: {
+            row: Row<UsedStorage>;
+          }) => formatSize(size),
+        },
+        {
+          id: "type",
+          accessorKey: "type",
+          enableSorting: false,
+          header: () => (
+            <div className="p-double-row__header-spacer">
+              <TableHeader sortKey="type">Type</TableHeader>
+              <TableHeader>NUMA node</TableHeader>
+            </div>
+          ),
+          cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) => (
+            <DoubleRow
+              data-testid="type"
+              primary={formatType(storage)}
+              secondary={
+                ("numa_node" in storage || "numa_nodes" in storage) && (
+                  <DiskNumaNodes disk={storage} />
+                )
+              }
+            />
+          ),
+        },
+        {
+          id: "health",
+          accessorKey: "health",
+          enableSorting: false,
+          header: () => (
+            <div className="p-double-row__header-spacer">
+              <TableHeader sortKey="health">Health</TableHeader>
+              <TableHeader>Tags</TableHeader>
+            </div>
+          ),
+          cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) => (
+            <DoubleRow
+              data-testid="health"
+              primary={
+                "test_status" in storage ? (
+                  <DiskTestStatus testStatus={storage.test_status} />
+                ) : (
+                  "—"
+                )
+              }
+              secondary={
+                <TagLinks
+                  getLinkURL={(tag) => {
+                    if (isMachine) {
+                      const filter = FilterMachines.filtersToQueryString({
+                        storage_tags: [`=${tag}`],
+                      });
+                      return `${urls.machines.index}${filter}`;
+                    }
+                    const filter = FilterControllers.filtersToQueryString({
+                      storage_tags: [`=${tag}`],
+                    });
+                    return `${urls.controllers.index}${filter}`;
+                  }}
+                  tags={storage.tags}
+                />
+              }
+            />
+          ),
+        },
+        {
+          id: "used_for",
+          accessorKey: "used_for",
+          enableSorting: true,
+          header: "Used for",
+        },
+      ] as UsedStorageColumnDef[],
+    [isMachine]
+  );
+};
+
+export default useUsedStorageTableColumns;

--- a/src/app/base/components/node/StorageTables/UsedStorageTable/useUsedStorageTableColumns/useUsedStorageTableColumns.tsx
+++ b/src/app/base/components/node/StorageTables/UsedStorageTable/useUsedStorageTableColumns/useUsedStorageTableColumns.tsx
@@ -3,7 +3,6 @@ import { useMemo } from "react";
 import type { ColumnDef, Row } from "@tanstack/react-table";
 
 import DoubleRow from "@/app/base/components/DoubleRow";
-import TableHeader from "@/app/base/components/TableHeader";
 import TagLinks from "@/app/base/components/TagLinks";
 import DiskBootStatus from "@/app/base/components/node/DiskBootStatus";
 import DiskNumaNodes from "@/app/base/components/node/DiskNumaNodes";
@@ -25,12 +24,12 @@ const useUsedStorageTableColumns = (
         {
           id: "name",
           accessorKey: "name",
-          enableSorting: true,
+          enableSorting: false,
           header: () => (
-            <div className="p-double-row__header-spacer">
-              <TableHeader sortKey="name">Name</TableHeader>
-              <TableHeader>Serial</TableHeader>
-            </div>
+            <span>
+              <div>Name</div>
+              <div>Serial</div>
+            </span>
           ),
           cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) => (
             <DoubleRow
@@ -42,12 +41,12 @@ const useUsedStorageTableColumns = (
         {
           id: "model",
           accessorKey: "model",
-          enableSorting: true,
+          enableSorting: false,
           header: () => (
-            <div className="p-double-row__header-spacer">
-              <TableHeader sortKey="model">Model</TableHeader>
-              <TableHeader>Firmware</TableHeader>
-            </div>
+            <span>
+              <div>Model</div>
+              <div>Firmware</div>
+            </span>
           ),
           cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) => (
             <DoubleRow
@@ -61,7 +60,7 @@ const useUsedStorageTableColumns = (
         {
           id: "boot",
           accessorKey: "boot",
-          enableSorting: true,
+          enableSorting: false,
           header: "Boot",
           cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) =>
             "is_boot" in storage ? <DiskBootStatus disk={storage} /> : "—",
@@ -69,7 +68,7 @@ const useUsedStorageTableColumns = (
         {
           id: "size",
           accessorKey: "size",
-          enableSorting: true,
+          enableSorting: false,
           header: "Size",
           cell: ({
             row: {
@@ -84,10 +83,10 @@ const useUsedStorageTableColumns = (
           accessorKey: "type",
           enableSorting: false,
           header: () => (
-            <div className="p-double-row__header-spacer">
-              <TableHeader sortKey="type">Type</TableHeader>
-              <TableHeader>NUMA node</TableHeader>
-            </div>
+            <span>
+              <div>Type</div>
+              <div>NUMA node</div>
+            </span>
           ),
           cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) => (
             <DoubleRow
@@ -106,10 +105,10 @@ const useUsedStorageTableColumns = (
           accessorKey: "health",
           enableSorting: false,
           header: () => (
-            <div className="p-double-row__header-spacer">
-              <TableHeader sortKey="health">Health</TableHeader>
-              <TableHeader>Tags</TableHeader>
-            </div>
+            <span>
+              <div>Health</div>
+              <div>Tags</div>
+            </span>
           ),
           cell: ({ row: { original: storage } }: { row: Row<UsedStorage> }) => (
             <DoubleRow
@@ -144,7 +143,7 @@ const useUsedStorageTableColumns = (
         {
           id: "used_for",
           accessorKey: "used_for",
-          enableSorting: true,
+          enableSorting: false,
           header: "Used for",
         },
       ] as UsedStorageColumnDef[],

--- a/yarn.lock
+++ b/yarn.lock
@@ -949,10 +949,10 @@
     "@types/tough-cookie" "^4.0.5"
     tough-cookie "^4.1.4"
 
-"@canonical/maas-react-components@1.33.3":
-  version "1.33.3"
-  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-1.33.3.tgz#682f47ef14e9872b8b08356cdb6f392946fafb48"
-  integrity sha512-TEwpTRgPBw7BYJ7MDBtge2036NZkTieraxtQoG6YUDQNiF7k4lvrHeJpBt4fXOs4av3NxFngdZsHkBAkmYUeug==
+"@canonical/maas-react-components@1.33.4":
+  version "1.33.4"
+  resolved "https://registry.yarnpkg.com/@canonical/maas-react-components/-/maas-react-components-1.33.4.tgz#1ce51c2dd86eb990156e6e2148a5035ea7c3e44d"
+  integrity sha512-D7u2A07GaF/cYBgM1mL8v2e+7kYTZbFYFN8GXWAvguBfPA4OwchpkoYUqNS0ASwgmtkfJy6ugE2B48mAvscOBQ==
 
 "@canonical/macaroon-bakery@1.3.2":
   version "1.3.2"
@@ -13017,6 +13017,7 @@ wordwrap@^1.0.0:
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 "wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
## Done

- Updated `mrc` for latest `GenericTable` sizing fix 
- Converted `UsedStorageTable` to `GenericTable`
- (drive-by) Converted `FilesystemsTable` and `DatastoresTable` to regular, removed sortable columns to match old version

## QA steps

- [ ] Navigate to a machine's details
- [ ] Go to Storage tab
- [ ] Verify the tables look the same
- [ ] Verify FilesystemsTable and DatastoresTable side panels still function properly

## Fixes

Resolves [MAASENG-5265](https://warthogs.atlassian.net/browse/MAASENG-5265)
