### PR TITLE
feat: add FIPS and hardening status info to status bar MAASENG-6810

### DIFF
--- a/openapi-ts.config.ts
+++ b/openapi-ts.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@hey-api/openapi-ts";
 
 export default defineConfig({
-  input: "http://maas-ui-demo.internal:5240/MAAS/a/openapi.json",
+  input: "http://localhost:8400/MAAS/a/openapi.json",
   output: {
     path: "src/app/apiclient",
     format: "prettier",

--- a/src/app/api/query/system.test.ts
+++ b/src/app/api/query/system.test.ts
@@ -1,0 +1,21 @@
+import { useSystemInfo } from "./system";
+
+import { mockSystemInfo, systemResolvers } from "@/testing/resolvers/system";
+import {
+  renderHookWithProviders,
+  setupMockServer,
+  waitFor,
+} from "@/testing/utils";
+
+setupMockServer(systemResolvers.getSystemInfo.handler());
+
+describe("useSystemInfo", () => {
+  it("should return system info data", async () => {
+    const { result } = renderHookWithProviders(() => useSystemInfo());
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual(mockSystemInfo);
+  });
+});

--- a/src/app/api/query/system.ts
+++ b/src/app/api/query/system.ts
@@ -1,0 +1,21 @@
+import type { UseQueryOptions } from "@tanstack/react-query";
+
+import { useWebsocketAwareQuery } from "./base";
+
+import type {
+  GetSystemInfoData,
+  GetSystemInfoError,
+  GetSystemInfoResponse,
+} from "@/app/apiclient";
+import { getSystemInfoOptions } from "@/app/apiclient/@tanstack/react-query.gen";
+import type { Options } from "@/app/apiclient/client";
+
+export const useSystemInfo = (options?: Options<GetSystemInfoData>) => {
+  return useWebsocketAwareQuery(
+    getSystemInfoOptions(options) as UseQueryOptions<
+      GetSystemInfoData,
+      GetSystemInfoError,
+      GetSystemInfoResponse
+    >
+  );
+};

--- a/src/app/apiclient/@tanstack/react-query.gen.ts
+++ b/src/app/apiclient/@tanstack/react-query.gen.ts
@@ -46,6 +46,7 @@ import {
   deletePackageRepository,
   getPackageRepository,
   updatePackageRepository,
+  listPowerTypes,
   listFabricVlanSubnetReservedIps,
   createFabricVlanSubnetReservedIp,
   deleteFabricVlanSubnetReservedIp,
@@ -57,6 +58,7 @@ import {
   getResourcePool,
   updateResourcePool,
   listResourcePoolsWithSummary,
+  getSystemInfo,
   listFabricVlanSubnetStaticroutes,
   createFabricVlanSubnetStaticroute,
   deleteFabricVlanSubnetStaticroute,
@@ -231,6 +233,7 @@ import type {
   UpdatePackageRepositoryData,
   UpdatePackageRepositoryError,
   UpdatePackageRepositoryResponse,
+  ListPowerTypesData,
   ListFabricVlanSubnetReservedIpsData,
   ListFabricVlanSubnetReservedIpsError,
   ListFabricVlanSubnetReservedIpsResponse,
@@ -260,6 +263,7 @@ import type {
   ListResourcePoolsWithSummaryData,
   ListResourcePoolsWithSummaryError,
   ListResourcePoolsWithSummaryResponse,
+  GetSystemInfoData,
   ListFabricVlanSubnetStaticroutesData,
   ListFabricVlanSubnetStaticroutesError,
   ListFabricVlanSubnetStaticroutesResponse,
@@ -2312,6 +2316,29 @@ export const updatePackageRepositoryMutation = (
   return mutationOptions;
 };
 
+export const listPowerTypesQueryKey = (options?: Options<ListPowerTypesData>) =>
+  createQueryKey("listPowerTypes", options);
+
+/**
+ * List Power Types
+ */
+export const listPowerTypesOptions = (
+  options?: Options<ListPowerTypesData>
+) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await listPowerTypes({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: listPowerTypesQueryKey(options),
+  });
+};
+
 export const listFabricVlanSubnetReservedIpsQueryKey = (
   options: Options<ListFabricVlanSubnetReservedIpsData>
 ) => createQueryKey("listFabricVlanSubnetReservedIps", options);
@@ -2795,6 +2822,27 @@ export const listResourcePoolsWithSummaryInfiniteOptions = (
       queryKey: listResourcePoolsWithSummaryInfiniteQueryKey(options),
     }
   );
+};
+
+export const getSystemInfoQueryKey = (options?: Options<GetSystemInfoData>) =>
+  createQueryKey("getSystemInfo", options);
+
+/**
+ * Get System Info
+ */
+export const getSystemInfoOptions = (options?: Options<GetSystemInfoData>) => {
+  return queryOptions({
+    queryFn: async ({ queryKey, signal }) => {
+      const { data } = await getSystemInfo({
+        ...options,
+        ...queryKey[0],
+        signal,
+        throwOnError: true,
+      });
+      return data;
+    },
+    queryKey: getSystemInfoQueryKey(options),
+  });
 };
 
 export const listFabricVlanSubnetStaticroutesQueryKey = (

--- a/src/app/apiclient/client.gen.ts
+++ b/src/app/apiclient/client.gen.ts
@@ -23,5 +23,9 @@ export type CreateClientConfig<T extends DefaultClientOptions = ClientOptions> =
   ) => Config<Required<DefaultClientOptions> & T>;
 
 export const client = createClient(
-  createClientConfig(createConfig<ClientOptions>())
+  createClientConfig(
+    createConfig<ClientOptions>({
+      baseUrl: "http://10.10.0.22:5240",
+    })
+  )
 );

--- a/src/app/apiclient/client.gen.ts
+++ b/src/app/apiclient/client.gen.ts
@@ -25,7 +25,7 @@ export type CreateClientConfig<T extends DefaultClientOptions = ClientOptions> =
 export const client = createClient(
   createClientConfig(
     createConfig<ClientOptions>({
-      baseUrl: "http://10.10.0.22:5240",
+      baseUrl: "http://localhost:8400",
     })
   )
 );

--- a/src/app/apiclient/sdk.gen.ts
+++ b/src/app/apiclient/sdk.gen.ts
@@ -139,6 +139,9 @@ import type {
   UpdatePackageRepositoryData,
   UpdatePackageRepositoryResponses,
   UpdatePackageRepositoryErrors,
+  ListPowerTypesData,
+  ListPowerTypesResponses,
+  ListPowerTypesErrors,
   ListFabricVlanSubnetReservedIpsData,
   ListFabricVlanSubnetReservedIpsResponses,
   ListFabricVlanSubnetReservedIpsErrors,
@@ -172,6 +175,9 @@ import type {
   ListResourcePoolsWithSummaryData,
   ListResourcePoolsWithSummaryResponses,
   ListResourcePoolsWithSummaryErrors,
+  GetSystemInfoData,
+  GetSystemInfoResponses,
+  GetSystemInfoErrors,
   ListFabricVlanSubnetStaticroutesData,
   ListFabricVlanSubnetStaticroutesResponses,
   ListFabricVlanSubnetStaticroutesErrors,
@@ -1392,6 +1398,28 @@ export const updatePackageRepository = <ThrowOnError extends boolean = false>(
 };
 
 /**
+ * List Power Types
+ */
+export const listPowerTypes = <ThrowOnError extends boolean = false>(
+  options?: Options<ListPowerTypesData, ThrowOnError>
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    ListPowerTypesResponses,
+    ListPowerTypesErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/MAAS/a/v3/power-types",
+    ...options,
+  });
+};
+
+/**
  * List Fabric Vlan Subnet Reserved Ips
  */
 export const listFabricVlanSubnetReservedIps = <
@@ -1658,6 +1686,28 @@ export const listResourcePoolsWithSummary = <
       },
     ],
     url: "/MAAS/a/v3/resource_pools_with_summary",
+    ...options,
+  });
+};
+
+/**
+ * Get System Info
+ */
+export const getSystemInfo = <ThrowOnError extends boolean = false>(
+  options?: Options<GetSystemInfoData, ThrowOnError>
+) => {
+  return (options?.client ?? _heyApiClient).get<
+    GetSystemInfoResponses,
+    GetSystemInfoErrors,
+    ThrowOnError
+  >({
+    security: [
+      {
+        scheme: "bearer",
+        type: "http",
+      },
+    ],
+    url: "/MAAS/a/v3/system/info",
     ...options,
   });
 };

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -8216,5 +8216,5 @@ export type ListZonesWithSummaryResponse =
   ListZonesWithSummaryResponses[keyof ListZonesWithSummaryResponses];
 
 export type ClientOptions = {
-  baseUrl: "http://10.10.0.22:5240" | (string & {});
+  baseUrl: "http://localhost:8400" | (string & {});
 };

--- a/src/app/apiclient/types.gen.ts
+++ b/src/app/apiclient/types.gen.ts
@@ -1844,6 +1844,92 @@ export type PowerTypeEnum =
   | "wedge";
 
 /**
+ * PowerTypeField
+ */
+export type PowerTypeField = {
+  /**
+   * Name
+   */
+  name: string;
+  /**
+   * Label
+   */
+  label: string;
+  /**
+   * Required
+   */
+  required: boolean;
+  /**
+   * Field Type
+   */
+  field_type: string;
+  /**
+   * Default
+   */
+  default?: unknown;
+  /**
+   * Choices
+   */
+  choices?: [unknown, unknown][];
+};
+
+/**
+ * PowerTypeResponse
+ */
+export type PowerTypeResponse = {
+  /**
+   * Driver Type
+   */
+  driver_type: string;
+  /**
+   * Name
+   */
+  name: string;
+  /**
+   * Description
+   */
+  description: string;
+  /**
+   * Fields
+   */
+  fields: PowerTypeField[];
+  /**
+   * Chassis
+   */
+  chassis: boolean;
+  /**
+   * Can Probe
+   */
+  can_probe: boolean;
+  /**
+   * Missing Packages
+   */
+  missing_packages: string[];
+  /**
+   * Queryable
+   */
+  queryable: boolean;
+  /**
+   * Fips Supported
+   */
+  fips_supported: boolean;
+  /**
+   * Fips Unsupported Reason
+   */
+  fips_unsupported_reason?: string;
+};
+
+/**
+ * PowerTypesListResponse
+ */
+export type PowerTypesListResponse = {
+  /**
+   * Items
+   */
+  items: PowerTypeResponse[];
+};
+
+/**
  * PreconditionFailedBodyResponse
  */
 export type PreconditionFailedBodyResponse = {
@@ -2928,6 +3014,24 @@ export type SubnetsListResponse = {
 };
 
 /**
+ * SystemInfoResponse
+ */
+export type SystemInfoResponse = {
+  /**
+   * Fips Active
+   */
+  fips_active: boolean;
+  /**
+   * Hardening Active
+   */
+  hardening_active: boolean;
+  /**
+   * Version
+   */
+  version: string;
+};
+
+/**
  * TXTRecord
  */
 export type TxtRecord = {
@@ -3465,6 +3569,10 @@ export type ValidationErrorBodyResponse = {
    * Kind
    */
   kind?: string;
+  /**
+   * Fips Violation
+   */
+  fips_violation?: boolean;
 };
 
 /**
@@ -5428,6 +5536,33 @@ export type UpdatePackageRepositoryResponses = {
 export type UpdatePackageRepositoryResponse =
   UpdatePackageRepositoryResponses[keyof UpdatePackageRepositoryResponses];
 
+export type ListPowerTypesData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/MAAS/a/v3/power-types";
+};
+
+export type ListPowerTypesErrors = {
+  /**
+   * Unprocessable Entity
+   */
+  422: ValidationErrorBodyResponse;
+};
+
+export type ListPowerTypesError =
+  ListPowerTypesErrors[keyof ListPowerTypesErrors];
+
+export type ListPowerTypesResponses = {
+  /**
+   * Successful Response
+   */
+  200: PowerTypesListResponse;
+};
+
+export type ListPowerTypesResponse =
+  ListPowerTypesResponses[keyof ListPowerTypesResponses];
+
 export type ListFabricVlanSubnetReservedIpsData = {
   body?: never;
   path: {
@@ -5901,6 +6036,32 @@ export type ListResourcePoolsWithSummaryResponses = {
 
 export type ListResourcePoolsWithSummaryResponse =
   ListResourcePoolsWithSummaryResponses[keyof ListResourcePoolsWithSummaryResponses];
+
+export type GetSystemInfoData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: "/MAAS/a/v3/system/info";
+};
+
+export type GetSystemInfoErrors = {
+  /**
+   * Unprocessable Entity
+   */
+  422: ValidationErrorBodyResponse;
+};
+
+export type GetSystemInfoError = GetSystemInfoErrors[keyof GetSystemInfoErrors];
+
+export type GetSystemInfoResponses = {
+  /**
+   * Successful Response
+   */
+  200: SystemInfoResponse;
+};
+
+export type GetSystemInfoResponse =
+  GetSystemInfoResponses[keyof GetSystemInfoResponses];
 
 export type ListFabricVlanSubnetStaticroutesData = {
   body?: never;
@@ -8055,5 +8216,5 @@ export type ListZonesWithSummaryResponse =
   ListZonesWithSummaryResponses[keyof ListZonesWithSummaryResponses];
 
 export type ClientOptions = {
-  baseUrl: `${string}://${string}` | (string & {});
+  baseUrl: "http://10.10.0.22:5240" | (string & {});
 };

--- a/src/app/base/components/StatusBar/StatusBar.test.tsx
+++ b/src/app/base/components/StatusBar/StatusBar.test.tsx
@@ -4,10 +4,17 @@ import { ConfigNames } from "@/app/store/config/types";
 import type { RootState } from "@/app/store/root/types";
 import { NodeStatus, NodeType } from "@/app/store/types/node";
 import * as factory from "@/testing/factories";
-import { screen, renderWithMockStore } from "@/testing/utils";
+import { systemResolvers } from "@/testing/resolvers/system";
+import {
+  screen,
+  renderWithMockStore,
+  setupMockServer,
+  waitFor,
+} from "@/testing/utils";
 
 let state: RootState;
 const originalEnv = process.env;
+const mockServer = setupMockServer(systemResolvers.getSystemInfo.handler());
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -35,7 +42,7 @@ afterEach(() => {
   process.env = originalEnv;
 });
 
-it("can show if a machine is currently commissioning", () => {
+it("can show if a machine is currently commissioning", async () => {
   state.machine.items = [
     factory.machineDetails({
       fqdn: "test.maas",
@@ -46,10 +53,14 @@ it("can show if a machine is currently commissioning", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(screen.getByText(/Commissioning in progress.../)).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Commissioning in progress.../)
+    ).toBeInTheDocument();
+  });
 });
 
-it("can show if a machine has not been commissioned yet", () => {
+it("can show if a machine has not been commissioned yet", async () => {
   state.machine.items = [
     factory.machineDetails({
       commissioning_start_time: factory.timestamp(""),
@@ -60,10 +71,12 @@ it("can show if a machine has not been commissioned yet", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(screen.getByText(/Not yet commissioned/)).toBeInTheDocument();
+  await waitFor(() => {
+    expect(screen.getByText(/Not yet commissioned/)).toBeInTheDocument();
+  });
 });
 
-it("can show the last time a machine was commissioned", () => {
+it("can show the last time a machine was commissioned", async () => {
   state.machine.items = [
     factory.machineDetails({
       enable_hw_sync: false,
@@ -76,12 +89,14 @@ it("can show the last time a machine was commissioned", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(
-    screen.getByText(/Last commissioned: 1 minute ago/)
-  ).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Last commissioned: 1 minute ago/)
+    ).toBeInTheDocument();
+  });
 });
 
-it("can handle an incorrectly formatted commissioning timestamp", () => {
+it("can handle an incorrectly formatted commissioning timestamp", async () => {
   state.machine.items = [
     factory.machineDetails({
       enable_hw_sync: false,
@@ -94,12 +109,14 @@ it("can handle an incorrectly formatted commissioning timestamp", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(
-    screen.getByText(/Unable to parse commissioning timestamp/)
-  ).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Unable to parse commissioning timestamp/)
+    ).toBeInTheDocument();
+  });
 });
 
-it("displays Last and Next sync instead of Last commissioned date for deployed machines with hardware sync enabled ", () => {
+it("displays Last and Next sync instead of Last commissioned date for deployed machines with hardware sync enabled ", async () => {
   state.machine.items = [
     factory.machineDetails({
       commissioning_start_time: factory.timestamp("Thu, 31 Dec. 2020 22:59:00"),
@@ -114,9 +131,11 @@ it("displays Last and Next sync instead of Last commissioned date for deployed m
 
   renderWithMockStore(<StatusBar />, { state: state });
 
-  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
-    /Last commissioned/
-  );
+  await waitFor(() => {
+    expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+      /Last commissioned/
+    );
+  });
   expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
     /test.maas/
   );
@@ -128,7 +147,7 @@ it("displays Last and Next sync instead of Last commissioned date for deployed m
   );
 });
 
-it("doesn't display last or next sync for deploying machines with hardware sync enabled", () => {
+it("doesn't display last or next sync for deploying machines with hardware sync enabled", async () => {
   state.machine.items = [
     factory.machineDetails({
       commissioning_start_time: factory.timestamp("Thu, 31 Dec. 2020 22:59:00"),
@@ -145,9 +164,11 @@ it("doesn't display last or next sync for deploying machines with hardware sync 
     state,
   });
 
-  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-    /Last commissioned/
-  );
+  await waitFor(() => {
+    expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+      /Last commissioned/
+    );
+  });
   expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
     /Last synced/
   );
@@ -156,7 +177,7 @@ it("doesn't display last or next sync for deploying machines with hardware sync 
   );
 });
 
-it("displays correct text for machines with hardware sync enabled and no last_sync or next_sync", () => {
+it("displays correct text for machines with hardware sync enabled and no last_sync or next_sync", async () => {
   state.machine.items = [
     factory.machineDetails({
       commissioning_start_time: factory.timestamp("Thu, 31 Dec. 2020 22:59:00"),
@@ -173,9 +194,11 @@ it("displays correct text for machines with hardware sync enabled and no last_sy
     state,
   });
 
-  expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
-    /Last commissioned/
-  );
+  await waitFor(() => {
+    expect(screen.getByTestId("status-bar-status")).not.toHaveTextContent(
+      /Last commissioned/
+    );
+  });
   expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
     /test.maas/
   );
@@ -187,7 +210,7 @@ it("displays correct text for machines with hardware sync enabled and no last_sy
   );
 });
 
-it("displays last image sync timestamp for a rack or region+rack controller", () => {
+it("displays last image sync timestamp for a rack or region+rack controller", async () => {
   const controller = factory.controllerDetails({
     last_image_sync: factory.timestamp("Thu, 02 Jun. 2022 00:48:41"),
     node_type: NodeType.RACK_CONTROLLER,
@@ -197,12 +220,14 @@ it("displays last image sync timestamp for a rack or region+rack controller", ()
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
-    `Last image sync: Thu, 02 Jun. 2022 00:48:41 (UTC)`
-  );
+  await waitFor(() => {
+    expect(screen.getByTestId("status-bar-status")).toHaveTextContent(
+      `Last image sync: Thu, 02 Jun. 2022 00:48:41 (UTC)`
+    );
+  });
 });
 
-it("displays the feedback link when analytics enabled and not in development environment", () => {
+it("displays the feedback link when analytics enabled and not in development environment", async () => {
   process.env = { ...originalEnv, NODE_ENV: "production" };
 
   state.config = factory.configState({
@@ -214,12 +239,14 @@ it("displays the feedback link when analytics enabled and not in development env
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(
-    screen.getByRole("button", { name: "Give feedback" })
-  ).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByRole("button", { name: "Give feedback" })
+    ).toBeInTheDocument();
+  });
 });
 
-it("hides the feedback link when analytics disabled", () => {
+it("hides the feedback link when analytics disabled", async () => {
   process.env = { ...originalEnv, NODE_ENV: "production" };
   state.config = factory.configState({
     items: [
@@ -229,12 +256,14 @@ it("hides the feedback link when analytics disabled", () => {
   });
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(
-    screen.queryByRole("button", { name: "Give feedback" })
-  ).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("button", { name: "Give feedback" })
+    ).not.toBeInTheDocument();
+  });
 });
 
-it("hides the feedback link in development environment", () => {
+it("hides the feedback link in development environment", async () => {
   process.env = { ...originalEnv, NODE_ENV: "development" };
   state.config = factory.configState({
     items: [
@@ -244,12 +273,14 @@ it("hides the feedback link in development environment", () => {
   });
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(
-    screen.queryByRole("button", { name: "Give feedback" })
-  ).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.queryByRole("button", { name: "Give feedback" })
+    ).not.toBeInTheDocument();
+  });
 });
 
-it("displays the status message when connected to MAAS Site Manager", () => {
+it("displays the status message when connected to MAAS Site Manager", async () => {
   state.msm = factory.msmState({
     status: factory.msmStatus({
       running: "not_connected",
@@ -258,9 +289,11 @@ it("displays the status message when connected to MAAS Site Manager", () => {
 
   const { rerender } = renderWithMockStore(<StatusBar />, { state });
 
-  expect(
-    screen.queryByText("Connected to MAAS Site Manager")
-  ).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.queryByText("Connected to MAAS Site Manager")
+    ).not.toBeInTheDocument();
+  });
 
   rerender(<StatusBar />, {
     state: (draft) => {
@@ -272,12 +305,14 @@ it("displays the status message when connected to MAAS Site Manager", () => {
     },
   });
 
-  expect(
-    screen.getByText("Connected to MAAS Site Manager")
-  ).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByText("Connected to MAAS Site Manager")
+    ).toBeInTheDocument();
+  });
 });
 
-it("correctly calculates the last commissioned time when multiple commissioning events are present", () => {
+it("correctly calculates the last commissioned time when multiple commissioning events are present", async () => {
   state.machine.items = [
     factory.machineDetails({
       fqdn: "multi-event.maas",
@@ -309,12 +344,14 @@ it("correctly calculates the last commissioned time when multiple commissioning 
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(
-    screen.getByText(/Last commissioned: about 1 hour ago/)
-  ).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Last commissioned: about 1 hour ago/)
+    ).toBeInTheDocument();
+  });
 });
 
-it("handles invalid commissioning event timestamp", () => {
+it("handles invalid commissioning event timestamp", async () => {
   state.machine.items = [
     factory.machineDetails({
       fqdn: "invalid-timestamp.maas",
@@ -334,7 +371,82 @@ it("handles invalid commissioning event timestamp", () => {
 
   renderWithMockStore(<StatusBar />, { state });
 
-  expect(
-    screen.getByText(/Unable to parse commissioning timestamp/)
-  ).toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      screen.getByText(/Unable to parse commissioning timestamp/)
+    ).toBeInTheDocument();
+  });
+});
+
+it("displays 'FIPS enabled' when FIPS is active and hardening is not", async () => {
+  mockServer.use(
+    systemResolvers.getSystemInfo.handler(
+      factory.systemInfo({
+        fips_active: true,
+        hardening_active: false,
+      })
+    )
+  );
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  await waitFor(() => {
+    expect(screen.getByText("FIPS enabled")).toBeInTheDocument();
+  });
+});
+
+it("displays 'Hardening enabled' link when hardening is active and FIPS is not", async () => {
+  mockServer.use(
+    systemResolvers.getSystemInfo.handler(
+      factory.systemInfo({
+        fips_active: false,
+        hardening_active: true,
+      })
+    )
+  );
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  await waitFor(() => {
+    expect(
+      screen.getByRole("link", {
+        name: "Hardening enabled",
+      })
+    ).toBeInTheDocument();
+  });
+  const hardeningLink = screen.getByRole("link", {
+    name: "Hardening enabled",
+  });
+  expect(hardeningLink).toHaveAttribute(
+    "href",
+    expect.stringContaining(
+      "/docs/reference/configuration-guides/security-hardening/"
+    )
+  );
+});
+
+it("displays 'FIPS and hardening enabled' with hardening as a link when both are active", async () => {
+  mockServer.use(
+    systemResolvers.getSystemInfo.handler(
+      factory.systemInfo({
+        fips_active: true,
+        hardening_active: true,
+      })
+    )
+  );
+
+  renderWithMockStore(<StatusBar />, { state });
+
+  await waitFor(() => {
+    expect(screen.getByText(/FIPS and/i)).toBeInTheDocument();
+  });
+  expect(screen.getByText(/enabled/i)).toBeInTheDocument();
+  const hardeningLink = screen.getByRole("link", { name: "hardening" });
+  expect(hardeningLink).toBeInTheDocument();
+  expect(hardeningLink).toHaveAttribute(
+    "href",
+    expect.stringContaining(
+      "/docs/reference/configuration-guides/security-hardening/"
+    )
+  );
 });

--- a/src/app/base/components/StatusBar/StatusBar.tsx
+++ b/src/app/base/components/StatusBar/StatusBar.tsx
@@ -5,6 +5,7 @@ import { useSelector } from "react-redux";
 
 import TooltipButton from "../TooltipButton";
 
+import { useSystemInfo } from "@/app/api/query/system";
 import { useFetchActions, useUsabilla } from "@/app/base/hooks";
 import configSelectors from "@/app/store/config/selectors";
 import controllerSelectors from "@/app/store/controller/selectors";
@@ -13,7 +14,6 @@ import {
   isRack,
   isRegionAndRack,
 } from "@/app/store/controller/utils";
-import { version as versionSelectors } from "@/app/store/general/selectors";
 import machineSelectors from "@/app/store/machine/selectors";
 import type { MachineDetails } from "@/app/store/machine/types";
 import {
@@ -88,14 +88,15 @@ const getSyncStatusString = (syncStatus: UtcDatetime) => {
 export const StatusBar = (): React.ReactElement | null => {
   const activeController = useSelector(controllerSelectors.active);
   const activeMachine = useSelector(machineSelectors.active);
-  const version = useSelector(versionSelectors.get);
   const maasName = useSelector(configSelectors.maasName);
   const allowUsabilla = useUsabilla();
   const msmRunning = useSelector(msmSelectors.running);
 
+  const systemInfo = useSystemInfo();
+
   useFetchActions([msmActions.fetch]);
 
-  if (!(maasName && version)) {
+  if (!(maasName && systemInfo.isSuccess)) {
     return null;
   }
 
@@ -136,7 +137,9 @@ export const StatusBar = (): React.ReactElement | null => {
         <div className="p-status-bar__primary u-flex--no-shrink u-flex--wrap">
           <strong data-testid="status-bar-maas-name">{maasName} MAAS</strong>
           :&nbsp;
-          <span data-testid="status-bar-version">{version}</span>
+          <span data-testid="status-bar-version">
+            {systemInfo.data.version}
+          </span>
         </div>
         <div className="p-status-bar__primary u-flex--no-shrink u-flex--wrap">
           <span data-testid="status-bar-msm-status">
@@ -153,6 +156,40 @@ Site Manager as its upstream image source."
           </span>
         </div>
         <ul className="p-inline-list--middot u-no-margin--bottom">
+          {systemInfo.data.fips_active || systemInfo.data.hardening_active ? (
+            <li className="p-inline-list__item">
+              {systemInfo.data.fips_active &&
+              !systemInfo.data.hardening_active ? (
+                <>FIPS enabled</>
+              ) : null}
+              {!systemInfo.data.fips_active &&
+              systemInfo.data.hardening_active ? (
+                <>
+                  <Link
+                    href={`${import.meta.env.VITE_APP_BASENAME}/docs/reference/configuration-guides/security-hardening/`}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    Hardening enabled
+                  </Link>
+                </>
+              ) : null}
+              {systemInfo.data.fips_active &&
+              systemInfo.data.hardening_active ? (
+                <>
+                  FIPS and{" "}
+                  <Link
+                    href={`${import.meta.env.VITE_APP_BASENAME}/docs/reference/configuration-guides/security-hardening/`}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    hardening
+                  </Link>{" "}
+                  enabled
+                </>
+              ) : null}
+            </li>
+          ) : null}
           <li className="p-inline-list__item">
             <Link
               href={`${import.meta.env.VITE_APP_BASENAME}/docs/`}

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -201,6 +201,7 @@ export {
   subnetStatistics,
   subnetStatisticsRange,
 } from "./subnet";
+export { systemInfo } from "./system";
 export { tag } from "./tag";
 export { token } from "./token";
 export { user } from "./user";

--- a/src/testing/factories/system.ts
+++ b/src/testing/factories/system.ts
@@ -1,0 +1,9 @@
+import { define } from "cooky-cutter";
+
+import type { SystemInfoResponse } from "@/app/apiclient";
+
+export const systemInfo = define<SystemInfoResponse>({
+  fips_active: false,
+  hardening_active: false,
+  version: "3.7",
+});

--- a/src/testing/resolvers/system.ts
+++ b/src/testing/resolvers/system.ts
@@ -1,0 +1,36 @@
+import { http, HttpResponse } from "msw";
+
+import { BASE_URL } from "../utils";
+
+import type {
+  GetSystemInfoError,
+  GetSystemInfoResponse,
+  SystemInfoResponse,
+} from "@/app/apiclient";
+import { systemInfo as systemInfoFactory } from "@/testing/factories";
+
+const mockSystemInfo: SystemInfoResponse = systemInfoFactory();
+
+const mockSystemInfoError: GetSystemInfoError = {
+  message: "Unauthorized",
+  code: 401,
+  kind: "Error",
+};
+
+const systemResolvers = {
+  getSystemInfo: {
+    resolved: false,
+    handler: (data: GetSystemInfoResponse = mockSystemInfo) =>
+      http.get(`${BASE_URL}MAAS/a/v3/system/info`, () => {
+        systemResolvers.getSystemInfo.resolved = true;
+        return HttpResponse.json(data);
+      }),
+    error: (error: GetSystemInfoError = mockSystemInfoError) =>
+      http.get(`${BASE_URL}MAAS/a/v3/system/info`, () => {
+        systemResolvers.getSystemInfo.resolved = true;
+        return HttpResponse.json(error, { status: error.code });
+      }),
+  },
+};
+
+export { systemResolvers, mockSystemInfo };


### PR DESCRIPTION
## Done

- Added info for hardening and FIPS to status bar
- Added link to local documentation on hardening
- Used API v3 for fetching version information
- Updated API client

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

You'll need a MAAS running the fips-3.7 branch.

- [x] Go to MAAS UI
- [x] Ensure the version displays correctly in the status bar
- [x] Either by actually enabling FIPS and hardening, or faking response data, ensure that the correct status information in the footer is displayed for:
- - [x] FIPS only
- - [x] Hardening only
- - [x] Both FIPS and hardening
- [x] Ensure that the link to documentation for hardening works and is appropriate

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6810](https://warthogs.atlassian.net/browse/MAASENG-6810)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots
<img width="479" height="318" alt="image" src="https://github.com/user-attachments/assets/0b0e96e0-2a58-4779-8daf-31cbc35f1085" />
<img width="370" height="209" alt="image" src="https://github.com/user-attachments/assets/5bb4489f-8d52-44c6-8452-ba1ee0b3f717" />
<img width="404" height="209" alt="image" src="https://github.com/user-attachments/assets/066fc906-830d-4d5b-ba29-3fe7d6062e5e" />


<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

[MAASENG-6810]: https://warthogs.atlassian.net/browse/MAASENG-6810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ