### PR TITLE
fix(machines): update machines list when a new machine is manually added

### DIFF
--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.tsx
@@ -161,6 +161,7 @@ export const AddMachineForm = (): ReactElement => {
             dispatch(machineActions.create(params));
           }}
           onSuccess={() => {
+            dispatch(machineActions.invalidateQueries());
             if (!secondarySubmit) {
               closeSidePanel();
             }


### PR DESCRIPTION
## Done

- Previously, from the `/machines` route, when you added a new machine using `Add Hardware` > `Machine`, the machines table would show stale values, and the new machine wasn't visible until you refreshed the page
- This PR fixes that by invalidating `machineActions` queries, forcing a re-fetch of the machines list

## QA steps

- [x] Sign in to MAAS and go to `/machines`
- [x] Click `Add hardware` > `Machine`
- [x] Give the machine a name, a sample MAC address, and select a power type of "Manual"
- [x] Click "Save machine"
- [x] Ensure the side panel closes and the machine is visible in the table
