### PR TITLE
fix(networks): wait for promises to resolve before validating form values

### DIFF
--- a/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
+++ b/src/app/networks/views/VLANs/views/VLANDetails/components/ConfigureDHCP/DHCPReservedRanges/DHCPReservedRanges.tsx
@@ -52,41 +52,42 @@ const DHCPReservedRanges = ({ id }: Props): React.ReactElement | null => {
   // based on the subnet's suggested dynamic range, or clear the fields.
   useEffect(() => {
     const subnet = subnets.find((s) => s.id === Number(values.subnet));
-    setFieldValue(
-      "endIP",
-      subnet?.statistics.suggested_dynamic_range?.end || ""
-    ).catch((reason: unknown) => {
-      throw new FormikFieldChangeError(
-        "endIP",
-        "setFieldValue",
-        reason as string
-      );
-    });
-    setFieldValue(
-      "gatewayIP",
-      subnet?.gateway_ip || subnet?.statistics.suggested_gateway || ""
-    ).catch((reason: unknown) => {
-      throw new FormikFieldChangeError(
+
+    const setField = (field: string, value: string) =>
+      setFieldValue(field, value).catch((reason: unknown) => {
+        throw new FormikFieldChangeError(
+          field,
+          "setFieldValue",
+          reason as string
+        );
+      });
+
+    // Wait for all form values to be populated before validation.
+    Promise.all([
+      setField("endIP", subnet?.statistics.suggested_dynamic_range?.end || ""),
+      setField(
         "gatewayIP",
-        "setFieldValue",
-        reason as string
-      );
-    });
-    setFieldValue(
-      "startIP",
-      subnet?.statistics.suggested_dynamic_range?.start || ""
-    ).catch((reason: unknown) => {
-      throw new FormikFieldChangeError(
+        subnet?.gateway_ip || subnet?.statistics.suggested_gateway || ""
+      ),
+      setField(
         "startIP",
-        "setFieldValue",
-        reason as string
-      );
-    });
-    if (isId(values.subnet)) {
-      setFieldTouched("subnet", true, false);
-    }
-    // need to manually call this as Yup does not automatically re-trigger the validation schema
-    validateForm();
+        subnet?.statistics.suggested_dynamic_range?.start || ""
+      ),
+    ])
+      .then(() => {
+        if (isId(values.subnet)) {
+          setFieldTouched("subnet", true, false);
+        }
+        // need to manually call this as Yup does not automatically re-trigger the validation schema
+        return validateForm();
+      })
+      .catch((reason: unknown) => {
+        throw new FormikFieldChangeError(
+          "subnet",
+          "validateForm",
+          reason as string
+        );
+      });
   }, [setFieldTouched, setFieldValue, subnets, validateForm, values.subnet]);
 
   const columns = useDHCPReservedRangesColumns({


### PR DESCRIPTION
## Done

- The "Configure DHCP" form for a VLAN had a bug causing the "Configure DHCP" button to be disabled despite the form having valid values. This was caused by the validation being run before the form was actually populated.
- This PR waits for the promises (for populating the form) to resolve before triggering validation.

## QA steps

- [x] Sign in to MAAS
- [x] Go to the networks page from the side nav
- [x] Locate a subnet that has "No DHCP", and select the corresponding VLAN
- [x] Select the "Configure DHCP" button
- [x] Check the "MAAS provides DHCP" option, and select any rack controller from the dropdown
- [x] Select a subnet from the "Reserved dynamic range" dropdown
- [x] Ensure the "Configure DHCP" button is now enabled (previously, due to the bug, this would still be disabled until the user focused one of the form fields)
- [x] Ensure clicking the "Configure DHCP" button adds the dynamic range to the list, enables DHCP, and closes the form
