### PR TITLE
fix(machines): prevent LXD password from overflowing container MAASENG-6820

### DIFF
--- a/src/app/base/components/Definition/Definition.tsx
+++ b/src/app/base/components/Definition/Definition.tsx
@@ -1,5 +1,6 @@
 import { Children } from "react";
 
+import "./_index.scss";
 import { useId } from "@/app/base/hooks/base";
 
 type CommonProps = {
@@ -25,12 +26,14 @@ const Definition = ({
 }: Props): React.ReactElement => {
   const id = useId();
   return (
-    <div>
-      <p className="u-text--muted" id={id}>
+    <div className="p-definition">
+      <p className="p-definition__label u-text--muted" id={id}>
         {label}
       </p>
       {description ? (
-        <p aria-labelledby={id}>{description}</p>
+        <p aria-labelledby={id} className="p-definition__description">
+          {description}
+        </p>
       ) : Children.toArray(children).filter((child) => child !== "").length >
         0 ? (
         Children.map(

--- a/src/app/base/components/Definition/_index.scss
+++ b/src/app/base/components/Definition/_index.scss
@@ -1,0 +1,5 @@
+.p-definition {
+  .p-definition__description {
+    overflow: clip;
+  }
+}


### PR DESCRIPTION
## Done

- Applied `overflow: clip` to description part of `Definition` component

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

- [x] Go to a machine
- [x] Set the power type to LXD
- [x] Fill in the form and give it a very long password
- [x] Save the form
- [x] Ensure the password clips before it overflows its container

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6820](https://warthogs.atlassian.net/browse/MAASENG-6820)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots

### Before
<img width="1683" height="994" alt="image" src="https://github.com/user-attachments/assets/ba235efa-ef58-40ee-b3da-3103c90b2420" />

### After
<img width="1683" height="994" alt="image" src="https://github.com/user-attachments/assets/d98f2928-cbfb-482e-b9dd-2d23899d9c7f" />

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->


[MAASENG-6820]: https://warthogs.atlassian.net/browse/MAASENG-6820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ