### PR TITLE
feat: Create Trusted SSH Host Keys Table MAASENG-6813

### DIFF
--- a/src/app/api/query/trustedSshHostKeys.test.ts
+++ b/src/app/api/query/trustedSshHostKeys.test.ts
@@ -1,0 +1,25 @@
+import { useTrustedSshHostKeys } from "./trustedSshHostKeys";
+
+import {
+  mockSshHostKeys,
+  sshHostKeysResolvers,
+} from "@/testing/resolvers/sshHostKeys";
+import {
+  renderHookWithProviders,
+  setupMockServer,
+  waitFor,
+} from "@/testing/utils";
+
+setupMockServer(sshHostKeysResolvers.listSshHostKeys.handler());
+
+describe("useTrustedSshHostKeys", () => {
+  it("should return a list of trusted SSH host keys", async () => {
+    const { result } = renderHookWithProviders(() => useTrustedSshHostKeys());
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data?.items).toEqual(mockSshHostKeys.items);
+  });
+});

--- a/src/app/api/query/trustedSshHostKeys.ts
+++ b/src/app/api/query/trustedSshHostKeys.ts
@@ -1,0 +1,23 @@
+import type { UseQueryOptions } from "@tanstack/react-query";
+
+import { useWebsocketAwareQuery } from "./base";
+
+import type {
+  ListSshHostKeysData,
+  ListSshHostKeysError,
+  ListSshHostKeysResponse,
+  Options,
+} from "@/app/apiclient";
+import { listSshHostKeysOptions } from "@/app/apiclient/@tanstack/react-query.gen";
+
+export const useTrustedSshHostKeys = (
+  options?: Options<ListSshHostKeysData>
+) => {
+  return useWebsocketAwareQuery(
+    listSshHostKeysOptions(options) as UseQueryOptions<
+      ListSshHostKeysData,
+      ListSshHostKeysError,
+      ListSshHostKeysResponse
+    >
+  );
+};

--- a/src/app/apiclient/@tanstack/react-query.gen.ts
+++ b/src/app/apiclient/@tanstack/react-query.gen.ts
@@ -68,6 +68,7 @@ import {
   getSpace,
   updateSpace,
   listUserSshkeys,
+  listSshHostKeys,
   createUserSshkeys,
   deleteUserSshkey,
   getUserSshkey,
@@ -285,6 +286,9 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysError,
   ListUserSshkeysResponse,
+  ListSshHostKeysData,
+  ListSshHostKeysError,
+  ListSshHostKeysResponse,
   CreateUserSshkeysData,
   CreateUserSshkeysError,
   CreateUserSshkeysResponse,
@@ -3405,6 +3409,81 @@ export const importUserSshkeysMutation = (
     },
   };
   return mutationOptions;
+};
+
+export const listSshHostKeysQueryKey = (
+  options?: Options<ListSshHostKeysData>
+) => createQueryKey("listSshHostKeys", options);
+
+/**
+ * List Ssh Host Keys
+ */
+export const listSshHostKeysOptions = (
+  options?: Options<ListSshHostKeysData>
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await listSshHostKeys({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: listSshHostKeysQueryKey(options),
+  });
+};
+
+export const listSshHostKeysInfiniteQueryKey = (
+  options?: Options<ListSshHostKeysData>
+): QueryKey<Options<ListSshHostKeysData>> =>
+  createQueryKey("listSshHostKeys", options, true);
+
+/**
+ * List Ssh Host Keys
+ */
+export const listSshHostKeysInfiniteOptions = (
+  options?: Options<ListSshHostKeysData>
+) => {
+  return infiniteQueryOptions<
+    ListSshHostKeysResponse,
+    ListSshHostKeysError,
+    InfiniteData<ListSshHostKeysResponse>,
+    QueryKey<Options<ListSshHostKeysData>>,
+    | Pick<
+        QueryKey<Options<ListSshHostKeysData>>[0],
+        "body" | "headers" | "path" | "query"
+      >
+    | number
+  >(
+    // @ts-ignore
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        // @ts-ignore
+        const page: Pick<
+          QueryKey<Options<ListSshHostKeysData>>[0],
+          "body" | "headers" | "path" | "query"
+        > =
+          typeof pageParam === "object"
+            ? pageParam
+            : {
+                query: {
+                  page: pageParam,
+                },
+              };
+        const params = createInfiniteParams(queryKey, page);
+        const { data } = await listSshHostKeys({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        });
+        return data;
+      },
+      queryKey: listSshHostKeysInfiniteQueryKey(options),
+    }
+  );
 };
 
 export const getUserSslkeysQueryKey = (options?: Options<GetUserSslkeysData>) =>

--- a/src/app/apiclient/@tanstack/react-query.gen.ts
+++ b/src/app/apiclient/@tanstack/react-query.gen.ts
@@ -68,7 +68,6 @@ import {
   getSpace,
   updateSpace,
   listUserSshkeys,
-  listSshHostKeys,
   createUserSshkeys,
   deleteUserSshkey,
   getUserSshkey,
@@ -78,6 +77,10 @@ import {
   deleteUserSslkey,
   getUserSslkey,
   getUserSslkeysWithSummary,
+  listSshHostKeys,
+  createSshHostKey,
+  deleteSshHostKey,
+  getSshHostKey,
   listFabricVlanSubnets,
   createFabricVlanSubnet,
   deleteFabricVlanSubnet,
@@ -286,9 +289,6 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysError,
   ListUserSshkeysResponse,
-  ListSshHostKeysData,
-  ListSshHostKeysError,
-  ListSshHostKeysResponse,
   CreateUserSshkeysData,
   CreateUserSshkeysError,
   CreateUserSshkeysResponse,
@@ -312,6 +312,16 @@ import type {
   GetUserSslkeysWithSummaryData,
   GetUserSslkeysWithSummaryError,
   GetUserSslkeysWithSummaryResponse,
+  ListSshHostKeysData,
+  ListSshHostKeysError,
+  ListSshHostKeysResponse,
+  CreateSshHostKeyData,
+  CreateSshHostKeyError,
+  CreateSshHostKeyResponse,
+  DeleteSshHostKeyData,
+  DeleteSshHostKeyError,
+  DeleteSshHostKeyResponse,
+  GetSshHostKeyData,
   ListFabricVlanSubnetsData,
   ListFabricVlanSubnetsError,
   ListFabricVlanSubnetsResponse,
@@ -3411,81 +3421,6 @@ export const importUserSshkeysMutation = (
   return mutationOptions;
 };
 
-export const listSshHostKeysQueryKey = (
-  options?: Options<ListSshHostKeysData>
-) => createQueryKey("listSshHostKeys", options);
-
-/**
- * List Ssh Host Keys
- */
-export const listSshHostKeysOptions = (
-  options?: Options<ListSshHostKeysData>
-) => {
-  return queryOptions({
-    queryFn: async ({ queryKey, signal }) => {
-      const { data } = await listSshHostKeys({
-        ...options,
-        ...queryKey[0],
-        signal,
-        throwOnError: true,
-      });
-      return data;
-    },
-    queryKey: listSshHostKeysQueryKey(options),
-  });
-};
-
-export const listSshHostKeysInfiniteQueryKey = (
-  options?: Options<ListSshHostKeysData>
-): QueryKey<Options<ListSshHostKeysData>> =>
-  createQueryKey("listSshHostKeys", options, true);
-
-/**
- * List Ssh Host Keys
- */
-export const listSshHostKeysInfiniteOptions = (
-  options?: Options<ListSshHostKeysData>
-) => {
-  return infiniteQueryOptions<
-    ListSshHostKeysResponse,
-    ListSshHostKeysError,
-    InfiniteData<ListSshHostKeysResponse>,
-    QueryKey<Options<ListSshHostKeysData>>,
-    | Pick<
-        QueryKey<Options<ListSshHostKeysData>>[0],
-        "body" | "headers" | "path" | "query"
-      >
-    | number
-  >(
-    // @ts-ignore
-    {
-      queryFn: async ({ pageParam, queryKey, signal }) => {
-        // @ts-ignore
-        const page: Pick<
-          QueryKey<Options<ListSshHostKeysData>>[0],
-          "body" | "headers" | "path" | "query"
-        > =
-          typeof pageParam === "object"
-            ? pageParam
-            : {
-                query: {
-                  page: pageParam,
-                },
-              };
-        const params = createInfiniteParams(queryKey, page);
-        const { data } = await listSshHostKeys({
-          ...options,
-          ...params,
-          signal,
-          throwOnError: true,
-        });
-        return data;
-      },
-      queryKey: listSshHostKeysInfiniteQueryKey(options),
-    }
-  );
-};
-
 export const getUserSslkeysQueryKey = (options?: Options<GetUserSslkeysData>) =>
   createQueryKey("getUserSslkeys", options);
 
@@ -3734,6 +3669,180 @@ export const getUserSslkeysWithSummaryInfiniteOptions = (
       queryKey: getUserSslkeysWithSummaryInfiniteQueryKey(options),
     }
   );
+};
+
+export const listSshHostKeysQueryKey = (
+  options?: Options<ListSshHostKeysData>
+) => createQueryKey("listSshHostKeys", options);
+
+/**
+ * List Ssh Host Keys
+ */
+export const listSshHostKeysOptions = (
+  options?: Options<ListSshHostKeysData>
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await listSshHostKeys({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: listSshHostKeysQueryKey(options),
+  });
+};
+
+export const listSshHostKeysInfiniteQueryKey = (
+  options?: Options<ListSshHostKeysData>
+): QueryKey<Options<ListSshHostKeysData>> =>
+  createQueryKey("listSshHostKeys", options, true);
+
+/**
+ * List Ssh Host Keys
+ */
+export const listSshHostKeysInfiniteOptions = (
+  options?: Options<ListSshHostKeysData>
+) => {
+  return infiniteQueryOptions<
+    ListSshHostKeysResponse,
+    ListSshHostKeysError,
+    InfiniteData<ListSshHostKeysResponse>,
+    QueryKey<Options<ListSshHostKeysData>>,
+    | Pick<
+        QueryKey<Options<ListSshHostKeysData>>[0],
+        "body" | "headers" | "path" | "query"
+      >
+    | number
+  >(
+    // @ts-ignore
+    {
+      queryFn: async ({ pageParam, queryKey, signal }) => {
+        // @ts-ignore
+        const page: Pick<
+          QueryKey<Options<ListSshHostKeysData>>[0],
+          "body" | "headers" | "path" | "query"
+        > =
+          typeof pageParam === "object"
+            ? pageParam
+            : {
+                query: {
+                  page: pageParam,
+                },
+              };
+        const params = createInfiniteParams(queryKey, page);
+        const { data } = await listSshHostKeys({
+          ...options,
+          ...params,
+          signal,
+          throwOnError: true,
+        });
+        return data;
+      },
+      queryKey: listSshHostKeysInfiniteQueryKey(options),
+    }
+  );
+};
+
+export const createSshHostKeyQueryKey = (
+  options: Options<CreateSshHostKeyData>
+) => createQueryKey("createSshHostKey", options);
+
+/**
+ * Create Ssh Host Key
+ */
+export const createSshHostKeyOptions = (
+  options: Options<CreateSshHostKeyData>
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await createSshHostKey({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: createSshHostKeyQueryKey(options),
+  });
+};
+
+/**
+ * Create Ssh Host Key
+ */
+export const createSshHostKeyMutation = (
+  options?: Partial<Options<CreateSshHostKeyData>>
+): UseMutationOptions<
+  CreateSshHostKeyResponse,
+  CreateSshHostKeyError,
+  Options<CreateSshHostKeyData>
+> => {
+  const mutationOptions: UseMutationOptions<
+    CreateSshHostKeyResponse,
+    CreateSshHostKeyError,
+    Options<CreateSshHostKeyData>
+  > = {
+    mutationFn: async (localOptions) => {
+      const { data } = await createSshHostKey({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+/**
+ * Delete Ssh Host Key
+ */
+export const deleteSshHostKeyMutation = (
+  options?: Partial<Options<DeleteSshHostKeyData>>
+): UseMutationOptions<
+  DeleteSshHostKeyResponse,
+  DeleteSshHostKeyError,
+  Options<DeleteSshHostKeyData>
+> => {
+  const mutationOptions: UseMutationOptions<
+    DeleteSshHostKeyResponse,
+    DeleteSshHostKeyError,
+    Options<DeleteSshHostKeyData>
+  > = {
+    mutationFn: async (localOptions) => {
+      const { data } = await deleteSshHostKey({
+        ...options,
+        ...localOptions,
+        throwOnError: true,
+      });
+      return data;
+    },
+  };
+  return mutationOptions;
+};
+
+export const getSshHostKeyQueryKey = (options: Options<GetSshHostKeyData>) =>
+  createQueryKey("getSshHostKey", options);
+
+/**
+ * Get Ssh Host Key
+ */
+export const getSshHostKeyOptions = (options: Options<GetSshHostKeyData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getSshHostKey({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getSshHostKeyQueryKey(options),
+  });
 };
 
 export const listFabricVlanSubnetsQueryKey = (

--- a/src/app/apiclient/sdk.gen.ts
+++ b/src/app/apiclient/sdk.gen.ts
@@ -205,9 +205,6 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysResponses,
   ListUserSshkeysErrors,
-  ListSshHostKeysData,
-  ListSshHostKeysResponses,
-  ListSshHostKeysErrors,
   CreateUserSshkeysData,
   CreateUserSshkeysResponses,
   CreateUserSshkeysErrors,
@@ -235,6 +232,18 @@ import type {
   GetUserSslkeysWithSummaryData,
   GetUserSslkeysWithSummaryResponses,
   GetUserSslkeysWithSummaryErrors,
+  ListSshHostKeysData,
+  ListSshHostKeysResponses,
+  ListSshHostKeysErrors,
+  CreateSshHostKeyData,
+  CreateSshHostKeyResponses,
+  CreateSshHostKeyErrors,
+  DeleteSshHostKeyData,
+  DeleteSshHostKeyResponses,
+  DeleteSshHostKeyErrors,
+  GetSshHostKeyData,
+  GetSshHostKeyResponses,
+  GetSshHostKeyErrors,
   ListFabricVlanSubnetsData,
   ListFabricVlanSubnetsResponses,
   ListFabricVlanSubnetsErrors,
@@ -1922,28 +1931,6 @@ export const listUserSshkeys = <ThrowOnError extends boolean = false>(
 };
 
 /**
- * List Ssh Host Keys
- */
-export const listSshHostKeys = <ThrowOnError extends boolean = false>(
-  options?: Options<ListSshHostKeysData, ThrowOnError>
-) => {
-  return (options?.client ?? _heyApiClient).get<
-    ListSshHostKeysResponses,
-    ListSshHostKeysErrors,
-    ThrowOnError
-  >({
-    security: [
-      {
-        scheme: "bearer",
-        type: "http",
-      },
-    ],
-    url: "/MAAS/a/v3/ssh-host-keys",
-    ...options,
-  });
-};
-
-/**
  * Create User Sshkeys
  */
 export const createUserSshkeys = <ThrowOnError extends boolean = false>(
@@ -2150,6 +2137,98 @@ export const getUserSslkeysWithSummary = <ThrowOnError extends boolean = false>(
       },
     ],
     url: "/MAAS/a/v3/users/me/sslkeys_with_summary",
+    ...options,
+  });
+};
+
+/**
+ * List Ssh Host Keys
+ */
+export const listSshHostKeys = <ThrowOnError extends boolean = false>(
+  options?: Options<ListSshHostKeysData, ThrowOnError>
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    ListSshHostKeysResponses,
+    ListSshHostKeysErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/MAAS/a/v3/ssh-host-keys",
+    ...options,
+  });
+};
+
+/**
+ * Create Ssh Host Key
+ */
+export const createSshHostKey = <ThrowOnError extends boolean = false>(
+  options: Options<CreateSshHostKeyData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).post<
+    CreateSshHostKeyResponses,
+    CreateSshHostKeyErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/MAAS/a/v3/ssh-host-keys",
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers,
+    },
+  });
+};
+
+/**
+ * Delete Ssh Host Key
+ */
+export const deleteSshHostKey = <ThrowOnError extends boolean = false>(
+  options: Options<DeleteSshHostKeyData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).delete<
+    DeleteSshHostKeyResponses,
+    DeleteSshHostKeyErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/MAAS/a/v3/ssh-host-keys/{ssh_host_key_id}",
+    ...options,
+  });
+};
+
+/**
+ * Get Ssh Host Key
+ */
+export const getSshHostKey = <ThrowOnError extends boolean = false>(
+  options: Options<GetSshHostKeyData, ThrowOnError>
+) => {
+  return (options.client ?? _heyApiClient).get<
+    GetSshHostKeyResponses,
+    GetSshHostKeyErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/MAAS/a/v3/ssh-host-keys/{ssh_host_key_id}",
     ...options,
   });
 };

--- a/src/app/apiclient/sdk.gen.ts
+++ b/src/app/apiclient/sdk.gen.ts
@@ -205,6 +205,9 @@ import type {
   ListUserSshkeysData,
   ListUserSshkeysResponses,
   ListUserSshkeysErrors,
+  ListSshHostKeysData,
+  ListSshHostKeysResponses,
+  ListSshHostKeysErrors,
   CreateUserSshkeysData,
   CreateUserSshkeysResponses,
   CreateUserSshkeysErrors,
@@ -1914,6 +1917,28 @@ export const listUserSshkeys = <ThrowOnError extends boolean = false>(
       },
     ],
     url: "/MAAS/a/v3/users/me/sshkeys",
+    ...options,
+  });
+};
+
+/**
+ * List Ssh Host Keys
+ */
+export const listSshHostKeys = <ThrowOnError extends boolean = false>(
+  options?: Options<ListSshHostKeysData, ThrowOnError>
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    ListSshHostKeysResponses,
+    ListSshHostKeysErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/MAAS/a/v3/ssh-host-keys",
     ...options,
   });
 };

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -1871,6 +1871,7 @@ export type PreconditionFailedBodyResponse = {
  */
 export type PublicConfigName =
   | "active_discovery_interval"
+  | "allow_only_trusted_transfers"
   | "auto_vlan_creation"
   | "boot_images_auto_import"
   | "boot_images_no_proxy"
@@ -2502,6 +2503,106 @@ export type SpacesListResponse = {
 };
 
 /**
+ * SshHostKeyRequest
+ */
+export type SshHostKeyRequest = {
+  /**
+   * Host
+   * The hostname or IP address.
+   */
+  host: string;
+  /**
+   * Key Type
+   * The SSH key type (e.g. ssh-rsa).
+   */
+  key_type: string;
+  /**
+   * Public Key
+   * The Base64-encoded public key.
+   */
+  public_key: string;
+  /**
+   * Label
+   * An optional human-readable label.
+   */
+  label?: string;
+};
+
+/**
+ * SshHostKeyResponse
+ * Base HAL response class that every response object must extend. The response object will look like
+ * {
+ * '_links': {
+ * 'self': {'href': '/api/v3/'}
+ * },
+ * '_embedded': {}
+ * }
+ */
+export type SshHostKeyResponse = {
+  _links?: BaseHal;
+  /**
+   *  Embedded
+   */
+  _embedded?: Record<string, unknown>;
+  /**
+   * Id
+   */
+  id: number;
+  /**
+   * Created
+   */
+  created: string;
+  /**
+   * Updated
+   */
+  updated: string;
+  /**
+   * Host
+   */
+  host: string;
+  /**
+   * Key Type
+   */
+  key_type: string;
+  /**
+   * Public Key
+   */
+  public_key: string;
+  /**
+   * Label
+   */
+  label?: string;
+  /**
+   * Kind
+   */
+  kind?: string;
+};
+
+/**
+ * SshHostKeysListResponse
+ * Base class for offset-paginated responses.
+ * Derived classes should overwrite the items property
+ */
+export type SshHostKeysListResponse = {
+  /**
+   * Items
+   */
+  items: SshHostKeyResponse[];
+  /**
+   * Total
+   */
+  total: number;
+  /**
+   * Next
+   */
+  next?: string;
+  /**
+   * Kind
+   */
+  kind?: string;
+};
+
+/**
  * SshKeyImportFromSourceRequest
  */
 export type SshKeyImportFromSourceRequest = {
@@ -2591,76 +2692,6 @@ export type SshKeysListResponse = {
  * An enumeration.
  */
 export type SshKeysProtocolType = "gh" | "lp";
-
-/**
- * SshHostKeyResponse
- * Base HAL response class that every response object must extend. The response object will look like
- * {
- * '_links': {
- * 'self': {'href': '/api/v3/'}
- * },
- * '_embedded': {}
- * }
- */
-export type SshHostKeyResponse = {
-  _links?: BaseHal;
-  /**
-   *  Embedded
-   */
-  _embedded?: Record<string, unknown>;
-  /**
-   * Id
-   */
-  id: number;
-  /**
-   * Created
-   */
-  created: string;
-  /**
-   * Updated
-   */
-  updated: string;
-  /**
-   * Host
-   */
-  host: string;
-  /**
-   * Key Type
-   */
-  key_type: string;
-  /**
-   * Public Key
-   */
-  public_key: string;
-  /**
-   * Label
-   */
-  label?: string;
-};
-
-/**
- * SshHostKeysListResponse
- * Base class for offset-paginated responses.
- * Derived classes should overwrite the items property
- */
-export type SshHostKeysListResponse = {
-  /**
-   * Items
-   */
-  items: SshHostKeyResponse[];
-  /**
-   * Total
-   */
-  total: number;
-  /**
-   * Next
-   */
-  next?: string;
-  /**
-   * Kind
-   */
-  kind?: string;
-};
 
 /**
  * StaticRouteRequest
@@ -6332,46 +6363,6 @@ export type ListUserSshkeysResponses = {
 export type ListUserSshkeysResponse =
   ListUserSshkeysResponses[keyof ListUserSshkeysResponses];
 
-export type ListSshHostKeysData = {
-  body?: never;
-  path?: never;
-  query?: {
-    /**
-     * Page
-     */
-    page?: number;
-    /**
-     * Size
-     */
-    size?: number;
-  };
-  url: "/MAAS/a/v3/ssh-host-keys";
-};
-
-export type ListSshHostKeysErrors = {
-  /**
-   * Unauthorized
-   */
-  401: UnauthorizedBodyResponse;
-  /**
-   * Unprocessable Entity
-   */
-  422: ValidationErrorBodyResponse;
-};
-
-export type ListSshHostKeysError =
-  ListSshHostKeysErrors[keyof ListSshHostKeysErrors];
-
-export type ListSshHostKeysResponses = {
-  /**
-   * Successful Response
-   */
-  200: SshHostKeysListResponse;
-};
-
-export type ListSshHostKeysResponse =
-  ListSshHostKeysResponses[keyof ListSshHostKeysResponses];
-
 export type CreateUserSshkeysData = {
   body: SshKeyManualUploadRequest;
   path?: never;
@@ -6707,6 +6698,150 @@ export type GetUserSslkeysWithSummaryResponses = {
 export type GetUserSslkeysWithSummaryResponse =
   GetUserSslkeysWithSummaryResponses[keyof GetUserSslkeysWithSummaryResponses];
 
+export type ListSshHostKeysData = {
+  body?: never;
+  path?: never;
+  query?: {
+    /**
+     * Page
+     */
+    page?: number;
+    /**
+     * Size
+     */
+    size?: number;
+  };
+  url: "/MAAS/a/v3/ssh-host-keys";
+};
+
+export type ListSshHostKeysErrors = {
+  /**
+   * Unprocessable Entity
+   */
+  422: ValidationErrorBodyResponse;
+};
+
+export type ListSshHostKeysError =
+  ListSshHostKeysErrors[keyof ListSshHostKeysErrors];
+
+export type ListSshHostKeysResponses = {
+  /**
+   * Successful Response
+   */
+  200: SshHostKeysListResponse;
+};
+
+export type ListSshHostKeysResponse =
+  ListSshHostKeysResponses[keyof ListSshHostKeysResponses];
+
+export type CreateSshHostKeyData = {
+  body: SshHostKeyRequest;
+  path?: never;
+  query?: never;
+  url: "/MAAS/a/v3/ssh-host-keys";
+};
+
+export type CreateSshHostKeyErrors = {
+  /**
+   * Unprocessable Entity
+   */
+  422: ValidationErrorBodyResponse;
+};
+
+export type CreateSshHostKeyError =
+  CreateSshHostKeyErrors[keyof CreateSshHostKeyErrors];
+
+export type CreateSshHostKeyResponses = {
+  /**
+   * Successful Response
+   */
+  201: SshHostKeyResponse;
+};
+
+export type CreateSshHostKeyResponse =
+  CreateSshHostKeyResponses[keyof CreateSshHostKeyResponses];
+
+export type DeleteSshHostKeyData = {
+  body?: never;
+  headers?: {
+    /**
+     * If-Match
+     */
+    "if-match"?: string;
+  };
+  path: {
+    /**
+     * Ssh Host Key Id
+     */
+    ssh_host_key_id: number;
+  };
+  query?: never;
+  url: "/MAAS/a/v3/ssh-host-keys/{ssh_host_key_id}";
+};
+
+export type DeleteSshHostKeyErrors = {
+  /**
+   * Not Found
+   */
+  404: NotFoundBodyResponse;
+  /**
+   * Precondition Failed
+   */
+  412: PreconditionFailedBodyResponse;
+  /**
+   * Unprocessable Entity
+   */
+  422: ValidationErrorBodyResponse;
+};
+
+export type DeleteSshHostKeyError =
+  DeleteSshHostKeyErrors[keyof DeleteSshHostKeyErrors];
+
+export type DeleteSshHostKeyResponses = {
+  /**
+   * Successful Response
+   */
+  204: void;
+};
+
+export type DeleteSshHostKeyResponse =
+  DeleteSshHostKeyResponses[keyof DeleteSshHostKeyResponses];
+
+export type GetSshHostKeyData = {
+  body?: never;
+  path: {
+    /**
+     * Ssh Host Key Id
+     */
+    ssh_host_key_id: number;
+  };
+  query?: never;
+  url: "/MAAS/a/v3/ssh-host-keys/{ssh_host_key_id}";
+};
+
+export type GetSshHostKeyErrors = {
+  /**
+   * Not Found
+   */
+  404: NotFoundBodyResponse;
+  /**
+   * Unprocessable Entity
+   */
+  422: ValidationErrorBodyResponse;
+};
+
+export type GetSshHostKeyError = GetSshHostKeyErrors[keyof GetSshHostKeyErrors];
+
+export type GetSshHostKeyResponses = {
+  /**
+   * Successful Response
+   */
+  200: SshHostKeyResponse;
+};
+
+export type GetSshHostKeyResponse =
+  GetSshHostKeyResponses[keyof GetSshHostKeyResponses];
+
 export type ListFabricVlanSubnetsData = {
   body?: never;
   path: {
@@ -6814,7 +6949,13 @@ export type DeleteFabricVlanSubnetData = {
      */
     id: number;
   };
-  query?: never;
+  query?: {
+    /**
+     * Force
+     * If true, delete the subnet even if it has IP addresses in use by nodes.
+     */
+    force?: boolean;
+  };
   url: "/MAAS/a/v3/fabrics/{fabric_id}/vlans/{vlan_id}/subnets/{id}";
 };
 
@@ -6823,6 +6964,10 @@ export type DeleteFabricVlanSubnetErrors = {
    * Not Found
    */
   404: NotFoundBodyResponse;
+  /**
+   * Precondition Failed
+   */
+  412: PreconditionFailedBodyResponse;
   /**
    * Unprocessable Entity
    */

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -2593,6 +2593,76 @@ export type SshKeysListResponse = {
 export type SshKeysProtocolType = "gh" | "lp";
 
 /**
+ * SshHostKeyResponse
+ * Base HAL response class that every response object must extend. The response object will look like
+ * {
+ * '_links': {
+ * 'self': {'href': '/api/v3/'}
+ * },
+ * '_embedded': {}
+ * }
+ */
+export type SshHostKeyResponse = {
+  _links?: BaseHal;
+  /**
+   *  Embedded
+   */
+  _embedded?: Record<string, unknown>;
+  /**
+   * Id
+   */
+  id: number;
+  /**
+   * Created
+   */
+  created: string;
+  /**
+   * Updated
+   */
+  updated: string;
+  /**
+   * Host
+   */
+  host: string;
+  /**
+   * Key Type
+   */
+  key_type: string;
+  /**
+   * Public Key
+   */
+  public_key: string;
+  /**
+   * Label
+   */
+  label?: string;
+};
+
+/**
+ * SshHostKeysListResponse
+ * Base class for offset-paginated responses.
+ * Derived classes should overwrite the items property
+ */
+export type SshHostKeysListResponse = {
+  /**
+   * Items
+   */
+  items: SshHostKeyResponse[];
+  /**
+   * Total
+   */
+  total: number;
+  /**
+   * Next
+   */
+  next?: string;
+  /**
+   * Kind
+   */
+  kind?: string;
+};
+
+/**
  * StaticRouteRequest
  */
 export type StaticRouteRequest = {
@@ -6261,6 +6331,46 @@ export type ListUserSshkeysResponses = {
 
 export type ListUserSshkeysResponse =
   ListUserSshkeysResponses[keyof ListUserSshkeysResponses];
+
+export type ListSshHostKeysData = {
+  body?: never;
+  path?: never;
+  query?: {
+    /**
+     * Page
+     */
+    page?: number;
+    /**
+     * Size
+     */
+    size?: number;
+  };
+  url: "/MAAS/a/v3/ssh-host-keys";
+};
+
+export type ListSshHostKeysErrors = {
+  /**
+   * Unauthorized
+   */
+  401: UnauthorizedBodyResponse;
+  /**
+   * Unprocessable Entity
+   */
+  422: ValidationErrorBodyResponse;
+};
+
+export type ListSshHostKeysError =
+  ListSshHostKeysErrors[keyof ListSshHostKeysErrors];
+
+export type ListSshHostKeysResponses = {
+  /**
+   * Successful Response
+   */
+  200: SshHostKeysListResponse;
+};
+
+export type ListSshHostKeysResponse =
+  ListSshHostKeysResponses[keyof ListSshHostKeysResponses];
 
 export type CreateUserSshkeysData = {
   body: SshKeyManualUploadRequest;

--- a/src/app/settings/components/Routes/Routes.tsx
+++ b/src/app/settings/components/Routes/Routes.tsx
@@ -29,6 +29,7 @@ import IpmiSettings from "@/app/settings/views/Security/IpmiSettings";
 import SecretStorage from "@/app/settings/views/Security/SecretStorage";
 import SecurityProtocols from "@/app/settings/views/Security/SecurityProtocols";
 import SessionTimeout from "@/app/settings/views/Security/SessionTimeout";
+import TrustedSSHHostKeys from "@/app/settings/views/Security/TrustedSSHHostKeys";
 import StorageForm from "@/app/settings/views/Storage/StorageForm";
 import UsersList from "@/app/settings/views/Users/views";
 import { getRelativeRoute } from "@/app/utils";
@@ -111,6 +112,14 @@ const Routes = (): React.ReactElement => {
           </PageContent>
         }
         path={getRelativeRoute(urls.settings.security.ipmiSettings, base)}
+      />
+      <Route
+        element={
+          <PageContent sidePanelContent={null} sidePanelTitle={null}>
+            <TrustedSSHHostKeys />
+          </PageContent>
+        }
+        path={getRelativeRoute(urls.settings.security.trustedSshHostKeys, base)}
       />
       <Route
         element={

--- a/src/app/settings/constants.ts
+++ b/src/app/settings/constants.ts
@@ -36,6 +36,10 @@ export const settingsNavItems: NavItem[] = [
         path: settingsURLs.security.ipmiSettings,
         label: "IPMI settings",
       },
+      {
+        path: settingsURLs.security.trustedSshHostKeys,
+        label: "Trusted SSH host keys",
+      },
     ],
   },
   {

--- a/src/app/settings/urls.ts
+++ b/src/app/settings/urls.ts
@@ -65,6 +65,7 @@ const urls = {
     securityProtocols: "/settings/security/security-protocols",
     ipmiSettings: "/settings/security/ipmi-settings",
     sessionTimeout: "/settings/security/session-timeout",
+    trustedSshHostKeys: "/settings/security/trusted-ssh-host-keys",
   },
   storage: "/settings/storage",
   users: {

--- a/src/app/settings/views/Security/TrustedSSHHostKeys/TrustedSSHHostKeys.test.tsx
+++ b/src/app/settings/views/Security/TrustedSSHHostKeys/TrustedSSHHostKeys.test.tsx
@@ -1,0 +1,22 @@
+import TrustedSSHHostKeys from "./TrustedSSHHostKeys";
+
+import { sshHostKeysResolvers } from "@/testing/resolvers/sshHostKeys";
+import {
+  renderWithProviders,
+  screen,
+  setupMockServer,
+  waitForLoading,
+} from "@/testing/utils";
+
+setupMockServer(sshHostKeysResolvers.listSshHostKeys.handler());
+
+describe("TrustedSSHHostKeys", () => {
+  it("renders the trusted SSH host keys table", async () => {
+    renderWithProviders(<TrustedSSHHostKeys />);
+    await waitForLoading();
+
+    expect(
+      screen.getByRole("columnheader", { name: "Host" })
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/settings/views/Security/TrustedSSHHostKeys/TrustedSSHHostKeys.tsx
+++ b/src/app/settings/views/Security/TrustedSSHHostKeys/TrustedSSHHostKeys.tsx
@@ -1,0 +1,11 @@
+import TrustedSSHHostKeysTable from "./components/TrustedSSHHostKeysTable";
+
+import { useWindowTitle } from "@/app/base/hooks";
+
+const TrustedSSHHostKeys = (): React.ReactElement => {
+  useWindowTitle("Trusted SSH host keys");
+
+  return <TrustedSSHHostKeysTable />;
+};
+
+export default TrustedSSHHostKeys;

--- a/src/app/settings/views/Security/TrustedSSHHostKeys/components/TrustedSSHHostKeysTable/TrustedSSHHostKeysTable.test.tsx
+++ b/src/app/settings/views/Security/TrustedSSHHostKeys/components/TrustedSSHHostKeysTable/TrustedSSHHostKeysTable.test.tsx
@@ -1,0 +1,95 @@
+import TrustedSSHHostKeysTable from "./TrustedSSHHostKeysTable";
+
+import { sshHostKey as sshHostKeyFactory } from "@/testing/factories";
+import { sshHostKeysResolvers } from "@/testing/resolvers/sshHostKeys";
+import {
+  mockIsPending,
+  renderWithProviders,
+  screen,
+  setupMockServer,
+  waitFor,
+} from "@/testing/utils";
+
+const mockServer = setupMockServer(
+  sshHostKeysResolvers.listSshHostKeys.handler()
+);
+
+describe("TrustedSSHHostKeysTable", () => {
+  it("displays a loading component if trusted SSH host keys are loading", async () => {
+    mockIsPending();
+    renderWithProviders(<TrustedSSHHostKeysTable />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Loading...")).toBeInTheDocument();
+    });
+  });
+
+  it("displays a message when rendering an empty list", async () => {
+    mockServer.use(
+      sshHostKeysResolvers.listSshHostKeys.handler({ items: [], total: 0 })
+    );
+    renderWithProviders(<TrustedSSHHostKeysTable />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("No trusted SSH host keys found.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("displays a message when an error is encountered", async () => {
+    mockServer.use(sshHostKeysResolvers.listSshHostKeys.error());
+    renderWithProviders(<TrustedSSHHostKeysTable />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Error while fetching trusted SSH host keys/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("displays the columns correctly", async () => {
+    renderWithProviders(<TrustedSSHHostKeysTable />);
+
+    for (const column of [
+      "Host",
+      "Key type",
+      "Label",
+      "Public key",
+      "Creation date",
+    ]) {
+      await waitFor(() => {
+        expect(
+          screen.getByRole("columnheader", { name: column })
+        ).toBeInTheDocument();
+      });
+    }
+  });
+
+  it("displays the row data correctly", async () => {
+    mockServer.use(
+      sshHostKeysResolvers.listSshHostKeys.handler({
+        items: [
+          sshHostKeyFactory({
+            id: 1,
+            host: "host1.example.com",
+            key_type: "ssh-ed25519",
+            label: "rack-1",
+            public_key: "AAAAC3NzaC1lZDI1NTE5AAAAIKV6QaqOcp8OMe9tw0i3aB7z",
+          }),
+        ],
+        total: 1,
+      })
+    );
+    renderWithProviders(<TrustedSSHHostKeysTable />);
+
+    await waitFor(() => {
+      expect(screen.getByText("host1.example.com")).toBeInTheDocument();
+    });
+    expect(screen.getByText("ssh-ed25519")).toBeInTheDocument();
+    expect(screen.getByText("rack-1")).toBeInTheDocument();
+    expect(
+      screen.getByText("AAAAC3NzaC1lZDI1NTE5AAAAIKV6QaqOcp8OMe9tw0i3aB7z")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/app/settings/views/Security/TrustedSSHHostKeys/components/TrustedSSHHostKeysTable/TrustedSSHHostKeysTable.tsx
+++ b/src/app/settings/views/Security/TrustedSSHHostKeys/components/TrustedSSHHostKeysTable/TrustedSSHHostKeysTable.tsx
@@ -1,0 +1,54 @@
+import { GenericTable, MainToolbar } from "@canonical/maas-react-components";
+import { Notification } from "@canonical/react-components";
+
+import useTrustedSSHHostKeysTableColumns from "./useTrustedSSHHostKeysTableColumns";
+
+import { useTrustedSshHostKeys } from "@/app/api/query/trustedSshHostKeys";
+import usePagination from "@/app/base/hooks/usePagination/usePagination";
+
+const TrustedSSHHostKeysTable = () => {
+  const { page, debouncedPage, size, handlePageSizeChange, setPage } =
+    usePagination();
+
+  const { data, isPending, isError, error } = useTrustedSshHostKeys({
+    query: {
+      page: debouncedPage,
+      size,
+    },
+  });
+
+  const columns = useTrustedSSHHostKeysTableColumns();
+
+  return (
+    <div className="trusted-ssh-host-keys-table">
+      <MainToolbar>
+        <MainToolbar.Title>Trusted SSH host keys</MainToolbar.Title>
+      </MainToolbar>
+      {isError && (
+        <Notification
+          severity="negative"
+          title="Error while fetching trusted SSH host keys"
+        >
+          {error.message}
+        </Notification>
+      )}
+      <GenericTable
+        columns={columns}
+        data={data?.items ?? []}
+        isLoading={isPending}
+        noData="No trusted SSH host keys found."
+        pagination={{
+          currentPage: page,
+          dataContext: "trusted SSH host keys",
+          handlePageSizeChange: handlePageSizeChange,
+          isPending: isPending,
+          itemsPerPage: size,
+          setCurrentPage: setPage,
+          totalItems: data?.total ?? 0,
+        }}
+      />
+    </div>
+  );
+};
+
+export default TrustedSSHHostKeysTable;

--- a/src/app/settings/views/Security/TrustedSSHHostKeys/components/TrustedSSHHostKeysTable/index.ts
+++ b/src/app/settings/views/Security/TrustedSSHHostKeys/components/TrustedSSHHostKeysTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TrustedSSHHostKeysTable";

--- a/src/app/settings/views/Security/TrustedSSHHostKeys/components/TrustedSSHHostKeysTable/useTrustedSSHHostKeysTableColumns.tsx
+++ b/src/app/settings/views/Security/TrustedSSHHostKeys/components/TrustedSSHHostKeysTable/useTrustedSSHHostKeysTableColumns.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+
+import type { ColumnDef } from "@tanstack/react-table";
+
+import type { SshHostKeyResponse } from "@/app/apiclient";
+
+type TrustedSSHHostKeysColumnDef = ColumnDef<
+  SshHostKeyResponse,
+  Partial<SshHostKeyResponse>
+>;
+
+const useTrustedSSHHostKeysTableColumns = (): TrustedSSHHostKeysColumnDef[] => {
+  return useMemo(
+    () => [
+      {
+        id: "host",
+        accessorKey: "host",
+        enableSorting: true,
+        header: "Host",
+        cell: ({ row: { original } }) => original.host || <>&mdash;</>,
+      },
+      {
+        id: "key_type",
+        accessorKey: "key_type",
+        enableSorting: true,
+        header: "Key type",
+        cell: ({ row: { original } }) => original.key_type || <>&mdash;</>,
+      },
+      {
+        id: "label",
+        accessorKey: "label",
+        enableSorting: true,
+        header: "Label",
+        cell: ({ row: { original } }) => original.label || <>&mdash;</>,
+      },
+      {
+        id: "public_key",
+        accessorKey: "public_key",
+        enableSorting: true,
+        header: "Public key",
+        cell: ({ row: { original } }) => original.public_key || <>&mdash;</>,
+      },
+      {
+        id: "created",
+        accessorKey: "created",
+        enableSorting: true,
+        header: "Creation date",
+        cell: ({ row: { original } }) => {
+          if (!original.created) return <>&mdash;</>;
+          return (
+            new Date(original.created)
+              .toLocaleString("en-GB", {
+                weekday: "short",
+                day: "2-digit",
+                month: "short",
+                year: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+                second: "2-digit",
+                timeZone: "UTC",
+                hour12: false,
+              })
+              .replace(",", "")
+              .replace(/(\d{2}):(\d{2}):(\d{2})/, "$1:$2:$3") + " (UTC)"
+          );
+        },
+      },
+    ],
+    []
+  );
+};
+
+export default useTrustedSSHHostKeysTableColumns;

--- a/src/app/settings/views/Security/TrustedSSHHostKeys/index.ts
+++ b/src/app/settings/views/Security/TrustedSSHHostKeys/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./TrustedSSHHostKeys";

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -184,6 +184,7 @@ export {
 export { script } from "./script";
 export { service } from "./service";
 export { space } from "./space";
+export { sshHostKey } from "./sshHostKey";
 export { sshKey } from "./sshkey";
 export { sslKey } from "./sslkey";
 export { staticRoute } from "./staticroute";

--- a/src/testing/factories/sshHostKey.ts
+++ b/src/testing/factories/sshHostKey.ts
@@ -1,0 +1,13 @@
+import { define, random } from "cooky-cutter";
+
+import type { SshHostKeyResponse } from "@/app/apiclient";
+
+export const sshHostKey = define<SshHostKeyResponse>({
+  id: random,
+  host: "test-host",
+  key_type: "ssh-ed25519",
+  public_key: "AAAAC3NzaC1lZDI1NTE5AAAAIKV6QaqOcp8OMe9tw0i3aB7z test-key",
+  label: "test label",
+  created: "2024-01-01T00:00:00",
+  updated: "2024-01-01T00:00:00",
+});

--- a/src/testing/resolvers/sshHostKeys.ts
+++ b/src/testing/resolvers/sshHostKeys.ts
@@ -1,0 +1,42 @@
+import { http, HttpResponse } from "msw";
+
+import { sshHostKey as sshHostKeyFactory } from "../factories";
+import { BASE_URL } from "../utils";
+
+import type {
+  ListSshHostKeysError,
+  ListSshHostKeysResponse,
+} from "@/app/apiclient";
+
+const mockSshHostKeys: ListSshHostKeysResponse = {
+  items: [
+    sshHostKeyFactory({ id: 1 }),
+    sshHostKeyFactory({ id: 2 }),
+    sshHostKeyFactory({ id: 3 }),
+  ],
+  total: 3,
+};
+
+const mockListSshHostKeysError: ListSshHostKeysError = {
+  message: "Unauthorized",
+  code: 401,
+  kind: "Error",
+};
+
+const sshHostKeysResolvers = {
+  listSshHostKeys: {
+    resolved: false,
+    handler: (data: ListSshHostKeysResponse = mockSshHostKeys) =>
+      http.get(`${BASE_URL}MAAS/a/v3/ssh-host-keys`, () => {
+        sshHostKeysResolvers.listSshHostKeys.resolved = true;
+        return HttpResponse.json(data);
+      }),
+    error: (error: ListSshHostKeysError = mockListSshHostKeysError) =>
+      http.get(`${BASE_URL}MAAS/a/v3/ssh-host-keys`, () => {
+        sshHostKeysResolvers.listSshHostKeys.resolved = true;
+        return HttpResponse.json(error, { status: error.code });
+      }),
+  },
+};
+
+export { mockSshHostKeys, sshHostKeysResolvers };


### PR DESCRIPTION
## Done

- Added `Trusted SSH Host Keys` view under Settings > Security
- Added `TrustedSSHHostKeysTable` component rendering host, key type, label, public key, and creation date columns
- Added `useTrustedSshHostKeys` query hook for `GET /MAAS/a/v3/ssh-host-keys`
- Updated API client types/schema for the new endpoint
- Added tests

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] got to /MAAS
- [x] go to /Settings/Security
- [x] check that Trusted SSH Host Keys view contains appropriate table with columns: host, key type, label, fingerprint, and creation date.

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6813](https://warthogs.atlassian.net/browse/MAASENG-6813)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-6813]: https://warthogs.atlassian.net/browse/MAASENG-6813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ