### PR TITLE
refactor(base): convert CacheSetsTable to GenericTable MAASENG-5263

### DIFF
--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteCacheSet/DeleteCacheSet.test.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteCacheSet/DeleteCacheSet.test.tsx
@@ -1,8 +1,9 @@
 import configureStore from "redux-mock-store";
 
-import DeleteDisk from "./DeleteDisk";
+import DeleteCacheSet from "./DeleteCacheSet";
 
 import type { RootState } from "@/app/store/root/types";
+import { DiskTypes } from "@/app/store/types/enum";
 import * as factory from "@/testing/factories";
 import { renderWithProviders, screen, userEvent } from "@/testing/utils";
 
@@ -10,7 +11,7 @@ const mockStore = configureStore<RootState>();
 const disk = factory.nodeDisk({
   id: 1,
   name: "floppy-disk",
-  partitions: [factory.nodePartition(), factory.nodePartition()],
+  type: DiskTypes.CACHE_SET,
 });
 
 const state = factory.rootState({
@@ -24,25 +25,29 @@ const state = factory.rootState({
 
 it("should render the form", () => {
   renderWithProviders(
-    <DeleteDisk close={vi.fn()} disk={disk} systemId="abc123" />,
+    <DeleteCacheSet close={vi.fn()} disk={disk} systemId="abc123" />,
     { state }
   );
 
-  expect(screen.getByRole("form", { name: "Delete disk" })).toBeInTheDocument();
+  expect(
+    screen.getByRole("form", { name: "Delete cache set" })
+  ).toBeInTheDocument();
 });
 
 it("should fire an action to delete a disk", async () => {
   const store = mockStore(state);
   renderWithProviders(
-    <DeleteDisk close={vi.fn()} disk={disk} systemId="abc123" />,
+    <DeleteCacheSet close={vi.fn()} disk={disk} systemId="abc123" />,
     { store }
   );
 
   await userEvent.click(
-    screen.getByRole("button", { name: "Remove physical disk" })
+    screen.getByRole("button", { name: "Remove cache set" })
   );
 
   expect(
-    store.getActions().some((action) => action.type === "machine/deleteDisk")
+    store
+      .getActions()
+      .some((action) => action.type === "machine/deleteCacheSet")
   ).toBe(true);
 });

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteCacheSet/DeleteCacheSet.tsx
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteCacheSet/DeleteCacheSet.tsx
@@ -1,0 +1,44 @@
+import { useDispatch } from "react-redux";
+
+import ModelActionForm from "@/app/base/components/ModelActionForm";
+import { machineActions } from "@/app/store/machine";
+import type { Machine } from "@/app/store/machine/types";
+import type { Disk } from "@/app/store/types/node";
+
+type Props = {
+  close: () => void;
+  systemId: Machine["system_id"];
+  disk: Disk;
+};
+
+const DeleteCacheSet = ({ systemId, disk, close }: Props) => {
+  const dispatch = useDispatch();
+  return (
+    <ModelActionForm
+      aria-label="Delete cache set"
+      initialValues={{}}
+      message={<>Are you sure you want to remove this cache set?</>}
+      modelType={"cache set"}
+      onCancel={close}
+      onSaveAnalytics={{
+        action: "Delete cache set",
+        category: "Machine storage",
+        label: "Remove cache set",
+      }}
+      onSubmit={() => {
+        dispatch(machineActions.cleanup());
+        dispatch(
+          machineActions.deleteCacheSet({
+            cacheSetId: disk.id,
+            systemId: systemId,
+          })
+        );
+        close();
+      }}
+      submitAppearance="negative"
+      submitLabel={"Remove cache set"}
+    />
+  );
+};
+
+export default DeleteCacheSet;

--- a/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteCacheSet/index.ts
+++ b/src/app/base/components/node/StorageTables/AvailableStorageTable/DeleteCacheSet/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DeleteCacheSet";

--- a/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.test.tsx
+++ b/src/app/base/components/node/StorageTables/CacheSetsTable/CacheSetsTable.test.tsx
@@ -1,141 +1,146 @@
-import { Provider } from "react-redux";
-import configureStore from "redux-mock-store";
+import type { Mock } from "vitest";
 
 import CacheSetsTable from "./CacheSetsTable";
 
-import { machineActions } from "@/app/store/machine";
+import { useSidePanel } from "@/app/base/side-panel-context";
+import { MachineSidePanelViews } from "@/app/machines/constants";
 import { DiskTypes } from "@/app/store/types/enum";
 import * as factory from "@/testing/factories";
-import { userEvent, render, screen } from "@/testing/utils";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  within,
+} from "@/testing/utils";
 
-const mockStore = configureStore();
+vi.mock("@/app/base/side-panel-context", async () => {
+  const actual = await vi.importActual("@/app/base/side-panel-context");
+  return {
+    ...actual,
+    useSidePanel: vi.fn(),
+  };
+});
 
-it("only shows disks that are cache sets", () => {
-  const [cacheSet, notCacheSet] = [
-    factory.nodeDisk({
-      name: "quiche",
+describe("CacheSetsTable", () => {
+  const mockSetSidePanelContent = vi.fn();
+
+  (useSidePanel as Mock).mockReturnValue({
+    setSidePanelContent: mockSetSidePanelContent,
+  });
+
+  it("only shows disks that are cache sets", () => {
+    const [cacheSet, notCacheSet] = [
+      factory.nodeDisk({
+        name: "quiche",
+        type: DiskTypes.CACHE_SET,
+      }),
+      factory.nodeDisk({
+        name: "frittata",
+        type: DiskTypes.PHYSICAL,
+      }),
+    ];
+    const machine = factory.machineDetails({
+      disks: [cacheSet, notCacheSet],
+      system_id: "abc123",
+    });
+    const state = factory.rootState({
+      machine: factory.machineState({
+        items: [machine],
+      }),
+    });
+    renderWithProviders(<CacheSetsTable canEditStorage node={machine} />, {
+      state,
+    });
+
+    const rows = within(screen.getAllByRole("rowgroup")[1]).getAllByRole("row");
+    expect(rows).toHaveLength(1);
+    expect(within(rows[0]).getAllByRole("cell")[0]).toHaveTextContent(
+      cacheSet.name
+    );
+  });
+
+  it("does not show an action column if node is a controller", () => {
+    const controller = factory.controllerDetails({
+      disks: [
+        factory.nodeDisk({
+          name: "quiche",
+          type: DiskTypes.CACHE_SET,
+        }),
+      ],
+      system_id: "abc123",
+    });
+    const state = factory.rootState({
+      controller: factory.controllerState({
+        items: [controller],
+      }),
+    });
+    renderWithProviders(
+      <CacheSetsTable canEditStorage={false} node={controller} />,
+      {
+        state,
+      }
+    );
+
+    expect(
+      screen.queryByRole("columnheader", { name: "actions" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows an action column if node is a machine", () => {
+    const machine = factory.machineDetails({
+      disks: [
+        factory.nodeDisk({
+          name: "quiche",
+          type: DiskTypes.CACHE_SET,
+        }),
+      ],
+      system_id: "abc123",
+    });
+    const state = factory.rootState({
+      machine: factory.machineState({
+        items: [machine],
+      }),
+    });
+    renderWithProviders(<CacheSetsTable canEditStorage node={machine} />, {
+      state,
+    });
+
+    expect(
+      screen.getByRole("columnheader", { name: "actions" })
+    ).toBeInTheDocument();
+  });
+
+  it("can open the side panel to delete a cache set if node is a machine", async () => {
+    const disk = factory.nodeDisk({
       type: DiskTypes.CACHE_SET,
-    }),
-    factory.nodeDisk({
-      name: "frittata",
-      type: DiskTypes.PHYSICAL,
-    }),
-  ];
-  const machine = factory.machineDetails({
-    disks: [cacheSet, notCacheSet],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <CacheSetsTable canEditStorage node={machine} />
-    </Provider>
-  );
-
-  expect(screen.getAllByRole("gridcell", { name: "Name" })).toHaveLength(1);
-  expect(screen.getByRole("gridcell", { name: "Name" })).toHaveTextContent(
-    cacheSet.name
-  );
-});
-
-it("does not show an action column if node is a controller", () => {
-  const controller = factory.controllerDetails({
-    disks: [
-      factory.nodeDisk({
-        name: "quiche",
-        type: DiskTypes.CACHE_SET,
+    });
+    const machine = factory.machineDetails({
+      disks: [disk],
+      system_id: "abc123",
+    });
+    const state = factory.rootState({
+      machine: factory.machineState({
+        items: [machine],
+        statuses: factory.machineStatuses({
+          abc123: factory.machineStatus(),
+        }),
       }),
-    ],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    controller: factory.controllerState({
-      items: [controller],
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <CacheSetsTable canEditStorage={false} node={controller} />
-    </Provider>
-  );
+    });
+    renderWithProviders(<CacheSetsTable canEditStorage node={machine} />, {
+      state,
+    });
 
-  expect(
-    screen.queryByRole("columnheader", { name: "Actions" })
-  ).not.toBeInTheDocument();
-});
+    await userEvent.click(screen.getByRole("button", { name: /Take action/ }));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Remove cache set..." })
+    );
 
-it("shows an action column if node is a machine", () => {
-  const machine = factory.machineDetails({
-    disks: [
-      factory.nodeDisk({
-        name: "quiche",
-        type: DiskTypes.CACHE_SET,
-      }),
-    ],
-    system_id: "abc123",
+    expect(mockSetSidePanelContent).toHaveBeenCalledWith({
+      view: MachineSidePanelViews.DELETE_CACHE_SET,
+      extras: {
+        disk,
+        systemId: machine.system_id,
+      },
+    });
   });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <CacheSetsTable canEditStorage node={machine} />
-    </Provider>
-  );
-
-  expect(
-    screen.getByRole("columnheader", { name: "Actions" })
-  ).toBeInTheDocument();
-});
-
-it("can delete a cache set if node is a machine", async () => {
-  const disk = factory.nodeDisk({
-    type: DiskTypes.CACHE_SET,
-  });
-  const machine = factory.machineDetails({
-    disks: [disk],
-    system_id: "abc123",
-  });
-  const state = factory.rootState({
-    machine: factory.machineState({
-      items: [machine],
-      statuses: factory.machineStatuses({
-        abc123: factory.machineStatus(),
-      }),
-    }),
-  });
-  const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <CacheSetsTable canEditStorage node={machine} />
-    </Provider>
-  );
-
-  await userEvent.click(screen.getByRole("button", { name: /Take action/ }));
-  await userEvent.click(
-    screen.getByRole("button", { name: "Remove cache set..." })
-  );
-  await userEvent.click(
-    screen.getByRole("button", { name: "Remove cache set" })
-  );
-
-  const expectedAction = machineActions.deleteCacheSet({
-    cacheSetId: disk.id,
-    systemId: machine.system_id,
-  });
-  expect(
-    screen.getByText("Are you sure you want to remove this cache set?")
-  ).toBeInTheDocument();
-  expect(
-    store.getActions().find((action) => action.type === expectedAction.type)
-  ).toStrictEqual(expectedAction);
 });

--- a/src/app/base/components/node/StorageTables/CacheSetsTable/useCacheSetsColumns/useCacheSetsColumns.tsx
+++ b/src/app/base/components/node/StorageTables/CacheSetsTable/useCacheSetsColumns/useCacheSetsColumns.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from "react";
+
+import type { ColumnDef, Row } from "@tanstack/react-table";
+
+import { CacheSetAction } from "../CacheSetsTable";
+
+import TableActionsDropdown from "@/app/base/components/TableActionsDropdown";
+import { useSidePanel } from "@/app/base/side-panel-context";
+import { MachineSidePanelViews } from "@/app/machines/constants";
+import type { Disk, Node } from "@/app/store/types/node";
+import { formatSize } from "@/app/store/utils";
+
+export type CacheSetsColumnDef = ColumnDef<Disk, Partial<Disk>>;
+
+type Props = {
+  isMachine: boolean;
+  canEditStorage: boolean;
+  systemId: Node["system_id"];
+};
+
+const useCacheSetsColumns = ({
+  isMachine,
+  canEditStorage,
+  systemId,
+}: Props): CacheSetsColumnDef[] => {
+  const { setSidePanelContent } = useSidePanel();
+
+  return useMemo<CacheSetsColumnDef[]>(
+    () => [
+      {
+        id: "name",
+        accessorKey: "name",
+        enableSorting: false,
+      },
+      {
+        id: "size",
+        accessorKey: "size",
+        enableSorting: false,
+        cell: ({ row: { original: disk } }) => formatSize(disk.size),
+      },
+      {
+        id: "used_for",
+        accessorKey: "used_for",
+        enableSorting: false,
+        header: "Used for",
+      },
+      ...(isMachine
+        ? [
+            {
+              id: "actions",
+              accessorKey: "actions",
+              enableSorting: false,
+              cell: ({ row: { original: disk } }: { row: Row<Disk> }) => (
+                <TableActionsDropdown
+                  actions={[
+                    {
+                      label: "Remove cache set...",
+                      type: CacheSetAction.DELETE,
+                    },
+                  ]}
+                  disabled={!canEditStorage}
+                  onActionClick={(action: CacheSetAction) => {
+                    if (action === CacheSetAction.DELETE) {
+                      setSidePanelContent({
+                        view: MachineSidePanelViews.DELETE_CACHE_SET,
+                        extras: { systemId, disk },
+                      });
+                    }
+                  }}
+                />
+              ),
+            },
+          ]
+        : []),
+    ],
+    [canEditStorage, isMachine, setSidePanelContent, systemId]
+  );
+};
+
+export default useCacheSetsColumns;

--- a/src/app/base/side-panel-context.tsx
+++ b/src/app/base/side-panel-context.tsx
@@ -45,6 +45,7 @@ const sidePanelTitleMap: Record<string, string> = {
   [SidePanelViews.CREATE_PARTITION[1]]: "Create partition",
   [SidePanelViews.CREATE_RAID[1]]: "Create raid",
   [SidePanelViews.CREATE_VOLUME_GROUP[1]]: "Create volume group",
+  [SidePanelViews.DELETE_CACHE_SET[1]]: "Delete cache set",
   [SidePanelViews.DELETE_DISK[1]]: "Delete disk",
   [SidePanelViews.DELETE_FILESYSTEM[1]]: "Delete filesystem",
   [SidePanelViews.DELETE_SPECIAL_FILESYSTEM[1]]: "Delete special filesystem",

--- a/src/app/machines/components/MachineForms/MachineForms.tsx
+++ b/src/app/machines/components/MachineForms/MachineForms.tsx
@@ -18,6 +18,7 @@ import CreateVolumeGroup from "@/app/base/components/node/StorageTables/Availabl
 import UpdateDatastore from "@/app/base/components/node/StorageTables/AvailableStorageTable/BulkActions/UpdateDatastore";
 import CreateBcache from "@/app/base/components/node/StorageTables/AvailableStorageTable/CreateBcache";
 import CreateCacheSet from "@/app/base/components/node/StorageTables/AvailableStorageTable/CreateCacheSet";
+import DeleteCacheSet from "@/app/base/components/node/StorageTables/AvailableStorageTable/DeleteCacheSet";
 import DeleteDisk from "@/app/base/components/node/StorageTables/AvailableStorageTable/DeleteDisk";
 import DeletePartition from "@/app/base/components/node/StorageTables/AvailableStorageTable/DeletePartition";
 import DeleteVolumeGroup from "@/app/base/components/node/StorageTables/AvailableStorageTable/DeleteVolumeGroup";
@@ -235,6 +236,16 @@ export const MachineForms = ({
         <CreateVolumeGroup
           closeForm={clearSidePanelContent}
           selected={bulkActionSelected}
+          systemId={systemId}
+        />
+      );
+    }
+    case MachineSidePanelViews.DELETE_CACHE_SET: {
+      if (!disk || !systemId) return null;
+      return (
+        <DeleteCacheSet
+          close={clearSidePanelContent}
+          disk={disk}
           systemId={systemId}
         />
       );

--- a/src/app/machines/constants.ts
+++ b/src/app/machines/constants.ts
@@ -47,6 +47,7 @@ export const MachineNonActionSidePanelViews = {
   CREATE_PARTITION: ["machineNonActionForm", "createPartition"],
   CREATE_RAID: ["machineNonActionForm", "createRaid"],
   CREATE_VOLUME_GROUP: ["machineNonActionForm", "createVolumeGroup"],
+  DELETE_CACHE_SET: ["machineNonActionForm", "deleteCacheSet"],
   DELETE_DISK: ["machineNonActionForm", "deleteDisk"],
   DELETE_FILESYSTEM: ["machineNonActionForm", "deleteFilesystem"],
   DELETE_SPECIAL_FILESYSTEM: [


### PR DESCRIPTION
## Done

- Refactored CacheSetsTable to use GenericTable
- Added a new side panel for deleting cache sets (replacing inline form)
- Refactored all touched tests (and a couple extras) to use `renderWithProviders`

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [ ] Go to a ready machine's storage tab that has cachesets (e.g. `sin73l00011` on maas-ui-demo)
- [ ] Ensure the table appears the same as previously
- [ ] Ensure clicking "Remove cache set" in the action dropdown opens the correct form
- [ ] Ensure submitting the form deletes the cache set

Optional, if you have a controller with cache sets:

- [ ] Go to the controller's storage tab
- [ ] Ensure the cache sets table does *not* have an "actions" column


<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-XXXX](https://warthogs.atlassian.net/browse/MAASENG-XXXX)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->
