### PR TITLE
fix: don't wait for spinner to load for sitespeed tests

### DIFF
--- a/sitespeed.io/login.js
+++ b/sitespeed.io/login.js
@@ -29,9 +29,5 @@ module.exports = async function (context, commands) {
     TIMEOUT
   );
   await commands.click.bySelector("button.p-button--positive");
-  await commands.wait.bySelector(
-    "[data-testid='section-header-title-spinner']",
-    TIMEOUT
-  );
   await commands.wait.byXpath("//a//span[text()='admin']", TIMEOUT);
 };


### PR DESCRIPTION
## Done

- In [PR#6124](https://github.com/canonical/maas-ui/pull/6124) (feat(base): Implement upstream layout MAASENG-6783), we implemented upstream loading utilities (like skeleton loaders)
- The sitespeed.io test was still waiting for the old loading indicator (the spinner) to be visible, causing the test to fail
- This check has now been removed

Successful test run: https://github.com/nehjoshi/maas-ui/actions/runs/34118372402/job/101730394063