### PR TITLE
feat(machines): apply FIPS restrictions to power fields MAASENG-6812

### DIFF
--- a/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.test.tsx
+++ b/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.test.tsx
@@ -103,6 +103,33 @@ describe("BasePowerField", () => {
     expect(screen.getByRole("combobox")).toBeInTheDocument();
   });
 
+  it("disables the field when disabled is true", () => {
+    const field = factory.powerField({ field_type: PowerFieldType.STRING });
+    render(
+      <Formik initialValues={{}} onSubmit={vi.fn()}>
+        <BasePowerField disabled field={field} />
+      </Formik>
+    );
+    expect(screen.getByRole("textbox")).toBeDisabled();
+  });
+
+  it("disables individual choices given in disabledChoices", () => {
+    const field = factory.powerField({
+      choices: [
+        ["choice1", "Choice 1"],
+        ["choice2", "Choice 2"],
+      ],
+      field_type: PowerFieldType.CHOICE,
+    });
+    render(
+      <Formik initialValues={{}} onSubmit={vi.fn()}>
+        <BasePowerField disabledChoices={["choice2"]} field={field} />
+      </Formik>
+    );
+    expect(screen.getByRole("option", { name: "Choice 1" })).not.toBeDisabled();
+    expect(screen.getByRole("option", { name: "Choice 2" })).toBeDisabled();
+  });
+
   it("correctly handles a multiple choice field type", async () => {
     const field = factory.powerField({
       choices: [

--- a/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.tsx
+++ b/src/app/base/components/PowerTypeFields/BasePowerField/BasePowerField.tsx
@@ -9,11 +9,15 @@ import type { PowerField } from "@/app/store/general/types";
 import type { PowerParameters } from "@/app/store/types/node";
 
 type Props = {
+  disabled?: boolean;
+  disabledChoices?: string[];
   field: PowerField;
   powerParametersValueName?: string;
 };
 
 export const BasePowerField = <V extends AnyObject>({
+  disabled,
+  disabledChoices,
   field,
   powerParametersValueName = "power_parameters",
 }: Props): React.ReactElement => {
@@ -63,12 +67,14 @@ export const BasePowerField = <V extends AnyObject>({
   return (
     <FormikField
       component={field_type === PowerFieldType.CHOICE ? Select : Input}
+      disabled={disabled}
       key={fieldName}
       label={label}
       name={fieldName}
       options={
         field_type === "choice"
           ? choices.map((choice) => ({
+              disabled: disabledChoices?.includes(choice[0]),
               key: `${name}-${choice[0]}`,
               label: choice[1],
               value: choice[0],

--- a/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.test.tsx
+++ b/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.test.tsx
@@ -1,7 +1,9 @@
 import { Formik } from "formik";
 
 import IPMIPowerFields, {
+  CIPHER_SUITE_ID_FIELD_NAME,
   NONE_WORKAROUND_VALUE,
+  SECURE_CIPHER_SUITE_ID,
   WORKAROUNDS_FIELD_NAME,
 } from "./IPMIPowerFields";
 
@@ -41,4 +43,75 @@ it("does not render the 'None' choice for the workaround flags field", async () 
     ).not.toBeInTheDocument();
   });
   expect(screen.getByRole("checkbox", { name: "One" })).toBeInTheDocument();
+});
+
+it("forces the cipher suite id field to the secure value and disables other choices when FIPS is active", async () => {
+  const cipherSuiteField = factory.powerField({
+    choices: [
+      ["", "freeipmi-tools default"],
+      ["3", "3 - HMAC-SHA1"],
+      [SECURE_CIPHER_SUITE_ID, "17 - HMAC-SHA256"],
+    ],
+    field_type: PowerFieldType.CHOICE,
+    label: "Cipher suite id",
+    name: CIPHER_SUITE_ID_FIELD_NAME,
+  });
+  render(
+    <Formik
+      initialValues={{
+        power_parameters: { [CIPHER_SUITE_ID_FIELD_NAME]: "3" },
+      }}
+      onSubmit={vi.fn()}
+    >
+      <IPMIPowerFields fields={[cipherSuiteField]} fipsActive />
+    </Formik>
+  );
+
+  const cipherSuiteSelect = screen.getByRole("combobox", {
+    name: "Cipher suite id",
+  });
+  await waitFor(() => {
+    expect(cipherSuiteSelect).toHaveValue(SECURE_CIPHER_SUITE_ID);
+  });
+  expect(
+    screen.getByRole("option", { name: "freeipmi-tools default" })
+  ).toBeDisabled();
+  expect(screen.getByRole("option", { name: "3 - HMAC-SHA1" })).toBeDisabled();
+  expect(
+    screen.getByRole("option", { name: "17 - HMAC-SHA256" })
+  ).not.toBeDisabled();
+});
+
+it("does not force the cipher suite id field when FIPS is not active", async () => {
+  const cipherSuiteField = factory.powerField({
+    choices: [
+      ["", "freeipmi-tools default"],
+      ["3", "3 - HMAC-SHA1"],
+      [SECURE_CIPHER_SUITE_ID, "17 - HMAC-SHA256"],
+    ],
+    field_type: PowerFieldType.CHOICE,
+    label: "Cipher suite id",
+    name: CIPHER_SUITE_ID_FIELD_NAME,
+  });
+  render(
+    <Formik
+      initialValues={{
+        power_parameters: { [CIPHER_SUITE_ID_FIELD_NAME]: "3" },
+      }}
+      onSubmit={vi.fn()}
+    >
+      <IPMIPowerFields fields={[cipherSuiteField]} />
+    </Formik>
+  );
+
+  const cipherSuiteSelect = screen.getByRole("combobox", {
+    name: "Cipher suite id",
+  });
+  expect(cipherSuiteSelect).toHaveValue("3");
+  expect(
+    screen.getByRole("option", { name: "3 - HMAC-SHA1" })
+  ).not.toBeDisabled();
+  expect(
+    screen.getByRole("option", { name: "17 - HMAC-SHA256" })
+  ).not.toBeDisabled();
 });

--- a/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.tsx
+++ b/src/app/base/components/PowerTypeFields/IPMIPowerFields/IPMIPowerFields.tsx
@@ -13,6 +13,7 @@ import type { PowerParameters } from "@/app/store/types/node";
 
 type Props = {
   fields: PowerFieldType[];
+  fipsActive?: boolean;
   powerParametersValueName?: string;
 };
 
@@ -20,8 +21,15 @@ export const WORKAROUNDS_FIELD_NAME = "workaround_flags";
 
 export const NONE_WORKAROUND_VALUE = "";
 
+export const CIPHER_SUITE_ID_FIELD_NAME = "cipher_suite_id";
+
+// Cipher suite 17 (HMAC-SHA256::HMAC_SHA256_128::AES-CBC-128) is the only
+// secure IPMI cipher suite, so it's enforced as the only selectable choice.
+export const SECURE_CIPHER_SUITE_ID = "17";
+
 export const IPMIPowerFields = <V extends AnyObject>({
   fields,
+  fipsActive = false,
   powerParametersValueName = "power_parameters",
 }: Props): React.ReactElement | null => {
   const { setFieldValue, values } = useFormikContext<V>();
@@ -30,6 +38,10 @@ export const IPMIPowerFields = <V extends AnyObject>({
     values[powerParametersValueName] as PowerParameters
   )[WORKAROUNDS_FIELD_NAME];
   const isMultiChoice = Array.isArray(workaroundsFieldValue);
+  const cipherSuiteFieldName = `${powerParametersValueName}.${CIPHER_SUITE_ID_FIELD_NAME}`;
+  const cipherSuiteFieldValue = (
+    values[powerParametersValueName] as PowerParameters
+  )[CIPHER_SUITE_ID_FIELD_NAME];
 
   // Automatically set workaround flags to "None" value if all choices are
   // unselected.
@@ -51,6 +63,22 @@ export const IPMIPowerFields = <V extends AnyObject>({
     workaroundsFieldName,
     workaroundsFieldValue,
   ]);
+
+  // Enforce the secure cipher suite as the only usable value when FIPS is
+  // active, regardless of what value the field previously had or defaults to.
+  useEffect(() => {
+    if (fipsActive && cipherSuiteFieldValue !== SECURE_CIPHER_SUITE_ID) {
+      setFieldValue(cipherSuiteFieldName, SECURE_CIPHER_SUITE_ID).catch(
+        (reason) => {
+          throw new FormikFieldChangeError(
+            cipherSuiteFieldName,
+            "setFieldValue",
+            reason
+          );
+        }
+      );
+    }
+  }, [cipherSuiteFieldName, cipherSuiteFieldValue, fipsActive, setFieldValue]);
 
   return (
     <>
@@ -105,8 +133,18 @@ export const IPMIPowerFields = <V extends AnyObject>({
             </div>
           );
         } else {
+          const isCipherSuiteField = name === CIPHER_SUITE_ID_FIELD_NAME;
           content.push(
             <BasePowerField
+              disabledChoices={
+                isCipherSuiteField && fipsActive
+                  ? choices
+                      .map(([choiceValue]) => choiceValue)
+                      .filter(
+                        (choiceValue) => choiceValue !== SECURE_CIPHER_SUITE_ID
+                      )
+                  : undefined
+              }
               field={field}
               key={field.name}
               powerParametersValueName={powerParametersValueName}

--- a/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
+++ b/src/app/base/components/PowerTypeFields/PowerTypeFields.test.tsx
@@ -1,6 +1,8 @@
 import { Formik } from "formik";
 
-import PowerTypeFields from "./PowerTypeFields";
+import PowerTypeFields, {
+  POWER_VERIFY_SSL_FIELD_NAME,
+} from "./PowerTypeFields";
 
 import { PowerTypeNames } from "@/app/store/general/constants";
 import { PowerFieldScope, PowerFieldType } from "@/app/store/general/types";
@@ -14,6 +16,7 @@ import {
   screen,
   setupMockServer,
   userEvent,
+  waitFor,
   waitForLoading,
   within,
 } from "@/testing/utils";
@@ -539,5 +542,142 @@ describe("PowerTypeFields", () => {
 
     // No FIPS reason tooltip should be shown for any option
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it.each([
+    PowerTypeNames.WEBHOOK,
+    PowerTypeNames.PROXMOX,
+    PowerTypeNames.HMCZ,
+  ])(
+    "forces SSL verification on and disables the field for %s when FIPS is active",
+    async (powerTypeName) => {
+      mockServer.use(
+        systemResolvers.getSystemInfo.handler(
+          factory.systemInfo({ fips_active: true })
+        )
+      );
+      const powerTypes = [
+        factory.powerType({
+          fields: [
+            factory.powerField({
+              choices: [
+                ["n", "No"],
+                ["y", "Yes"],
+              ],
+              default: "n",
+              field_type: PowerFieldType.CHOICE,
+              label: "Verify SSL",
+              name: POWER_VERIFY_SSL_FIELD_NAME,
+            }),
+          ],
+          name: powerTypeName,
+        }),
+      ];
+      state.general.powerTypes.data = powerTypes;
+      renderWithMockStore(
+        <Formik
+          initialValues={{
+            power_parameters: { [POWER_VERIFY_SSL_FIELD_NAME]: "n" },
+            power_type: powerTypeName,
+          }}
+          onSubmit={vi.fn()}
+        >
+          <PowerTypeFields />
+        </Formik>,
+        { state }
+      );
+
+      await waitForLoading();
+
+      const verifySslField = screen.getByRole("combobox", {
+        name: "Verify SSL",
+      });
+      await waitFor(() => {
+        expect(verifySslField).toHaveValue("y");
+      });
+      expect(verifySslField).toBeDisabled();
+    }
+  );
+
+  it("does not force SSL verification for power types that don't require it", async () => {
+    const powerTypes = [
+      factory.powerType({
+        fields: [
+          factory.powerField({
+            choices: [
+              ["n", "No"],
+              ["y", "Yes"],
+            ],
+            default: "n",
+            field_type: PowerFieldType.CHOICE,
+            label: "Verify SSL",
+            name: POWER_VERIFY_SSL_FIELD_NAME,
+          }),
+        ],
+        name: PowerTypeNames.MANUAL,
+      }),
+    ];
+    state.general.powerTypes.data = powerTypes;
+    renderWithMockStore(
+      <Formik
+        initialValues={{
+          power_parameters: { [POWER_VERIFY_SSL_FIELD_NAME]: "n" },
+          power_type: PowerTypeNames.MANUAL,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <PowerTypeFields />
+      </Formik>,
+      { state }
+    );
+
+    await waitForLoading();
+
+    const verifySslField = screen.getByRole("combobox", {
+      name: "Verify SSL",
+    });
+    expect(verifySslField).toHaveValue("n");
+    expect(verifySslField).not.toBeDisabled();
+  });
+
+  it("does not force SSL verification when FIPS is not active", async () => {
+    const powerTypes = [
+      factory.powerType({
+        fields: [
+          factory.powerField({
+            choices: [
+              ["n", "No"],
+              ["y", "Yes"],
+            ],
+            default: "n",
+            field_type: PowerFieldType.CHOICE,
+            label: "Verify SSL",
+            name: POWER_VERIFY_SSL_FIELD_NAME,
+          }),
+        ],
+        name: PowerTypeNames.WEBHOOK,
+      }),
+    ];
+    state.general.powerTypes.data = powerTypes;
+    renderWithMockStore(
+      <Formik
+        initialValues={{
+          power_parameters: { [POWER_VERIFY_SSL_FIELD_NAME]: "n" },
+          power_type: PowerTypeNames.WEBHOOK,
+        }}
+        onSubmit={vi.fn()}
+      >
+        <PowerTypeFields />
+      </Formik>,
+      { state }
+    );
+
+    await waitForLoading();
+
+    const verifySslField = screen.getByRole("combobox", {
+      name: "Verify SSL",
+    });
+    expect(verifySslField).toHaveValue("n");
+    expect(verifySslField).not.toBeDisabled();
   });
 });

--- a/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
+++ b/src/app/base/components/PowerTypeFields/PowerTypeFields.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { useEffect } from "react";
 
 import { CustomSelect, Spinner, Tooltip } from "@canonical/react-components";
 import { useFormikContext } from "formik";
@@ -23,6 +24,19 @@ import {
   getFieldsInScope,
   getPowerTypeFromName,
 } from "@/app/store/general/utils";
+import type { PowerParameters } from "@/app/store/types/node";
+
+export const POWER_VERIFY_SSL_FIELD_NAME = "power_verify_ssl";
+
+export const SSL_VERIFICATION_ENABLED_VALUE = "y";
+
+// These power types connect over HTTPS; when FIPS is active their SSL
+// verification must always be on, so the field is locked on.
+export const SSL_VERIFICATION_ENFORCED_POWER_TYPES: string[] = [
+  PowerTypeNames.WEBHOOK,
+  PowerTypeNames.PROXMOX,
+  PowerTypeNames.HMCZ,
+];
 
 type Props = {
   customFieldProps?: {
@@ -77,6 +91,41 @@ export const PowerTypeFields = <V extends AnyObject>({
   const selectedPowerType = powerTypes.find(
     (type) => type.name === values[powerTypeValueName]
   );
+
+  const sslVerificationEnforced = Boolean(
+    fipsActive &&
+      selectedPowerType &&
+      SSL_VERIFICATION_ENFORCED_POWER_TYPES.includes(selectedPowerType.name)
+  );
+  const verifySslFieldName = `${powerParametersValueName}.${POWER_VERIFY_SSL_FIELD_NAME}`;
+  const verifySslFieldValue = (
+    values[powerParametersValueName] as PowerParameters | undefined
+  )?.[POWER_VERIFY_SSL_FIELD_NAME];
+
+  // Force SSL verification on for power types that require it, regardless of
+  // what value the field previously had or defaults to.
+  useEffect(() => {
+    if (
+      sslVerificationEnforced &&
+      verifySslFieldValue !== SSL_VERIFICATION_ENABLED_VALUE
+    ) {
+      setFieldValue(verifySslFieldName, SSL_VERIFICATION_ENABLED_VALUE).catch(
+        (reason) => {
+          throw new FormikFieldChangeError(
+            verifySslFieldName,
+            "setFieldValue",
+            reason
+          );
+        }
+      );
+    }
+  }, [
+    setFieldValue,
+    sslVerificationEnforced,
+    verifySslFieldName,
+    verifySslFieldValue,
+  ]);
+
   if (
     !powerTypesLoaded ||
     systemInfo.isPending ||
@@ -90,6 +139,7 @@ export const PowerTypeFields = <V extends AnyObject>({
         fieldContent = (
           <IPMIPowerFields
             fields={fieldsInScope}
+            fipsActive={fipsActive}
             powerParametersValueName={powerParametersValueName}
           />
         );
@@ -106,6 +156,10 @@ export const PowerTypeFields = <V extends AnyObject>({
       default:
         fieldContent = fieldsInScope.map((field) => (
           <BasePowerField
+            disabled={
+              sslVerificationEnforced &&
+              field.name === POWER_VERIFY_SSL_FIELD_NAME
+            }
             field={field}
             key={field.name}
             powerParametersValueName={powerParametersValueName}


### PR DESCRIPTION
## Done

- Restricted cipher suite of IPMI to 17 only, disabled other options
- Forced Proxmox, IBM HMC Z and Webhook to enable SSL verification

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to a machine's configuration page
- [x] Edit the power configuration
- [x] Select IPMI
- [x] Ensure the cipher suite is set to 17 and all other cipher suite options are disabled
- [x] Select Webhook/IBM HMC Z/Proxmox
- [x] Ensure "Verify certificate..."/"Verify SSL..." is forced to "Yes" and the field disabled
- [x] Repeat for "Add machine" form

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6812](https://warthogs.atlassian.net/browse/MAASENG-6812)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots
<img width="824" height="876" alt="image" src="https://github.com/user-attachments/assets/71f864dc-fd4c-4760-9498-cf5fc84c8a2e" />
<img width="824" height="598" alt="image" src="https://github.com/user-attachments/assets/826c06e1-188f-4119-9dbc-8c8f2c049ed6" />

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-6812]: https://warthogs.atlassian.net/browse/MAASENG-6812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ