### PR TITLE
fix(base): Make AppStatus render conditional on authentication MAASENG-5419

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -205,9 +205,11 @@ export const App = (): React.ReactElement => {
             >
               {content}
             </Suspense>
-            <AppStatus>
-              <StatusBar />
-            </AppStatus>
+            {authenticated && (
+              <AppStatus>
+                <StatusBar />
+              </AppStatus>
+            )}
           </NotificationProvider>
         </ToastNotificationProvider>
       </ThemePreviewContextProvider>


### PR DESCRIPTION
## Done

- Made the AppStatus render conditional depending on the authentication status

## QA steps

- [x] Open MAAS UI
- [x] Open the Network debugger
- [x] Log out
- [x] Verify that when logged out, no notification calls are executed
- [x] Refresh the page while logged out to make sure no notification calls occur

## Fixes

Resolves [MAASENG-5419](https://warthogs.atlassian.net/browse/MAASENG-5419)


[MAASENG-5419]: https://warthogs.atlassian.net/browse/MAASENG-5419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ