### PR TITLE
feat(machines): disable power types not supported by FIPS when active MAASENG-6811

### DIFF
--- a/cypress/e2e/with-users/machines/details.spec.ts
+++ b/cypress/e2e/with-users/machines/details.spec.ts
@@ -15,7 +15,8 @@ context("Machine details", () => {
     });
     cy.findByLabelText("Machine name").type(name);
     cy.findByLabelText("MAC address").type(generateMac());
-    cy.findByLabelText("Power type").select("Manual");
+    cy.findByRole("button", { name: /Power type/i }).click();
+    cy.findByText("Manual").click();
     cy.get("button[type='submit']").click();
     return { name };
   };

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -49,8 +49,9 @@ Cypress.Commands.add("addMachine", (hostname = generateName()) => {
   cy.get(".p-contextual-menu__link").contains("Machine").click();
   cy.get("input[name='hostname']").type(hostname);
   cy.get("input[name='pxe_mac']").type(generateMac());
-  cy.get("select[name='power_type']").select("manual");
-  cy.get("select[name='power_type']").blur();
+  cy.findByRole("button", { name: /Power type/i }).click();
+  cy.findByText("Manual").click();
+  cy.findByRole("button", { name: /Power type/i }).blur();
   cy.findByRole("button", { name: /save machine/i }).click();
   cy.get(`[data-testid='message']:contains(${hostname} added successfully.)`, {
     timeout: LONG_TIMEOUT,

--- a/src/app/api/query/powerTypes.test.ts
+++ b/src/app/api/query/powerTypes.test.ts
@@ -1,0 +1,25 @@
+import { usePowerTypes } from "./powerTypes";
+
+import {
+  mockPowerTypes,
+  powerTypesResolvers,
+} from "@/testing/resolvers/powerTypes";
+import {
+  renderHookWithProviders,
+  setupMockServer,
+  waitFor,
+} from "@/testing/utils";
+
+setupMockServer(powerTypesResolvers.listPowerTypes.handler());
+
+describe("usePowerTypes", () => {
+  it("should return power types data", async () => {
+    const { result } = renderHookWithProviders(() => usePowerTypes());
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockPowerTypes);
+  });
+});

--- a/src/app/api/query/powerTypes.ts
+++ b/src/app/api/query/powerTypes.ts
@@ -1,0 +1,21 @@
+import type { UseQueryOptions } from "@tanstack/react-query";
+
+import { useWebsocketAwareQuery } from "./base";
+
+import type {
+  ListPowerTypesData,
+  ListPowerTypesError,
+  ListPowerTypesResponse,
+  Options,
+} from "@/app/apiclient";
+import { listPowerTypesOptions } from "@/app/apiclient/@tanstack/react-query.gen";
+
+export const usePowerTypes = (options?: Options<ListPowerTypesData>) => {
+  return useWebsocketAwareQuery(
+    listPowerTypesOptions(options) as UseQueryOptions<
+      ListPowerTypesData,
+      ListPowerTypesError,
+      ListPowerTypesResponse
+    >
+  );
+};

--- a/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
+++ b/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
@@ -6,12 +6,21 @@ import { PowerTypeNames } from "@/app/store/general/constants";
 import { PowerFieldScope, PowerFieldType } from "@/app/store/general/types";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
+import { powerTypesResolvers } from "@/testing/resolvers/powerTypes";
+import { systemResolvers } from "@/testing/resolvers/system";
 import {
   renderWithMockStore,
   screen,
+  setupMockServer,
   userEvent,
+  waitForLoading,
   within,
 } from "@/testing/utils";
+
+const mockServer = setupMockServer(
+  powerTypesResolvers.listPowerTypes.handler(),
+  systemResolvers.getSystemInfo.handler()
+);
 
 describe("PowerTypeFields", () => {
   let state: RootState;
@@ -25,7 +34,7 @@ describe("PowerTypeFields", () => {
     });
   });
 
-  it("correctly generates power options from power type", () => {
+  it("correctly generates power options from power type", async () => {
     const powerTypes = [
       factory.powerType({
         fields: [
@@ -65,6 +74,8 @@ describe("PowerTypeFields", () => {
       { state }
     );
 
+    await waitForLoading();
+
     expect(
       screen.getByRole("textbox", { name: "Required text" })
     ).toBeInTheDocument();
@@ -92,7 +103,7 @@ describe("PowerTypeFields", () => {
     });
   });
 
-  it("does not show select if showSelect is false", () => {
+  it("does not show select if showSelect is false", async () => {
     const powerTypes = [
       factory.powerType({
         fields: [
@@ -113,10 +124,12 @@ describe("PowerTypeFields", () => {
       { state }
     );
 
+    await waitForLoading();
+
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
   });
 
-  it("can limit the fields to show based on their scope", () => {
+  it("can limit the fields to show based on their scope", async () => {
     const powerTypes = [
       factory.powerType({
         fields: [
@@ -145,6 +158,8 @@ describe("PowerTypeFields", () => {
       { state }
     );
 
+    await waitForLoading();
+
     expect(
       screen.getByRole("textbox", { name: "Field 1" })
     ).toBeInTheDocument();
@@ -153,7 +168,7 @@ describe("PowerTypeFields", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("can only show power types suitable for chassis", () => {
+  it("can only show power types suitable for chassis", async () => {
     const powerTypes = [
       factory.powerType({
         can_probe: true,
@@ -176,13 +191,15 @@ describe("PowerTypeFields", () => {
       { state }
     );
 
+    await waitForLoading();
+
     expect(screen.getByRole("option", { name: "virsh" })).toBeInTheDocument();
     expect(
       screen.queryByRole("option", { name: "manual" })
     ).not.toBeInTheDocument();
   });
 
-  it("can be given different values for formik field names", () => {
+  it("can be given different values for formik field names", async () => {
     const powerTypes = [
       factory.powerType({
         fields: [
@@ -208,6 +225,8 @@ describe("PowerTypeFields", () => {
       { state }
     );
 
+    await waitForLoading();
+
     expect(
       screen.getByRole("combobox", { name: "Power type" })
     ).toBeInTheDocument();
@@ -220,7 +239,7 @@ describe("PowerTypeFields", () => {
     );
   });
 
-  it("can disable the power type select", () => {
+  it("can disable the power type select", async () => {
     renderWithMockStore(
       <Formik
         initialValues={{
@@ -233,6 +252,8 @@ describe("PowerTypeFields", () => {
       </Formik>,
       { state }
     );
+
+    await waitForLoading();
 
     expect(screen.getByRole("combobox", { name: "Power type" })).toBeDisabled();
   });
@@ -291,6 +312,8 @@ describe("PowerTypeFields", () => {
       { state }
     );
 
+    await waitForLoading();
+
     // Fields should have changed parameters
     expect(screen.getByRole("textbox", { name: "Parameter 1" })).toHaveValue(
       "changed parameter1"
@@ -317,7 +340,7 @@ describe("PowerTypeFields", () => {
     );
   });
 
-  it("renders LXD power fields with custom props if selected", () => {
+  it("renders LXD power fields with custom props if selected", async () => {
     const powerTypes = [
       factory.powerType({
         fields: [
@@ -344,6 +367,8 @@ describe("PowerTypeFields", () => {
       { state }
     );
 
+    await waitForLoading();
+
     expect(
       screen.getByRole("textbox", { name: "Password" })
     ).toBeInTheDocument();
@@ -365,5 +390,152 @@ describe("PowerTypeFields", () => {
     expect(
       screen.getByRole("textbox", { name: "Upload private key" })
     ).toBeInTheDocument();
+  });
+
+  it("disables power types not supported by FIPS when FIPS is active and shows reasons", async () => {
+    const fipsUnsupportedPowerTypesResponse = {
+      items: [
+        factory.powerTypeV3({
+          name: "manual",
+          description: "Manual",
+          fips_supported: true,
+          fips_unsupported_reason: undefined,
+        }),
+        factory.powerTypeV3({
+          name: "amt",
+          description: "Intel AMT",
+          fips_supported: false,
+          fips_unsupported_reason: "uses non-approved cryptography",
+        }),
+        factory.powerTypeV3({
+          name: "apc",
+          description: "APC PDU",
+          fips_supported: false,
+          fips_unsupported_reason: "network vulnerability",
+        }),
+      ],
+    };
+
+    mockServer.use(
+      powerTypesResolvers.listPowerTypes.handler(
+        fipsUnsupportedPowerTypesResponse
+      ),
+      systemResolvers.getSystemInfo.handler(
+        factory.systemInfo({ fips_active: true })
+      )
+    );
+
+    const powerTypes = [
+      factory.powerType({
+        name: "manual",
+        description: "Manual",
+      }),
+      factory.powerType({
+        name: "amt",
+        description: "Intel AMT",
+      }),
+      factory.powerType({
+        name: "apc",
+        description: "APC PDU",
+      }),
+    ];
+    state.general.powerTypes.data = powerTypes;
+
+    renderWithMockStore(
+      <Formik
+        initialValues={{
+          power_parameters: {},
+          power_type: PowerTypeNames.MANUAL,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <PowerTypeFields />
+      </Formik>,
+      { state }
+    );
+
+    await waitForLoading();
+
+    // Manual power type should be enabled
+    expect(screen.getByRole("option", { name: /Manual$/ })).not.toBeDisabled();
+
+    // FIPS-unsupported power types should be disabled and show the reason
+    expect(
+      screen.getByRole("option", {
+        name: "Intel AMT - disabled due to uses non-approved cryptography",
+      })
+    ).toBeDisabled();
+
+    expect(
+      screen.getByRole("option", {
+        name: "APC PDU - disabled due to network vulnerability",
+      })
+    ).toBeDisabled();
+  });
+
+  it("shows all power types without FIPS reasons when FIPS is not active", async () => {
+    const noFipsRestrictionsResponse = {
+      items: [
+        factory.powerTypeV3({
+          name: "manual",
+          description: "Manual",
+          fips_supported: true,
+          fips_unsupported_reason: undefined,
+        }),
+        factory.powerTypeV3({
+          name: "amt",
+          description: "Intel AMT",
+          fips_supported: false,
+          fips_unsupported_reason: "uses non-approved cryptography",
+        }),
+      ],
+    };
+
+    mockServer.use(
+      powerTypesResolvers.listPowerTypes.handler(noFipsRestrictionsResponse),
+      systemResolvers.getSystemInfo.handler(
+        factory.systemInfo({ fips_active: false })
+      )
+    );
+
+    const powerTypes = [
+      factory.powerType({
+        name: "manual",
+        description: "Manual",
+      }),
+      factory.powerType({
+        name: "amt",
+        description: "Intel AMT",
+      }),
+    ];
+    state.general.powerTypes.data = powerTypes;
+
+    renderWithMockStore(
+      <Formik
+        initialValues={{
+          power_parameters: {},
+          power_type: PowerTypeNames.MANUAL,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <PowerTypeFields />
+      </Formik>,
+      { state }
+    );
+
+    await waitForLoading();
+
+    // All power types should be enabled
+    expect(screen.getByRole("option", { name: "Manual" })).not.toBeDisabled();
+    expect(
+      screen.getByRole("option", { name: "Intel AMT" })
+    ).not.toBeDisabled();
+
+    // No FIPS reason messages should be shown in the labels
+    expect(
+      screen.queryByRole("option", {
+        name: /disabled due to/,
+      })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
+++ b/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
@@ -9,6 +9,7 @@ import * as factory from "@/testing/factories";
 import { powerTypesResolvers } from "@/testing/resolvers/powerTypes";
 import { systemResolvers } from "@/testing/resolvers/system";
 import {
+  expectTooltipOnHover,
   renderWithMockStore,
   screen,
   setupMockServer,
@@ -193,6 +194,8 @@ describe("PowerTypeFields", () => {
 
     await waitForLoading();
 
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+
     expect(screen.getByRole("option", { name: "virsh" })).toBeInTheDocument();
     expect(
       screen.queryByRole("option", { name: "manual" })
@@ -228,7 +231,7 @@ describe("PowerTypeFields", () => {
     await waitForLoading();
 
     expect(
-      screen.getByRole("combobox", { name: "Power type" })
+      screen.getByRole("button", { name: "Power type" })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("textbox", { name: "Parameter 1" })
@@ -255,7 +258,10 @@ describe("PowerTypeFields", () => {
 
     await waitForLoading();
 
-    expect(screen.getByRole("combobox", { name: "Power type" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Power type" })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
   });
 
   it("resets the fields of the selected power type on change", async () => {
@@ -323,10 +329,8 @@ describe("PowerTypeFields", () => {
     );
 
     // Change power type to "virsh"
-    await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: "Power type" }),
-      screen.getByRole("option", { name: "virsh" })
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+    await userEvent.click(screen.getByRole("option", { name: "virsh" }));
 
     // Fields of selected power type should be reset to defaults
     expect(screen.getByRole("textbox", { name: "Parameter 1" })).toHaveValue(
@@ -456,21 +460,22 @@ describe("PowerTypeFields", () => {
 
     await waitForLoading();
 
-    // Manual power type should be enabled
-    expect(screen.getByRole("option", { name: /Manual$/ })).not.toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
 
-    // FIPS-unsupported power types should be disabled and show the reason
-    expect(
-      screen.getByRole("option", {
-        name: "Intel AMT - disabled due to uses non-approved cryptography",
-      })
-    ).toBeDisabled();
-
-    expect(
-      screen.getByRole("option", {
-        name: "APC PDU - disabled due to network vulnerability",
-      })
-    ).toBeDisabled();
+    // FIPS-unsupported power types should show their reason as a tooltip
+    // (hover the tooltip's inner wrapper, since it holds the hover handlers)
+    await expectTooltipOnHover(
+      within(screen.getByRole("option", { name: "Intel AMT" })).getByText(
+        "Intel AMT"
+      ).parentElement,
+      "Disabled due to uses non-approved cryptography"
+    );
+    await expectTooltipOnHover(
+      within(screen.getByRole("option", { name: "APC PDU" })).getByText(
+        "APC PDU"
+      ).parentElement,
+      "Disabled due to network vulnerability"
+    );
   });
 
   it("shows all power types without FIPS reasons when FIPS is not active", async () => {
@@ -525,17 +530,14 @@ describe("PowerTypeFields", () => {
 
     await waitForLoading();
 
-    // All power types should be enabled
-    expect(screen.getByRole("option", { name: "Manual" })).not.toBeDisabled();
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+
+    expect(screen.getByRole("option", { name: "Manual" })).toBeInTheDocument();
     expect(
       screen.getByRole("option", { name: "Intel AMT" })
-    ).not.toBeDisabled();
+    ).toBeInTheDocument();
 
-    // No FIPS reason messages should be shown in the labels
-    expect(
-      screen.queryByRole("option", {
-        name: /disabled due to/,
-      })
-    ).not.toBeInTheDocument();
+    // No FIPS reason tooltip should be shown for any option
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 });

--- a/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -9,6 +9,8 @@ import IPMIPowerFields from "./IPMIPowerFields";
 import type { LXDPowerFieldsProps } from "./LXDPowerFields";
 import LXDPowerFields from "./LXDPowerFields";
 
+import { usePowerTypes } from "@/app/api/query/powerTypes";
+import { useSystemInfo } from "@/app/api/query/system";
 import FormikField from "@/app/base/components/FormikField";
 import { FormikFieldChangeError } from "@/app/base/components/FormikField/FormikField";
 import { useFetchActions } from "@/app/base/hooks";
@@ -58,6 +60,15 @@ export const PowerTypeFields = <V extends AnyObject>({
 
   useFetchActions([generalActions.fetchPowerTypes]);
 
+  const systemInfo = useSystemInfo();
+  const powerTypesResponse = usePowerTypes();
+
+  const powerTypesResponseData = powerTypesResponse.data?.items || [];
+  const fipsDisabledPowerTypes = powerTypesResponseData.filter(
+    (powerType) => powerType.fips_supported === false
+  );
+  const fipsActive = systemInfo.data?.fips_active;
+
   // Only power types that can probe are suitable for use when adding a chassis.
   const powerTypes = forChassis ? chassisPowerTypes : allPowerTypes;
 
@@ -67,7 +78,11 @@ export const PowerTypeFields = <V extends AnyObject>({
   const selectedPowerType = powerTypes.find(
     (type) => type.name === values[powerTypeValueName]
   );
-  if (!powerTypesLoaded) {
+  if (
+    !powerTypesLoaded ||
+    systemInfo.isPending ||
+    powerTypesResponse.isPending
+  ) {
     fieldContent = <Spinner text="Loading..." />;
   } else if (selectedPowerType) {
     const fieldsInScope = getFieldsInScope(selectedPowerType, fieldScopes);
@@ -140,8 +155,13 @@ export const PowerTypeFields = <V extends AnyObject>({
             { label: "Select power type", value: "", disabled: true },
             ...powerTypes.map((powerType) => ({
               key: `power-type-${powerType.name}`,
-              label: powerType.description,
+              label: `${powerType.description}${fipsActive && fipsDisabledPowerTypes?.some((type) => powerType.name === type.name) ? ` - disabled due to ${fipsDisabledPowerTypes.find((type) => type.name === powerType.name)?.fips_unsupported_reason}` : ""}`,
               value: powerType.name,
+              disabled:
+                fipsActive &&
+                fipsDisabledPowerTypes?.some(
+                  (disabledType) => powerType.name === disabledType.name
+                ),
             })),
           ]}
           required

--- a/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { Select, Spinner } from "@canonical/react-components";
+import { CustomSelect, Spinner, Tooltip } from "@canonical/react-components";
 import { useFormikContext } from "formik";
 import { useSelector } from "react-redux";
 
@@ -49,7 +49,6 @@ export const PowerTypeFields = <V extends AnyObject>({
   const chassisPowerTypes = useSelector(powerTypesSelectors.canProbe);
   const powerTypesLoaded = useSelector(powerTypesSelectors.loaded);
   const {
-    handleChange,
     initialErrors,
     initialTouched,
     setErrors,
@@ -119,19 +118,27 @@ export const PowerTypeFields = <V extends AnyObject>({
     <>
       {showSelect && (
         <FormikField
-          component={Select}
+          component={CustomSelect}
           disabled={!powerTypesLoaded || disableSelect}
           label="Power type"
           name={powerTypeValueName}
-          onChange={async (e: React.ChangeEvent<HTMLSelectElement>) => {
+          onChange={async (value: string) => {
             // Reset errors and touched formik state when selecting a new power
             // type, in order to start validation from new.
-            // eslint-disable-next-line @typescript-eslint/no-confusing-void-expression
-            await handleChange(e);
+
+            // CustomSelect passes the raw string value, not an event, so set
+            // the field directly rather than via formik's handleChange.
+            await setFieldValue(powerTypeValueName, value).catch((reason) => {
+              throw new FormikFieldChangeError(
+                powerTypeValueName,
+                "setFieldValue",
+                reason
+              );
+            });
             setErrors(initialErrors);
             setTouched(initialTouched);
 
-            const powerType = getPowerTypeFromName(powerTypes, e.target.value);
+            const powerType = getPowerTypeFromName(powerTypes, value);
             // Explicitly set the fields of the selected power type to defaults.
             // This is necessary because some field names are shared across
             // power types (e.g. "power_address"), meaning the value would otherwise
@@ -155,7 +162,28 @@ export const PowerTypeFields = <V extends AnyObject>({
             { label: "Select power type", value: "", disabled: true },
             ...powerTypes.map((powerType) => ({
               key: `power-type-${powerType.name}`,
-              label: `${powerType.description}${fipsActive && fipsDisabledPowerTypes?.some((type) => powerType.name === type.name) ? ` - disabled due to ${fipsDisabledPowerTypes.find((type) => type.name === powerType.name)?.fips_unsupported_reason}` : ""}`,
+              label: (
+                <>
+                  <Tooltip
+                    message={
+                      fipsActive &&
+                      fipsDisabledPowerTypes?.some(
+                        (type) => powerType.name === type.name
+                      )
+                        ? `Disabled due to ${
+                            fipsDisabledPowerTypes.find(
+                              (type) => type.name === powerType.name
+                            )?.fips_unsupported_reason
+                          }`
+                        : ""
+                    }
+                    position="left"
+                  >
+                    {powerType.description}
+                  </Tooltip>
+                </>
+              ),
+              text: powerType.description,
               value: powerType.name,
               disabled:
                 fipsActive &&
@@ -165,6 +193,8 @@ export const PowerTypeFields = <V extends AnyObject>({
             })),
           ]}
           required
+          searchable="never"
+          value={`${values[powerTypeValueName]}`}
         />
       )}
       {fieldContent}

--- a/src/app/machines/components/MachineForms/AddChassis/AddChassisForm/AddChassisForm.test.tsx
+++ b/src/app/machines/components/MachineForms/AddChassis/AddChassisForm/AddChassisForm.test.tsx
@@ -164,10 +164,8 @@ describe("AddChassisForm", () => {
     );
 
     // Select vmware from power types dropdown
-    await userEvent.selectOptions(
-      screen.getByLabelText("Power type"),
-      "vmware"
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+    await userEvent.click(screen.getByRole("option", { name: "VMware" }));
 
     await userEvent.type(
       screen.getByRole("textbox", { name: "VMware IP" }),

--- a/src/app/machines/components/MachineForms/AddChassis/AddChassisFormFields/AddChassisFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/AddChassis/AddChassisFormFields/AddChassisFormFields.test.tsx
@@ -34,7 +34,7 @@ describe("AddChassisFormFields", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("option", { name: "maas" })).toBeInTheDocument();
     expect(
-      screen.getByRole("combobox", { name: "Power type" })
+      screen.getByRole("button", { name: "Power type" })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Save chassis" })
@@ -84,10 +84,13 @@ describe("AddChassisFormFields", () => {
       { route: "/machines/chassis/add", state }
     );
 
-    const powerTypeSelect = screen.getByRole("combobox", {
+    const powerTypeSelect = screen.getByRole("button", {
       name: "Power type",
     });
-    await userEvent.selectOptions(powerTypeSelect, PowerTypeNames.VIRSH);
+    await userEvent.click(powerTypeSelect);
+    await userEvent.click(
+      screen.getByRole("option", { name: "Virsh (virtual systems)" })
+    );
 
     expect(screen.getByLabelText(/Address/i)).toBeInTheDocument();
     expect(screen.queryByLabelText(/Virsh VM ID/i)).not.toBeInTheDocument();

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineForm/AddMachineForm.test.tsx
@@ -49,10 +49,12 @@ describe("AddMachineForm", () => {
           data: [
             factory.powerType({
               name: "manual",
+              description: "Manual",
               fields: [],
             }),
             factory.powerType({
               name: "amt",
+              description: "AMT",
               fields: [
                 factory.powerField({
                   name: "power_address",
@@ -63,6 +65,7 @@ describe("AddMachineForm", () => {
             }),
             factory.powerType({
               name: "apc",
+              description: "APC",
               fields: [
                 factory.powerField({
                   name: "power_id",
@@ -131,10 +134,10 @@ describe("AddMachineForm", () => {
     await waitFor(() => {
       expect(screen.queryByTestId(/Loading/)).not.toBeInTheDocument();
     });
-    await userEvent.selectOptions(
-      await screen.findByRole("combobox", { name: "Power type" }),
-      "manual"
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Power type" })
     );
+    await userEvent.click(screen.getByRole("option", { name: "Manual" }));
     await userEvent.type(
       screen.getByRole("textbox", { name: "MAC address" }),
       "11:11:11:11:11:11"
@@ -192,10 +195,8 @@ describe("AddMachineForm", () => {
     await userEvent.click(
       screen.getByRole("checkbox", { name: /Register as DPU/i })
     );
-    await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: "Power type" }),
-      "manual"
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+    await userEvent.click(screen.getByRole("option", { name: "Manual" }));
     await userEvent.click(screen.getByRole("button", { name: "Save machine" }));
 
     const expectedAction = machineActions.create({
@@ -238,18 +239,14 @@ describe("AddMachineForm", () => {
       screen.getByRole("textbox", { name: "MAC address" }),
       "11:11:11:11:11:11"
     );
-    await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: "Power type" }),
-      "amt"
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+    await userEvent.click(screen.getByRole("option", { name: "AMT" }));
     const amtField = screen.getByRole("textbox", { name: "IP address" });
     await userEvent.type(amtField, "192.168.1.1");
 
     // Change power type and fill in new fields.
-    await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: "Power type" }),
-      "apc"
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+    await userEvent.click(screen.getByRole("option", { name: "APC" }));
     const apcField = screen.getByRole("textbox", { name: "Power ID" });
     await userEvent.clear(apcField);
     await userEvent.type(apcField, "12345");
@@ -290,15 +287,13 @@ describe("AddMachineForm", () => {
     );
     await waitFor(() => {
       expect(
-        screen.getByRole("combobox", { name: "Power type" })
+        screen.getByRole("button", { name: "Power type" })
       ).toBeInTheDocument();
     });
 
     // Submit the form with two extra macs, where one is an empty string
-    await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: "Power type" }),
-      "manual"
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+    await userEvent.click(screen.getByRole("option", { name: "Manual" }));
     await userEvent.type(
       screen.getByRole("textbox", { name: "MAC address" }),
       "11:11:11:11:11:11"

--- a/src/app/machines/components/MachineForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
+++ b/src/app/machines/components/MachineForms/AddMachine/AddMachineFormFields/AddMachineFormFields.test.tsx
@@ -168,10 +168,8 @@ describe("AddMachineFormFields", () => {
     });
     expect(screen.getByRole("textbox", { name: "MAC address" })).toBeRequired();
 
-    await userEvent.selectOptions(
-      screen.getByRole("combobox", { name: "Power type" }),
-      "ipmi"
-    );
+    await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+    await userEvent.click(screen.getByRole("option", { name: "IPMI" }));
 
     expect(
       screen.getByRole("textbox", { name: "MAC address" })

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerForm.test.tsx
@@ -27,6 +27,7 @@ beforeEach(() => {
       powerTypes: factory.powerTypesState({
         data: [
           factory.powerType({
+            description: "AMT",
             fields: [
               factory.powerField({
                 name: "amt-field",
@@ -38,6 +39,7 @@ beforeEach(() => {
             name: PowerTypeNames.AMT,
           }),
           factory.powerType({
+            description: "APC",
             fields: [
               factory.powerField({
                 name: "apc-field",
@@ -49,6 +51,7 @@ beforeEach(() => {
             name: PowerTypeNames.APC,
           }),
           factory.powerType({
+            description: "IPMI",
             fields: [
               factory.powerField({
                 name: "ip_address",
@@ -118,16 +121,10 @@ it("is editable if machine has edit permission", () => {
 
 it("renders read-only text fields until edit button is pressed", async () => {
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <PowerForm systemId="abc123" />
-      </MemoryRouter>
-    </Provider>
-  );
+  renderWithBrowserRouter(<PowerForm systemId="abc123" />, { store });
 
   expect(
-    screen.queryByRole("combobox", { name: "Power type" })
+    screen.queryByRole("button", { name: "Power type" })
   ).not.toBeInTheDocument();
 
   await userEvent.click(
@@ -135,7 +132,7 @@ it("renders read-only text fields until edit button is pressed", async () => {
   );
 
   expect(
-    screen.getByRole("combobox", { name: "Power type" })
+    screen.getByRole("button", { name: "Power type" })
   ).toBeInTheDocument();
 });
 
@@ -147,10 +144,8 @@ it("can validate IPv6 addresses with a port for IPMI power type", async () => {
     screen.getAllByRole("button", { name: Labels.EditButton })[0]
   );
 
-  await userEvent.selectOptions(
-    screen.getByRole("combobox", { name: "Power type" }),
-    PowerTypeNames.IPMI
-  );
+  await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+  await userEvent.click(screen.getByRole("option", { name: "IPMI" }));
 
   await userEvent.clear(screen.getByRole("textbox", { name: "IP address" }));
   await userEvent.type(
@@ -187,10 +182,8 @@ it("can validate IPv4 addresses with a port for IPMI power type", async () => {
     screen.getAllByRole("button", { name: Labels.EditButton })[0]
   );
 
-  await userEvent.selectOptions(
-    screen.getByRole("combobox", { name: "Power type" }),
-    PowerTypeNames.IPMI
-  );
+  await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+  await userEvent.click(screen.getByRole("option", { name: "IPMI" }));
 
   await userEvent.clear(screen.getByRole("textbox", { name: "IP address" }));
   await userEvent.type(
@@ -225,21 +218,13 @@ it("correctly dispatches an action to update a machine's power", async () => {
   });
   state.machine.items = [machine];
   const store = mockStore(state);
-  render(
-    <Provider store={store}>
-      <MemoryRouter>
-        <PowerForm systemId="abc123" />
-      </MemoryRouter>
-    </Provider>
-  );
+  renderWithBrowserRouter(<PowerForm systemId="abc123" />, { store });
 
   await userEvent.click(
     screen.getAllByRole("button", { name: Labels.EditButton })[0]
   );
-  await userEvent.selectOptions(
-    screen.getByRole("combobox", { name: "Power type" }),
-    PowerTypeNames.APC
-  );
+  await userEvent.click(screen.getByRole("button", { name: "Power type" }));
+  await userEvent.click(screen.getByRole("option", { name: "APC" }));
   await userEvent.clear(screen.getByRole("textbox", { name: "APC field" }));
   await userEvent.type(
     screen.getByRole("textbox", { name: "APC field" }),

--- a/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.test.tsx
+++ b/src/app/machines/views/MachineDetails/MachineConfiguration/PowerForm/PowerFormFields/PowerFormFields.test.tsx
@@ -5,7 +5,19 @@ import PowerFormFields from ".";
 import { PowerFieldScope } from "@/app/store/general/types";
 import type { RootState } from "@/app/store/root/types";
 import * as factory from "@/testing/factories";
-import { screen, renderWithMockStore } from "@/testing/utils";
+import { powerTypesResolvers } from "@/testing/resolvers/powerTypes";
+import { systemResolvers } from "@/testing/resolvers/system";
+import {
+  screen,
+  renderWithMockStore,
+  setupMockServer,
+  waitForLoading,
+} from "@/testing/utils";
+
+setupMockServer(
+  powerTypesResolvers.listPowerTypes.handler(),
+  systemResolvers.getSystemInfo.handler()
+);
 
 describe("PowerFormFields", () => {
   let state: RootState;
@@ -21,7 +33,7 @@ describe("PowerFormFields", () => {
     });
   });
 
-  it("disables the power select and limits field scopes to node if machine is in a pod", () => {
+  it("disables the power select and limits field scopes to node if machine is in a pod", async () => {
     state.general.powerTypes.data = [
       factory.powerType({
         fields: [
@@ -62,7 +74,12 @@ describe("PowerFormFields", () => {
       { state }
     );
 
-    expect(screen.getByRole("combobox", { name: /Power type/ })).toBeDisabled();
+    await waitForLoading();
+
+    expect(screen.getByRole("button", { name: /Power type/ })).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    );
     expect(
       screen.getByRole("textbox", { name: "Node field" })
     ).toBeInTheDocument();

--- a/src/testing/factories/index.ts
+++ b/src/testing/factories/index.ts
@@ -173,6 +173,7 @@ export { modelRef } from "./model";
 export { nodeDevice } from "./nodedevice";
 export { notification } from "./notification";
 export { packageRepository } from "./packagerepository";
+export { powerTypeV3 } from "./powertype";
 export { reservedIp, reservedIpNodeSummary } from "./reservedip";
 export { resourcePool } from "./resourcepool";
 export {

--- a/src/testing/factories/powertype.ts
+++ b/src/testing/factories/powertype.ts
@@ -1,0 +1,26 @@
+import { define } from "cooky-cutter";
+
+import type { PowerTypeField, PowerTypeResponse } from "@/app/apiclient";
+import { PowerFieldType } from "@/app/store/general/types";
+
+export const powerFieldV3 = define<PowerTypeField>({
+  choices: () => [],
+  default: "auto",
+  field_type: PowerFieldType.STRING,
+  label: (i: number) => `test-powerfield-label-${i}`,
+  name: (i: number) => `test-powerfield-name-${i}`,
+  required: false,
+});
+
+export const powerTypeV3 = define<PowerTypeResponse>({
+  driver_type: "power",
+  name: "amt",
+  description: "Intel AMT",
+  fields: () => [powerFieldV3()],
+  chassis: false,
+  can_probe: false,
+  missing_packages: () => [],
+  queryable: true,
+  fips_supported: true,
+  fips_unsupported_reason: undefined,
+});

--- a/src/testing/resolvers/powerTypes.ts
+++ b/src/testing/resolvers/powerTypes.ts
@@ -1,0 +1,59 @@
+import { http, HttpResponse } from "msw";
+
+import { powerTypeV3 } from "../factories";
+import { BASE_URL } from "../utils";
+
+import type {
+  ListPowerTypesError,
+  ListPowerTypesResponse,
+} from "@/app/apiclient";
+
+const mockPowerTypes: ListPowerTypesResponse = {
+  items: [
+    powerTypeV3({
+      name: "manual",
+      description: "Manual",
+      driver_type: "power",
+    }),
+    powerTypeV3({
+      name: "amt",
+      description: "Intel AMT",
+      driver_type: "power",
+    }),
+    powerTypeV3({
+      name: "apc",
+      description:
+        "American Power Conversion (APC) Power Distribution Unit (PDU)",
+      driver_type: "power",
+    }),
+    powerTypeV3({
+      name: "lxd",
+      description: "LXD",
+      driver_type: "power",
+    }),
+  ],
+};
+
+const mockListPowerTypesError: ListPowerTypesError = {
+  message: "Unauthorized",
+  code: 401,
+  kind: "Error", // This will always be 'Error' for every error response
+};
+
+const powerTypesResolvers = {
+  listPowerTypes: {
+    resolved: false,
+    handler: (data: ListPowerTypesResponse = mockPowerTypes) =>
+      http.get(`${BASE_URL}MAAS/a/v3/power-types`, () => {
+        powerTypesResolvers.listPowerTypes.resolved = true;
+        return HttpResponse.json(data);
+      }),
+    error: (error: ListPowerTypesError = mockListPowerTypesError) =>
+      http.get(`${BASE_URL}MAAS/a/v3/power-types`, () => {
+        powerTypesResolvers.listPowerTypes.resolved = true;
+        return HttpResponse.json(error, { status: error.code });
+      }),
+  },
+};
+
+export { powerTypesResolvers, mockPowerTypes };


### PR DESCRIPTION
## Done

- Created query hook for power types
- Replaced HTML select with CustomSelect
- Disabled power types that FIPS does not support when FIPS is active

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to the machine list
- [x] Click "Add hardware" --> "Add machine"
- [x] Open the power type dropdown 
- [x] Ensure the list populates as normal
- [x] Go to a machine's details --> configuration
- [x] Modify the power type
- [x] Ensure the dropdown displays as normal
- [x] Modify L70 in `src/app/base/components/PowerTypeFields/PowerTypeFields.tsx` to be hardcoded to `true`
- [x] Repeat steps above and ensure that some power types are disabled, with reasons shown as tooltips

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6811](https://warthogs.atlassian.net/browse/MAASENG-6811)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots
<img width="936" height="500" alt="image" src="https://github.com/user-attachments/assets/634f219b-ce07-464d-bd40-71d17a54b5be" />

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->

## Notes

<!--
(Optional)
Leave any additional notes for the reviewer here.
-->


[MAASENG-6811]: https://warthogs.atlassian.net/browse/MAASENG-6811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ