### PR TITLE
feat(settings): Create table for detailed hardening status MAASENG-6815

### DIFF
--- a/src/app/base/components/NotificationList/NotificationList.test.tsx
+++ b/src/app/base/components/NotificationList/NotificationList.test.tsx
@@ -220,4 +220,77 @@ describe("NotificationList", () => {
     });
     expect(container.firstChild).toHaveClass("u-nudge-down");
   });
+
+  it("aggregates hardening notifications into a single notification", () => {
+    state.notification.items = [
+      factory.notification({
+        id: 1,
+        category: NotificationCategory.ERROR,
+        ident: "hardening-wildcard-bind-api-bind",
+        message:
+          "api_bind is not configured Run: maas config-hardening set api_bind <specific-ip-address>",
+      }),
+      factory.notification({
+        id: 2,
+        category: NotificationCategory.ERROR,
+        ident: "hardening-wildcard-bind-dns-bind",
+        message:
+          "dns_bind is not configured Run: maas config-hardening set dns_bind <specific-ip-address>",
+      }),
+    ];
+    renderWithBrowserRouter(<NotificationList />, {
+      route: "/machines",
+      state,
+    });
+
+    const notification = screen.getByTestId("hardening-notification");
+    expect(notification).toHaveTextContent(
+      "Hardening has been enabled, but 2 conditions have not been met."
+    );
+    expect(
+      screen.getByRole("link", { name: "Go to hardening settings..." })
+    ).toBeInTheDocument();
+    // The raw hardening messages are not displayed directly.
+    expect(
+      screen.queryByText(/maas config-hardening set/)
+    ).not.toBeInTheDocument();
+  });
+
+  it("uses singular wording for a single hardening notification", () => {
+    state.notification.items = [
+      factory.notification({
+        id: 1,
+        category: NotificationCategory.ERROR,
+        ident: "hardening-wildcard-bind-api-bind",
+        message:
+          "api_bind is not configured Run: maas config-hardening set api_bind <specific-ip-address>",
+      }),
+    ];
+    renderWithBrowserRouter(<NotificationList />, {
+      route: "/machines",
+      state,
+    });
+
+    expect(screen.getByTestId("hardening-notification")).toHaveTextContent(
+      "Hardening has been enabled, but 1 condition has not been met."
+    );
+  });
+
+  it("does not display a hardening notification when there are none", () => {
+    state.notification.items = [
+      factory.notification({
+        id: 1,
+        category: NotificationCategory.ERROR,
+        message: "an error",
+      }),
+    ];
+    renderWithBrowserRouter(<NotificationList />, {
+      route: "/machines",
+      state,
+    });
+
+    expect(
+      screen.queryByTestId("hardening-notification")
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/app/base/components/NotificationList/NotificationList.tsx
+++ b/src/app/base/components/NotificationList/NotificationList.tsx
@@ -4,10 +4,12 @@ import {
 } from "@canonical/react-components";
 import classNames from "classnames";
 import { useDispatch, useSelector } from "react-redux";
+import { Link } from "react-router";
 
 import NotificationGroup from "@/app/base/components/NotificationGroup";
 import NotificationGroupNotification from "@/app/base/components/NotificationGroup/Notification";
 import { useFetchActions } from "@/app/base/hooks";
+import urls from "@/app/base/urls";
 import { messageActions } from "@/app/store/message";
 import messageSelectors from "@/app/store/message/selectors";
 import type { Message } from "@/app/store/message/types";
@@ -37,13 +39,18 @@ const Messages = ({ messages }: { messages: Message[] }) => {
 export const useNotifications = () => {
   useFetchActions([notificationActions.fetch]);
 
+  const errors = useSelector(notificationSelectors.errors);
+  const hardening = useSelector(notificationSelectors.hardening);
+  const hardeningIds = new Set(hardening.map(({ id }) => id));
+
   return {
     warnings: {
       items: useSelector(notificationSelectors.warnings),
       severity: NotificationSeverity.CAUTION,
     },
     errors: {
-      items: useSelector(notificationSelectors.errors),
+      // Hardening notifications are surfaced as a single aggregated notification.
+      items: errors.filter(({ id }) => !hardeningIds.has(id)),
       severity: NotificationSeverity.NEGATIVE,
     },
     success: {
@@ -59,13 +66,28 @@ export const useNotifications = () => {
 
 const NotificationList = (): React.ReactElement => {
   const notifications = useNotifications();
+  const hardeningNotifications = useSelector(notificationSelectors.hardening);
   const messages = useSelector(messageSelectors.all);
   const messageCount = useSelector(messageSelectors.count);
   const notificationCount = useSelector(notificationSelectors.count);
   const hasContent = messageCount > 0 || notificationCount > 0;
+  const hardeningCount = hardeningNotifications.length;
 
   return (
     <div className={classNames({ "u-nudge-down": hasContent })}>
+      {hardeningCount > 0 && (
+        <Notification
+          data-testid="hardening-notification"
+          severity={NotificationSeverity.NEGATIVE}
+        >
+          Hardening has been enabled, but {hardeningCount} condition
+          {hardeningCount === 1 ? "" : "s"}{" "}
+          {hardeningCount === 1 ? "has" : "have"} not been met.{" "}
+          <Link to={urls.settings.security.hardeningStatus}>
+            Go to hardening settings...
+          </Link>
+        </Notification>
+      )}
       {Object.values(notifications).map((group) => {
         const items = group.items;
         const severity = group.severity;

--- a/src/app/settings/components/Routes/Routes.test.tsx
+++ b/src/app/settings/components/Routes/Routes.test.tsx
@@ -67,6 +67,10 @@ const routes = [
     path: urls.settings.security.ipmiSettings,
   },
   {
+    title: "Hardening status",
+    path: urls.settings.security.hardeningStatus,
+  },
+  {
     title: "Users",
     path: urls.settings.users.index,
   },

--- a/src/app/settings/components/Routes/Routes.tsx
+++ b/src/app/settings/components/Routes/Routes.tsx
@@ -25,6 +25,7 @@ import SyslogForm from "@/app/settings/views/Network/SyslogForm";
 import RepositoriesList from "@/app/settings/views/Repositories/views";
 import ScriptsList from "@/app/settings/views/Scripts/ScriptsList";
 import ScriptsUpload from "@/app/settings/views/Scripts/ScriptsUpload";
+import HardeningStatus from "@/app/settings/views/Security/HardeningStatus";
 import IpmiSettings from "@/app/settings/views/Security/IpmiSettings";
 import SecretStorage from "@/app/settings/views/Security/SecretStorage";
 import SecurityProtocols from "@/app/settings/views/Security/SecurityProtocols";
@@ -116,6 +117,14 @@ const Routes = (): React.ReactElement => {
       <Route
         element={<TrustedSSHHostKeys />}
         path={getRelativeRoute(urls.settings.security.trustedSshHostKeys, base)}
+      />
+      <Route
+        element={
+          <PageContent sidePanelContent={null} sidePanelTitle={null}>
+            <HardeningStatus />
+          </PageContent>
+        }
+        path={getRelativeRoute(urls.settings.security.hardeningStatus, base)}
       />
       <Route
         element={

--- a/src/app/settings/constants.ts
+++ b/src/app/settings/constants.ts
@@ -40,6 +40,10 @@ export const settingsNavItems: NavItem[] = [
         path: settingsURLs.security.trustedSshHostKeys,
         label: "Trusted SSH host keys",
       },
+      {
+        path: settingsURLs.security.hardeningStatus,
+        label: "Hardening status",
+      },
     ],
   },
   {

--- a/src/app/settings/urls.ts
+++ b/src/app/settings/urls.ts
@@ -66,6 +66,7 @@ const urls = {
     ipmiSettings: "/settings/security/ipmi-settings",
     sessionTimeout: "/settings/security/session-timeout",
     trustedSshHostKeys: "/settings/security/trusted-ssh-host-keys",
+    hardeningStatus: "/settings/security/hardening-status",
   },
   storage: "/settings/storage",
   users: {

--- a/src/app/settings/views/Security/HardeningStatus/HardeningStatus.test.tsx
+++ b/src/app/settings/views/Security/HardeningStatus/HardeningStatus.test.tsx
@@ -1,0 +1,85 @@
+import HardeningStatus from "./HardeningStatus";
+
+import { systemInfo as systemInfoFactory } from "@/testing/factories";
+import * as factory from "@/testing/factories";
+import { systemResolvers } from "@/testing/resolvers/system";
+import {
+  renderWithProviders,
+  screen,
+  setupMockServer,
+  waitFor,
+} from "@/testing/utils";
+
+const mockServer = setupMockServer(
+  systemResolvers.getSystemInfo.handler(
+    systemInfoFactory({ hardening_active: true })
+  )
+);
+
+it("renders the failing hardening requirements from notifications", async () => {
+  const state = factory.rootState({
+    notification: factory.notificationState({
+      loaded: true,
+      items: [
+        factory.notification({
+          ident: "hardening-wildcard-bind-api-bind",
+          message:
+            "api_bind is not configured Run: maas config-hardening set api_bind <specific-ip-address>",
+        }),
+      ],
+    }),
+  });
+
+  renderWithProviders(<HardeningStatus />, { state });
+
+  await waitFor(() => {
+    expect(screen.getByText("api_bind")).toBeInTheDocument();
+  });
+  expect(
+    screen.getByText("maas config-hardening set api_bind <specific-ip-address>")
+  ).toBeInTheDocument();
+});
+
+it("ignores notifications that are not hardening notifications", async () => {
+  const state = factory.rootState({
+    notification: factory.notificationState({
+      loaded: true,
+      items: [
+        factory.notification({
+          ident: "default",
+          message: "Some other notification",
+        }),
+      ],
+    }),
+  });
+
+  renderWithProviders(<HardeningStatus />, { state });
+
+  await waitFor(() => {
+    expect(
+      screen.getByText("All hardening requirements are met.")
+    ).toBeInTheDocument();
+  });
+});
+
+it("shows how to enable hardening when it is not active", async () => {
+  mockServer.use(
+    systemResolvers.getSystemInfo.handler(
+      systemInfoFactory({ hardening_active: false })
+    )
+  );
+
+  renderWithProviders(<HardeningStatus />);
+
+  await waitFor(() => {
+    expect(screen.getByText(/Hardening is not enabled/)).toBeInTheDocument();
+  });
+  expect(screen.getByText("maas config-hardening enable")).toBeInTheDocument();
+  expect(
+    screen.getByRole("link", { name: "Learn more about security hardening" })
+  ).toBeInTheDocument();
+  // The requirements table is not rendered when hardening is disabled.
+  expect(
+    screen.queryByText("All hardening requirements are met.")
+  ).not.toBeInTheDocument();
+});

--- a/src/app/settings/views/Security/HardeningStatus/HardeningStatus.tsx
+++ b/src/app/settings/views/Security/HardeningStatus/HardeningStatus.tsx
@@ -1,0 +1,77 @@
+import { ContentSection } from "@canonical/maas-react-components";
+import {
+  CodeSnippet,
+  CodeSnippetBlockAppearance,
+  Link,
+  Spinner,
+} from "@canonical/react-components";
+import { useSelector } from "react-redux";
+
+import HardeningStatusTable from "./components/HardeningStatusTable";
+import { parseHardeningNotifications } from "./utils";
+
+import { useSystemInfo } from "@/app/api/query/system";
+import { useFetchActions, useWindowTitle } from "@/app/base/hooks";
+import { notificationActions } from "@/app/store/notification";
+import notificationSelectors from "@/app/store/notification/selectors";
+
+const HARDENING_DOCS_URL = `${import.meta.env.VITE_APP_BASENAME}/docs/reference/configuration-guides/security-hardening/`;
+
+const HardeningStatus = (): React.ReactElement => {
+  useWindowTitle("Hardening status");
+  useFetchActions([notificationActions.fetch]);
+
+  const systemInfo = useSystemInfo();
+  const notifications = useSelector(notificationSelectors.hardening);
+  const loaded = useSelector(notificationSelectors.loaded);
+  const requirements = parseHardeningNotifications(notifications);
+
+  return (
+    <ContentSection>
+      <ContentSection.Title className="section-header__title">
+        Hardening status
+      </ContentSection.Title>
+      <ContentSection.Content>
+        {systemInfo.isPending ? (
+          <Spinner text="Loading..." />
+        ) : systemInfo.data?.hardening_active ? (
+          <>
+            <p>
+              Hardening requirements that are not met are listed below, along
+              with the <code>maas config-hardening set</code> command that
+              resolves each one. This view is read-only; changes made with the
+              command take effect on the next region restart.
+            </p>
+            <HardeningStatusTable
+              isLoading={!loaded}
+              requirements={requirements}
+            />
+          </>
+        ) : (
+          <>
+            <p>
+              Hardening is not enabled. Enable it by running the following
+              command on a region controller; the change takes effect on the
+              next region restart.
+            </p>
+            <CodeSnippet
+              blocks={[
+                {
+                  appearance: CodeSnippetBlockAppearance.LINUX_PROMPT,
+                  code: "maas config-hardening enable",
+                },
+              ]}
+            />
+            <p>
+              <Link href={HARDENING_DOCS_URL} rel="noreferrer" target="_blank">
+                Learn more about security hardening
+              </Link>
+            </p>
+          </>
+        )}
+      </ContentSection.Content>
+    </ContentSection>
+  );
+};
+
+export default HardeningStatus;

--- a/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/HardeningStatusTable.test.tsx
+++ b/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/HardeningStatusTable.test.tsx
@@ -1,0 +1,50 @@
+import HardeningStatusTable from "./HardeningStatusTable";
+
+import type { HardeningRequirement } from "@/app/settings/views/Security/HardeningStatus/utils";
+import { renderWithProviders, screen } from "@/testing/utils";
+
+const requirements: HardeningRequirement[] = [
+  {
+    id: 1,
+    configKey: "api_bind",
+    description: "api_bind is not configured",
+    command: "maas config-hardening set api_bind <specific-ip-address>",
+  },
+];
+
+it("displays a loading state", () => {
+  renderWithProviders(<HardeningStatusTable isLoading requirements={[]} />);
+
+  expect(screen.getByText("Loading...")).toBeInTheDocument();
+});
+
+it("displays a message when all requirements are met", () => {
+  renderWithProviders(
+    <HardeningStatusTable isLoading={false} requirements={[]} />
+  );
+
+  expect(
+    screen.getByText("All hardening requirements are met.")
+  ).toBeInTheDocument();
+});
+
+it("displays a failing requirement with its resolving command", () => {
+  renderWithProviders(
+    <HardeningStatusTable isLoading={false} requirements={requirements} />
+  );
+
+  expect(screen.getByText("api_bind")).toBeInTheDocument();
+  expect(screen.getByText("Not met")).toBeInTheDocument();
+  expect(screen.getByText("api_bind is not configured")).toBeInTheDocument();
+  expect(
+    screen.getByText("maas config-hardening set api_bind <specific-ip-address>")
+  ).toBeInTheDocument();
+});
+
+it("displays a copy button for the resolving command", () => {
+  renderWithProviders(
+    <HardeningStatusTable isLoading={false} requirements={requirements} />
+  );
+
+  expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+});

--- a/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/HardeningStatusTable.tsx
+++ b/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/HardeningStatusTable.tsx
@@ -1,0 +1,33 @@
+import { GenericTable } from "@canonical/maas-react-components";
+
+import useHardeningStatusTableColumns from "./useHardeningStatusTableColumns";
+
+import type { HardeningRequirement } from "@/app/settings/views/Security/HardeningStatus/utils";
+
+import "./_index.scss";
+
+type Props = {
+  requirements: HardeningRequirement[];
+  isLoading: boolean;
+};
+
+const HardeningStatusTable = ({
+  requirements,
+  isLoading,
+}: Props): React.ReactElement => {
+  const columns = useHardeningStatusTableColumns();
+
+  return (
+    <GenericTable
+      aria-label="Hardening status"
+      className="hardening-status-table"
+      columns={columns}
+      data={requirements}
+      isLoading={isLoading}
+      noData="All hardening requirements are met."
+      variant="regular"
+    />
+  );
+};
+
+export default HardeningStatusTable;

--- a/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/_index.scss
+++ b/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/_index.scss
@@ -1,0 +1,36 @@
+.hardening-status-table {
+  // Shrink the leading columns so the resolution command has room to breathe.
+  .configKey {
+    width: 10rem;
+  }
+
+  .status {
+    width: 8rem;
+  }
+
+  // Bound the resolution cell so its command scrolls within the cell instead
+  // of widening the table and clipping off the page.
+  .command {
+    max-width: 32rem;
+  }
+
+  // Override the GenericTable rule that right-aligns the last column.
+  .p-generic-table__table thead th.command:last-child,
+  .p-generic-table__table tbody td.command:last-child {
+    text-align: left;
+  }
+
+  &__command {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    max-width: 100%;
+  }
+
+  &__command-snippet {
+    // Scroll the command on its own when it is too wide for the cell.
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-x: auto;
+  }
+}

--- a/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/index.ts
+++ b/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HardeningStatusTable";

--- a/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/useHardeningStatusTableColumns.tsx
+++ b/src/app/settings/views/Security/HardeningStatus/components/HardeningStatusTable/useHardeningStatusTableColumns.tsx
@@ -1,0 +1,73 @@
+import { useMemo } from "react";
+
+import {
+  CodeSnippet,
+  CodeSnippetBlockAppearance,
+  Icon,
+} from "@canonical/react-components";
+import type { ColumnDef } from "@tanstack/react-table";
+
+import CopyButton from "@/app/base/components/CopyButton";
+import type { HardeningRequirement } from "@/app/settings/views/Security/HardeningStatus/utils";
+
+type HardeningStatusColumnDef = ColumnDef<
+  HardeningRequirement,
+  Partial<HardeningRequirement>
+>;
+
+const useHardeningStatusTableColumns = (): HardeningStatusColumnDef[] =>
+  useMemo(
+    () => [
+      {
+        id: "configKey",
+        accessorKey: "configKey",
+        enableSorting: true,
+        header: "Requirement",
+        cell: ({ row: { original } }) => original.configKey || <>&mdash;</>,
+      },
+      {
+        id: "status",
+        accessorKey: "id",
+        enableSorting: false,
+        header: "Status",
+        cell: () => (
+          <span>
+            <Icon name="error" /> Not met
+          </span>
+        ),
+      },
+      {
+        id: "description",
+        accessorKey: "description",
+        enableSorting: false,
+        header: "Details",
+        cell: ({ row: { original } }) => original.description || <>&mdash;</>,
+      },
+      {
+        id: "command",
+        accessorKey: "command",
+        enableSorting: false,
+        header: "Resolution",
+        cell: ({ row: { original } }) =>
+          original.command ? (
+            <div className="hardening-status-table__command">
+              <CopyButton value={original.command} />
+              <CodeSnippet
+                blocks={[
+                  {
+                    appearance: CodeSnippetBlockAppearance.LINUX_PROMPT,
+                    code: original.command,
+                  },
+                ]}
+                className="hardening-status-table__command-snippet u-no-margin--bottom"
+              />
+            </div>
+          ) : (
+            <>&mdash;</>
+          ),
+      },
+    ],
+    []
+  );
+
+export default useHardeningStatusTableColumns;

--- a/src/app/settings/views/Security/HardeningStatus/index.ts
+++ b/src/app/settings/views/Security/HardeningStatus/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./HardeningStatus";

--- a/src/app/settings/views/Security/HardeningStatus/utils.test.ts
+++ b/src/app/settings/views/Security/HardeningStatus/utils.test.ts
@@ -1,0 +1,85 @@
+import {
+  parseHardeningNotification,
+  parseHardeningNotifications,
+} from "./utils";
+
+import * as factory from "@/testing/factories";
+
+describe("parseHardeningNotification", () => {
+  it("splits the description and the resolving command", () => {
+    const notification = factory.notification({
+      id: 1,
+      ident: "hardening-wildcard-bind-api-bind",
+      message:
+        "api_bind is not configured; the service would bind to all interfaces, which is not allowed when hardening is active Run: maas config-hardening set api_bind <specific-ip-address>",
+    });
+
+    expect(parseHardeningNotification(notification)).toStrictEqual({
+      id: 1,
+      configKey: "api_bind",
+      description:
+        "api_bind is not configured; the service would bind to all interfaces, which is not allowed when hardening is active",
+      command: "maas config-hardening set api_bind <specific-ip-address>",
+    });
+  });
+
+  it("extracts the config key from the resolving command", () => {
+    const notification = factory.notification({
+      ident: "hardening-invalid-bind-dns-bind",
+      message:
+        "dns_bind 'nope' is not a valid IP address Run: maas config-hardening set dns_bind <specific-ip-address>",
+    });
+
+    expect(parseHardeningNotification(notification).configKey).toBe("dns_bind");
+  });
+
+  it("keeps a controller-scoped prefix in the description", () => {
+    const notification = factory.notification({
+      ident: "hardening-ctrl-abc123-api_bind",
+      message:
+        "[abc123] api_bind '0.0.0.0' binds to all interfaces, which is not allowed when hardening is active Run: maas config-hardening set api_bind <specific-ip-address>",
+    });
+
+    const parsed = parseHardeningNotification(notification);
+    expect(parsed.description).toBe(
+      "[abc123] api_bind '0.0.0.0' binds to all interfaces, which is not allowed when hardening is active"
+    );
+    expect(parsed.configKey).toBe("api_bind");
+    expect(parsed.command).toBe(
+      "maas config-hardening set api_bind <specific-ip-address>"
+    );
+  });
+
+  it("handles a message without a resolving command", () => {
+    const notification = factory.notification({
+      ident: "hardening-unknown",
+      message: "Something is wrong",
+    });
+
+    expect(parseHardeningNotification(notification)).toStrictEqual({
+      id: notification.id,
+      configKey: "",
+      description: "Something is wrong",
+      command: "",
+    });
+  });
+});
+
+describe("parseHardeningNotifications", () => {
+  it("parses a list of notifications", () => {
+    const notifications = [
+      factory.notification({
+        message:
+          "api_bind is not configured Run: maas config-hardening set api_bind <specific-ip-address>",
+      }),
+      factory.notification({
+        message:
+          "dns_bind is not configured Run: maas config-hardening set dns_bind <specific-ip-address>",
+      }),
+    ];
+
+    expect(
+      parseHardeningNotifications(notifications).map((r) => r.configKey)
+    ).toStrictEqual(["api_bind", "dns_bind"]);
+  });
+});

--- a/src/app/settings/views/Security/HardeningStatus/utils.ts
+++ b/src/app/settings/views/Security/HardeningStatus/utils.ts
@@ -1,0 +1,43 @@
+import type { Notification } from "@/app/store/notification/types";
+
+export type HardeningRequirement = {
+  id: Notification["id"];
+  configKey: string;
+  description: string;
+  command: string;
+};
+
+// Hardening notification messages have the shape "<description> Run: <command>",
+// where the command is the resolving `maas config-hardening set ...` invocation.
+const RUN_SEPARATOR = " Run: ";
+const CONFIG_KEY_REGEX = /config-hardening set (\S+)/;
+
+/**
+ * Parse a single hardening notification into a requirement row.
+ * @param notification - a hardening notification.
+ * @returns The parsed hardening requirement.
+ */
+export const parseHardeningNotification = (
+  notification: Notification
+): HardeningRequirement => {
+  const message = notification.message ?? "";
+  const runIndex = message.indexOf(RUN_SEPARATOR);
+  const hasCommand = runIndex !== -1;
+  const description = (
+    hasCommand ? message.slice(0, runIndex) : message
+  ).trim();
+  const command = hasCommand
+    ? message.slice(runIndex + RUN_SEPARATOR.length).trim()
+    : "";
+  const configKey = CONFIG_KEY_REGEX.exec(command)?.[1] ?? "";
+  return { id: notification.id, configKey, description, command };
+};
+
+/**
+ * Parse hardening notifications into requirement rows for the table.
+ * @param notifications - hardening notifications.
+ * @returns The parsed hardening requirements.
+ */
+export const parseHardeningNotifications = (
+  notifications: Notification[]
+): HardeningRequirement[] => notifications.map(parseHardeningNotification);

--- a/src/app/store/notification/selectors.test.ts
+++ b/src/app/store/notification/selectors.test.ts
@@ -155,4 +155,21 @@ describe("notification selectors", () => {
     });
     expect(notification.getById(state, 909)).toStrictEqual(items[1]);
   });
+
+  it("can get hardening notifications", () => {
+    const hardeningNotification = factory.notification({
+      ident: "hardening-wildcard-bind-api-bind",
+    });
+    const state = factory.rootState({
+      notification: factory.notificationState({
+        items: [
+          hardeningNotification,
+          factory.notification({ ident: "default" }),
+        ],
+      }),
+    });
+    expect(notification.hardening(state)).toStrictEqual([
+      hardeningNotification,
+    ]);
+  });
 });

--- a/src/app/store/notification/selectors.ts
+++ b/src/app/store/notification/selectors.ts
@@ -11,6 +11,7 @@ import type {
   Notification,
   NotificationState,
 } from "@/app/store/notification/types";
+import { isHardeningNotification } from "@/app/store/notification/utils";
 import type { RootState } from "@/app/store/root/types";
 import { generateBaseSelectors } from "@/app/store/utils";
 
@@ -114,10 +115,20 @@ const info = createSelector([allEnabled], (notifications) =>
   )
 );
 
+/**
+ * Returns notifications advertising hardening requirements.
+ * @param {RootState} state - The redux state.
+ * @returns {Notification[]} Hardening notifications.
+ */
+const hardening = createSelector([allEnabled], (notifications) =>
+  notifications.filter(isHardeningNotification)
+);
+
 const selectors = {
   ...defaultSelectors,
   allEnabled,
   errors,
+  hardening,
   info,
   success,
   warnings,

--- a/src/app/store/notification/types/enum.ts
+++ b/src/app/store/notification/types/enum.ts
@@ -20,3 +20,7 @@ export enum ReleaseNotificationPaths {
   machines = "/machines",
   settings = "/settings",
 }
+
+// Hardening requirement notifications share this stable ident prefix (set by
+// the region's sync_hardening_notifications); their idents are otherwise dynamic.
+export const HARDENING_NOTIFICATION_IDENT_PREFIX = "hardening-";

--- a/src/app/store/notification/types/index.ts
+++ b/src/app/store/notification/types/index.ts
@@ -3,6 +3,7 @@ export type { CreateParams } from "./actions";
 export type { Notification, NotificationState } from "./base";
 
 export {
+  HARDENING_NOTIFICATION_IDENT_PREFIX,
   NotificationCategory,
   NotificationIdent,
   NotificationMeta,

--- a/src/app/store/notification/utils.test.ts
+++ b/src/app/store/notification/utils.test.ts
@@ -1,4 +1,8 @@
-import { isReleaseNotification, isUpgradeNotification } from "./utils";
+import {
+  isHardeningNotification,
+  isReleaseNotification,
+  isUpgradeNotification,
+} from "./utils";
 
 import { NotificationIdent } from "@/app/store/notification/types";
 import * as factory from "@/testing/factories";
@@ -40,6 +44,22 @@ describe("utils", () => {
         ident: NotificationIdent.RELEASE,
       });
       expect(isUpgradeNotification(notification)).toBe(false);
+    });
+  });
+
+  describe("isHardeningNotification", () => {
+    it("identifies a hardening notification by its ident prefix", () => {
+      const notification = factory.notification({
+        ident: "hardening-wildcard-bind-api-bind",
+      });
+      expect(isHardeningNotification(notification)).toBe(true);
+    });
+
+    it("handles other notifications", () => {
+      const notification = factory.notification({
+        ident: NotificationIdent.RELEASE,
+      });
+      expect(isHardeningNotification(notification)).toBe(false);
     });
   });
 });

--- a/src/app/store/notification/utils.ts
+++ b/src/app/store/notification/utils.ts
@@ -1,4 +1,7 @@
-import { NotificationIdent } from "@/app/store/notification/types";
+import {
+  HARDENING_NOTIFICATION_IDENT_PREFIX,
+  NotificationIdent,
+} from "@/app/store/notification/types";
 import type { Notification } from "@/app/store/notification/types";
 
 /**
@@ -7,6 +10,13 @@ import type { Notification } from "@/app/store/notification/types";
  */
 export const isReleaseNotification = (notification: Notification): boolean =>
   notification.ident === NotificationIdent.RELEASE;
+
+/**
+ * Util to check if a notification advertises a hardening requirement.
+ * @param notification - a notification.
+ */
+export const isHardeningNotification = (notification: Notification): boolean =>
+  notification.ident.startsWith(HARDENING_NOTIFICATION_IDENT_PREFIX);
 
 /**
  * Util to check if a notification is an upgrade notification.


### PR DESCRIPTION
## Done

- Created hardening status table in settings
- Created parser for aggregating hardeing status notifications

<!--
- Itemised list of what was changed by this PR.
-->

## QA steps

Ensure you're running MAAS on fips-3.7. Start with hardening disabled.
- [x] Go to settings --> hardening status
- [x] Ensure a message appears about how to enable hardening with a link to the docs
- [x] On your maas: `sudo maas config-hardening enable && sudo snap restart maas`
- [x] Wait a little, then refresh the page
- [x] Ensure a table appears with information on what steps are needed to complete hardening
- [x] Go to any page
- [x] Ensure there is a notification at the top that shows the number of steps remaining to complete hardening
- [x] In your editor, go to `src/app/store/notification/selectors.ts`
- [x] Modify `errors` (L86) and `hardening` (L122) to simply return empty arrays
- [x] Go back to the hardening settings page in the UI
- [x] Ensure the table shows an appropriate empty state message and the header shows no notifications

<!-- Steps for QA. -->

## Fixes

Resolves [MAASENG-6815](https://warthogs.atlassian.net/browse/MAASENG-6815)

<!-- Make sure you link the relevant Jira ticket or Launchpad bug above, if applicable. -->

## Screenshots
<img width="1764" height="877" alt="image" src="https://github.com/user-attachments/assets/7d51fed1-e892-4036-8890-a60d7d2acb45" />
<img width="1764" height="877" alt="image" src="https://github.com/user-attachments/assets/b32a92cd-fc46-425e-bac0-51b6fe07d176" />
<img width="1764" height="877" alt="image" src="https://github.com/user-attachments/assets/b58b0396-5e0d-42c6-9308-cf42aad31c63" />

<!--
Attach any screenshots or videos that help illustrate or demonstrate the changes made in this PR.
-->



[MAASENG-6815]: https://warthogs.atlassian.net/browse/MAASENG-6815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ